### PR TITLE
Backlog 13-14: fetch real PubMed metadata for every cited study

### DIFF
--- a/ops/cache/pubmed-metadata.json
+++ b/ops/cache/pubmed-metadata.json
@@ -1,0 +1,13391 @@
+{
+  "fetchedAt": "2026-08-16T00:50:31.246Z",
+  "count": 836,
+  "failures": [
+    {
+      "pmid": "17127598",
+      "reason": "cannot get document summary"
+    }
+  ],
+  "records": {
+    "1924160": {
+      "pmid": "1924160",
+      "title": "Pharmacokinetic study of an iridoid glucoside: aucubin",
+      "authors": "Suh NJ et al.",
+      "authorCount": 5,
+      "journal": "Pharm Res",
+      "year": 1991,
+      "volume": "8",
+      "pages": "1059-63",
+      "doi": "10.1023/a:1015821527621",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "8629725": {
+      "pmid": "8629725",
+      "title": "Tracking community sentinel events: breast cancer mortality and neighborhood risk for advanced-stage tumors in Denver",
+      "authors": "Andres TL et al.",
+      "authorCount": 4,
+      "journal": "Am J Public Health",
+      "year": 1996,
+      "volume": "86",
+      "pages": "717-22",
+      "doi": "10.2105/ajph.86.5.717",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "9313662": {
+      "pmid": "9313662",
+      "title": "A multicentric, placebo-controlled, double-blind clinical trial of beta-sitosterol (phytosterol) for the treatment of benign prostatic hyperplasia. German BPH-Phyto Study group",
+      "authors": "Klippel KF et al.",
+      "authorCount": 3,
+      "journal": "Br J Urol",
+      "year": 1997,
+      "volume": "80",
+      "pages": "427-32",
+      "doi": "",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "9820262": {
+      "pmid": "9820262",
+      "title": "Garcinia cambogia (hydroxycitric acid) as a potential antiobesity agent: a randomized controlled trial",
+      "authors": "Heymsfield SB et al.",
+      "authorCount": 6,
+      "journal": "JAMA",
+      "year": 1998,
+      "volume": "280",
+      "pages": "1596-600",
+      "doi": "10.1001/jama.280.18.1596",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "9878519": {
+      "pmid": "9878519",
+      "title": "Bioavailability of ferulic acid",
+      "authors": "Bourne LC and Rice-Evans C",
+      "authorCount": 2,
+      "journal": "Biochem Biophys Res Commun",
+      "year": 1998,
+      "volume": "253",
+      "pages": "222-7",
+      "doi": "10.1006/bbrc.1998.9681",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "10372249": {
+      "pmid": "10372249",
+      "title": "A randomized double-blind trial of acarbose in type 2 diabetes shows improved glycemic control over 3 years (U.K. Prospective Diabetes Study 44)",
+      "authors": "Holman RR et al.",
+      "authorCount": 3,
+      "journal": "Diabetes Care",
+      "year": 1999,
+      "volume": "22",
+      "pages": "960-4",
+      "doi": "10.2337/diacare.22.6.960",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "10410847": {
+      "pmid": "10410847",
+      "title": "Creatine supplementation. Its role in human performance",
+      "authors": "Kraemer WJ and Volek JS",
+      "authorCount": 2,
+      "journal": "Clin Sports Med",
+      "year": 1999,
+      "volume": "18",
+      "pages": "651-66, ix",
+      "doi": "10.1016/s0278-5919(05)70174-5",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "10675182": {
+      "pmid": "10675182",
+      "title": "Herb-drug interactions",
+      "authors": "Fugh-Berman A",
+      "authorCount": 1,
+      "journal": "Lancet",
+      "year": 2000,
+      "volume": "355",
+      "pages": "134-8",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "10767672": {
+      "pmid": "10767672",
+      "title": "Berberine",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "Altern Med Rev",
+      "year": 2000,
+      "volume": "5",
+      "pages": "175-7",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "10881250": {
+      "pmid": "10881250",
+      "title": "Galantamine in AD: A 6-month randomized, placebo-controlled trial with a 6-month extension. The Galantamine USA-1 Study Group",
+      "authors": "Raskind MA et al.",
+      "authorCount": 4,
+      "journal": "Neurology",
+      "year": 2000,
+      "volume": "54",
+      "pages": "2261-8",
+      "doi": "10.1212/wnl.54.12.2261",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "10919969": {
+      "pmid": "10919969",
+      "title": "Selected herbals and human exercise performance",
+      "authors": "Bucci LR",
+      "authorCount": 1,
+      "journal": "Am J Clin Nutr",
+      "year": 2000,
+      "volume": "72",
+      "pages": "624S-36S",
+      "doi": "10.1093/ajcn/72.2.624S",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "11275030": {
+      "pmid": "11275030",
+      "title": "Ginger for nausea and vomiting in pregnancy: randomized, double-masked, placebo-controlled trial",
+      "authors": "Vutyavanich T et al.",
+      "authorCount": 3,
+      "journal": "Obstet Gynecol",
+      "year": 2001,
+      "volume": "97",
+      "pages": "577-82",
+      "doi": "10.1016/s0029-7844(00)01228-x",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "11311045": {
+      "pmid": "11311045",
+      "title": "The effect of aging on glutathione peroxidase-i knockout mice-resistance of the lens to oxidative stress",
+      "authors": "Spector A et al.",
+      "authorCount": 4,
+      "journal": "Exp Eye Res",
+      "year": 2001,
+      "volume": "72",
+      "pages": "533-45",
+      "doi": "10.1006/exer.2001.0980",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "11362284": {
+      "pmid": "11362284",
+      "title": "Essiac",
+      "authors": "Majchrowicz MA",
+      "authorCount": 1,
+      "journal": "Notes Undergr",
+      "year": 1995,
+      "volume": "",
+      "pages": "6-7",
+      "doi": "",
+      "publicationTypes": [
+        "Newspaper Article",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "11406863": {
+      "pmid": "11406863",
+      "title": "Mutagenicity and antioxidant assessment of Stachitarpheta jamaicensis (L.) Vahl",
+      "authors": "Ramos A et al.",
+      "authorCount": 6,
+      "journal": "Phytother Res",
+      "year": 2001,
+      "volume": "15",
+      "pages": "360-3",
+      "doi": "10.1002/ptr.708",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "11752510": {
+      "pmid": "11752510",
+      "title": "Treatment of low back pain with a herbal or synthetic anti-rheumatic: a randomized controlled study. Willow bark extract for low back pain",
+      "authors": "Chrubasik S et al.",
+      "authorCount": 5,
+      "journal": "Rheumatology (Oxford)",
+      "year": 2001,
+      "volume": "40",
+      "pages": "1388-93",
+      "doi": "10.1093/rheumatology/40.12.1388",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Comparative Study",
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12112282": {
+      "pmid": "12112282",
+      "title": "Biological activities of lavender essential oil",
+      "authors": "Cavanagh HM and Wilkinson JM",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2002,
+      "volume": "16",
+      "pages": "301-8",
+      "doi": "10.1002/ptr.1103",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12131602": {
+      "pmid": "12131602",
+      "title": "A placebo-controlled study of Kava kava in generalized anxiety disorder",
+      "authors": "Connor KM and Davidson JR",
+      "authorCount": 2,
+      "journal": "Int Clin Psychopharmacol",
+      "year": 2002,
+      "volume": "17",
+      "pages": "185-8",
+      "doi": "10.1097/00004850-200207000-00005",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12140984": {
+      "pmid": "12140984",
+      "title": "[Identification of fragmented bodies of the killed from group burials]",
+      "authors": "Kolkutin VV et al.",
+      "authorCount": 3,
+      "journal": "Voen Med Zh",
+      "year": 2002,
+      "volume": "323",
+      "pages": "13-7, 96",
+      "doi": "",
+      "publicationTypes": [
+        "English Abstract",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12467979": {
+      "pmid": "12467979",
+      "title": "A putative novel nuclear-encoded subunit of the cytochrome c oxidase complex in trypanosomatids",
+      "authors": "Maslov DA et al.",
+      "authorCount": 4,
+      "journal": "Mol Biochem Parasitol",
+      "year": 2002,
+      "volume": "125",
+      "pages": "113-25",
+      "doi": "10.1016/s0166-6851(02)00235-9",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12482446": {
+      "pmid": "12482446",
+      "title": "Rosmarinic acid",
+      "authors": "Petersen M and Simmonds MS",
+      "authorCount": 2,
+      "journal": "Phytochemistry",
+      "year": 2003,
+      "volume": "62",
+      "pages": "121-5",
+      "doi": "10.1016/s0031-9422(02)00513-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12494336": {
+      "pmid": "12494336",
+      "title": "Kavalactones and dihydrokavain modulate GABAergic activity in a rat gastric-brainstem preparation",
+      "authors": "Yuan CS et al.",
+      "authorCount": 7,
+      "journal": "Planta Med",
+      "year": 2002,
+      "volume": "68",
+      "pages": "1092-6",
+      "doi": "10.1055/s-2002-36338",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12542115": {
+      "pmid": "12542115",
+      "title": "Evolution of the mortality rate in the age class of 75-84 years worldwide",
+      "authors": "Kesteloot H",
+      "authorCount": 1,
+      "journal": "Acta Cardiol",
+      "year": 2002,
+      "volume": "57",
+      "pages": "397-8",
+      "doi": "10.2143/AC.57.6.2005461",
+      "publicationTypes": [
+        "Comparative Study",
+        "Editorial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12597258": {
+      "pmid": "12597258",
+      "title": "Hawthorn",
+      "authors": "Fong HH and Bauman JL",
+      "authorCount": 2,
+      "journal": "J Cardiovasc Nurs",
+      "year": 2002,
+      "volume": "16",
+      "pages": "1-8",
+      "doi": "10.1097/00005082-200207000-00002",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12612144": {
+      "pmid": "12612144",
+      "title": "The consumption of processed tomato products enhances plasma lycopene concentrations in association with a reduced lipoprotein sensitivity to oxidative damage",
+      "authors": "Hadley CW et al.",
+      "authorCount": 3,
+      "journal": "J Nutr",
+      "year": 2003,
+      "volume": "133",
+      "pages": "727-32",
+      "doi": "10.1093/jn/133.3.727",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12706309": {
+      "pmid": "12706309",
+      "title": "Occurrence of oxygen desaturation events during preterm infant bottle feeding near discharge",
+      "authors": "Thoyre SM and Carlson J",
+      "authorCount": 2,
+      "journal": "Early Hum Dev",
+      "year": 2003,
+      "volume": "72",
+      "pages": "25-36",
+      "doi": "10.1016/s0378-3782(03)00008-2",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12874400": {
+      "pmid": "12874400",
+      "title": "Abeta1-42 promotes cholinergic sprouting in patients with AD and Lewy body variant of AD",
+      "authors": "Masliah E et al.",
+      "authorCount": 8,
+      "journal": "Neurology",
+      "year": 2003,
+      "volume": "61",
+      "pages": "206-11",
+      "doi": "10.1212/01.wnl.0000073987.79060.4b",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "12930169": {
+      "pmid": "12930169",
+      "title": "The effects of L-carnitine L-tartrate supplementation on hormonal responses to resistance exercise and recovery",
+      "authors": "Kraemer WJ et al.",
+      "authorCount": 11,
+      "journal": "J Strength Cond Res",
+      "year": 2003,
+      "volume": "17",
+      "pages": "455-62",
+      "doi": "10.1519/1533-4287(2003)017<0455:teolls>2.0.co;2",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "14668278": {
+      "pmid": "14668278",
+      "title": "Water-miscible, emulsified, and solid forms of retinol supplements are more toxic than oil-based preparations",
+      "authors": "Myhre AM et al.",
+      "authorCount": 6,
+      "journal": "Am J Clin Nutr",
+      "year": 2003,
+      "volume": "78",
+      "pages": "1152-9",
+      "doi": "10.1093/ajcn/78.6.1152",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "14725492": {
+      "pmid": "14725492",
+      "title": "Huperzine A",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "Drugs R D",
+      "year": 2004,
+      "volume": "5",
+      "pages": "44-5",
+      "doi": "10.2165/00126839-200405010-00009",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "14767959": {
+      "pmid": "14767959",
+      "title": "Disclosing new inhibitors by finding similarities in three-dimensional active-site architectures of polynuclear zinc phospholipases and aminopeptidases",
+      "authors": "González-Roura A et al.",
+      "authorCount": 5,
+      "journal": "Angew Chem Int Ed Engl",
+      "year": 2004,
+      "volume": "43",
+      "pages": "862-5",
+      "doi": "10.1002/anie.200352241",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15070181": {
+      "pmid": "15070181",
+      "title": "Pharmacokinetic study of 11-Keto beta-Boswellic acid",
+      "authors": "Sharma S et al.",
+      "authorCount": 6,
+      "journal": "Phytomedicine",
+      "year": 2004,
+      "volume": "11",
+      "pages": "255-60",
+      "doi": "10.1078/0944-7113-00290",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15095142": {
+      "pmid": "15095142",
+      "title": "Andrographis paniculata in the treatment of upper respiratory tract infections: a systematic review of safety and efficacy",
+      "authors": "Coon JT and Ernst E",
+      "authorCount": 2,
+      "journal": "Planta Med",
+      "year": 2004,
+      "volume": "70",
+      "pages": "293-8",
+      "doi": "10.1055/s-2004-818938",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15208835": {
+      "pmid": "15208835",
+      "title": "A scientific review: the role of chromium in insulin resistance",
+      "authors": "Havel PJ",
+      "authorCount": 1,
+      "journal": "Diabetes Educ",
+      "year": 2004,
+      "volume": "Suppl",
+      "pages": "2-14",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15496046": {
+      "pmid": "15496046",
+      "title": "Efficacy of zinc against common cold viruses: an overview",
+      "authors": "Hulisz D",
+      "authorCount": 1,
+      "journal": "J Am Pharm Assoc (2003)",
+      "year": 2004,
+      "volume": "44",
+      "pages": "594-603",
+      "doi": "10.1331/1544-3191.44.5.594.hulisz",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15548480": {
+      "pmid": "15548480",
+      "title": "Mucuna pruriens in Parkinson's disease: a double blind clinical and pharmacological study",
+      "authors": "Katzenschlager R et al.",
+      "authorCount": 9,
+      "journal": "J Neurol Neurosurg Psychiatry",
+      "year": 2004,
+      "volume": "75",
+      "pages": "1672-7",
+      "doi": "10.1136/jnnp.2003.028761",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15598647": {
+      "pmid": "15598647",
+      "title": "Phosphorylation by Pho85 cyclin-dependent kinase acts as a signal for the down-regulation of the yeast sphingoid long-chain base kinase Lcb4 during the stationary phase",
+      "authors": "Iwaki S et al.",
+      "authorCount": 4,
+      "journal": "J Biol Chem",
+      "year": 2005,
+      "volume": "280",
+      "pages": "6520-7",
+      "doi": "10.1074/jbc.M410908200",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15607555": {
+      "pmid": "15607555",
+      "title": "A novel therapeutic strategy for Ehlers-Danlos syndrome based on nutritional supplements",
+      "authors": "Mantle D et al.",
+      "authorCount": 3,
+      "journal": "Med Hypotheses",
+      "year": 2005,
+      "volume": "64",
+      "pages": "279-83",
+      "doi": "10.1016/j.mehy.2004.07.023",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15671130": {
+      "pmid": "15671130",
+      "title": "Treatment of depression: time to consider folic acid and vitamin B12",
+      "authors": "Coppen A and Bolander-Gouaille C",
+      "authorCount": 2,
+      "journal": "J Psychopharmacol",
+      "year": 2005,
+      "volume": "19",
+      "pages": "59-65",
+      "doi": "10.1177/0269881105048899",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15671695": {
+      "pmid": "15671695",
+      "title": "Effects of malted barley extract and banaba extract on blood glucose levels in genetically diabetic mice",
+      "authors": "Hong H and Jai Maeng W",
+      "authorCount": 2,
+      "journal": "J Med Food",
+      "year": 2004,
+      "volume": "7",
+      "pages": "487-90",
+      "doi": "10.1089/jmf.2004.7.487",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15734706": {
+      "pmid": "15734706",
+      "title": "The effects of iodine on intelligence in children: a meta-analysis of studies conducted in China",
+      "authors": "Qian M et al.",
+      "authorCount": 7,
+      "journal": "Asia Pac J Clin Nutr",
+      "year": 2005,
+      "volume": "14",
+      "pages": "32-42",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15748367": {
+      "pmid": "15748367",
+      "title": "Evaluating the efficiency of a combination of Pygeum africanum and stinging nettle (Urtica dioica) extracts in treating benign prostatic hyperplasia (BPH): double-blind, randomized, placebo controlled trial",
+      "authors": "Melo EA et al.",
+      "authorCount": 4,
+      "journal": "Int Braz J Urol",
+      "year": 2002,
+      "volume": "28",
+      "pages": "418-25",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "15927925": {
+      "pmid": "15927925",
+      "title": "Iberis amara L. and Iberogast--results of a systematic review concerning functional dyspepsia",
+      "authors": "Melzer J et al.",
+      "authorCount": 4,
+      "journal": "J Herb Pharmacother",
+      "year": 2004,
+      "volume": "4",
+      "pages": "51-9",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16129715": {
+      "pmid": "16129715",
+      "title": "Body composition and hormonal adaptations associated with forskolin consumption in overweight and obese men",
+      "authors": "Godard MP et al.",
+      "authorCount": 3,
+      "journal": "Obes Res",
+      "year": 2005,
+      "volume": "13",
+      "pages": "1335-43",
+      "doi": "10.1038/oby.2005.162",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16281088": {
+      "pmid": "16281088",
+      "title": "Aphrodisiac potentials of the aqueous extract of Fadogia agrestis (Schweinf. Ex Hiern) stem in male albino rats",
+      "authors": "Yakubu MT et al.",
+      "authorCount": 3,
+      "journal": "Asian J Androl",
+      "year": 2005,
+      "volume": "7",
+      "pages": "399-404",
+      "doi": "10.1111/j.1745-7262.2005.00052.x",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16332936": {
+      "pmid": "16332936",
+      "title": "Testosterone, dehydroepiandrosterone, and physical performance in older men: results from the Massachusetts Male Aging Study",
+      "authors": "O'Donnell AB et al.",
+      "authorCount": 5,
+      "journal": "J Clin Endocrinol Metab",
+      "year": 2006,
+      "volume": "91",
+      "pages": "425-31",
+      "doi": "10.1210/jc.2005-1227",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16416332": {
+      "pmid": "16416332",
+      "title": "Effect of creatine supplementation and sleep deprivation, with mild exercise, on cognitive and psychomotor performance, mood state, and plasma concentrations of catecholamines and cortisol",
+      "authors": "McMorris T et al.",
+      "authorCount": 9,
+      "journal": "Psychopharmacology (Berl)",
+      "year": 2006,
+      "volume": "185",
+      "pages": "93-103",
+      "doi": "10.1007/s00213-005-0269-z",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16552829": {
+      "pmid": "16552829",
+      "title": "Biochemical basis of the \"Qi-invigorating\" action of Schisandra berry (wu-wei-zi) in Chinese medicine",
+      "authors": "Ko KM and Chiu PY",
+      "authorCount": 2,
+      "journal": "Am J Chin Med",
+      "year": 2006,
+      "volume": "34",
+      "pages": "171-6",
+      "doi": "10.1142/S0192415X06003734",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16767798": {
+      "pmid": "16767798",
+      "title": "A review of the bioactivity and potential health benefits of peppermint tea (Mentha piperita L.)",
+      "authors": "McKay DL and Blumberg JB",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2006,
+      "volume": "20",
+      "pages": "619-33",
+      "doi": "10.1002/ptr.1936",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16857355": {
+      "pmid": "16857355",
+      "title": "Pharmaceutical prerequisites for a multi-target therapy",
+      "authors": "Kroll U and Cordes C",
+      "authorCount": 2,
+      "journal": "Phytomedicine",
+      "year": 2006,
+      "volume": "13 Suppl 5",
+      "pages": "12-9",
+      "doi": "10.1016/j.phymed.2006.03.016",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16891209": {
+      "pmid": "16891209",
+      "title": "Absinthe--a review",
+      "authors": "Lachenmeier DW et al.",
+      "authorCount": 4,
+      "journal": "Crit Rev Food Sci Nutr",
+      "year": 2006,
+      "volume": "46",
+      "pages": "365-77",
+      "doi": "10.1080/10408690590957322",
+      "publicationTypes": [
+        "Historical Article",
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16948356": {
+      "pmid": "16948356",
+      "title": "Buckwheat allergy",
+      "authors": "Stember RH",
+      "authorCount": 1,
+      "journal": "Allergy Asthma Proc",
+      "year": 2006,
+      "volume": "27",
+      "pages": "393-5",
+      "doi": "10.2500/aap.2006.27.2879",
+      "publicationTypes": [
+        "Case Reports",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "16988364": {
+      "pmid": "16988364",
+      "title": "Brassica oleracea",
+      "authors": "Sparrow PA et al.",
+      "authorCount": 3,
+      "journal": "Methods Mol Biol",
+      "year": 2006,
+      "volume": "343",
+      "pages": "417-26",
+      "doi": "10.1385/1-59745-130-4:417",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17089328": {
+      "pmid": "17089328",
+      "title": "Moringa oleifera: a food plant with multiple medicinal uses",
+      "authors": "Anwar F et al.",
+      "authorCount": 4,
+      "journal": "Phytother Res",
+      "year": 2007,
+      "volume": "21",
+      "pages": "17-25",
+      "doi": "10.1002/ptr.2023",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17095909": {
+      "pmid": "17095909",
+      "title": "Reassessment of cardiovascular risk in diabetes",
+      "authors": "Jaffe JR et al.",
+      "authorCount": 4,
+      "journal": "Curr Opin Lipidol",
+      "year": 2006,
+      "volume": "17",
+      "pages": "644-52",
+      "doi": "10.1097/MOL.0b013e3280106208",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17121765": {
+      "pmid": "17121765",
+      "title": "Bromelain as an adjunctive treatment for moderate-to-severe osteoarthritis of the knee: a randomized placebo-controlled pilot study",
+      "authors": "Brien S et al.",
+      "authorCount": 6,
+      "journal": "QJM",
+      "year": 2006,
+      "volume": "99",
+      "pages": "841-50",
+      "doi": "10.1093/qjmed/hcl118",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17128436": {
+      "pmid": "17128436",
+      "title": "A review of the biological and potential therapeutic actions of Harpagophytum procumbens",
+      "authors": "Grant L et al.",
+      "authorCount": 4,
+      "journal": "Phytother Res",
+      "year": 2007,
+      "volume": "21",
+      "pages": "199-209",
+      "doi": "10.1002/ptr.2029",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17145239": {
+      "pmid": "17145239",
+      "title": "Valerian for sleep: a systematic review and meta-analysis",
+      "authors": "Bent S et al.",
+      "authorCount": 5,
+      "journal": "Am J Med",
+      "year": 2006,
+      "volume": "119",
+      "pages": "1005-12",
+      "doi": "10.1016/j.amjmed.2006.02.026",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, N.I.H., Extramural",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17194255": {
+      "pmid": "17194255",
+      "title": "Effects of twenty-eight days of beta-alanine and creatine monohydrate supplementation on the physical working capacity at neuromuscular fatigue threshold",
+      "authors": "Stout JR et al.",
+      "authorCount": 6,
+      "journal": "J Strength Cond Res",
+      "year": 2006,
+      "volume": "20",
+      "pages": "928-31",
+      "doi": "10.1519/R-19655.1",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17210508": {
+      "pmid": "17210508",
+      "title": "Cat's claw: an Amazonian vine decreases inflammation in osteoarthritis",
+      "authors": "Hardin SR",
+      "authorCount": 1,
+      "journal": "Complement Ther Clin Pract",
+      "year": 2007,
+      "volume": "13",
+      "pages": "25-8",
+      "doi": "10.1016/j.ctcp.2006.10.003",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17212570": {
+      "pmid": "17212570",
+      "title": "Devil's Claw (Harpagophytum procumbens) as a treatment for osteoarthritis: a review of efficacy and safety",
+      "authors": "Brien S et al.",
+      "authorCount": 3,
+      "journal": "J Altern Complement Med",
+      "year": 2006,
+      "volume": "12",
+      "pages": "981-93",
+      "doi": "10.1089/acm.2006.12.981",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17344500": {
+      "pmid": "17344500",
+      "title": "Iron treatment normalizes cognitive functioning in young women",
+      "authors": "Murray-Kolb LE and Beard JL",
+      "authorCount": 2,
+      "journal": "Am J Clin Nutr",
+      "year": 2007,
+      "volume": "85",
+      "pages": "778-87",
+      "doi": "10.1093/ajcn/85.3.778",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, U.S. Gov't, Non-P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17427617": {
+      "pmid": "17427617",
+      "title": "Peppermint oil",
+      "authors": "Kligler B and Chaudhary S",
+      "authorCount": 2,
+      "journal": "Am Fam Physician",
+      "year": 2007,
+      "volume": "75",
+      "pages": "1027-30",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17470176": {
+      "pmid": "17470176",
+      "title": "Hematospermia associated with congenital arteriovenous malformation of internal iliac vessels",
+      "authors": "Suzuki K et al.",
+      "authorCount": 4,
+      "journal": "Int J Urol",
+      "year": 2007,
+      "volume": "14",
+      "pages": "370-2",
+      "doi": "10.1111/j.1442-2042.2007.01576.x",
+      "publicationTypes": [
+        "Case Reports",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17470980": {
+      "pmid": "17470980",
+      "title": "Esophageal temperature monitoring during radiofrequency catheter ablation: experimental study based on an agar phantom model",
+      "authors": "Rodríguez I et al.",
+      "authorCount": 5,
+      "journal": "Physiol Meas",
+      "year": 2007,
+      "volume": "28",
+      "pages": "453-63",
+      "doi": "10.1088/0967-3334/28/5/001",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17509841": {
+      "pmid": "17509841",
+      "title": "A comprehensive review on the stinging nettle effect and efficacy profiles. Part II: urticae radix",
+      "authors": "Chrubasik JE et al.",
+      "authorCount": 4,
+      "journal": "Phytomedicine",
+      "year": 2007,
+      "volume": "14",
+      "pages": "568-79",
+      "doi": "10.1016/j.phymed.2007.03.014",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17530942": {
+      "pmid": "17530942",
+      "title": "The effect of five weeks of Tribulus terrestris supplementation on muscle strength and body composition during preseason training in elite rugby league players",
+      "authors": "Rogerson S et al.",
+      "authorCount": 6,
+      "journal": "J Strength Cond Res",
+      "year": 2007,
+      "volume": "21",
+      "pages": "348-53",
+      "doi": "10.1519/R-18395.1",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17715566": {
+      "pmid": "17715566",
+      "title": "Protective effect of Cyclea peltata Lam on cisplatin-induced nephrotoxicity and oxidative damage",
+      "authors": "Vijayan FP et al.",
+      "authorCount": 6,
+      "journal": "J Basic Clin Physiol Pharmacol",
+      "year": 2007,
+      "volume": "18",
+      "pages": "101-14",
+      "doi": "10.1515/jbcpp.2007.18.2.101",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17919303": {
+      "pmid": "17919303",
+      "title": "Contact allergy and medicinal herbs",
+      "authors": "Aberer W",
+      "authorCount": 1,
+      "journal": "J Dtsch Dermatol Ges",
+      "year": 2008,
+      "volume": "6",
+      "pages": "15-24",
+      "doi": "10.1111/j.1610-0387.2007.06425.x",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "17995816": {
+      "pmid": "17995816",
+      "title": "Roselle (Hibiscus sabdariffa) seed oil is a rich source of gamma-tocopherol",
+      "authors": "Mohamed R et al.",
+      "authorCount": 4,
+      "journal": "J Food Sci",
+      "year": 2007,
+      "volume": "72",
+      "pages": "S207-11",
+      "doi": "10.1111/j.1750-3841.2007.00285.x",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18072817": {
+      "pmid": "18072817",
+      "title": "Spotlight on rasagiline in Parkinson's disease",
+      "authors": "Oldfield V et al.",
+      "authorCount": 3,
+      "journal": "CNS Drugs",
+      "year": 2008,
+      "volume": "22",
+      "pages": "83-6",
+      "doi": "10.2165/00023210-200822010-00007",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18204103": {
+      "pmid": "18204103",
+      "title": "Safety and efficacy of cranberry (vaccinium macrocarpon) during pregnancy and lactation",
+      "authors": "Dugoua JJ et al.",
+      "authorCount": 5,
+      "journal": "Can J Clin Pharmacol",
+      "year": 2008,
+      "volume": "15",
+      "pages": "e80-6",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18326600": {
+      "pmid": "18326600",
+      "title": "Weight-loss diet that includes consumption of medium-chain triacylglycerol oil leads to a greater rate of weight and fat mass loss than does olive oil",
+      "authors": "St-Onge MP and Bosarge A",
+      "authorCount": 2,
+      "journal": "Am J Clin Nutr",
+      "year": 2008,
+      "volume": "87",
+      "pages": "621-6",
+      "doi": "10.1093/ajcn/87.3.621",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18442638": {
+      "pmid": "18442638",
+      "title": "Efficacy of berberine in patients with type 2 diabetes mellitus",
+      "authors": "Yin J et al.",
+      "authorCount": 3,
+      "journal": "Metabolism",
+      "year": 2008,
+      "volume": "57",
+      "pages": "712-7",
+      "doi": "10.1016/j.metabol.2008.01.013",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18446848": {
+      "pmid": "18446848",
+      "title": "Review of pharmacological effects of Glycyrrhiza sp. and its bioactive compounds",
+      "authors": "Asl MN and Hosseinzadeh H",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2008,
+      "volume": "22",
+      "pages": "709-24",
+      "doi": "10.1002/ptr.2362",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18497367": {
+      "pmid": "18497367",
+      "title": "Adaptation of orientation vectors of otolith-related central vestibular neurons to gravity",
+      "authors": "Eron JN et al.",
+      "authorCount": 4,
+      "journal": "J Neurophysiol",
+      "year": 2008,
+      "volume": "100",
+      "pages": "1686-90",
+      "doi": "10.1152/jn.90289.2008",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18499602": {
+      "pmid": "18499602",
+      "title": "Preoperative oral Passiflora incarnata reduces anxiety in ambulatory surgery patients: a double-blind, placebo-controlled study",
+      "authors": "Movafegh A et al.",
+      "authorCount": 5,
+      "journal": "Anesth Analg",
+      "year": 2008,
+      "volume": "106",
+      "pages": "1728-32",
+      "doi": "10.1213/ane.0b013e318172c3f9",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18611150": {
+      "pmid": "18611150",
+      "title": "Effects of a standardized Bacopa monnieri extract on cognitive performance, anxiety, and depression in the elderly: a randomized, double-blind, placebo-controlled trial",
+      "authors": "Calabrese C et al.",
+      "authorCount": 6,
+      "journal": "J Altern Complement Med",
+      "year": 2008,
+      "volume": "14",
+      "pages": "707-13",
+      "doi": "10.1089/acm.2008.0018",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18681988": {
+      "pmid": "18681988",
+      "title": "The combined effects of L-theanine and caffeine on cognitive performance and mood",
+      "authors": "Owen GN et al.",
+      "authorCount": 4,
+      "journal": "Nutr Neurosci",
+      "year": 2008,
+      "volume": "11",
+      "pages": "193-8",
+      "doi": "10.1179/147683008X301513",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18711167": {
+      "pmid": "18711167",
+      "title": "Why choose serum cystatin C levels over serum creatinine levels as a serologic marker of kidney function?",
+      "authors": "Ben-Dov IZ",
+      "authorCount": 1,
+      "journal": "Ann Intern Med",
+      "year": 2008,
+      "volume": "149",
+      "pages": "284; author reply 284",
+      "doi": "10.7326/0003-4819-149-4-200808190-00016",
+      "publicationTypes": [
+        "Comment",
+        "Letter"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18842808": {
+      "pmid": "18842808",
+      "title": "Effect of glucomannan on plasma lipid and glucose concentrations, body weight, and blood pressure: systematic review and meta-analysis",
+      "authors": "Sood N et al.",
+      "authorCount": 3,
+      "journal": "Am J Clin Nutr",
+      "year": 2008,
+      "volume": "88",
+      "pages": "1167-75",
+      "doi": "10.1093/ajcn/88.4.1167",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18844328": {
+      "pmid": "18844328",
+      "title": "Improving effects of the mushroom Yamabushitake (Hericium erinaceus) on mild cognitive impairment: a double-blind placebo-controlled clinical trial",
+      "authors": "Mori K et al.",
+      "authorCount": 5,
+      "journal": "Phytother Res",
+      "year": 2009,
+      "volume": "23",
+      "pages": "367-72",
+      "doi": "10.1002/ptr.2634",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18940228": {
+      "pmid": "18940228",
+      "title": "Ameliorative effect of ajwain extract on hexachlorocyclohexane-induced lipid peroxidation in rat liver",
+      "authors": "Anilakumar KR et al.",
+      "authorCount": 4,
+      "journal": "Food Chem Toxicol",
+      "year": 2009,
+      "volume": "47",
+      "pages": "279-82",
+      "doi": "10.1016/j.fct.2008.09.061",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18971533": {
+      "pmid": "18971533",
+      "title": "Effects of nattokinase on blood pressure: a randomized, controlled trial",
+      "authors": "Kim JY et al.",
+      "authorCount": 10,
+      "journal": "Hypertens Res",
+      "year": 2008,
+      "volume": "31",
+      "pages": "1583-8",
+      "doi": "10.1291/hypres.31.1583",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "18992801": {
+      "pmid": "18992801",
+      "title": "Red Lapacho (Tabebuia impetiginosa)--a global ethnopharmacological commodity?",
+      "authors": "Gómez Castellanos JR et al.",
+      "authorCount": 3,
+      "journal": "J Ethnopharmacol",
+      "year": 2009,
+      "volume": "121",
+      "pages": "1-13",
+      "doi": "10.1016/j.jep.2008.10.004",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19016404": {
+      "pmid": "19016404",
+      "title": "A randomised, double-blind, placebo-controlled, parallel-group study of the standardised extract shr-5 of the roots of Rhodiola rosea in the treatment of subjects with stress-related fatigue",
+      "authors": "Olsson EM et al.",
+      "authorCount": 3,
+      "journal": "Planta Med",
+      "year": 2009,
+      "volume": "75",
+      "pages": "105-12",
+      "doi": "10.1055/s-0028-1088346",
+      "publicationTypes": [
+        "Clinical Trial, Phase III",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19126292": {
+      "pmid": "19126292",
+      "title": "Curcuma zedoaria Rosc. (white turmeric): a review of its chemical, pharmacological and ethnomedicinal properties",
+      "authors": "Lobo R et al.",
+      "authorCount": 4,
+      "journal": "J Pharm Pharmacol",
+      "year": 2009,
+      "volume": "61",
+      "pages": "13-21",
+      "doi": "10.1211/jpp/61.01.0003",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19147492": {
+      "pmid": "19147492",
+      "title": "Oxidative stress-induced peptidoglycan deacetylase in Helicobacter pylori",
+      "authors": "Wang G et al.",
+      "authorCount": 4,
+      "journal": "J Biol Chem",
+      "year": 2009,
+      "volume": "284",
+      "pages": "6790-800",
+      "doi": "10.1074/jbc.M808071200",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, Non-P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19397987": {
+      "pmid": "19397987",
+      "title": "Gastric antisecretory and antiulcer activities of Cyclea peltata (Lam.) Hook. f. & Thoms. in rats",
+      "authors": "Shine VJ et al.",
+      "authorCount": 8,
+      "journal": "J Ethnopharmacol",
+      "year": 2009,
+      "volume": "125",
+      "pages": "350-5",
+      "doi": "10.1016/j.jep.2009.04.039",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19507027": {
+      "pmid": "19507027",
+      "title": "The effect of enteric-coated, delayed-release peppermint oil on irritable bowel syndrome",
+      "authors": "Merat S et al.",
+      "authorCount": 6,
+      "journal": "Dig Dis Sci",
+      "year": 2010,
+      "volume": "55",
+      "pages": "1385-90",
+      "doi": "10.1007/s10620-009-0854-9",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19576959": {
+      "pmid": "19576959",
+      "title": "Microneurography of pruritus",
+      "authors": "Handwerker HO",
+      "authorCount": 1,
+      "journal": "Neurosci Lett",
+      "year": 2010,
+      "volume": "470",
+      "pages": "193-6",
+      "doi": "10.1016/j.neulet.2009.06.092",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19589961": {
+      "pmid": "19589961",
+      "title": "Ingestion of whey hydrolysate, casein, or soy protein isolate: effects on mixed muscle protein synthesis at rest and following resistance exercise in young men",
+      "authors": "Tang JE et al.",
+      "authorCount": 5,
+      "journal": "J Appl Physiol (1985)",
+      "year": 2009,
+      "volume": "107",
+      "pages": "987-92",
+      "doi": "10.1152/japplphysiol.00076.2009",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19593179": {
+      "pmid": "19593179",
+      "title": "A randomized, double-blind, placebo-controlled trial of oral Matricaria recutita (chamomile) extract therapy for generalized anxiety disorder",
+      "authors": "Amsterdam JD et al.",
+      "authorCount": 6,
+      "journal": "J Clin Psychopharmacol",
+      "year": 2009,
+      "volume": "29",
+      "pages": "378-82",
+      "doi": "10.1097/JCP.0b013e3181ac935c",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19594223": {
+      "pmid": "19594223",
+      "title": "Anti-inflammatory properties of curcumin, a major constituent of Curcuma longa: a review of preclinical and clinical research",
+      "authors": "Jurenka JS",
+      "authorCount": 1,
+      "journal": "Altern Med Rev",
+      "year": 2009,
+      "volume": "14",
+      "pages": "141-53",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19597519": {
+      "pmid": "19597519",
+      "title": "The effects of green tea on weight loss and weight maintenance: a meta-analysis",
+      "authors": "Hursel R et al.",
+      "authorCount": 3,
+      "journal": "Int J Obes (Lond)",
+      "year": 2009,
+      "volume": "33",
+      "pages": "956-61",
+      "doi": "10.1038/ijo.2009.135",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19719333": {
+      "pmid": "19719333",
+      "title": "Interactions between herbal medicines and prescribed drugs: an updated systematic review",
+      "authors": "Izzo AA and Ernst E",
+      "authorCount": 2,
+      "journal": "Drugs",
+      "year": 2009,
+      "volume": "69",
+      "pages": "1777-98",
+      "doi": "10.2165/11317010-000000000-00000",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19773644": {
+      "pmid": "19773644",
+      "title": "Cognitive effects of creatine ethyl ester supplementation",
+      "authors": "Ling J et al.",
+      "authorCount": 3,
+      "journal": "Behav Pharmacol",
+      "year": 2009,
+      "volume": "20",
+      "pages": "673-9",
+      "doi": "10.1097/FBP.0b013e3283323c2a",
+      "publicationTypes": [
+        "Controlled Clinical Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19789403": {
+      "pmid": "19789403",
+      "title": "Hawthorn Extract Randomized Blinded Chronic Heart Failure (HERB CHF) trial",
+      "authors": "Zick SM et al.",
+      "authorCount": 4,
+      "journal": "Eur J Heart Fail",
+      "year": 2009,
+      "volume": "11",
+      "pages": "990-9",
+      "doi": "10.1093/eurjhf/hfp116",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19912732": {
+      "pmid": "19912732",
+      "title": "An update on Shankhpushpi, a cognition-boosting Ayurvedic medicine",
+      "authors": "Sethiya NK et al.",
+      "authorCount": 4,
+      "journal": "Zhong Xi Yi Jie He Xue Bao",
+      "year": 2009,
+      "volume": "7",
+      "pages": "1001-22",
+      "doi": "10.3736/jcim20091101",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "19926708": {
+      "pmid": "19926708",
+      "title": "Apoptosis by dietary agents for prevention and treatment of prostate cancer",
+      "authors": "Khan N et al.",
+      "authorCount": 3,
+      "journal": "Endocr Relat Cancer",
+      "year": 2010,
+      "volume": "17",
+      "pages": "R39-52",
+      "doi": "10.1677/ERC-09-0262",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20032972": {
+      "pmid": "20032972",
+      "title": "Pharmacokinetics of 23-epi-26-deoxyactein in women after oral administration of a standardized extract of black cohosh",
+      "authors": "van Breemen RB et al.",
+      "authorCount": 17,
+      "journal": "Clin Pharmacol Ther",
+      "year": 2010,
+      "volume": "87",
+      "pages": "219-25",
+      "doi": "10.1038/clpt.2009.251",
+      "publicationTypes": [
+        "Clinical Trial, Phase I",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20091037": {
+      "pmid": "20091037",
+      "title": "Biopsychosocial determinants of physical and mental fatigue in patients with spondyloarthropathy",
+      "authors": "Da Costa D et al.",
+      "authorCount": 3,
+      "journal": "Rheumatol Int",
+      "year": 2011,
+      "volume": "31",
+      "pages": "473-80",
+      "doi": "10.1007/s00296-009-1250-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20182035": {
+      "pmid": "20182035",
+      "title": "Is caffeine a cognitive enhancer?",
+      "authors": "Nehlig A",
+      "authorCount": 1,
+      "journal": "J Alzheimers Dis",
+      "year": 2010,
+      "volume": "20 Suppl 1",
+      "pages": "S85-94",
+      "doi": "10.3233/JAD-2010-091315",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20301409": {
+      "pmid": "20301409",
+      "title": "Isolated Methylmalonic Acidemia",
+      "authors": "Manoli I et al.",
+      "authorCount": 3,
+      "journal": "",
+      "year": 2022,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20378318": {
+      "pmid": "20378318",
+      "title": "Rosenroot (Rhodiola rosea): traditional use, chemical composition, pharmacology and clinical efficacy",
+      "authors": "Panossian A et al.",
+      "authorCount": 3,
+      "journal": "Phytomedicine",
+      "year": 2010,
+      "volume": "17",
+      "pages": "481-93",
+      "doi": "10.1016/j.phymed.2010.02.002",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20386132": {
+      "pmid": "20386132",
+      "title": "Citrulline malate enhances athletic anaerobic performance and relieves muscle soreness",
+      "authors": "Pérez-Guisado J and Jakeman PM",
+      "authorCount": 2,
+      "journal": "J Strength Cond Res",
+      "year": 2010,
+      "volume": "24",
+      "pages": "1215-22",
+      "doi": "10.1519/JSC.0b013e3181cb28e0",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20458757": {
+      "pmid": "20458757",
+      "title": "Systematic review and meta-analysis of Saccharomyces boulardii in adult patients",
+      "authors": "McFarland LV",
+      "authorCount": 1,
+      "journal": "World J Gastroenterol",
+      "year": 2010,
+      "volume": "16",
+      "pages": "2202-22",
+      "doi": "10.3748/wjg.v16.i18.2202",
+      "publicationTypes": [
+        "Editorial",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20505356": {
+      "pmid": "20505356",
+      "title": "Stress-induced flowering",
+      "authors": "Wada KC and Takeno K",
+      "authorCount": 2,
+      "journal": "Plant Signal Behav",
+      "year": 2010,
+      "volume": "5",
+      "pages": "944-7",
+      "doi": "10.4161/psb.5.8.11826",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "20981575": {
+      "pmid": "20981575",
+      "title": "A review of the pharmacological effects of Arctium lappa (burdock)",
+      "authors": "Chan YS et al.",
+      "authorCount": 9,
+      "journal": "Inflammopharmacology",
+      "year": 2011,
+      "volume": "19",
+      "pages": "245-54",
+      "doi": "10.1007/s10787-010-0062-4",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21129941": {
+      "pmid": "21129941",
+      "title": "Comparative effects of daily and weekly boron supplementation on plasma steroid hormones and proinflammatory cytokines",
+      "authors": "Naghii MR et al.",
+      "authorCount": 5,
+      "journal": "J Trace Elem Med Biol",
+      "year": 2011,
+      "volume": "25",
+      "pages": "54-8",
+      "doi": "10.1016/j.jtemb.2010.10.001",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21144345": {
+      "pmid": "21144345",
+      "title": "Mentha piperita (peppermint)",
+      "authors": "Herro E and Jacob SE",
+      "authorCount": 2,
+      "journal": "Dermatitis",
+      "year": 2010,
+      "volume": "21",
+      "pages": "327-9",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21170695": {
+      "pmid": "21170695",
+      "title": "Efficacy and safety of silexan, a new, orally administered lavender oil preparation, in subthreshold anxiety disorder - evidence from clinical trials",
+      "authors": "Kasper S et al.",
+      "authorCount": 7,
+      "journal": "Wien Med Wochenschr",
+      "year": 2010,
+      "volume": "160",
+      "pages": "547-56",
+      "doi": "10.1007/s10354-010-0845-7",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21254395": {
+      "pmid": "21254395",
+      "title": "Pharmacokinetics of α-mangostin in rats after intravenous and oral application",
+      "authors": "Li L et al.",
+      "authorCount": 7,
+      "journal": "Mol Nutr Food Res",
+      "year": 2011,
+      "volume": "55 Suppl 1",
+      "pages": "S67-74",
+      "doi": "10.1002/mnfr.201000511",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Validation Study"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21315814": {
+      "pmid": "21315814",
+      "title": "Kudzu root: traditional uses and potential medicinal benefits in diabetes and cardiovascular diseases",
+      "authors": "Wong KH et al.",
+      "authorCount": 5,
+      "journal": "J Ethnopharmacol",
+      "year": 2011,
+      "volume": "134",
+      "pages": "584-607",
+      "doi": "10.1016/j.jep.2011.02.001",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21346706": {
+      "pmid": "21346706",
+      "title": "Fatal laboratory-acquired infection with an attenuated Yersinia pestis Strain--Chicago, Illinois, 2009",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "MMWR Morb Mortal Wkly Rep",
+      "year": 2011,
+      "volume": "60",
+      "pages": "201-5",
+      "doi": "",
+      "publicationTypes": [
+        "Case Reports",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21443487": {
+      "pmid": "21443487",
+      "title": "Molecular mechanisms of inflammation. Anti-inflammatory benefits of virgin olive oil and the phenolic compound oleocanthal",
+      "authors": "Lucas L et al.",
+      "authorCount": 3,
+      "journal": "Curr Pharm Des",
+      "year": 2011,
+      "volume": "17",
+      "pages": "754-68",
+      "doi": "10.2174/138161211795428911",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21480800": {
+      "pmid": "21480800",
+      "title": "Maitake (D fraction) mushroom extract induces apoptosis in breast cancer cells by BAK-1 gene activation",
+      "authors": "Soares R et al.",
+      "authorCount": 8,
+      "journal": "J Med Food",
+      "year": 2011,
+      "volume": "14",
+      "pages": "563-72",
+      "doi": "10.1089/jmf.2010.0095",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21589758": {
+      "pmid": "21589758",
+      "title": "Variation in gymnemic acid content and non-destructive harvesting of Gymnema sylvestre (Gudmar)",
+      "authors": "Pandey AK and Yadav S",
+      "authorCount": 2,
+      "journal": "Pharmacognosy Res",
+      "year": 2010,
+      "volume": "2",
+      "pages": "309-12",
+      "doi": "10.4103/0974-8490.72330",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21708034": {
+      "pmid": "21708034",
+      "title": "Efficacy of methylsulfonylmethane supplementation on osteoarthritis of the knee: a randomized controlled study",
+      "authors": "Debbi EM et al.",
+      "authorCount": 9,
+      "journal": "BMC Complement Altern Med",
+      "year": 2011,
+      "volume": "11",
+      "pages": "50",
+      "doi": "10.1186/1472-6882-11-50",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21875536": {
+      "pmid": "21875536",
+      "title": "Spice allergy",
+      "authors": "Chen JL and Bahna SL",
+      "authorCount": 2,
+      "journal": "Ann Allergy Asthma Immunol",
+      "year": 2011,
+      "volume": "107",
+      "pages": "191-9; quiz 199, 265",
+      "doi": "10.1016/j.anai.2011.06.020",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21908763": {
+      "pmid": "21908763",
+      "title": "Methysticin and 7,8-dihydromethysticin are two major kavalactones in kava extract to induce CYP1A1",
+      "authors": "Li Y et al.",
+      "authorCount": 7,
+      "journal": "Toxicol Sci",
+      "year": 2011,
+      "volume": "124",
+      "pages": "388-99",
+      "doi": "10.1093/toxsci/kfr235",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, Non-P.H.S.",
+        "Research Support, U.S. Gov't, P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21942448": {
+      "pmid": "21942448",
+      "title": "Artemisia dracunculus L. (tarragon): a critical review of its traditional use, chemical composition, pharmacology, and safety",
+      "authors": "Obolskiy D et al.",
+      "authorCount": 5,
+      "journal": "J Agric Food Chem",
+      "year": 2011,
+      "volume": "59",
+      "pages": "11367-84",
+      "doi": "10.1021/jf202277w",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "21945692": {
+      "pmid": "21945692",
+      "title": "SUMA",
+      "authors": "Saad ZS and Reynolds RC",
+      "authorCount": 2,
+      "journal": "Neuroimage",
+      "year": 2012,
+      "volume": "62",
+      "pages": "768-73",
+      "doi": "10.1016/j.neuroimage.2011.09.016",
+      "publicationTypes": [
+        "Historical Article",
+        "Journal Article",
+        "Research Support, N.I.H., Intramural",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22024337": {
+      "pmid": "22024337",
+      "title": "Comprehensive toxicity study of safrole using a medium-term animal model with gpt delta rats",
+      "authors": "Jin M et al.",
+      "authorCount": 10,
+      "journal": "Toxicology",
+      "year": 2011,
+      "volume": "290",
+      "pages": "312-21",
+      "doi": "10.1016/j.tox.2011.09.088",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22095937": {
+      "pmid": "22095937",
+      "title": "A review of the efficacy and safety of banaba (Lagerstroemia speciosa L.) and corosolic acid",
+      "authors": "Stohs SJ et al.",
+      "authorCount": 3,
+      "journal": "Phytother Res",
+      "year": 2012,
+      "volume": "26",
+      "pages": "317-24",
+      "doi": "10.1002/ptr.3664",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22167571": {
+      "pmid": "22167571",
+      "title": "Increased bioavailability of 11-keto-β-boswellic acid following single oral dose frankincense extract administration after a standardized meal in healthy male volunteers: modeling and simulation considerations for evaluating drug exposures",
+      "authors": "Skarke C et al.",
+      "authorCount": 9,
+      "journal": "J Clin Pharmacol",
+      "year": 2012,
+      "volume": "52",
+      "pages": "1592-600",
+      "doi": "10.1177/0091270011422811",
+      "publicationTypes": [
+        "Clinical Trial, Phase I",
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22228940": {
+      "pmid": "22228940",
+      "title": "Mangifera indica (mango)",
+      "authors": "Shah KA et al.",
+      "authorCount": 4,
+      "journal": "Pharmacogn Rev",
+      "year": 2010,
+      "volume": "4",
+      "pages": "42-8",
+      "doi": "10.4103/0973-7847.65325",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22271614": {
+      "pmid": "22271614",
+      "title": "Synthesis of hyperbranched polyethylene amphiphiles by chain walking polymerization in tandem with RAFT polymerization and supramolecular self-assembly vesicles",
+      "authors": "Shi X et al.",
+      "authorCount": 6,
+      "journal": "Macromol Rapid Commun",
+      "year": 2012,
+      "volume": "33",
+      "pages": "374-9",
+      "doi": "10.1002/marc.201100825",
+      "publicationTypes": [
+        "Evaluation Study",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22414105": {
+      "pmid": "22414105",
+      "title": "Nature against depression",
+      "authors": "El-Alfy AT et al.",
+      "authorCount": 3,
+      "journal": "Curr Med Chem",
+      "year": 2012,
+      "volume": "19",
+      "pages": "2229-41",
+      "doi": "10.2174/092986712800229096",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22450800": {
+      "pmid": "22450800",
+      "title": "Bupleurum falcatum prevents depression and anxiety-like behaviors in rats exposed to repeated restraint stress",
+      "authors": "Lee B et al.",
+      "authorCount": 5,
+      "journal": "J Microbiol Biotechnol",
+      "year": 2012,
+      "volume": "22",
+      "pages": "422-30",
+      "doi": "10.4014/jmb.1110.10077",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22460444": {
+      "pmid": "22460444",
+      "title": "Medical applications of phytoestrogens from the Thai herb Pueraria mirifica",
+      "authors": "Malaivijitnond S",
+      "authorCount": 1,
+      "journal": "Front Med",
+      "year": 2012,
+      "volume": "6",
+      "pages": "8-21",
+      "doi": "10.1007/s11684-012-0184-8",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22492349": {
+      "pmid": "22492349",
+      "title": "Prevalence and pattern of congenital heart disease in Uttarakhand, India",
+      "authors": "Bhat NK et al.",
+      "authorCount": 6,
+      "journal": "Indian J Pediatr",
+      "year": 2013,
+      "volume": "80",
+      "pages": "281-5",
+      "doi": "10.1007/s12098-012-0738-4",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22554242": {
+      "pmid": "22554242",
+      "title": "The shikimate pathway and aromatic amino Acid biosynthesis in plants",
+      "authors": "Maeda H and Dudareva N",
+      "authorCount": 2,
+      "journal": "Annu Rev Plant Biol",
+      "year": 2012,
+      "volume": "63",
+      "pages": "73-105",
+      "doi": "10.1146/annurev-arplant-042811-105439",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, U.S. Gov't, Non-P.H.S.",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22561883": {
+      "pmid": "22561883",
+      "title": "Estragole: a weak direct-acting food-borne genotoxin and potential carcinogen",
+      "authors": "Martins C et al.",
+      "authorCount": 7,
+      "journal": "Mutat Res",
+      "year": 2012,
+      "volume": "747",
+      "pages": "86-92",
+      "doi": "10.1016/j.mrgentox.2012.04.009",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22592140": {
+      "pmid": "22592140",
+      "title": "Police custody following drink-driving: a prospective study",
+      "authors": "Lepresle A et al.",
+      "authorCount": 6,
+      "journal": "Drug Alcohol Depend",
+      "year": 2012,
+      "volume": "126",
+      "pages": "51-4",
+      "doi": "10.1016/j.drugalcdep.2012.04.013",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22632862": {
+      "pmid": "22632862",
+      "title": "The use of herbal medicine in cancer-related anorexia/ cachexia treatment around the world",
+      "authors": "Cheng KC et al.",
+      "authorCount": 3,
+      "journal": "Curr Pharm Des",
+      "year": 2012,
+      "volume": "18",
+      "pages": "4819-26",
+      "doi": "10.2174/138161212803216979",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22719626": {
+      "pmid": "22719626",
+      "title": "(1S,5R,7R,30S)-14-De-oxy-isogarcinol",
+      "authors": "Kaur R et al.",
+      "authorCount": 3,
+      "journal": "Acta Crystallogr Sect E Struct Rep Online",
+      "year": 2012,
+      "volume": "68",
+      "pages": "o1861-2",
+      "doi": "10.1107/S1600536812020788",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22736219": {
+      "pmid": "22736219",
+      "title": "Who should be included in a clinical trial of screening for bladder cancer?: a decision analysis of data from the Prostate, Lung, Colorectal and Ovarian Cancer Screening Trial",
+      "authors": "Vickers AJ et al.",
+      "authorCount": 7,
+      "journal": "Cancer",
+      "year": 2013,
+      "volume": "119",
+      "pages": "143-9",
+      "doi": "10.1002/cncr.27692",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22739410": {
+      "pmid": "22739410",
+      "title": "Lipid-lowering effect of berberine in human subjects and rats",
+      "authors": "Hu Y et al.",
+      "authorCount": 16,
+      "journal": "Phytomedicine",
+      "year": 2012,
+      "volume": "19",
+      "pages": "861-7",
+      "doi": "10.1016/j.phymed.2012.05.009",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22746542": {
+      "pmid": "22746542",
+      "title": "Beneficial effects of artichoke leaf extract supplementation on increasing HDL-cholesterol in subjects with primary mild hypercholesterolaemia: a double-blind, randomized, placebo-controlled trial",
+      "authors": "Rondanelli M et al.",
+      "authorCount": 9,
+      "journal": "Int J Food Sci Nutr",
+      "year": 2013,
+      "volume": "64",
+      "pages": "7-15",
+      "doi": "10.3109/09637486.2012.700920",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22772918": {
+      "pmid": "22772918",
+      "title": "Isobavachalcone: an overview",
+      "authors": "Kuete V and Sandjo LP",
+      "authorCount": 2,
+      "journal": "Chin J Integr Med",
+      "year": 2012,
+      "volume": "18",
+      "pages": "543-7",
+      "doi": "10.1007/s11655-012-1142-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22960104": {
+      "pmid": "22960104",
+      "title": "Coumarins from Angelica archangelica Linn. and their effects on anxiety-like behavior",
+      "authors": "Kumar D et al.",
+      "authorCount": 4,
+      "journal": "Prog Neuropsychopharmacol Biol Psychiatry",
+      "year": 2013,
+      "volume": "40",
+      "pages": "180-6",
+      "doi": "10.1016/j.pnpbp.2012.08.004",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "22976133": {
+      "pmid": "22976133",
+      "title": "A review and evaluation of the efficacy and safety of Cissus quadrangularis extracts",
+      "authors": "Stohs SJ and Ray SD",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2013,
+      "volume": "27",
+      "pages": "1107-14",
+      "doi": "10.1002/ptr.4846",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23089553": {
+      "pmid": "23089553",
+      "title": "Aegle marmelos (L.) Correa (Bael) and its phytochemicals in the treatment and prevention of cancer",
+      "authors": "Baliga MS et al.",
+      "authorCount": 5,
+      "journal": "Integr Cancer Ther",
+      "year": 2013,
+      "volume": "12",
+      "pages": "187-96",
+      "doi": "10.1177/1534735412451320",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23347199": {
+      "pmid": "23347199",
+      "title": "High prevalence of rheumatic heart disease in schoolchildren detected by echocardiography screening in New Caledonia",
+      "authors": "Baroux N et al.",
+      "authorCount": 6,
+      "journal": "J Paediatr Child Health",
+      "year": 2013,
+      "volume": "49",
+      "pages": "109-14",
+      "doi": "10.1111/jpc.12087",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23369181": {
+      "pmid": "23369181",
+      "title": "The skin prick test - European standards",
+      "authors": "Heinzerling L et al.",
+      "authorCount": 14,
+      "journal": "Clin Transl Allergy",
+      "year": 2013,
+      "volume": "3",
+      "pages": "3",
+      "doi": "10.1186/2045-7022-3-3",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23440782": {
+      "pmid": "23440782",
+      "title": "Vitamin C for preventing and treating the common cold",
+      "authors": "Hemilä H and Chalker E",
+      "authorCount": 2,
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2013,
+      "volume": "2013",
+      "pages": "CD000980",
+      "doi": "10.1002/14651858.CD000980.pub4",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23472485": {
+      "pmid": "23472485",
+      "title": "Adverse effects of herbal medicines: an overview of systematic reviews",
+      "authors": "Posadzki P et al.",
+      "authorCount": 3,
+      "journal": "Clin Med (Lond)",
+      "year": 2013,
+      "volume": "13",
+      "pages": "7-12",
+      "doi": "10.7861/clinmedicine.13-1-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23609775": {
+      "pmid": "23609775",
+      "title": "Fiber and prebiotics: mechanisms and health benefits",
+      "authors": "Slavin J",
+      "authorCount": 1,
+      "journal": "Nutrients",
+      "year": 2013,
+      "volume": "5",
+      "pages": "1417-35",
+      "doi": "10.3390/nu5041417",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23644932": {
+      "pmid": "23644932",
+      "title": "Lutein + zeaxanthin and omega-3 fatty acids for age-related macular degeneration: the Age-Related Eye Disease Study 2 (AREDS2) randomized clinical trial",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "JAMA",
+      "year": 2013,
+      "volume": "309",
+      "pages": "2005-15",
+      "doi": "10.1001/jama.2013.4997",
+      "publicationTypes": [
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, N.I.H., Intramural"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23646296": {
+      "pmid": "23646296",
+      "title": "A review on therapeutic potential of Nigella sativa: A miracle herb",
+      "authors": "Ahmad A et al.",
+      "authorCount": 8,
+      "journal": "Asian Pac J Trop Biomed",
+      "year": 2013,
+      "volume": "3",
+      "pages": "337-52",
+      "doi": "10.1016/S2221-1691(13)60075-1",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23691095": {
+      "pmid": "23691095",
+      "title": "Meta-analysis: melatonin for the treatment of primary sleep disorders",
+      "authors": "Ferracioli-Oda E et al.",
+      "authorCount": 3,
+      "journal": "PLoS One",
+      "year": 2013,
+      "volume": "8",
+      "pages": "e63773",
+      "doi": "10.1371/journal.pone.0063773",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23723672": {
+      "pmid": "23723672",
+      "title": "Clinical efficacy of Gokshura-Punarnava Basti in the management of microalbuminuria in diabetes mellitus",
+      "authors": "Ramteke RS et al.",
+      "authorCount": 4,
+      "journal": "Ayu",
+      "year": 2012,
+      "volume": "33",
+      "pages": "537-41",
+      "doi": "10.4103/0974-8520.110535",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23754792": {
+      "pmid": "23754792",
+      "title": "Tongkat Ali as a potential herbal supplement for physically active male and female seniors--a pilot study",
+      "authors": "Henkel RR et al.",
+      "authorCount": 7,
+      "journal": "Phytother Res",
+      "year": 2014,
+      "volume": "28",
+      "pages": "544-50",
+      "doi": "10.1002/ptr.5017",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23832433": {
+      "pmid": "23832433",
+      "title": "Efficacy and safety of curcumin in major depressive disorder: a randomized controlled trial",
+      "authors": "Sanmukhani J et al.",
+      "authorCount": 8,
+      "journal": "Phytother Res",
+      "year": 2014,
+      "volume": "28",
+      "pages": "579-85",
+      "doi": "10.1002/ptr.5025",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23853635": {
+      "pmid": "23853635",
+      "title": "The effect of magnesium supplementation on primary insomnia in elderly: A double-blind placebo-controlled clinical trial",
+      "authors": "Abbasi B et al.",
+      "authorCount": 6,
+      "journal": "J Res Med Sci",
+      "year": 2012,
+      "volume": "17",
+      "pages": "1161-9",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "23949208": {
+      "pmid": "23949208",
+      "title": "Oral supplementation of specific collagen peptides has beneficial effects on human skin physiology: a double-blind, placebo-controlled study",
+      "authors": "Proksch E et al.",
+      "authorCount": 6,
+      "journal": "Skin Pharmacol Physiol",
+      "year": 2014,
+      "volume": "27",
+      "pages": "47-55",
+      "doi": "10.1159/000351376",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24035939": {
+      "pmid": "24035939",
+      "title": "Effects of Allium sativum (garlic) on systolic and diastolic blood pressure in patients with essential hypertension",
+      "authors": "Ashraf R et al.",
+      "authorCount": 4,
+      "journal": "Pak J Pharm Sci",
+      "year": 2013,
+      "volume": "26",
+      "pages": "859-63",
+      "doi": "",
+      "publicationTypes": [
+        "Controlled Clinical Trial",
+        "Journal Article",
+        "Multicenter Study"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24153020": {
+      "pmid": "24153020",
+      "title": "Undenatured type II collagen (UC-II®) for joint support: a randomized, double-blind, placebo-controlled study in healthy volunteers",
+      "authors": "Lugo JP et al.",
+      "authorCount": 7,
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2013,
+      "volume": "10",
+      "pages": "48",
+      "doi": "10.1186/1550-2783-10-48",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24191306": {
+      "pmid": "24191306",
+      "title": "Response to: 'Trends in cardiovascular diseases and cancer mortality in 45 countries from five continents (1980-2010)', by, Araújo F, Gouvinhas C, Fontes F, et al",
+      "authors": "Lotufo PA and Bensenor IM",
+      "authorCount": 2,
+      "journal": "Eur J Prev Cardiol",
+      "year": 2015,
+      "volume": "22",
+      "pages": "213-4",
+      "doi": "10.1177/2047487313510894",
+      "publicationTypes": [
+        "Letter",
+        "Comment"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24339367": {
+      "pmid": "24339367",
+      "title": "Puerarin: a review of pharmacological effects",
+      "authors": "Zhou YX et al.",
+      "authorCount": 3,
+      "journal": "Phytother Res",
+      "year": 2014,
+      "volume": "28",
+      "pages": "961-75",
+      "doi": "10.1002/ptr.5083",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24365638": {
+      "pmid": "24365638",
+      "title": "Danggui to Angelica sinensis root: are potential benefits to European women lost in translation? A review",
+      "authors": "Hook IL",
+      "authorCount": 1,
+      "journal": "J Ethnopharmacol",
+      "year": 2014,
+      "volume": "152",
+      "pages": "1-13",
+      "doi": "10.1016/j.jep.2013.12.018",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24456909": {
+      "pmid": "24456909",
+      "title": "Lavender oil preparation Silexan is effective in generalized anxiety disorder--a randomized, double-blind comparison to placebo and paroxetine",
+      "authors": "Kasper S et al.",
+      "authorCount": 7,
+      "journal": "Int J Neuropsychopharmacol",
+      "year": 2014,
+      "volume": "17",
+      "pages": "859-69",
+      "doi": "10.1017/S1461145714000017",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24471735": {
+      "pmid": "24471735",
+      "title": "Bakuchiol: a retinol-like functional compound revealed by gene expression profiling and clinically proven to have anti-aging effects",
+      "authors": "Chaudhuri RK and Bojanowski K",
+      "authorCount": 2,
+      "journal": "Int J Cosmet Sci",
+      "year": 2014,
+      "volume": "36",
+      "pages": "221-30",
+      "doi": "10.1111/ics.12117",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24533610": {
+      "pmid": "24533610",
+      "title": "The efficacy of glucomannan supplementation in overweight and obesity: a systematic review and meta-analysis of randomized clinical trials",
+      "authors": "Onakpoya I et al.",
+      "authorCount": 3,
+      "journal": "J Am Coll Nutr",
+      "year": 2014,
+      "volume": "33",
+      "pages": "70-8",
+      "doi": "10.1080/07315724.2014.870013",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24554461": {
+      "pmid": "24554461",
+      "title": "Echinacea for preventing and treating the common cold",
+      "authors": "Karsch-Völk M et al.",
+      "authorCount": 6,
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2014,
+      "volume": "2014",
+      "pages": "CD000530",
+      "doi": "10.1002/14651858.CD000530.pub3",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, N.I.H., Intramural",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24575672": {
+      "pmid": "24575672",
+      "title": "In vitro antioxidant activities of extract and oil from roselle (Hibiscus sabdariffa L.) seed against sunflower oil autoxidation",
+      "authors": "Nyam KL et al.",
+      "authorCount": 4,
+      "journal": "Malays J Nutr",
+      "year": 2012,
+      "volume": "18",
+      "pages": "265-74",
+      "doi": "",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24598311": {
+      "pmid": "24598311",
+      "title": "The role of L-DOPA in plants",
+      "authors": "Soares AR et al.",
+      "authorCount": 6,
+      "journal": "Plant Signal Behav",
+      "year": 2014,
+      "volume": "9",
+      "pages": "e28275",
+      "doi": "10.4161/psb.28275",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24600529": {
+      "pmid": "24600529",
+      "title": "Terminalia arjuna in Chronic Stable Angina: Systematic Review and Meta-Analysis",
+      "authors": "Kaur N et al.",
+      "authorCount": 8,
+      "journal": "Cardiol Res Pract",
+      "year": 2014,
+      "volume": "2014",
+      "pages": "281483",
+      "doi": "10.1155/2014/281483",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24646717": {
+      "pmid": "24646717",
+      "title": "Pau d'arco activates Nrf2-dependent gene expression via the MEK/ERK-pathway",
+      "authors": "Richter M et al.",
+      "authorCount": 8,
+      "journal": "J Toxicol Sci",
+      "year": 2014,
+      "volume": "39",
+      "pages": "353-61",
+      "doi": "10.2131/jts.39.353",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24672232": {
+      "pmid": "24672232",
+      "title": "Efficacy and safety of Curcuma domestica extracts compared with ibuprofen in patients with knee osteoarthritis: a multicenter study",
+      "authors": "Kuptniratsaikul V et al.",
+      "authorCount": 9,
+      "journal": "Clin Interv Aging",
+      "year": 2014,
+      "volume": "9",
+      "pages": "451-8",
+      "doi": "10.2147/CIA.S58535",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24780090": {
+      "pmid": "24780090",
+      "title": "LDL-cholesterol-lowering effect of plant sterols and stanols across different dose ranges: a meta-analysis of randomised controlled studies",
+      "authors": "Ras RT et al.",
+      "authorCount": 3,
+      "journal": "Br J Nutr",
+      "year": 2014,
+      "volume": "112",
+      "pages": "214-9",
+      "doi": "10.1017/S0007114514000750",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Meta-Analysis"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24886774": {
+      "pmid": "24886774",
+      "title": "Lawsonia inermis L. (henna): ethnobotanical, phytochemical and pharmacological aspects",
+      "authors": "Badoni Semwal R et al.",
+      "authorCount": 5,
+      "journal": "J Ethnopharmacol",
+      "year": 2014,
+      "volume": "155",
+      "pages": "80-103",
+      "doi": "10.1016/j.jep.2014.05.042",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24912386": {
+      "pmid": "24912386",
+      "title": "Expert consensus document. The International Scientific Association for Probiotics and Prebiotics consensus statement on the scope and appropriate use of the term probiotic",
+      "authors": "Hill C et al.",
+      "authorCount": 12,
+      "journal": "Nat Rev Gastroenterol Hepatol",
+      "year": 2014,
+      "volume": "11",
+      "pages": "506-14",
+      "doi": "10.1038/nrgastro.2014.66",
+      "publicationTypes": [
+        "Consensus Statement",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24915350": {
+      "pmid": "24915350",
+      "title": "Tea and its consumption: benefits and risks",
+      "authors": "Hayat K et al.",
+      "authorCount": 5,
+      "journal": "Crit Rev Food Sci Nutr",
+      "year": 2015,
+      "volume": "55",
+      "pages": "939-54",
+      "doi": "10.1080/10408398.2012.678949",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "24941673": {
+      "pmid": "24941673",
+      "title": "Capsaicin for osteoarthritis pain",
+      "authors": "Laslett LL and Jones G",
+      "authorCount": 2,
+      "journal": "Prog Drug Res",
+      "year": 2014,
+      "volume": "68",
+      "pages": "277-91",
+      "doi": "10.1007/978-3-0348-0828-6_11",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25005060": {
+      "pmid": "25005060",
+      "title": "Biotechnological production of eleutherosides: current state and perspectives",
+      "authors": "Murthy HN et al.",
+      "authorCount": 4,
+      "journal": "Appl Microbiol Biotechnol",
+      "year": 2014,
+      "volume": "98",
+      "pages": "7319-29",
+      "doi": "10.1007/s00253-014-5899-9",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25059961": {
+      "pmid": "25059961",
+      "title": "One Health: time to move on from just talking",
+      "authors": "Honey L",
+      "authorCount": 1,
+      "journal": "Vet Rec",
+      "year": 2014,
+      "volume": "175",
+      "pages": "83",
+      "doi": "10.1136/vr.g4746",
+      "publicationTypes": [
+        "News"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25128263": {
+      "pmid": "25128263",
+      "title": "Wound ballistics of firearm-related injuries--part 2: mechanisms of skeletal injury and characteristics of maxillofacial ballistic trauma",
+      "authors": "Stefanopoulos PK et al.",
+      "authorCount": 4,
+      "journal": "Int J Oral Maxillofac Surg",
+      "year": 2015,
+      "volume": "44",
+      "pages": "67-78",
+      "doi": "10.1016/j.ijom.2014.07.012",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25153873": {
+      "pmid": "25153873",
+      "title": "Allicin: chemistry and biological properties",
+      "authors": "Borlinghaus J et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2014,
+      "volume": "19",
+      "pages": "12591-618",
+      "doi": "10.3390/molecules190812591",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25174896": {
+      "pmid": "25174896",
+      "title": "New insights into the development of infantile intraocular medulloepithelioma",
+      "authors": "Jakobiec FA et al.",
+      "authorCount": 7,
+      "journal": "Am J Ophthalmol",
+      "year": 2014,
+      "volume": "158",
+      "pages": "1275-1296.e1",
+      "doi": "10.1016/j.ajo.2014.08.036",
+      "publicationTypes": [
+        "Case Reports",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25240931": {
+      "pmid": "25240931",
+      "title": "GC-MS, LC-MS(n), LC-high resolution-MS(n), and NMR studies on the metabolism and toxicological detection of mesembrine and mesembrenone, the main alkaloids of the legal high \"Kanna\" isolated from Sceletium tortuosum",
+      "authors": "Meyer GM et al.",
+      "authorCount": 4,
+      "journal": "Anal Bioanal Chem",
+      "year": 2015,
+      "volume": "407",
+      "pages": "761-78",
+      "doi": "10.1007/s00216-014-8109-9",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25282031": {
+      "pmid": "25282031",
+      "title": "The effect of coenzyme Q10 on morbidity and mortality in chronic heart failure: results from Q-SYMBIO: a randomized double-blind trial",
+      "authors": "Mortensen SA et al.",
+      "authorCount": 9,
+      "journal": "JACC Heart Fail",
+      "year": 2014,
+      "volume": "2",
+      "pages": "641-9",
+      "doi": "10.1016/j.jchf.2014.06.008",
+      "publicationTypes": [
+        "Clinical Trial, Phase II",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25287985": {
+      "pmid": "25287985",
+      "title": "Blue blocker glasses as a countermeasure for alerting effects of evening light-emitting diode screen exposure in male teenagers",
+      "authors": "van der Lely S et al.",
+      "authorCount": 10,
+      "journal": "J Adolesc Health",
+      "year": 2015,
+      "volume": "56",
+      "pages": "113-9",
+      "doi": "10.1016/j.jadohealth.2014.08.002",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25374169": {
+      "pmid": "25374169",
+      "title": "Health benefits of Moringa oleifera",
+      "authors": "Abdull Razis AF et al.",
+      "authorCount": 3,
+      "journal": "Asian Pac J Cancer Prev",
+      "year": 2014,
+      "volume": "15",
+      "pages": "8571-6",
+      "doi": "10.7314/apjcp.2014.15.20.8571",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25484177": {
+      "pmid": "25484177",
+      "title": "Crocin, the main active saffron constituent, as an adjunctive treatment in major depressive disorder: a randomized, double-blind, placebo-controlled, pilot clinical trial",
+      "authors": "Talaei A et al.",
+      "authorCount": 4,
+      "journal": "J Affect Disord",
+      "year": 2015,
+      "volume": "174",
+      "pages": "51-6",
+      "doi": "10.1016/j.jad.2014.11.035",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25498346": {
+      "pmid": "25498346",
+      "title": "Meta-analysis of the effect and safety of berberine in the treatment of type 2 diabetes mellitus, hyperlipemia and hypertension",
+      "authors": "Lan J et al.",
+      "authorCount": 7,
+      "journal": "J Ethnopharmacol",
+      "year": 2015,
+      "volume": "161",
+      "pages": "69-81",
+      "doi": "10.1016/j.jep.2014.09.049",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25576957": {
+      "pmid": "25576957",
+      "title": "Toxicological assessment of Ashitaba Chalcone",
+      "authors": "Maronpot RR",
+      "authorCount": 1,
+      "journal": "Food Chem Toxicol",
+      "year": 2015,
+      "volume": "77",
+      "pages": "111-9",
+      "doi": "10.1016/j.fct.2014.12.021",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25588369": {
+      "pmid": "25588369",
+      "title": "Clinical evaluation of Moro (Citrus sinensis (L.) Osbeck) orange juice supplementation for the weight management",
+      "authors": "Cardile V et al.",
+      "authorCount": 3,
+      "journal": "Nat Prod Res",
+      "year": 2015,
+      "volume": "29",
+      "pages": "2256-60",
+      "doi": "10.1080/14786419.2014.1000897",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25676062": {
+      "pmid": "25676062",
+      "title": "Association of human papillomavirus type 58 with breast cancer in Shaanxi province of China",
+      "authors": "Fu L et al.",
+      "authorCount": 6,
+      "journal": "J Med Virol",
+      "year": 2015,
+      "volume": "87",
+      "pages": "1034-40",
+      "doi": "10.1002/jmv.24142",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25784877": {
+      "pmid": "25784877",
+      "title": "Citrus bergamia essential oil: from basic research to clinical application",
+      "authors": "Navarra M et al.",
+      "authorCount": 4,
+      "journal": "Front Pharmacol",
+      "year": 2015,
+      "volume": "6",
+      "pages": "36",
+      "doi": "10.3389/fphar.2015.00036",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25808252": {
+      "pmid": "25808252",
+      "title": "Celebrate World Hypertension Day (WHD) on May 17, 2015, and contribute to improving awareness of hypertension",
+      "authors": "Campbell N et al.",
+      "authorCount": 5,
+      "journal": "J Clin Hypertens (Greenwich)",
+      "year": 2015,
+      "volume": "17",
+      "pages": "317-8",
+      "doi": "10.1111/jch.12542",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25889885": {
+      "pmid": "25889885",
+      "title": "Salacia reticulata (Kothala himbutu) revisited; a missed opportunity to treat diabetes and obesity?",
+      "authors": "Medagama AB",
+      "authorCount": 1,
+      "journal": "Nutr J",
+      "year": 2015,
+      "volume": "14",
+      "pages": "21",
+      "doi": "10.1186/s12937-015-0013-4",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "25933483": {
+      "pmid": "25933483",
+      "title": "Phosphatidylserine and the human brain",
+      "authors": "Glade MJ and Smith K",
+      "authorCount": 2,
+      "journal": "Nutrition",
+      "year": 2015,
+      "volume": "31",
+      "pages": "781-6",
+      "doi": "10.1016/j.nut.2014.10.014",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26000480": {
+      "pmid": "26000480",
+      "title": "Treatment of obesity with celastrol",
+      "authors": "Liu J et al.",
+      "authorCount": 5,
+      "journal": "Cell",
+      "year": 2015,
+      "volume": "161",
+      "pages": "999-1011",
+      "doi": "10.1016/j.cell.2015.05.011",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26031882": {
+      "pmid": "26031882",
+      "title": "Anti-diabetic and Anti-hyperlipidemic Effects and Safety of Salacia reticulata and Related Species",
+      "authors": "Stohs SJ and Ray S",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2015,
+      "volume": "29",
+      "pages": "986-95",
+      "doi": "10.1002/ptr.5382",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26046143": {
+      "pmid": "26046143",
+      "title": "Dendrobium micropropagation: a review",
+      "authors": "da Silva JA et al.",
+      "authorCount": 4,
+      "journal": "Plant Cell Rep",
+      "year": 2015,
+      "volume": "34",
+      "pages": "671-704",
+      "doi": "10.1007/s00299-015-1754-4",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26093535": {
+      "pmid": "26093535",
+      "title": "Therapeutic effect of high-dose green tea extract on weight reduction: A randomized, double-blind, placebo-controlled clinical trial",
+      "authors": "Chen IJ et al.",
+      "authorCount": 4,
+      "journal": "Clin Nutr",
+      "year": 2016,
+      "volume": "35",
+      "pages": "592-9",
+      "doi": "10.1016/j.clnu.2015.05.003",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26231448": {
+      "pmid": "26231448",
+      "title": "Ethanol extract of Bupleurum falcatum and saikosaponins inhibit neuroinflammation via inhibition of NF-κB",
+      "authors": "Park WH et al.",
+      "authorCount": 8,
+      "journal": "J Ethnopharmacol",
+      "year": 2015,
+      "volume": "174",
+      "pages": "37-44",
+      "doi": "10.1016/j.jep.2015.07.039",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26243582": {
+      "pmid": "26243582",
+      "title": "Cnidium monnieri: A Review of Traditional Uses, Phytochemical and Ethnopharmacological Properties",
+      "authors": "Li YM et al.",
+      "authorCount": 8,
+      "journal": "Am J Chin Med",
+      "year": 2015,
+      "volume": "43",
+      "pages": "835-77",
+      "doi": "10.1142/S0192415X15500500",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26310198": {
+      "pmid": "26310198",
+      "title": "Pharmacological Studies of Artichoke Leaf Extract and Their Health Benefits",
+      "authors": "Ben Salem M et al.",
+      "authorCount": 7,
+      "journal": "Plant Foods Hum Nutr",
+      "year": 2015,
+      "volume": "70",
+      "pages": "441-53",
+      "doi": "10.1007/s11130-015-0503-8",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26395129": {
+      "pmid": "26395129",
+      "title": "Clinical evaluation of purified Shilajit on testosterone levels in healthy volunteers",
+      "authors": "Pandit S et al.",
+      "authorCount": 6,
+      "journal": "Andrologia",
+      "year": 2016,
+      "volume": "48",
+      "pages": "570-5",
+      "doi": "10.1111/and.12482",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26448818": {
+      "pmid": "26448818",
+      "title": "Anti-Aging Potential of Phytoextract Loaded-Pharmaceutical Creams for Human Skin Cell Longetivity",
+      "authors": "Jadoon S et al.",
+      "authorCount": 8,
+      "journal": "Oxid Med Cell Longev",
+      "year": 2015,
+      "volume": "2015",
+      "pages": "709628",
+      "doi": "10.1155/2015/709628",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26528921": {
+      "pmid": "26528921",
+      "title": "Curcumin, an active component of turmeric (Curcuma longa), and its effects on health",
+      "authors": "Kocaadam B and Şanlier N",
+      "authorCount": 2,
+      "journal": "Crit Rev Food Sci Nutr",
+      "year": 2017,
+      "volume": "57",
+      "pages": "2889-2895",
+      "doi": "10.1080/10408398.2015.1077195",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26664234": {
+      "pmid": "26664234",
+      "title": "A clinical study of Punarnava Mandura in the management of Pandu Roga in old age (geriatric anemia)",
+      "authors": "Pandya MG and Dave AR",
+      "authorCount": 2,
+      "journal": "Ayu",
+      "year": 2014,
+      "volume": "35",
+      "pages": "252-60",
+      "doi": "10.4103/0974-8520.153735",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26811286": {
+      "pmid": "26811286",
+      "title": "Phosphatidylethanolamine Metabolism in Health and Disease",
+      "authors": "Calzada E et al.",
+      "authorCount": 3,
+      "journal": "Int Rev Cell Mol Biol",
+      "year": 2016,
+      "volume": "321",
+      "pages": "29-88",
+      "doi": "10.1016/bs.ircmb.2015.10.001",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26875640": {
+      "pmid": "26875640",
+      "title": "Nigella sativa (black seed) effects on plasma lipid concentrations in humans: A systematic review and meta-analysis of randomized placebo-controlled trials",
+      "authors": "Sahebkar A et al.",
+      "authorCount": 5,
+      "journal": "Pharmacol Res",
+      "year": 2016,
+      "volume": "106",
+      "pages": "37-50",
+      "doi": "10.1016/j.phrs.2016.02.008",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26899361": {
+      "pmid": "26899361",
+      "title": "Tetrandrine--A molecule of wide bioactivity",
+      "authors": "Bhagya N and Chandrashekar KR",
+      "authorCount": 2,
+      "journal": "Phytochemistry",
+      "year": 2016,
+      "volume": "125",
+      "pages": "5-13",
+      "doi": "10.1016/j.phytochem.2016.02.005",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26907242": {
+      "pmid": "26907242",
+      "title": "Multicomponent Synthesis and Evaluation of New 1,2,3-Triazole Derivatives of Dihydropyrimidinones as Acidic Corrosion Inhibitors for Steel",
+      "authors": "González-Olvera R et al.",
+      "authorCount": 6,
+      "journal": "Molecules",
+      "year": 2016,
+      "volume": "21",
+      "pages": "250",
+      "doi": "10.3390/molecules21020250",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "26916911": {
+      "pmid": "26916911",
+      "title": "Astragalus membranaceus: A Review of its Protection Against Inflammation and Gastrointestinal Cancers",
+      "authors": "Auyeung KK et al.",
+      "authorCount": 3,
+      "journal": "Am J Chin Med",
+      "year": 2016,
+      "volume": "44",
+      "pages": "1-22",
+      "doi": "10.1142/S0192415X16500014",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27000311": {
+      "pmid": "27000311",
+      "title": "Dietary supplements for dysmenorrhoea",
+      "authors": "Pattanittum P et al.",
+      "authorCount": 7,
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2016,
+      "volume": "3",
+      "pages": "CD002124",
+      "doi": "10.1002/14651858.CD002124.pub2",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27117114": {
+      "pmid": "27117114",
+      "title": "Frankincense--therapeutic properties",
+      "authors": "Al-Yasiry AR and Kiczorowska B",
+      "authorCount": 2,
+      "journal": "Postepy Hig Med Dosw (Online)",
+      "year": 2016,
+      "volume": "70",
+      "pages": "380-91",
+      "doi": "10.5604/17322693.1200553",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27132744": {
+      "pmid": "27132744",
+      "title": "Manjunath",
+      "authors": "Pandya S",
+      "authorCount": 1,
+      "journal": "Natl Med J India",
+      "year": 2015,
+      "volume": "28",
+      "pages": "211-2",
+      "doi": "",
+      "publicationTypes": [
+        "Letter",
+        "Comment"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27187333": {
+      "pmid": "27187333",
+      "title": "Quercetin and Its Anti-Allergic Immune Response",
+      "authors": "Mlcek J et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2016,
+      "volume": "21",
+      "pages": "",
+      "doi": "10.3390/molecules21050623",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27188216": {
+      "pmid": "27188216",
+      "title": "Emodin: A Review of its Pharmacology, Toxicity and Pharmacokinetics",
+      "authors": "Dong X et al.",
+      "authorCount": 7,
+      "journal": "Phytother Res",
+      "year": 2016,
+      "volume": "30",
+      "pages": "1207-18",
+      "doi": "10.1002/ptr.5631",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27213821": {
+      "pmid": "27213821",
+      "title": "Effects of Turmeric (Curcuma longa) on Skin Health: A Systematic Review of the Clinical Evidence",
+      "authors": "Vaughn AR et al.",
+      "authorCount": 3,
+      "journal": "Phytother Res",
+      "year": 2016,
+      "volume": "30",
+      "pages": "1243-64",
+      "doi": "10.1002/ptr.5640",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27222528": {
+      "pmid": "27222528",
+      "title": "Sunflower seed allergy",
+      "authors": "Ukleja-Sokołowska N et al.",
+      "authorCount": 5,
+      "journal": "Int J Immunopathol Pharmacol",
+      "year": 2016,
+      "volume": "29",
+      "pages": "498-503",
+      "doi": "10.1177/0394632016651648",
+      "publicationTypes": [
+        "Case Reports",
+        "Letter"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27282571": {
+      "pmid": "27282571",
+      "title": "Molecular characterization of six new cases of red blood cell hexokinase deficiency yields four novel mutations in HK1",
+      "authors": "Koralkova P et al.",
+      "authorCount": 10,
+      "journal": "Blood Cells Mol Dis",
+      "year": 2016,
+      "volume": "59",
+      "pages": "71-6",
+      "doi": "10.1016/j.bcmd.2016.04.002",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27347994": {
+      "pmid": "27347994",
+      "title": "Efficacy of Aloe Vera Supplementation on Prediabetes and Early Non-Treated Diabetic Patients: A Systematic Review and Meta-Analysis of Randomized Controlled Trials",
+      "authors": "Zhang Y et al.",
+      "authorCount": 5,
+      "journal": "Nutrients",
+      "year": 2016,
+      "volume": "8",
+      "pages": "",
+      "doi": "10.3390/nu8070388",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27399234": {
+      "pmid": "27399234",
+      "title": "A Review of the Medicinal Uses and Pharmacology of Ashitaba",
+      "authors": "Caesar LK and Cech NB",
+      "authorCount": 2,
+      "journal": "Planta Med",
+      "year": 2016,
+      "volume": "82",
+      "pages": "1236-45",
+      "doi": "10.1055/s-0042-110496",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27403209": {
+      "pmid": "27403209",
+      "title": "Impact of the 'Artful Moments' Intervention on Persons with Dementia and Their Care Partners: a Pilot Study",
+      "authors": "Hazzan AA et al.",
+      "authorCount": 9,
+      "journal": "Can Geriatr J",
+      "year": 2016,
+      "volume": "19",
+      "pages": "1-8",
+      "doi": "10.5770/cgj.19.220",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27533649": {
+      "pmid": "27533649",
+      "title": "Efficacy of Turmeric Extracts and Curcumin for Alleviating the Symptoms of Joint Arthritis: A Systematic Review and Meta-Analysis of Randomized Clinical Trials",
+      "authors": "Daily JW et al.",
+      "authorCount": 3,
+      "journal": "J Med Food",
+      "year": 2016,
+      "volume": "19",
+      "pages": "717-29",
+      "doi": "10.1089/jmf.2016.3705",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27551171": {
+      "pmid": "27551171",
+      "title": "Effects of Native Type II Collagen Treatment on Knee Osteoarthritis: A Randomized Controlled Trial",
+      "authors": "Bakilan F et al.",
+      "authorCount": 6,
+      "journal": "Eurasian J Med",
+      "year": 2016,
+      "volume": "48",
+      "pages": "95-101",
+      "doi": "10.5152/eurasianjmed.2015.15030",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27568784": {
+      "pmid": "27568784",
+      "title": "Systemic allergic dermatitis caused by sesquiterpene lactones",
+      "authors": "Paulsen E",
+      "authorCount": 1,
+      "journal": "Contact Dermatitis",
+      "year": 2017,
+      "volume": "76",
+      "pages": "1-10",
+      "doi": "10.1111/cod.12671",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27659301": {
+      "pmid": "27659301",
+      "title": "Anti-ageing active ingredients from herbs and nutraceuticals used in traditional Chinese medicine: pharmacological mechanisms and implications for drug discovery",
+      "authors": "Shen CY et al.",
+      "authorCount": 5,
+      "journal": "Br J Pharmacol",
+      "year": 2017,
+      "volume": "174",
+      "pages": "1395-1425",
+      "doi": "10.1111/bph.13631",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27671811": {
+      "pmid": "27671811",
+      "title": "Berberine and Its Role in Chronic Disease",
+      "authors": "Cicero AF and Baggioni A",
+      "authorCount": 2,
+      "journal": "Adv Exp Med Biol",
+      "year": 2016,
+      "volume": "928",
+      "pages": "27-45",
+      "doi": "10.1007/978-3-319-41334-1_2",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27677719": {
+      "pmid": "27677719",
+      "title": "Botanicals and Their Bioactive Phytochemicals for Women's Health",
+      "authors": "Dietz BM et al.",
+      "authorCount": 4,
+      "journal": "Pharmacol Rev",
+      "year": 2016,
+      "volume": "68",
+      "pages": "1026-1073",
+      "doi": "10.1124/pr.115.010843",
+      "publicationTypes": [
+        "Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27747942": {
+      "pmid": "27747942",
+      "title": "Clinical Pharmacology of Citrus bergamia: A Systematic Review",
+      "authors": "Mannucci C et al.",
+      "authorCount": 6,
+      "journal": "Phytother Res",
+      "year": 2017,
+      "volume": "31",
+      "pages": "27-39",
+      "doi": "10.1002/ptr.5734",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27771932": {
+      "pmid": "27771932",
+      "title": "Guggulsterone and Its Role in Chronic Diseases",
+      "authors": "Yamada T and Sugimoto K",
+      "authorCount": 2,
+      "journal": "Adv Exp Med Biol",
+      "year": 2016,
+      "volume": "929",
+      "pages": "329-361",
+      "doi": "10.1007/978-3-319-41342-6_15",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27833367": {
+      "pmid": "27833367",
+      "title": "Clinical efficacy of Punarnava Mandura and Dhatri Lauha in the management of Garbhini Pandu (anemia in pregnancy)",
+      "authors": "Khandelwal DA et al.",
+      "authorCount": 3,
+      "journal": "Ayu",
+      "year": 2015,
+      "volume": "36",
+      "pages": "397-403",
+      "doi": "10.4103/0974-8520.190700",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27837604": {
+      "pmid": "27837604",
+      "title": "Curcumin (Turmeric) and cancer",
+      "authors": "Unlu A et al.",
+      "authorCount": 5,
+      "journal": "J BUON",
+      "year": 2016,
+      "volume": "21",
+      "pages": "1050-1060",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27888156": {
+      "pmid": "27888156",
+      "title": "Effects of pomegranate juice on blood pressure: A systematic review and meta-analysis of randomized controlled trials",
+      "authors": "Sahebkar A et al.",
+      "authorCount": 6,
+      "journal": "Pharmacol Res",
+      "year": 2017,
+      "volume": "115",
+      "pages": "149-161",
+      "doi": "10.1016/j.phrs.2016.11.018",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27914909": {
+      "pmid": "27914909",
+      "title": "Benefits, pitfalls and risks of phytotherapy in clinical practice in otorhinolaryngology",
+      "authors": "Laccourreye O et al.",
+      "authorCount": 4,
+      "journal": "Eur Ann Otorhinolaryngol Head Neck Dis",
+      "year": 2017,
+      "volume": "134",
+      "pages": "95-99",
+      "doi": "10.1016/j.anorl.2016.11.001",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27920089": {
+      "pmid": "27920089",
+      "title": "World Endometriosis Society consensus on the classification of endometriosis",
+      "authors": "Johnson NP et al.",
+      "authorCount": 12,
+      "journal": "Hum Reprod",
+      "year": 2017,
+      "volume": "32",
+      "pages": "315-324",
+      "doi": "10.1093/humrep/dew293",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Consensus Statement"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27939420": {
+      "pmid": "27939420",
+      "title": "Mesembrine alkaloids: Review of their occurrence, chemistry, and pharmacology",
+      "authors": "Krstenansky JL",
+      "authorCount": 1,
+      "journal": "J Ethnopharmacol",
+      "year": 2017,
+      "volume": "195",
+      "pages": "10-19",
+      "doi": "10.1016/j.jep.2016.12.004",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27984799": {
+      "pmid": "27984799",
+      "title": "Antidiabetic activity of Embelia ribes, embelin and its derivatives: A systematic review and meta-analysis",
+      "authors": "Durg S et al.",
+      "authorCount": 4,
+      "journal": "Biomed Pharmacother",
+      "year": 2017,
+      "volume": "86",
+      "pages": "195-204",
+      "doi": "10.1016/j.biopha.2016.12.001",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "27994215": {
+      "pmid": "27994215",
+      "title": "Antimicrobial Activity of Basil, Oregano, and Thyme Essential Oils",
+      "authors": "Sakkas H and Papadopoulou C",
+      "authorCount": 2,
+      "journal": "J Microbiol Biotechnol",
+      "year": 2017,
+      "volume": "27",
+      "pages": "429-438",
+      "doi": "10.4014/jmb.1608.08024",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28098857": {
+      "pmid": "28098857",
+      "title": "Anticancer effects of ginsenoside Rg3 (Review)",
+      "authors": "Sun M et al.",
+      "authorCount": 6,
+      "journal": "Int J Mol Med",
+      "year": 2017,
+      "volume": "39",
+      "pages": "507-518",
+      "doi": "10.3892/ijmm.2017.2857",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28202713": {
+      "pmid": "28202713",
+      "title": "Vitamin D supplementation to prevent acute respiratory tract infections: systematic review and meta-analysis of individual participant data",
+      "authors": "Martineau AR et al.",
+      "authorCount": 25,
+      "journal": "BMJ",
+      "year": 2017,
+      "volume": "356",
+      "pages": "i6583",
+      "doi": "10.1136/bmj.i6583",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28266134": {
+      "pmid": "28266134",
+      "title": "A small plant with big benefits: Fenugreek (Trigonella foenum-graecum Linn.) for disease prevention and health promotion",
+      "authors": "Nagulapalli Venkata KC et al.",
+      "authorCount": 4,
+      "journal": "Mol Nutr Food Res",
+      "year": 2017,
+      "volume": "61",
+      "pages": "",
+      "doi": "10.1002/mnfr.201600950",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28267306": {
+      "pmid": "28267306",
+      "title": "Medicinal Mushrooms (PDQ®): Patient Version",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28275210": {
+      "pmid": "28275210",
+      "title": "Phytomedicine in Joint Disorders",
+      "authors": "Dragos D et al.",
+      "authorCount": 7,
+      "journal": "Nutrients",
+      "year": 2017,
+      "volume": "9",
+      "pages": "",
+      "doi": "10.3390/nu9010070",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28289385": {
+      "pmid": "28289385",
+      "title": "Plant Derived Phytocompound, Embelin in CNS Disorders: A Systematic Review",
+      "authors": "Kundap UP et al.",
+      "authorCount": 5,
+      "journal": "Front Pharmacol",
+      "year": 2017,
+      "volume": "8",
+      "pages": "76",
+      "doi": "10.3389/fphar.2017.00076",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28346030": {
+      "pmid": "28346030",
+      "title": "Antimicrobial activity of eugenol and essential oils containing eugenol: A mechanistic viewpoint",
+      "authors": "Marchese A et al.",
+      "authorCount": 10,
+      "journal": "Crit Rev Microbiol",
+      "year": 2017,
+      "volume": "43",
+      "pages": "668-689",
+      "doi": "10.1080/1040841X.2017.1295225",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28400848": {
+      "pmid": "28400848",
+      "title": "The Clinical Efficacy and Safety of Tulsi in Humans: A Systematic Review of the Literature",
+      "authors": "Jamshidi N and Cohen MM",
+      "authorCount": 2,
+      "journal": "Evid Based Complement Alternat Med",
+      "year": 2017,
+      "volume": "2017",
+      "pages": "9217567",
+      "doi": "10.1155/2017/9217567",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28407959": {
+      "pmid": "28407959",
+      "title": "Identification of phenolic compounds and biologically related activities from Ocotea odorifera aqueous extract leaves",
+      "authors": "Gontijo DC et al.",
+      "authorCount": 7,
+      "journal": "Food Chem",
+      "year": 2017,
+      "volume": "230",
+      "pages": "618-626",
+      "doi": "10.1016/j.foodchem.2017.03.087",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28419855": {
+      "pmid": "28419855",
+      "title": "A Randomized Trial of Silymarin for the Treatment of Nonalcoholic Steatohepatitis",
+      "authors": "Wah Kheong C et al.",
+      "authorCount": 3,
+      "journal": "Clin Gastroenterol Hepatol",
+      "year": 2017,
+      "volume": "15",
+      "pages": "1940-1949.e8",
+      "doi": "10.1016/j.cgh.2017.04.016",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28471760": {
+      "pmid": "28471760",
+      "title": "Magnesium Supplementation in Vitamin D Deficiency",
+      "authors": "Reddy P and Edwards LR",
+      "authorCount": 2,
+      "journal": "Am J Ther",
+      "year": 2019,
+      "volume": "26",
+      "pages": "e124-e132",
+      "doi": "10.1097/MJT.0000000000000538",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28503050": {
+      "pmid": "28503050",
+      "title": "Fingerroot, Boesenbergia rotunda and its Aphrodisiac Activity",
+      "authors": "Ongwisespaiboon O and Jiraungkoorskul W",
+      "authorCount": 2,
+      "journal": "Pharmacogn Rev",
+      "year": 2017,
+      "volume": "11",
+      "pages": "27-30",
+      "doi": "10.4103/phrev.phrev_50_16",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28587101": {
+      "pmid": "28587101",
+      "title": "Therapeutic Applications of Rose Hips from Different Rosa Species",
+      "authors": "Mármol I et al.",
+      "authorCount": 5,
+      "journal": "Int J Mol Sci",
+      "year": 2017,
+      "volume": "18",
+      "pages": "",
+      "doi": "10.3390/ijms18061137",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28615996": {
+      "pmid": "28615996",
+      "title": "International Society of Sports Nutrition position stand: safety and efficacy of creatine supplementation in exercise, sport, and medicine",
+      "authors": "Kreider RB et al.",
+      "authorCount": 10,
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2017,
+      "volume": "14",
+      "pages": "18",
+      "doi": "10.1186/s12970-017-0173-z",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28621716": {
+      "pmid": "28621716",
+      "title": "Antibacterial and Antifungal Activities of Spices",
+      "authors": "Liu Q et al.",
+      "authorCount": 6,
+      "journal": "Int J Mol Sci",
+      "year": 2017,
+      "volume": "18",
+      "pages": "",
+      "doi": "10.3390/ijms18061283",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28732807": {
+      "pmid": "28732807",
+      "title": "Pharmacology and toxicology of α- and β-Asarone: A review of preclinical evidence",
+      "authors": "Chellian R et al.",
+      "authorCount": 3,
+      "journal": "Phytomedicine",
+      "year": 2017,
+      "volume": "32",
+      "pages": "41-58",
+      "doi": "10.1016/j.phymed.2017.04.003",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28735826": {
+      "pmid": "28735826",
+      "title": "affron(®) a novel saffron extract (Crocus sativus L.) improves mood in healthy adults over 4 weeks in a double-blind, parallel, randomized, placebo-controlled clinical trial",
+      "authors": "Kell G et al.",
+      "authorCount": 6,
+      "journal": "Complement Ther Med",
+      "year": 2017,
+      "volume": "33",
+      "pages": "58-64",
+      "doi": "10.1016/j.ctim.2017.06.001",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28762712": {
+      "pmid": "28762712",
+      "title": "Common Herbal Dietary Supplement-Drug Interactions",
+      "authors": "Asher GN et al.",
+      "authorCount": 3,
+      "journal": "Am Fam Physician",
+      "year": 2017,
+      "volume": "96",
+      "pages": "101-107",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28798396": {
+      "pmid": "28798396",
+      "title": "Flavonoid glycosides isolated from Epimedium brevicornum and their estrogen biosynthesis-promoting effects",
+      "authors": "Li F et al.",
+      "authorCount": 11,
+      "journal": "Sci Rep",
+      "year": 2017,
+      "volume": "7",
+      "pages": "7760",
+      "doi": "10.1038/s41598-017-08203-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28833680": {
+      "pmid": "28833680",
+      "title": "Toxicological Effects of Glycyrrhiza glabra (Licorice): A Review",
+      "authors": "Nazari S et al.",
+      "authorCount": 3,
+      "journal": "Phytother Res",
+      "year": 2017,
+      "volume": "31",
+      "pages": "1635-1650",
+      "doi": "10.1002/ptr.5893",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "28837410": {
+      "pmid": "28837410",
+      "title": "New insights into artemisinin regulation",
+      "authors": "Lv Z et al.",
+      "authorCount": 3,
+      "journal": "Plant Signal Behav",
+      "year": 2017,
+      "volume": "12",
+      "pages": "e1366398",
+      "doi": "10.1080/15592324.2017.1366398",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29018060": {
+      "pmid": "29018060",
+      "title": "Dietary supplements for treating osteoarthritis: a systematic review and meta-analysis",
+      "authors": "Liu X et al.",
+      "authorCount": 5,
+      "journal": "Br J Sports Med",
+      "year": 2018,
+      "volume": "52",
+      "pages": "167-175",
+      "doi": "10.1136/bjsports-2016-097333",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29028587": {
+      "pmid": "29028587",
+      "title": "Chemical constituents and medical benefits of Plantago major",
+      "authors": "Adom MB et al.",
+      "authorCount": 8,
+      "journal": "Biomed Pharmacother",
+      "year": 2017,
+      "volume": "96",
+      "pages": "348-360",
+      "doi": "10.1016/j.biopha.2017.09.152",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29034191": {
+      "pmid": "29034191",
+      "title": "Pharmacological properties of Salvia officinalis and its components",
+      "authors": "Ghorbani A and Esmaeilizadeh M",
+      "authorCount": 2,
+      "journal": "J Tradit Complement Med",
+      "year": 2017,
+      "volume": "7",
+      "pages": "433-440",
+      "doi": "10.1016/j.jtcme.2016.12.014",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29065496": {
+      "pmid": "29065496",
+      "title": "Curcumin: A Review of Its Effects on Human Health",
+      "authors": "Hewlings SJ and Kalman DS",
+      "authorCount": 2,
+      "journal": "Foods",
+      "year": 2017,
+      "volume": "6",
+      "pages": "",
+      "doi": "10.3390/foods6100092",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29083760": {
+      "pmid": "29083760",
+      "title": "Capsaicin",
+      "authors": "Chang A et al.",
+      "authorCount": 3,
+      "journal": "",
+      "year": 2023,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Study Guide"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29119920": {
+      "pmid": "29119920",
+      "title": "Polyphenols: Inflammation",
+      "authors": "Natsume M",
+      "authorCount": 1,
+      "journal": "Curr Pharm Des",
+      "year": 2018,
+      "volume": "24",
+      "pages": "191-202",
+      "doi": "10.2174/1381612823666171109104141",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29141563": {
+      "pmid": "29141563",
+      "title": "Ganoderma lucidum Polysaccharides as An Anti-cancer Agent",
+      "authors": "Sohretoglu D and Huang S",
+      "authorCount": 2,
+      "journal": "Anticancer Agents Med Chem",
+      "year": 2018,
+      "volume": "18",
+      "pages": "667-674",
+      "doi": "10.2174/1871520617666171113121246",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29155174": {
+      "pmid": "29155174",
+      "title": "Ethnopharmacology, phytochemistry, and pharmacology of Cornus officinalis Sieb. et Zucc",
+      "authors": "Huang J et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2018,
+      "volume": "213",
+      "pages": "280-301",
+      "doi": "10.1016/j.jep.2017.11.010",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29232282": {
+      "pmid": "29232282",
+      "title": "Selected Food/Herb-Drug Interactions: Mechanisms and Clinical Relevance",
+      "authors": "Amadi CN and Mgbahurike AA",
+      "authorCount": 2,
+      "journal": "Am J Ther",
+      "year": 2018,
+      "volume": "25",
+      "pages": "e423-e433",
+      "doi": "10.1097/MJT.0000000000000705",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29280987": {
+      "pmid": "29280987",
+      "title": "Anti-Inflammatory and Skin Barrier Repair Effects of Topical Application of Some Plant Oils",
+      "authors": "Lin TK et al.",
+      "authorCount": 3,
+      "journal": "Int J Mol Sci",
+      "year": 2017,
+      "volume": "19",
+      "pages": "",
+      "doi": "10.3390/ijms19010070",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29344414": {
+      "pmid": "29344414",
+      "title": "Herba Cistanches: Anti-aging",
+      "authors": "Wang N et al.",
+      "authorCount": 6,
+      "journal": "Aging Dis",
+      "year": 2017,
+      "volume": "8",
+      "pages": "740-759",
+      "doi": "10.14336/AD.2017.0720",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29403626": {
+      "pmid": "29403626",
+      "title": "A review of effective herbal medicines in controlling menopausal symptoms",
+      "authors": "Kargozar R et al.",
+      "authorCount": 3,
+      "journal": "Electron Physician",
+      "year": 2017,
+      "volume": "9",
+      "pages": "5826-5833",
+      "doi": "10.19082/5826",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29456638": {
+      "pmid": "29456638",
+      "title": "Biobran/MGN-3, an arabinoxylan rice bran, enhances NK cell activity in geriatric subjects: A randomized, double-blind, placebo-controlled clinical trial",
+      "authors": "Elsaid AF et al.",
+      "authorCount": 3,
+      "journal": "Exp Ther Med",
+      "year": 2018,
+      "volume": "15",
+      "pages": "2313-2320",
+      "doi": "10.3892/etm.2018.5713",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29464801": {
+      "pmid": "29464801",
+      "title": "Herbal medicine for depression and anxiety: A systematic review with assessment of potential psycho-oncologic relevance",
+      "authors": "Yeung KS et al.",
+      "authorCount": 5,
+      "journal": "Phytother Res",
+      "year": 2018,
+      "volume": "32",
+      "pages": "865-891",
+      "doi": "10.1002/ptr.6033",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29498933": {
+      "pmid": "29498933",
+      "title": "Management of women with PCOS using myo-inositol and folic acid. New clinical data and review of the literature",
+      "authors": "Regidor PA et al.",
+      "authorCount": 4,
+      "journal": "Horm Mol Biol Clin Investig",
+      "year": 2018,
+      "volume": "34",
+      "pages": "",
+      "doi": "10.1515/hmbci-2017-0067",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29551532": {
+      "pmid": "29551532",
+      "title": "Effect of ginger, Paullinia cupana, muira puama and l- citrulline, singly or in combination, on modulation of the inducible nitric oxide- NO-cGMP pathway in rat penile smooth muscle cells",
+      "authors": "Ferrini MG et al.",
+      "authorCount": 6,
+      "journal": "Nitric Oxide",
+      "year": 2018,
+      "volume": "76",
+      "pages": "81-86",
+      "doi": "10.1016/j.niox.2018.03.010",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29568244": {
+      "pmid": "29568244",
+      "title": "Herbal medicine for sports: a review",
+      "authors": "Sellami M et al.",
+      "authorCount": 7,
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2018,
+      "volume": "15",
+      "pages": "14",
+      "doi": "10.1186/s12970-018-0218-y",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29615046": {
+      "pmid": "29615046",
+      "title": "Phytochemical composition, antilipidemic and antihypercholestrolemic perspectives of Bael leaf extracts",
+      "authors": "Asghar N et al.",
+      "authorCount": 6,
+      "journal": "Lipids Health Dis",
+      "year": 2018,
+      "volume": "17",
+      "pages": "68",
+      "doi": "10.1186/s12944-018-0713-9",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29679349": {
+      "pmid": "29679349",
+      "title": "Timeline (Bioavailability) of Magnesium Compounds in Hours: Which Magnesium Compound Works Best?",
+      "authors": "Uysal N et al.",
+      "authorCount": 9,
+      "journal": "Biol Trace Elem Res",
+      "year": 2019,
+      "volume": "187",
+      "pages": "128-136",
+      "doi": "10.1007/s12011-018-1351-9",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29698387": {
+      "pmid": "29698387",
+      "title": "Salvia miltiorrhizaBurge (Danshen): a golden herbal medicine in cardiovascular therapeutics",
+      "authors": "Li ZM et al.",
+      "authorCount": 3,
+      "journal": "Acta Pharmacol Sin",
+      "year": 2018,
+      "volume": "39",
+      "pages": "802-824",
+      "doi": "10.1038/aps.2017.193",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29698776": {
+      "pmid": "29698776",
+      "title": "Aloysia citrodora Paláu (Lemon verbena): A review of phytochemistry and pharmacology",
+      "authors": "Bahramsoltani R et al.",
+      "authorCount": 6,
+      "journal": "J Ethnopharmacol",
+      "year": 2018,
+      "volume": "222",
+      "pages": "34-51",
+      "doi": "10.1016/j.jep.2018.04.021",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29702210": {
+      "pmid": "29702210",
+      "title": "Antibacterial mechanisms of cinnamon and its constituents: A review",
+      "authors": "Vasconcelos NG et al.",
+      "authorCount": 3,
+      "journal": "Microb Pathog",
+      "year": 2018,
+      "volume": "120",
+      "pages": "198-203",
+      "doi": "10.1016/j.micpath.2018.04.036",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29785774": {
+      "pmid": "29785774",
+      "title": "Thymol, thyme, and other plant sources: Health and potential uses",
+      "authors": "Salehi B et al.",
+      "authorCount": 10,
+      "journal": "Phytother Res",
+      "year": 2018,
+      "volume": "32",
+      "pages": "1688-1706",
+      "doi": "10.1002/ptr.6109",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29805742": {
+      "pmid": "29805742",
+      "title": "Antitumoral and antimetastatic activity of Maitake D-Fraction in triple-negative breast cancer cells",
+      "authors": "Alonso EN et al.",
+      "authorCount": 8,
+      "journal": "Oncotarget",
+      "year": 2018,
+      "volume": "9",
+      "pages": "23396-23412",
+      "doi": "10.18632/oncotarget.25174",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29880082": {
+      "pmid": "29880082",
+      "title": "Possible antithrombotic effects of Angelica keiskei (Ashitaba)",
+      "authors": "Ohkura N et al.",
+      "authorCount": 5,
+      "journal": "Pharmazie",
+      "year": 2018,
+      "volume": "73",
+      "pages": "315-317",
+      "doi": "10.1691/ph.2018.8370",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29925102": {
+      "pmid": "29925102",
+      "title": "Safety and Toxicology of Magnolol and Honokiol",
+      "authors": "Sarrica A et al.",
+      "authorCount": 5,
+      "journal": "Planta Med",
+      "year": 2018,
+      "volume": "84",
+      "pages": "1151-1164",
+      "doi": "10.1055/a-0642-1966",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29975606": {
+      "pmid": "29975606",
+      "title": "Lessons from the Incursion of Myrtle Rust in Australia",
+      "authors": "Carnegie AJ and Pegg GS",
+      "authorCount": 2,
+      "journal": "Annu Rev Phytopathol",
+      "year": 2018,
+      "volume": "56",
+      "pages": "457-478",
+      "doi": "10.1146/annurev-phyto-080516-035256",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29976894": {
+      "pmid": "29976894",
+      "title": "Biological Activities and Safety of Citrus spp. Essential Oils",
+      "authors": "Dosoky NS and Setzer WN",
+      "authorCount": 2,
+      "journal": "Int J Mol Sci",
+      "year": 2018,
+      "volume": "19",
+      "pages": "",
+      "doi": "10.3390/ijms19071966",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "29999893": {
+      "pmid": "29999893",
+      "title": "Oil of Lemon Eucalyptus",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2022,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000526": {
+      "pmid": "30000526",
+      "title": "Interferon Alfacon-1",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000829": {
+      "pmid": "30000829",
+      "title": "St. John's Wort",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000830": {
+      "pmid": "30000830",
+      "title": "Milk Thistle",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2026,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000844": {
+      "pmid": "30000844",
+      "title": "Raspberry",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000850": {
+      "pmid": "30000850",
+      "title": "Caraway",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000851": {
+      "pmid": "30000851",
+      "title": "Coriander",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000865": {
+      "pmid": "30000865",
+      "title": "Eleuthero",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000869": {
+      "pmid": "30000869",
+      "title": "Echinacea",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000884": {
+      "pmid": "30000884",
+      "title": "Capsicum",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2021,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000886": {
+      "pmid": "30000886",
+      "title": "Basil",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000891": {
+      "pmid": "30000891",
+      "title": "Hawthorn",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2021,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000896": {
+      "pmid": "30000896",
+      "title": "Dong Quai",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2026,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000897": {
+      "pmid": "30000897",
+      "title": "Cranberry",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2022,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000898": {
+      "pmid": "30000898",
+      "title": "Nutmeg",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000904": {
+      "pmid": "30000904",
+      "title": "Oregano",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000912": {
+      "pmid": "30000912",
+      "title": "Vervain",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000922": {
+      "pmid": "30000922",
+      "title": "Rhubarb",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000936": {
+      "pmid": "30000936",
+      "title": "Black Seed",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000940": {
+      "pmid": "30000940",
+      "title": "Parsley",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000952": {
+      "pmid": "30000952",
+      "title": "Bitter Orange",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2021,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000954": {
+      "pmid": "30000954",
+      "title": "Evening Primrose",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2021,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30000962": {
+      "pmid": "30000962",
+      "title": "Peony",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30036891": {
+      "pmid": "30036891",
+      "title": "The Efficacy of Saffron in the Treatment of Mild to Moderate Depression: A Meta-analysis",
+      "authors": "Tóth B et al.",
+      "authorCount": 14,
+      "journal": "Planta Med",
+      "year": 2019,
+      "volume": "85",
+      "pages": "24-31",
+      "doi": "10.1055/a-0660-9565",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30037060": {
+      "pmid": "30037060",
+      "title": "The Purified Extract from the Medicinal Plant Bacopa monnieri, Bacopaside II, Inhibits Growth of Colon Cancer Cells In Vitro by Inducing Cell Cycle Arrest and Apoptosis",
+      "authors": "Smith E et al.",
+      "authorCount": 9,
+      "journal": "Cells",
+      "year": 2018,
+      "volume": "7",
+      "pages": "",
+      "doi": "10.3390/cells7070081",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30040451": {
+      "pmid": "30040451",
+      "title": "Overview of pharmacological activities of Andrographis paniculata and its major compound andrographolide",
+      "authors": "Dai Y et al.",
+      "authorCount": 6,
+      "journal": "Crit Rev Food Sci Nutr",
+      "year": 2019,
+      "volume": "59",
+      "pages": "S17-S29",
+      "doi": "10.1080/10408398.2018.1501657",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30058034": {
+      "pmid": "30058034",
+      "title": "Insomnia in Elderly Patients: Recommendations for Pharmacological Management",
+      "authors": "Abad VC and Guilleminault C",
+      "authorCount": 2,
+      "journal": "Drugs Aging",
+      "year": 2018,
+      "volume": "35",
+      "pages": "791-817",
+      "doi": "10.1007/s40266-018-0569-8",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30066218": {
+      "pmid": "30066218",
+      "title": "Genome-wide researches and applications on Dendrobium",
+      "authors": "Zheng SG et al.",
+      "authorCount": 7,
+      "journal": "Planta",
+      "year": 2018,
+      "volume": "248",
+      "pages": "769-784",
+      "doi": "10.1007/s00425-018-2960-4",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30080294": {
+      "pmid": "30080294",
+      "title": "Milk thistle (Silybum marianum): A concise overview on its chemistry, pharmacological, and nutraceutical uses in liver diseases",
+      "authors": "Abenavoli L et al.",
+      "authorCount": 6,
+      "journal": "Phytother Res",
+      "year": 2018,
+      "volume": "32",
+      "pages": "2202-2213",
+      "doi": "10.1002/ptr.6171",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30117204": {
+      "pmid": "30117204",
+      "title": "Liquorice (Glycyrrhiza glabra): A phytochemical and pharmacological review",
+      "authors": "Pastorino G et al.",
+      "authorCount": 5,
+      "journal": "Phytother Res",
+      "year": 2018,
+      "volume": "32",
+      "pages": "2323-2339",
+      "doi": "10.1002/ptr.6178",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30144752": {
+      "pmid": "30144752",
+      "title": "Advancement in the chemical analysis of Paeoniae Radix (Shaoyao)",
+      "authors": "Yan B et al.",
+      "authorCount": 5,
+      "journal": "J Pharm Biomed Anal",
+      "year": 2018,
+      "volume": "160",
+      "pages": "276-288",
+      "doi": "10.1016/j.jpba.2018.08.009",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30150795": {
+      "pmid": "30150795",
+      "title": "Acerola, an untapped functional superfruit: a review on latest frontiers",
+      "authors": "Prakash A and Baskaran R",
+      "authorCount": 2,
+      "journal": "J Food Sci Technol",
+      "year": 2018,
+      "volume": "55",
+      "pages": "3373-3384",
+      "doi": "10.1007/s13197-018-3309-5",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30179119": {
+      "pmid": "30179119",
+      "title": "Chemical Constituents and Pharmacological Activities of Stellera chamaejasme",
+      "authors": "Li XQ et al.",
+      "authorCount": 4,
+      "journal": "Curr Pharm Des",
+      "year": 2018,
+      "volume": "24",
+      "pages": "2825-2838",
+      "doi": "10.2174/1381612824666180903110802",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30198828": {
+      "pmid": "30198828",
+      "title": "Effects of Yeast (1,3)-(1,6)-Beta-Glucan on Severity of Upper Respiratory Tract Infections: A Double-Blind, Randomized, Placebo-Controlled Study in Healthy Subjects",
+      "authors": "Dharsono T et al.",
+      "authorCount": 4,
+      "journal": "J Am Coll Nutr",
+      "year": 2019,
+      "volume": "38",
+      "pages": "40-50",
+      "doi": "10.1080/07315724.2018.1478339",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30239559": {
+      "pmid": "30239559",
+      "title": "Effect of psyllium (Plantago ovata) fiber on LDL cholesterol and alternative lipid targets, non-HDL cholesterol and apolipoprotein B: a systematic review and meta-analysis of randomized controlled trials",
+      "authors": "Jovanovski E et al.",
+      "authorCount": 10,
+      "journal": "Am J Clin Nutr",
+      "year": 2018,
+      "volume": "108",
+      "pages": "922-932",
+      "doi": "10.1093/ajcn/nqy115",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30303602": {
+      "pmid": "30303602",
+      "title": "Chromatographic separation, determination and identification of ecdysteroids: Focus on Maral root (Rhaponticum carthamoides, Leuzea carthamoides)",
+      "authors": "Głazowska J et al.",
+      "authorCount": 3,
+      "journal": "J Sep Sci",
+      "year": 2018,
+      "volume": "41",
+      "pages": "4304-4314",
+      "doi": "10.1002/jssc.201800506",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30317989": {
+      "pmid": "30317989",
+      "title": "Phytochemistry, Traditional Uses and Pharmacological Profile of Rose Hip: A Review",
+      "authors": "Ayati Z et al.",
+      "authorCount": 6,
+      "journal": "Curr Pharm Des",
+      "year": 2018,
+      "volume": "24",
+      "pages": "4101-4124",
+      "doi": "10.2174/1381612824666181010151849",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30372004": {
+      "pmid": "30372004",
+      "title": "Chocolate",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30415628": {
+      "pmid": "30415628",
+      "title": "Cardiovascular Risk Reduction with Icosapent Ethyl for Hypertriglyceridemia",
+      "authors": "Bhatt DL et al.",
+      "authorCount": 12,
+      "journal": "N Engl J Med",
+      "year": 2019,
+      "volume": "380",
+      "pages": "11-22",
+      "doi": "10.1056/NEJMoa1812792",
+      "publicationTypes": [
+        "Clinical Trial, Phase III",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30428203": {
+      "pmid": "30428203",
+      "title": "Ultrasound and Microwave-Assisted Extraction of Elecampane (Inula helenium) Roots",
+      "authors": "Petkova N et al.",
+      "authorCount": 5,
+      "journal": "Nat Prod Commun",
+      "year": 2017,
+      "volume": "12",
+      "pages": "171-174",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30600979": {
+      "pmid": "30600979",
+      "title": "Migraine Headache Prophylaxis",
+      "authors": "Ha H and Gonzalez A",
+      "authorCount": 2,
+      "journal": "Am Fam Physician",
+      "year": 2019,
+      "volume": "99",
+      "pages": "17-24",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30621719": {
+      "pmid": "30621719",
+      "title": "Rosmarinus officinalis L. (rosemary) as therapeutic and prophylactic agent",
+      "authors": "de Oliveira JR et al.",
+      "authorCount": 3,
+      "journal": "J Biomed Sci",
+      "year": 2019,
+      "volume": "26",
+      "pages": "5",
+      "doi": "10.1186/s12929-019-0499-8",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30637820": {
+      "pmid": "30637820",
+      "title": "Berberine and barberry (Berberis vulgaris): A clinical review",
+      "authors": "Imenshahidi M and Hosseinzadeh H",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2019,
+      "volume": "33",
+      "pages": "504-523",
+      "doi": "10.1002/ptr.6252",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30651162": {
+      "pmid": "30651162",
+      "title": "Health Benefits of Culinary Herbs and Spices",
+      "authors": "Jiang TA",
+      "authorCount": 1,
+      "journal": "J AOAC Int",
+      "year": 2019,
+      "volume": "102",
+      "pages": "395-411",
+      "doi": "10.5740/jaoacint.18-0418",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30670267": {
+      "pmid": "30670267",
+      "title": "Black elderberry (Sambucus nigra) supplementation effectively treats upper respiratory symptoms: A meta-analysis of randomized, controlled clinical trials",
+      "authors": "Hawkins J et al.",
+      "authorCount": 4,
+      "journal": "Complement Ther Med",
+      "year": 2019,
+      "volume": "42",
+      "pages": "361-365",
+      "doi": "10.1016/j.ctim.2018.12.004",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30678239": {
+      "pmid": "30678239",
+      "title": "High Performance Liquid Chromatography Determination and Optimization of the Extraction Process for the Total Alkaloids from Traditional Herb Stephania cepharantha Hayata",
+      "authors": "Xiao J et al.",
+      "authorCount": 8,
+      "journal": "Molecules",
+      "year": 2019,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/molecules24030388",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30686880": {
+      "pmid": "30686880",
+      "title": "Progress in Fetal Surgery: A Buoyant Start or Watchful Reluctance? Perspectives for India",
+      "authors": "Sharma S",
+      "authorCount": 1,
+      "journal": "J Indian Assoc Pediatr Surg",
+      "year": 2019,
+      "volume": "24",
+      "pages": "1-3",
+      "doi": "10.4103/jiaps.JIAPS_84_18",
+      "publicationTypes": [
+        "Editorial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30708034": {
+      "pmid": "30708034",
+      "title": "Chinese Skullcap (Scutellaria baicalensis Georgi) inhibits inflammation and proliferation on benign prostatic hyperplasia in rats",
+      "authors": "Jin BR et al.",
+      "authorCount": 4,
+      "journal": "J Ethnopharmacol",
+      "year": 2019,
+      "volume": "235",
+      "pages": "481-488",
+      "doi": "10.1016/j.jep.2019.01.039",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30722342": {
+      "pmid": "30722342",
+      "title": "First Report of Fruit Rot on Schisandra chinensis Caused by Penicillium glabrum and P. adametzii in China",
+      "authors": "Chen CQ et al.",
+      "authorCount": 3,
+      "journal": "Plant Dis",
+      "year": 2013,
+      "volume": "97",
+      "pages": "288",
+      "doi": "10.1094/PDIS-08-12-0799-PDN",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30731931": {
+      "pmid": "30731931",
+      "title": "First Report of Botrytis Leaf Blight and Fruit Rot on Schisandra chinensis Caused by Botrytis cinerea in China",
+      "authors": "Yu RH et al.",
+      "authorCount": 4,
+      "journal": "Plant Dis",
+      "year": 2011,
+      "volume": "95",
+      "pages": "769",
+      "doi": "10.1094/PDIS-02-11-0086",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30823394": {
+      "pmid": "30823394",
+      "title": "Cytotoxic Properties of Damiana (Turnera diffusa) Extracts and Constituents and A Validated Quantitative UHPLC-DAD Assay",
+      "authors": "Willer J et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2019,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/molecules24050855",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30884305": {
+      "pmid": "30884305",
+      "title": "Sesquiterpenes from Curcuma zedoaria rhizomes and their cytotoxicity against human gastric cancer AGS cells",
+      "authors": "Lee TK et al.",
+      "authorCount": 7,
+      "journal": "Bioorg Chem",
+      "year": 2019,
+      "volume": "87",
+      "pages": "117-122",
+      "doi": "10.1016/j.bioorg.2019.03.015",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30934670": {
+      "pmid": "30934670",
+      "title": "Resveratrol and Its Effects on the Vascular System",
+      "authors": "Breuss JM et al.",
+      "authorCount": 3,
+      "journal": "Int J Mol Sci",
+      "year": 2019,
+      "volume": "20",
+      "pages": "",
+      "doi": "10.3390/ijms20071523",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30980598": {
+      "pmid": "30980598",
+      "title": "An overview of herbal alternatives in androgenetic alopecia",
+      "authors": "Dhariwala MY and Ravikumar P",
+      "authorCount": 2,
+      "journal": "J Cosmet Dermatol",
+      "year": 2019,
+      "volume": "18",
+      "pages": "966-975",
+      "doi": "10.1111/jocd.12930",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "30981186": {
+      "pmid": "30981186",
+      "title": "Atractylenolide III ameliorates cerebral ischemic injury and neuroinflammation associated with inhibiting JAK2/STAT3/Drp1-dependent mitochondrial fission in microglia",
+      "authors": "Zhou K et al.",
+      "authorCount": 12,
+      "journal": "Phytomedicine",
+      "year": 2019,
+      "volume": "59",
+      "pages": "152922",
+      "doi": "10.1016/j.phymed.2019.152922",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31030097": {
+      "pmid": "31030097",
+      "title": "Paeonol: pharmacological effects and mechanisms of action",
+      "authors": "Zhang L et al.",
+      "authorCount": 3,
+      "journal": "Int Immunopharmacol",
+      "year": 2019,
+      "volume": "72",
+      "pages": "413-421",
+      "doi": "10.1016/j.intimp.2019.04.033",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31030757": {
+      "pmid": "31030757",
+      "title": "The structures and biological functions of polysaccharides from traditional Chinese herbs",
+      "authors": "Zeng P et al.",
+      "authorCount": 4,
+      "journal": "Prog Mol Biol Transl Sci",
+      "year": 2019,
+      "volume": "163",
+      "pages": "423-444",
+      "doi": "10.1016/bs.pmbts.2019.03.003",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31051106": {
+      "pmid": "31051106",
+      "title": "Deficient Endoplasmic Reticulum-Mitochondrial Phosphatidylserine Transfer Causes Liver Disease",
+      "authors": "Hernández-Alvarez MI et al.",
+      "authorCount": 33,
+      "journal": "Cell",
+      "year": 2019,
+      "volume": "177",
+      "pages": "881-895.e17",
+      "doi": "10.1016/j.cell.2019.04.010",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31069872": {
+      "pmid": "31069872",
+      "title": "Safety and toxicity of silymarin, the major constituent of milk thistle extract: An updated review",
+      "authors": "Soleimani V et al.",
+      "authorCount": 4,
+      "journal": "Phytother Res",
+      "year": 2019,
+      "volume": "33",
+      "pages": "1627-1638",
+      "doi": "10.1002/ptr.6361",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31070530": {
+      "pmid": "31070530",
+      "title": "A comprehensive review on phytochemistry, pharmacology, and flavonoid biosynthesis of Scutellaria baicalensis",
+      "authors": "Wang ZL et al.",
+      "authorCount": 6,
+      "journal": "Pharm Biol",
+      "year": 2018,
+      "volume": "56",
+      "pages": "465-484",
+      "doi": "10.1080/13880209.2018.1492620",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31090276": {
+      "pmid": "31090276",
+      "title": "Pericarp and seed of litchi and longan fruits: constituent, extraction, bioactive activity, and potential utilization",
+      "authors": "Zhu XR et al.",
+      "authorCount": 6,
+      "journal": "J Zhejiang Univ Sci B",
+      "year": 2019,
+      "volume": "20",
+      "pages": "503-512",
+      "doi": "10.1631/jzus.B1900161",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31145533": {
+      "pmid": "31145533",
+      "title": "A systematic review of Calendula officinalis extract for wound healing",
+      "authors": "Givol O et al.",
+      "authorCount": 6,
+      "journal": "Wound Repair Regen",
+      "year": 2019,
+      "volume": "27",
+      "pages": "548-561",
+      "doi": "10.1111/wrr.12737",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31151279": {
+      "pmid": "31151279",
+      "title": "Bioactive Compounds and Bioactivities of Ginger (Zingiber officinale Roscoe)",
+      "authors": "Mao QQ et al.",
+      "authorCount": 7,
+      "journal": "Foods",
+      "year": 2019,
+      "volume": "8",
+      "pages": "",
+      "doi": "10.3390/foods8060185",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31163183": {
+      "pmid": "31163183",
+      "title": "Screening of pharmacological uses of Urtica dioica and others benefits",
+      "authors": "Dhouibi R et al.",
+      "authorCount": 7,
+      "journal": "Prog Biophys Mol Biol",
+      "year": 2020,
+      "volume": "150",
+      "pages": "67-77",
+      "doi": "10.1016/j.pbiomolbio.2019.05.008",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31173794": {
+      "pmid": "31173794",
+      "title": "Wild parsnip (Pastinaca sativa)-induced photosensitization",
+      "authors": "Stegelmeier BL et al.",
+      "authorCount": 5,
+      "journal": "Toxicon",
+      "year": 2019,
+      "volume": "167",
+      "pages": "60-66",
+      "doi": "10.1016/j.toxicon.2019.06.007",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31236960": {
+      "pmid": "31236960",
+      "title": "Scutellaria baicalensis Georgi. (Lamiaceae): a review of its traditional uses, botany, phytochemistry, pharmacology and toxicology",
+      "authors": "Zhao T et al.",
+      "authorCount": 7,
+      "journal": "J Pharm Pharmacol",
+      "year": 2019,
+      "volume": "71",
+      "pages": "1353-1369",
+      "doi": "10.1111/jphp.13129",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31275019": {
+      "pmid": "31275019",
+      "title": "Lithospermum erythrorhizon cell cultures: Present and future aspects",
+      "authors": "Yazaki K",
+      "authorCount": 1,
+      "journal": "Plant Biotechnol (Tokyo)",
+      "year": 2017,
+      "volume": "34",
+      "pages": "131-142",
+      "doi": "10.5511/plantbiotechnology.17.0823a",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31366209": {
+      "pmid": "31366209",
+      "title": "A critical review of the composition and history of safe use of guayusa: a stimulant and antioxidant novel food",
+      "authors": "Wise G and Negrin A",
+      "authorCount": 2,
+      "journal": "Crit Rev Food Sci Nutr",
+      "year": 2020,
+      "volume": "60",
+      "pages": "2393-2404",
+      "doi": "10.1080/10408398.2019.1643286",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31376068": {
+      "pmid": "31376068",
+      "title": "Neuroprotective and Antioxidant Effect of Ginkgo biloba Extract Against AD and Other Neurological Disorders",
+      "authors": "Singh SK et al.",
+      "authorCount": 5,
+      "journal": "Neurotherapeutics",
+      "year": 2019,
+      "volume": "16",
+      "pages": "666-674",
+      "doi": "10.1007/s13311-019-00767-8",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31431019": {
+      "pmid": "31431019",
+      "title": "Schisandra chinensis and its phytotherapeutical applications",
+      "authors": "Rybnikář M et al.",
+      "authorCount": 3,
+      "journal": "Ceska Slov Farm",
+      "year": 2019,
+      "volume": "68",
+      "pages": "95-118",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31442619": {
+      "pmid": "31442619",
+      "title": "Sophora alopecuroides L.: An ethnopharmacological, phytochemical, and pharmacological review",
+      "authors": "Wang R et al.",
+      "authorCount": 11,
+      "journal": "J Ethnopharmacol",
+      "year": 2020,
+      "volume": "248",
+      "pages": "112172",
+      "doi": "10.1016/j.jep.2019.112172",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31447414": {
+      "pmid": "31447414",
+      "title": "Sexual Performance Anxiety",
+      "authors": "Pyke RE",
+      "authorCount": 1,
+      "journal": "Sex Med Rev",
+      "year": 2020,
+      "volume": "8",
+      "pages": "183-190",
+      "doi": "10.1016/j.sxmr.2019.07.001",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31504785": {
+      "pmid": "31504785",
+      "title": "Identification and functional characterization of a novel selenocysteine methyltransferase from Brassica juncea L",
+      "authors": "Chen M et al.",
+      "authorCount": 6,
+      "journal": "J Exp Bot",
+      "year": 2019,
+      "volume": "70",
+      "pages": "6401-6416",
+      "doi": "10.1093/jxb/erz390",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31517876": {
+      "pmid": "31517876",
+      "title": "An investigation into the stress-relieving and pharmacological actions of an ashwagandha (Withania somnifera) extract: A randomized, double-blind, placebo-controlled study",
+      "authors": "Lopresti AL et al.",
+      "authorCount": 4,
+      "journal": "Medicine (Baltimore)",
+      "year": 2019,
+      "volume": "98",
+      "pages": "e17186",
+      "doi": "10.1097/MD.0000000000017186",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31521398": {
+      "pmid": "31521398",
+      "title": "Mediterranean diet: The role of long-chain ω-3 fatty acids in fish; polyphenols in fruits, vegetables, cereals, coffee, tea, cacao and wine; probiotics and vitamins in prevention of stroke, age-related cognitive decline, and Alzheimer disease",
+      "authors": "Román GC et al.",
+      "authorCount": 5,
+      "journal": "Rev Neurol (Paris)",
+      "year": 2019,
+      "volume": "175",
+      "pages": "724-741",
+      "doi": "10.1016/j.neurol.2019.08.005",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31577095": {
+      "pmid": "31577095",
+      "title": "Nutraceutical treatment and prevention of benign prostatic hyperplasia and prostate cancer",
+      "authors": "Cicero AFG et al.",
+      "authorCount": 12,
+      "journal": "Arch Ital Urol Androl",
+      "year": 2019,
+      "volume": "91",
+      "pages": "",
+      "doi": "10.4081/aiua.2019.3.139",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31578592": {
+      "pmid": "31578592",
+      "title": "Cytotoxicity of Cichorium intybus L. metabolites (Review)",
+      "authors": "Imam KMSU et al.",
+      "authorCount": 5,
+      "journal": "Oncol Rep",
+      "year": 2019,
+      "volume": "42",
+      "pages": "2196-2212",
+      "doi": "10.3892/or.2019.7336",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31583011": {
+      "pmid": "31583011",
+      "title": "Functional polysaccharides of carob fruit: a review",
+      "authors": "Zhu BJ et al.",
+      "authorCount": 5,
+      "journal": "Chin Med",
+      "year": 2019,
+      "volume": "14",
+      "pages": "40",
+      "doi": "10.1186/s13020-019-0261-x",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31605258": {
+      "pmid": "31605258",
+      "title": "Awareness and current knowledge of epilepsy",
+      "authors": "Khan AU et al.",
+      "authorCount": 11,
+      "journal": "Metab Brain Dis",
+      "year": 2020,
+      "volume": "35",
+      "pages": "45-63",
+      "doi": "10.1007/s11011-019-00494-1",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31627309": {
+      "pmid": "31627309",
+      "title": "A Collagen Supplement Improves Skin Hydration, Elasticity, Roughness, and Density: Results of a Randomized, Placebo-Controlled, Blind Study",
+      "authors": "Bolke L et al.",
+      "authorCount": 4,
+      "journal": "Nutrients",
+      "year": 2019,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/nu11102494",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31643260": {
+      "pmid": "31643260",
+      "title": "Green Tea",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2020,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31643417": {
+      "pmid": "31643417",
+      "title": "Garcinia Cambogia",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2019,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31643542": {
+      "pmid": "31643542",
+      "title": "Horse Chestnut",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2018,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31643645": {
+      "pmid": "31643645",
+      "title": "Cat's Claw",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2019,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31643695": {
+      "pmid": "31643695",
+      "title": "Noni",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2020,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31644013": {
+      "pmid": "31644013",
+      "title": "Yohimbine",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2020,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31649123": {
+      "pmid": "31649123",
+      "title": "Celebrating 20 Years of Genetic Discoveries in Legume Nodulation and Symbiotic Nitrogen Fixation",
+      "authors": "Roy S et al.",
+      "authorCount": 9,
+      "journal": "Plant Cell",
+      "year": 2020,
+      "volume": "32",
+      "pages": "15-41",
+      "doi": "10.1105/tpc.19.00279",
+      "publicationTypes": [
+        "Historical Article",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, U.S. Gov't, Non-P.H.S.",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31654344": {
+      "pmid": "31654344",
+      "title": "Trends in Drain Utilization in Bariatric Surgery: an Analysis of the MBSAQIP Database 2015-2017",
+      "authors": "Clapp B et al.",
+      "authorCount": 9,
+      "journal": "Obes Surg",
+      "year": 2020,
+      "volume": "30",
+      "pages": "569-579",
+      "doi": "10.1007/s11695-019-04215-6",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31655395": {
+      "pmid": "31655395",
+      "title": "Effects of lavender on anxiety: A systematic review and meta-analysis",
+      "authors": "Donelli D et al.",
+      "authorCount": 5,
+      "journal": "Phytomedicine",
+      "year": 2019,
+      "volume": "65",
+      "pages": "153099",
+      "doi": "10.1016/j.phymed.2019.153099",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31680350": {
+      "pmid": "31680350",
+      "title": "Aloe-emodin: A review of its pharmacology, toxicity, and pharmacokinetics",
+      "authors": "Dong X et al.",
+      "authorCount": 7,
+      "journal": "Phytother Res",
+      "year": 2020,
+      "volume": "34",
+      "pages": "270-281",
+      "doi": "10.1002/ptr.6532",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31714321": {
+      "pmid": "31714321",
+      "title": "Effects of Passiflora incarnata Linnaeus on polysomnographic sleep parameters in subjects with insomnia disorder: a double-blind randomized placebo-controlled study",
+      "authors": "Lee J et al.",
+      "authorCount": 5,
+      "journal": "Int Clin Psychopharmacol",
+      "year": 2020,
+      "volume": "35",
+      "pages": "29-35",
+      "doi": "10.1097/YIC.0000000000000291",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31756276": {
+      "pmid": "31756276",
+      "title": "Resveratrol: a review of plant sources, synthesis, stability, modification and food application",
+      "authors": "Tian B and Liu J",
+      "authorCount": 2,
+      "journal": "J Sci Food Agric",
+      "year": 2020,
+      "volume": "100",
+      "pages": "1392-1404",
+      "doi": "10.1002/jsfa.10152",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31763928": {
+      "pmid": "31763928",
+      "title": "Effect of Pycnogenol on Blood Pressure: Findings From a PRISMA Compliant Systematic Review and Meta-Analysis of Randomized, Double-Blind, Placebo-Controlled, Clinical Studies",
+      "authors": "Fogacci F et al.",
+      "authorCount": 6,
+      "journal": "Angiology",
+      "year": 2020,
+      "volume": "71",
+      "pages": "217-225",
+      "doi": "10.1177/0003319719889428",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31765761": {
+      "pmid": "31765761",
+      "title": "A review on the phytopharmacological studies of the genus Polygala",
+      "authors": "Lacaille-Dubois MA et al.",
+      "authorCount": 3,
+      "journal": "J Ethnopharmacol",
+      "year": 2020,
+      "volume": "249",
+      "pages": "112417",
+      "doi": "10.1016/j.jep.2019.112417",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31778363": {
+      "pmid": "31778363",
+      "title": "The use of Huperzia species for the treatment of Alzheimer's disease",
+      "authors": "Kim Thu D et al.",
+      "authorCount": 5,
+      "journal": "J Basic Clin Physiol Pharmacol",
+      "year": 2019,
+      "volume": "31",
+      "pages": "",
+      "doi": "10.1515/jbcpp-2019-0159",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31807332": {
+      "pmid": "31807332",
+      "title": "Use of saw palmetto (Serenoa repens) extract for benign prostatic hyperplasia",
+      "authors": "Kwon Y",
+      "authorCount": 1,
+      "journal": "Food Sci Biotechnol",
+      "year": 2019,
+      "volume": "28",
+      "pages": "1599-1606",
+      "doi": "10.1007/s10068-019-00605-9",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31807931": {
+      "pmid": "31807931",
+      "title": "Telovelar surgical approach",
+      "authors": "Ghali MGZ",
+      "authorCount": 1,
+      "journal": "Neurosurg Rev",
+      "year": 2021,
+      "volume": "44",
+      "pages": "61-76",
+      "doi": "10.1007/s10143-019-01190-5",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31836457": {
+      "pmid": "31836457",
+      "title": "Anti-inflammatory and immunoregulatory effects of paeoniflorin and total glucosides of paeony",
+      "authors": "Zhang L and Wei W",
+      "authorCount": 2,
+      "journal": "Pharmacol Ther",
+      "year": 2020,
+      "volume": "207",
+      "pages": "107452",
+      "doi": "10.1016/j.pharmthera.2019.107452",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31840355": {
+      "pmid": "31840355",
+      "title": "Indian Morinda species: A review",
+      "authors": "Singh B and Sharma RA",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2020,
+      "volume": "34",
+      "pages": "924-1007",
+      "doi": "10.1002/ptr.6579",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31860103": {
+      "pmid": "31860103",
+      "title": "Vitamin D and Calcium for the Prevention of Fracture: A Systematic Review and Meta-analysis",
+      "authors": "Yao P et al.",
+      "authorCount": 7,
+      "journal": "JAMA Netw Open",
+      "year": 2019,
+      "volume": "2",
+      "pages": "e1917789",
+      "doi": "10.1001/jamanetworkopen.2019.17789",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31951246": {
+      "pmid": "31951246",
+      "title": "Medicinal effects of Peruvian maca (Lepidium meyenii): a review",
+      "authors": "da Silva Leitão Peres N et al.",
+      "authorCount": 7,
+      "journal": "Food Funct",
+      "year": 2020,
+      "volume": "11",
+      "pages": "83-92",
+      "doi": "10.1039/c9fo02732g",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31958255": {
+      "pmid": "31958255",
+      "title": "Pharmacological applications of farnesol (C(15)H(26)O): a patent review",
+      "authors": "Delmondes GA et al.",
+      "authorCount": 12,
+      "journal": "Expert Opin Ther Pat",
+      "year": 2020,
+      "volume": "30",
+      "pages": "227-234",
+      "doi": "10.1080/13543776.2020.1718653",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "31975502": {
+      "pmid": "31975502",
+      "title": "Anti-aging and brightening effects of a topical treatment containing vitamin C, vitamin E, and raspberry leaf cell culture extract: A split-face, randomized controlled trial",
+      "authors": "Rattanawiwatpong P et al.",
+      "authorCount": 4,
+      "journal": "J Cosmet Dermatol",
+      "year": 2020,
+      "volume": "19",
+      "pages": "671-676",
+      "doi": "10.1111/jocd.13305",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32019140": {
+      "pmid": "32019140",
+      "title": "Syzygium aromaticum L. (Myrtaceae): Traditional Uses, Bioactive Chemical Constituents, Pharmacological and Toxicological Activities",
+      "authors": "Batiha GE et al.",
+      "authorCount": 6,
+      "journal": "Biomolecules",
+      "year": 2020,
+      "volume": "10",
+      "pages": "",
+      "doi": "10.3390/biom10020202",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32028721": {
+      "pmid": "32028721",
+      "title": "Phytochemistry, Ethnopharmacology, Pharmacokinetics and Toxicology of Cnidium monnieri (L.) Cusson",
+      "authors": "Sun Y et al.",
+      "authorCount": 3,
+      "journal": "Int J Mol Sci",
+      "year": 2020,
+      "volume": "21",
+      "pages": "",
+      "doi": "10.3390/ijms21031006",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32048383": {
+      "pmid": "32048383",
+      "title": "Effect of fenugreek extract supplement on testosterone levels in male: A meta-analysis of clinical trials",
+      "authors": "Mansoori A et al.",
+      "authorCount": 5,
+      "journal": "Phytother Res",
+      "year": 2020,
+      "volume": "34",
+      "pages": "1550-1555",
+      "doi": "10.1002/ptr.6627",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32061978": {
+      "pmid": "32061978",
+      "title": "Selective in vivo molecular and cellular biocompatibility of black peppercorns by piperine-protein intrinsic atomic interaction with elicited oxidative stress and apoptosis in zebrafish eleuthero embryos",
+      "authors": "Patel P et al.",
+      "authorCount": 9,
+      "journal": "Ecotoxicol Environ Saf",
+      "year": 2020,
+      "volume": "192",
+      "pages": "110321",
+      "doi": "10.1016/j.ecoenv.2020.110321",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32065376": {
+      "pmid": "32065376",
+      "title": "Silymarin as Supportive Treatment in Liver Diseases: A Narrative Review",
+      "authors": "Gillessen A and Schmidt HH",
+      "authorCount": 2,
+      "journal": "Adv Ther",
+      "year": 2020,
+      "volume": "37",
+      "pages": "1279-1301",
+      "doi": "10.1007/s12325-020-01251-y",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32066284": {
+      "pmid": "32066284",
+      "title": "A review of the treatment of male pattern hair loss",
+      "authors": "York K et al.",
+      "authorCount": 4,
+      "journal": "Expert Opin Pharmacother",
+      "year": 2020,
+      "volume": "21",
+      "pages": "603-612",
+      "doi": "10.1080/14656566.2020.1721463",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32114166": {
+      "pmid": "32114166",
+      "title": "Amygdalin - A pharmacological and toxicological review",
+      "authors": "He XY et al.",
+      "authorCount": 6,
+      "journal": "J Ethnopharmacol",
+      "year": 2020,
+      "volume": "254",
+      "pages": "112717",
+      "doi": "10.1016/j.jep.2020.112717",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32171732": {
+      "pmid": "32171732",
+      "title": "Toward a \"Green Revolution\" for Soybean",
+      "authors": "Liu S et al.",
+      "authorCount": 4,
+      "journal": "Mol Plant",
+      "year": 2020,
+      "volume": "13",
+      "pages": "688-697",
+      "doi": "10.1016/j.molp.2020.03.002",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32173933": {
+      "pmid": "32173933",
+      "title": "Ethnomedicinal, phytochemical and pharmacological updates on Peppermint (Mentha × piperita L.)-A review",
+      "authors": "Mahendran G and Rahman LU",
+      "authorCount": 2,
+      "journal": "Phytother Res",
+      "year": 2020,
+      "volume": "34",
+      "pages": "2088-2139",
+      "doi": "10.1002/ptr.6664",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32183224": {
+      "pmid": "32183224",
+      "title": "Pharmacological Update Properties of Aloe Vera and its Major Active Constituents",
+      "authors": "Sánchez M et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2020,
+      "volume": "25",
+      "pages": "",
+      "doi": "10.3390/molecules25061324",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32213941": {
+      "pmid": "32213941",
+      "title": "Chemical Constituents and Pharmacological Activities of Garlic (Allium sativum L.): A Review",
+      "authors": "El-Saber Batiha G et al.",
+      "authorCount": 9,
+      "journal": "Nutrients",
+      "year": 2020,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/nu12030872",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32280205": {
+      "pmid": "32280205",
+      "title": "Nanoparticle Drug Delivery Systems for α-Mangostin",
+      "authors": "Wathoni N et al.",
+      "authorCount": 6,
+      "journal": "Nanotechnol Sci Appl",
+      "year": 2020,
+      "volume": "13",
+      "pages": "23-36",
+      "doi": "10.2147/NSA.S243017",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32323812": {
+      "pmid": "32323812",
+      "title": "Therapeutic targets of thunder god vine (Tripterygium wilfordii hook) in rheumatoid arthritis (Review)",
+      "authors": "Song X et al.",
+      "authorCount": 3,
+      "journal": "Mol Med Rep",
+      "year": 2020,
+      "volume": "21",
+      "pages": "2303-2310",
+      "doi": "10.3892/mmr.2020.11052",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32335802": {
+      "pmid": "32335802",
+      "title": "Biological properties and clinical applications of berberine",
+      "authors": "Song D et al.",
+      "authorCount": 3,
+      "journal": "Front Med",
+      "year": 2020,
+      "volume": "14",
+      "pages": "564-582",
+      "doi": "10.1007/s11684-019-0724-6",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32353900": {
+      "pmid": "32353900",
+      "title": "Short-range regulatory chromatin loops in plants",
+      "authors": "Gagliardi D and Manavella PA",
+      "authorCount": 2,
+      "journal": "New Phytol",
+      "year": 2020,
+      "volume": "228",
+      "pages": "466-471",
+      "doi": "10.1111/nph.16632",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32360044": {
+      "pmid": "32360044",
+      "title": "Ethnopharmacology, phytochemistry, pharmacology, clinical applications and toxicology of the genus Stellera Linn.: A review",
+      "authors": "Zhang N et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2021,
+      "volume": "264",
+      "pages": "112915",
+      "doi": "10.1016/j.jep.2020.112915",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32364226": {
+      "pmid": "32364226",
+      "title": "Experimental assembly reveals ecological drift as a major driver of root nodule bacterial diversity in a woody legume crop",
+      "authors": "Ramoneda J et al.",
+      "authorCount": 5,
+      "journal": "FEMS Microbiol Ecol",
+      "year": 2020,
+      "volume": "96",
+      "pages": "",
+      "doi": "10.1093/femsec/fiaa083",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32367410": {
+      "pmid": "32367410",
+      "title": "Therapeutic application of Carica papaya leaf extract in the management of human diseases",
+      "authors": "Singh SP et al.",
+      "authorCount": 10,
+      "journal": "Daru",
+      "year": 2020,
+      "volume": "28",
+      "pages": "735-744",
+      "doi": "10.1007/s40199-020-00348-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32478963": {
+      "pmid": "32478963",
+      "title": "Warfarin and food, herbal or dietary supplement interactions: A systematic review",
+      "authors": "Tan CSS and Lee SWH",
+      "authorCount": 2,
+      "journal": "Br J Clin Pharmacol",
+      "year": 2021,
+      "volume": "87",
+      "pages": "352-374",
+      "doi": "10.1111/bcp.14404",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32600229": {
+      "pmid": "32600229",
+      "title": "Herbal Extracts with Antifungal Activity against Candida albicans: A Systematic Review",
+      "authors": "Hsu H et al.",
+      "authorCount": 3,
+      "journal": "Mini Rev Med Chem",
+      "year": 2021,
+      "volume": "21",
+      "pages": "90-117",
+      "doi": "10.2174/1389557520666200628032116",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32650511": {
+      "pmid": "32650511",
+      "title": "Short-Term Effect of a New Oral Sodium Hyaluronate Formulation on Knee Osteoarthritis: A Double-Blind, Randomized, Placebo-Controlled Clinical Trial",
+      "authors": "Cicero AFG et al.",
+      "authorCount": 6,
+      "journal": "Diseases",
+      "year": 2020,
+      "volume": "8",
+      "pages": "",
+      "doi": "10.3390/diseases8030026",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32680575": {
+      "pmid": "32680575",
+      "title": "Effectiveness of Boswellia and Boswellia extract for osteoarthritis patients: a systematic review and meta-analysis",
+      "authors": "Yu G et al.",
+      "authorCount": 6,
+      "journal": "BMC Complement Med Ther",
+      "year": 2020,
+      "volume": "20",
+      "pages": "225",
+      "doi": "10.1186/s12906-020-02985-6",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32752183": {
+      "pmid": "32752183",
+      "title": "Cranberry Polyphenols and Prevention against Urinary Tract Infections: Relevant Considerations",
+      "authors": "González de Llano D et al.",
+      "authorCount": 3,
+      "journal": "Molecules",
+      "year": 2020,
+      "volume": "25",
+      "pages": "",
+      "doi": "10.3390/molecules25153523",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32768902": {
+      "pmid": "32768902",
+      "title": "Chicory (Cichorium intybus L.) as a food ingredient - Nutritional composition, bioactivity, safety, and health claims: A review",
+      "authors": "Perović J et al.",
+      "authorCount": 8,
+      "journal": "Food Chem",
+      "year": 2021,
+      "volume": "336",
+      "pages": "127676",
+      "doi": "10.1016/j.foodchem.2020.127676",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32825719": {
+      "pmid": "32825719",
+      "title": "Applications of Compounds from Coffee Processing By-Products",
+      "authors": "Iriondo-DeHond A et al.",
+      "authorCount": 3,
+      "journal": "Biomolecules",
+      "year": 2020,
+      "volume": "10",
+      "pages": "",
+      "doi": "10.3390/biom10091219",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32848497": {
+      "pmid": "32848497",
+      "title": "Scientific Rigour in the Assessment and Interpretation of Youth Cardiopulmonary Fitness: A Response to the Paper 'Normative Reference Values and International Comparisons for the 20-Metre Shuttle Run Test: Analysis of 69,960 Test Results among Chinese Children and Youth'",
+      "authors": "Armstrong N and Welsman J",
+      "authorCount": 2,
+      "journal": "J Sports Sci Med",
+      "year": 2020,
+      "volume": "19",
+      "pages": "627-629",
+      "doi": "",
+      "publicationTypes": [
+        "Letter",
+        "Comment"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32917001": {
+      "pmid": "32917001",
+      "title": "Thymol and Thyme Essential Oil-New Insights into Selected Therapeutic Applications",
+      "authors": "Kowalczyk A et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2020,
+      "volume": "25",
+      "pages": "",
+      "doi": "10.3390/molecules25184125",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32918995": {
+      "pmid": "32918995",
+      "title": "Confirmation of ethnopharmacological anti-inflammatory properties of Ocotea odorifera and determination of its main active compounds",
+      "authors": "de Alcântara BGV et al.",
+      "authorCount": 11,
+      "journal": "J Ethnopharmacol",
+      "year": 2021,
+      "volume": "264",
+      "pages": "113378",
+      "doi": "10.1016/j.jep.2020.113378",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32929825": {
+      "pmid": "32929825",
+      "title": "Piperine: A review of its biological effects",
+      "authors": "Haq IU et al.",
+      "authorCount": 6,
+      "journal": "Phytother Res",
+      "year": 2021,
+      "volume": "35",
+      "pages": "680-700",
+      "doi": "10.1002/ptr.6855",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32937665": {
+      "pmid": "32937665",
+      "title": "Verbena officinalis (Common Vervain) - A Review on the Investigations of This Medicinally Important Plant Species",
+      "authors": "Kubica P et al.",
+      "authorCount": 5,
+      "journal": "Planta Med",
+      "year": 2020,
+      "volume": "86",
+      "pages": "1241-1257",
+      "doi": "10.1055/a-1232-5758",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32951763": {
+      "pmid": "32951763",
+      "title": "Hypoglycemic efficacy and safety of Momordica charantia (bitter melon) in patients with type 2 diabetes mellitus",
+      "authors": "Kim SK et al.",
+      "authorCount": 7,
+      "journal": "Complement Ther Med",
+      "year": 2020,
+      "volume": "52",
+      "pages": "102524",
+      "doi": "10.1016/j.ctim.2020.102524",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33034447": {
+      "pmid": "33034447",
+      "title": "Garcinol Is an HDAC11 Inhibitor",
+      "authors": "Son SI et al.",
+      "authorCount": 4,
+      "journal": "ACS Chem Biol",
+      "year": 2020,
+      "volume": "15",
+      "pages": "2866-2871",
+      "doi": "10.1021/acschembio.0c00719",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, U.S. Gov't, Non-P.H.S."
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33047814": {
+      "pmid": "33047814",
+      "title": "Optimization of extraction conditions of Angelica archangelica extract and activity evaluation in experimental fibromyalgia",
+      "authors": "Kaur A et al.",
+      "authorCount": 4,
+      "journal": "J Food Sci",
+      "year": 2020,
+      "volume": "85",
+      "pages": "3700-3710",
+      "doi": "10.1111/1750-3841.15476",
+      "publicationTypes": [
+        "Evaluation Study",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33057963": {
+      "pmid": "33057963",
+      "title": "Traditional Herbal Medicines Against CNS Disorders from Bangladesh",
+      "authors": "Uddin MJ and Zidorn C",
+      "authorCount": 2,
+      "journal": "Nat Prod Bioprospect",
+      "year": 2020,
+      "volume": "10",
+      "pages": "377-410",
+      "doi": "10.1007/s13659-020-00269-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33086877": {
+      "pmid": "33086877",
+      "title": "Valerian Root in Treating Sleep Problems and Associated Disorders-A Systematic Review and Meta-Analysis",
+      "authors": "Shinjyo N et al.",
+      "authorCount": 3,
+      "journal": "J Evid Based Integr Med",
+      "year": 2020,
+      "volume": "25",
+      "pages": "2515690X20967323",
+      "doi": "10.1177/2515690X20967323",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33090664": {
+      "pmid": "33090664",
+      "title": "Molecular mechanisms for the photoperiodic regulation of flowering in soybean",
+      "authors": "Lin X et al.",
+      "authorCount": 5,
+      "journal": "J Integr Plant Biol",
+      "year": 2021,
+      "volume": "63",
+      "pages": "981-994",
+      "doi": "10.1111/jipb.13021",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33127555": {
+      "pmid": "33127555",
+      "title": "Chemical constituents of Panax ginseng and Panax notoginseng explain why they differ in therapeutic efficacy",
+      "authors": "Liu H et al.",
+      "authorCount": 4,
+      "journal": "Pharmacol Res",
+      "year": 2020,
+      "volume": "161",
+      "pages": "105263",
+      "doi": "10.1016/j.phrs.2020.105263",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33138751": {
+      "pmid": "33138751",
+      "title": "Biological and Pharmacological Effects of Gamma-oryzanol: An Updated Review of the Molecular Mechanisms",
+      "authors": "Ramazani E et al.",
+      "authorCount": 4,
+      "journal": "Curr Pharm Des",
+      "year": 2021,
+      "volume": "27",
+      "pages": "2299-2316",
+      "doi": "10.2174/1381612826666201102101428",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33150931": {
+      "pmid": "33150931",
+      "title": "Examining the Effects of Herbs on Testosterone Concentrations in Men: A Systematic Review",
+      "authors": "Smith SJ et al.",
+      "authorCount": 4,
+      "journal": "Adv Nutr",
+      "year": 2021,
+      "volume": "12",
+      "pages": "744-765",
+      "doi": "10.1093/advances/nmaa134",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33171832": {
+      "pmid": "33171832",
+      "title": "Grape Pomace Valorization: A Systematic Review and Meta-Analysis",
+      "authors": "Antonić B et al.",
+      "authorCount": 4,
+      "journal": "Foods",
+      "year": 2020,
+      "volume": "9",
+      "pages": "",
+      "doi": "10.3390/foods9111627",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33174095": {
+      "pmid": "33174095",
+      "title": "Plants Used as Antihypertensive",
+      "authors": "Verma T et al.",
+      "authorCount": 6,
+      "journal": "Nat Prod Bioprospect",
+      "year": 2021,
+      "volume": "11",
+      "pages": "155-184",
+      "doi": "10.1007/s13659-020-00281-x",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33206347": {
+      "pmid": "33206347",
+      "title": "Phytochemical and pharmacological properties of Myristica fragrans Houtt.: an updated review",
+      "authors": "Ha MT et al.",
+      "authorCount": 6,
+      "journal": "Arch Pharm Res",
+      "year": 2020,
+      "volume": "43",
+      "pages": "1067-1092",
+      "doi": "10.1007/s12272-020-01285-4",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33242239": {
+      "pmid": "33242239",
+      "title": "Berberine",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2020,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33317112": {
+      "pmid": "33317112",
+      "title": "Brassica juncea L. (Mustard) Extract Silver NanoParticles and Knocking off Oxidative Stress, ProInflammatory Cytokine and Reverse DNA Genotoxicity",
+      "authors": "Hassan SA et al.",
+      "authorCount": 6,
+      "journal": "Biomolecules",
+      "year": 2020,
+      "volume": "10",
+      "pages": "",
+      "doi": "10.3390/biom10121650",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33338751": {
+      "pmid": "33338751",
+      "title": "Myricetin: A review of the most recent research",
+      "authors": "Song X et al.",
+      "authorCount": 10,
+      "journal": "Biomed Pharmacother",
+      "year": 2021,
+      "volume": "134",
+      "pages": "111017",
+      "doi": "10.1016/j.biopha.2020.111017",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33352740": {
+      "pmid": "33352740",
+      "title": "Passiflora incarnata in Neuropsychiatric Disorders-A Systematic Review",
+      "authors": "Janda K et al.",
+      "authorCount": 5,
+      "journal": "Nutrients",
+      "year": 2020,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/nu12123894",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33374338": {
+      "pmid": "33374338",
+      "title": "Neuroprotective Effects of Coffee Bioactive Compounds: A Review",
+      "authors": "Socała K et al.",
+      "authorCount": 5,
+      "journal": "Int J Mol Sci",
+      "year": 2020,
+      "volume": "22",
+      "pages": "",
+      "doi": "10.3390/ijms22010107",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33383165": {
+      "pmid": "33383165",
+      "title": "Neither soy nor isoflavone intake affects male reproductive hormones: An expanded and updated meta-analysis of clinical studies",
+      "authors": "Reed KE et al.",
+      "authorCount": 5,
+      "journal": "Reprod Toxicol",
+      "year": 2021,
+      "volume": "100",
+      "pages": "60-67",
+      "doi": "10.1016/j.reprotox.2020.12.019",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33391017": {
+      "pmid": "33391017",
+      "title": "Anise Hyssop Agastache foeniculum Increases Lifespan, Stress Resistance, and Metabolism by Affecting Free Radical Processes in Drosophila",
+      "authors": "Strilbytska OM et al.",
+      "authorCount": 8,
+      "journal": "Front Physiol",
+      "year": 2020,
+      "volume": "11",
+      "pages": "596729",
+      "doi": "10.3389/fphys.2020.596729",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33424664": {
+      "pmid": "33424664",
+      "title": "Pharmacotherapy of Anxiety Disorders: Current and Emerging Treatment Options",
+      "authors": "Garakani A et al.",
+      "authorCount": 7,
+      "journal": "Front Psychiatry",
+      "year": 2020,
+      "volume": "11",
+      "pages": "595584",
+      "doi": "10.3389/fpsyt.2020.595584",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33480339": {
+      "pmid": "33480339",
+      "title": "Anti-anxiety Properties of Selected Medicinal Plants",
+      "authors": "Khan A et al.",
+      "authorCount": 11,
+      "journal": "Curr Pharm Biotechnol",
+      "year": 2022,
+      "volume": "23",
+      "pages": "1041-1060",
+      "doi": "10.2174/1389201022666210122125131",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33494677": {
+      "pmid": "33494677",
+      "title": "Radioprotectors: Nature's Boon",
+      "authors": "Lang DK et al.",
+      "authorCount": 7,
+      "journal": "Mini Rev Med Chem",
+      "year": 2021,
+      "volume": "21",
+      "pages": "3074-3096",
+      "doi": "10.2174/1389557521666210120112814",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33506690": {
+      "pmid": "33506690",
+      "title": "Functional foods modulating inflammation and metabolism in chronic diseases: a systematic review",
+      "authors": "Luvián-Morales J et al.",
+      "authorCount": 5,
+      "journal": "Crit Rev Food Sci Nutr",
+      "year": 2022,
+      "volume": "62",
+      "pages": "4371-4392",
+      "doi": "10.1080/10408398.2021.1875189",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33541567": {
+      "pmid": "33541567",
+      "title": "A 6-month, double-blind, placebo-controlled, randomized trial to evaluate the effect of Eurycoma longifolia (Tongkat Ali) and concurrent training on erectile function and testosterone levels in androgen deficiency of aging males (ADAM)",
+      "authors": "Leitão AE et al.",
+      "authorCount": 5,
+      "journal": "Maturitas",
+      "year": 2021,
+      "volume": "145",
+      "pages": "78-85",
+      "doi": "10.1016/j.maturitas.2020.12.002",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33666283": {
+      "pmid": "33666283",
+      "title": "Phytotherapy and food applications from Brassica genus",
+      "authors": "Salehi B et al.",
+      "authorCount": 25,
+      "journal": "Phytother Res",
+      "year": 2021,
+      "volume": "35",
+      "pages": "3590-3609",
+      "doi": "10.1002/ptr.7048",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33762150": {
+      "pmid": "33762150",
+      "title": "The effects of foods on LDL cholesterol levels: A systematic review of the accumulated evidence from systematic reviews and meta-analyses of randomized controlled trials",
+      "authors": "Schoeneck M and Iggman D",
+      "authorCount": 2,
+      "journal": "Nutr Metab Cardiovasc Dis",
+      "year": 2021,
+      "volume": "31",
+      "pages": "1325-1338",
+      "doi": "10.1016/j.numecd.2020.12.032",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33779758": {
+      "pmid": "33779758",
+      "title": "Isatis indigotica: a review of phytochemistry, pharmacological activities and clinical applications",
+      "authors": "Chen Q et al.",
+      "authorCount": 7,
+      "journal": "J Pharm Pharmacol",
+      "year": 2021,
+      "volume": "73",
+      "pages": "1137-1150",
+      "doi": "10.1093/jpp/rgab014",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33799504": {
+      "pmid": "33799504",
+      "title": "Garcinol-A Natural Histone Acetyltransferase Inhibitor and New Anti-Cancer Epigenetic Drug",
+      "authors": "Kopytko P et al.",
+      "authorCount": 4,
+      "journal": "Int J Mol Sci",
+      "year": 2021,
+      "volume": "22",
+      "pages": "",
+      "doi": "10.3390/ijms22062828",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33802176": {
+      "pmid": "33802176",
+      "title": "The Use and Impact of Cognitive Enhancers among University Students: A Systematic Review",
+      "authors": "Sharif S et al.",
+      "authorCount": 4,
+      "journal": "Brain Sci",
+      "year": 2021,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/brainsci11030355",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33827515": {
+      "pmid": "33827515",
+      "title": "Elderberry for prevention and treatment of viral respiratory illnesses: a systematic review",
+      "authors": "Wieland LS et al.",
+      "authorCount": 8,
+      "journal": "BMC Complement Med Ther",
+      "year": 2021,
+      "volume": "21",
+      "pages": "112",
+      "doi": "10.1186/s12906-021-03283-5",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33833896": {
+      "pmid": "33833896",
+      "title": "Review of Pharmacological Properties and Chemical Constituents of Pastinaca sativa",
+      "authors": "Kenari HM et al.",
+      "authorCount": 5,
+      "journal": "J Pharmacopuncture",
+      "year": 2021,
+      "volume": "24",
+      "pages": "14-23",
+      "doi": "10.3831/KPI.2021.24.1.14",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33840996": {
+      "pmid": "33840996",
+      "title": "Tamarind (Tamarindus indica L.) Seed a Candidate Protein Source with Potential for Combating SARS-CoV-2 Infection in Obesity",
+      "authors": "Morais AHA et al.",
+      "authorCount": 7,
+      "journal": "Drug Target Insights",
+      "year": 2021,
+      "volume": "15",
+      "pages": "5-12",
+      "doi": "10.33393/dti.2021.2192",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33874310": {
+      "pmid": "33874310",
+      "title": "Reviews",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "New Phytol",
+      "year": 1991,
+      "volume": "117",
+      "pages": "507-514",
+      "doi": "10.1111/j.1469-8137.1991.tb00015.x",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33916044": {
+      "pmid": "33916044",
+      "title": "Biological Properties and Prospects for the Application of Eugenol-A Review",
+      "authors": "Ulanowska M and Olas B",
+      "authorCount": 2,
+      "journal": "Int J Mol Sci",
+      "year": 2021,
+      "volume": "22",
+      "pages": "",
+      "doi": "10.3390/ijms22073671",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33917159": {
+      "pmid": "33917159",
+      "title": "The Use of Chinese Skullcap (Scutellaria baicalensis) and Its Extracts for Sustainable Animal Production",
+      "authors": "Yin B et al.",
+      "authorCount": 5,
+      "journal": "Animals (Basel)",
+      "year": 2021,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/ani11041039",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33917843": {
+      "pmid": "33917843",
+      "title": "Neuroprotective Herbs for the Management of Alzheimer's Disease",
+      "authors": "Gregory J et al.",
+      "authorCount": 4,
+      "journal": "Biomolecules",
+      "year": 2021,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/biom11040543",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33924742": {
+      "pmid": "33924742",
+      "title": "A Chewable Cure \"Kanna\": Biological and Pharmaceutical Properties of Sceletium tortuosum",
+      "authors": "Manganyi MC et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2021,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/molecules26092557",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33927629": {
+      "pmid": "33927629",
+      "title": "Artemisia dracunculus (Tarragon): A Review of Its Traditional Uses, Phytochemistry and Pharmacology",
+      "authors": "Ekiert H et al.",
+      "authorCount": 7,
+      "journal": "Front Pharmacol",
+      "year": 2021,
+      "volume": "12",
+      "pages": "653993",
+      "doi": "10.3389/fphar.2021.653993",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33978188": {
+      "pmid": "33978188",
+      "title": "Citicoline and Memory Function in Healthy Older Adults: A Randomized, Double-Blind, Placebo-Controlled Clinical Trial",
+      "authors": "Nakazaki E et al.",
+      "authorCount": 5,
+      "journal": "J Nutr",
+      "year": 2021,
+      "volume": "151",
+      "pages": "2153-2160",
+      "doi": "10.1093/jn/nxab119",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "33992045": {
+      "pmid": "33992045",
+      "title": "The anti-obesity and health-promoting effects of tea and coffee",
+      "authors": "Sirotkin AV and Kolesárová A",
+      "authorCount": 2,
+      "journal": "Physiol Res",
+      "year": 2021,
+      "volume": "70",
+      "pages": "161-168",
+      "doi": "10.33549/physiolres.934674",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34029903": {
+      "pmid": "34029903",
+      "title": "Inhibition of α-glucosidases by tea polyphenols in rat intestinal extract and Caco-2 cells grown on Transwell",
+      "authors": "Kan L et al.",
+      "authorCount": 7,
+      "journal": "Food Chem",
+      "year": 2021,
+      "volume": "361",
+      "pages": "130047",
+      "doi": "10.1016/j.foodchem.2021.130047",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34071454": {
+      "pmid": "34071454",
+      "title": "A Systematic Review and Meta-Analysis of Ayurvedic Herbal Preparations for Hypercholesterolemia",
+      "authors": "Gyawali D et al.",
+      "authorCount": 5,
+      "journal": "Medicina (Kaunas)",
+      "year": 2021,
+      "volume": "57",
+      "pages": "",
+      "doi": "10.3390/medicina57060546",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34073784": {
+      "pmid": "34073784",
+      "title": "Black Cumin (Nigella sativa L.): A Comprehensive Review on Phytochemistry, Health Benefits, Molecular Pharmacology, and Safety",
+      "authors": "Hannan MA et al.",
+      "authorCount": 24,
+      "journal": "Nutrients",
+      "year": 2021,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/nu13061784",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34087741": {
+      "pmid": "34087741",
+      "title": "The role of quercetin in plants",
+      "authors": "Singh P et al.",
+      "authorCount": 4,
+      "journal": "Plant Physiol Biochem",
+      "year": 2021,
+      "volume": "166",
+      "pages": "10-19",
+      "doi": "10.1016/j.plaphy.2021.05.023",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34090852": {
+      "pmid": "34090852",
+      "title": "Extraction, structure, pharmacological activities and drug carrier applications of Angelica sinensis polysaccharide",
+      "authors": "Nai J et al.",
+      "authorCount": 9,
+      "journal": "Int J Biol Macromol",
+      "year": 2021,
+      "volume": "183",
+      "pages": "2337-2353",
+      "doi": "10.1016/j.ijbiomac.2021.05.213",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34102992": {
+      "pmid": "34102992",
+      "title": "Anti-oxidant and Anticancerous Effect of Fomitopsis officinalis (Vill. ex Fr. Bond. et Sing) Mushroom on Hepatocellular Carcinoma Cells In Vitro through NF-kB Pathway",
+      "authors": "Altannavch N et al.",
+      "authorCount": 7,
+      "journal": "Anticancer Agents Med Chem",
+      "year": 2022,
+      "volume": "22",
+      "pages": "1561-1570",
+      "doi": "10.2174/1871520621666210608101152",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34239993": {
+      "pmid": "34239993",
+      "title": "The effects of twenty-four nutrients and phytonutrients on immune system function and inflammation: A narrative review",
+      "authors": "Poles J et al.",
+      "authorCount": 5,
+      "journal": "J Clin Transl Res",
+      "year": 2021,
+      "volume": "7",
+      "pages": "333-376",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34269984": {
+      "pmid": "34269984",
+      "title": "Atractylenolides (I, II, and III): a review of their pharmacology and pharmacokinetics",
+      "authors": "Deng M et al.",
+      "authorCount": 6,
+      "journal": "Arch Pharm Res",
+      "year": 2021,
+      "volume": "44",
+      "pages": "633-654",
+      "doi": "10.1007/s12272-021-01342-6",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34283916": {
+      "pmid": "34283916",
+      "title": "Effectiveness of Inhaled Aromatherapy on Chemotherapy-Induced Nausea and Vomiting: A Systematic Review",
+      "authors": "Toniolo J et al.",
+      "authorCount": 3,
+      "journal": "J Altern Complement Med",
+      "year": 2021,
+      "volume": "27",
+      "pages": "1058-1069",
+      "doi": "10.1089/acm.2021.0067",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34302944": {
+      "pmid": "34302944",
+      "title": "The traditional and modern uses of Selaginella tamariscina (P.Beauv.) Spring, in medicine and cosmetic: Applications and bioactive ingredients",
+      "authors": "Bailly C",
+      "authorCount": 1,
+      "journal": "J Ethnopharmacol",
+      "year": 2021,
+      "volume": "280",
+      "pages": "114444",
+      "doi": "10.1016/j.jep.2021.114444",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34307603": {
+      "pmid": "34307603",
+      "title": "Herb-induced liver injury: Systematic review and meta-analysis",
+      "authors": "Ballotin VR et al.",
+      "authorCount": 6,
+      "journal": "World J Clin Cases",
+      "year": 2021,
+      "volume": "9",
+      "pages": "5490-5513",
+      "doi": "10.12998/wjcc.v9.i20.5490",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34345890": {
+      "pmid": "34345890",
+      "title": "Toxicity From Blue Lotus (Nymphaea caerulea) After Ingestion or Inhalation: A Case Series",
+      "authors": "Schimpf M et al.",
+      "authorCount": 4,
+      "journal": "Mil Med",
+      "year": 2023,
+      "volume": "188",
+      "pages": "",
+      "doi": "10.1093/milmed/usab328",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34361003": {
+      "pmid": "34361003",
+      "title": "Effect of Neferine on DNCB-Induced Atopic Dermatitis in HaCaT Cells and BALB/c Mice",
+      "authors": "Yang CC et al.",
+      "authorCount": 8,
+      "journal": "Int J Mol Sci",
+      "year": 2021,
+      "volume": "22",
+      "pages": "",
+      "doi": "10.3390/ijms22158237",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34368883": {
+      "pmid": "34368883",
+      "title": "Oxymatrine attenuates oxidized low‑density lipoprotein‑induced HUVEC injury by inhibiting NLRP3 inflammasome‑mediated pyroptosis via the activation of the SIRT1/Nrf2 signaling pathway",
+      "authors": "Jin X et al.",
+      "authorCount": 6,
+      "journal": "Int J Mol Med",
+      "year": 2021,
+      "volume": "48",
+      "pages": "",
+      "doi": "10.3892/ijmm.2021.5020",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34376917": {
+      "pmid": "34376917",
+      "title": "Effects of anthocyanin, astaxanthin, and lutein on eye functions: a randomized, double-blind, placebo-controlled study",
+      "authors": "Kizawa Y et al.",
+      "authorCount": 6,
+      "journal": "J Clin Biochem Nutr",
+      "year": 2021,
+      "volume": "69",
+      "pages": "77-90",
+      "doi": "10.3164/jcbn.20-149",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34402103": {
+      "pmid": "34402103",
+      "title": "Rooibos (Aspalathus linearis) influence on health and ovarian functions",
+      "authors": "Sirotkin AV",
+      "authorCount": 1,
+      "journal": "J Anim Physiol Anim Nutr (Berl)",
+      "year": 2022,
+      "volume": "106",
+      "pages": "995-999",
+      "doi": "10.1111/jpn.13624",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34410296": {
+      "pmid": "34410296",
+      "title": "Lemon myrtle extract inhibits lactate production by Streptococcus mutans",
+      "authors": "Yabuta Y et al.",
+      "authorCount": 7,
+      "journal": "Biosci Biotechnol Biochem",
+      "year": 2021,
+      "volume": "85",
+      "pages": "2185-2190",
+      "doi": "10.1093/bbb/zbab147",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34411377": {
+      "pmid": "34411377",
+      "title": "Ganoderma lucidum (Reishi) an edible mushroom; a comprehensive and critical review of its nutritional, cosmeceutical, mycochemical, pharmacological, clinical, and toxicological properties",
+      "authors": "Ahmad R et al.",
+      "authorCount": 7,
+      "journal": "Phytother Res",
+      "year": 2021,
+      "volume": "35",
+      "pages": "6030-6062",
+      "doi": "10.1002/ptr.7215",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34439010": {
+      "pmid": "34439010",
+      "title": "Biologically Active Extracts from Different Medicinal Plants Tested as Potential Additives against Bee Pathogens",
+      "authors": "Pașca C et al.",
+      "authorCount": 6,
+      "journal": "Antibiotics (Basel)",
+      "year": 2021,
+      "volume": "10",
+      "pages": "",
+      "doi": "10.3390/antibiotics10080960",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34445021": {
+      "pmid": "34445021",
+      "title": "Plant Adaptogens-History and Future Perspectives",
+      "authors": "Todorova V et al.",
+      "authorCount": 6,
+      "journal": "Nutrients",
+      "year": 2021,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/nu13082861",
+      "publicationTypes": [
+        "Historical Article",
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34449930": {
+      "pmid": "34449930",
+      "title": "The effects of lemon balm (Melissa officinalis L.) on depression and anxiety in clinical trials: A systematic review and meta-analysis",
+      "authors": "Ghazizadeh J et al.",
+      "authorCount": 9,
+      "journal": "Phytother Res",
+      "year": 2021,
+      "volume": "35",
+      "pages": "6690-6705",
+      "doi": "10.1002/ptr.7252",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34451622": {
+      "pmid": "34451622",
+      "title": "Oxypeucedanin: Chemotaxonomy, Isolation, and Bioactivities",
+      "authors": "Mottaghipisheh J",
+      "authorCount": 1,
+      "journal": "Plants (Basel)",
+      "year": 2021,
+      "volume": "10",
+      "pages": "",
+      "doi": "10.3390/plants10081577",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34451740": {
+      "pmid": "34451740",
+      "title": "Seed Geometry in the Vitaceae",
+      "authors": "Cervantes E et al.",
+      "authorCount": 4,
+      "journal": "Plants (Basel)",
+      "year": 2021,
+      "volume": "10",
+      "pages": "",
+      "doi": "10.3390/plants10081695",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34467577": {
+      "pmid": "34467577",
+      "title": "The effect of Gymnema sylvestre supplementation on glycemic control in type 2 diabetes patients: A systematic review and meta-analysis",
+      "authors": "Devangan S et al.",
+      "authorCount": 5,
+      "journal": "Phytother Res",
+      "year": 2021,
+      "volume": "35",
+      "pages": "6802-6812",
+      "doi": "10.1002/ptr.7265",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34472292": {
+      "pmid": "34472292",
+      "title": "[Fruit cracking: a review]",
+      "authors": "Li H et al.",
+      "authorCount": 4,
+      "journal": "Sheng Wu Gong Cheng Xue Bao",
+      "year": 2021,
+      "volume": "37",
+      "pages": "2737-2752",
+      "doi": "10.13345/j.cjb.200553",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34503406": {
+      "pmid": "34503406",
+      "title": "Review of the Phytochemistry and Biological Activity of Cissus incisa Leaves",
+      "authors": "Nocedo-Mena D et al.",
+      "authorCount": 4,
+      "journal": "Curr Top Med Chem",
+      "year": 2021,
+      "volume": "21",
+      "pages": "2409-2424",
+      "doi": "10.2174/1568026621666210909163612",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34503527": {
+      "pmid": "34503527",
+      "title": "International Society of Sports Nutrition position stand: sodium bicarbonate and exercise performance",
+      "authors": "Grgic J et al.",
+      "authorCount": 17,
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2021,
+      "volume": "18",
+      "pages": "61",
+      "doi": "10.1186/s12970-021-00458-w",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34529902": {
+      "pmid": "34529902",
+      "title": "Phytochemistry and pharmacology of Celastrus paniculatus Wild.: a nootropic drug",
+      "authors": "Aleem M",
+      "authorCount": 1,
+      "journal": "J Complement Integr Med",
+      "year": 2021,
+      "volume": "20",
+      "pages": "24-46",
+      "doi": "10.1515/jcim-2021-0251",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34559859": {
+      "pmid": "34559859",
+      "title": "Effect of Ashwagandha (Withania somnifera) extract on sleep: A systematic review and meta-analysis",
+      "authors": "Cheah KL et al.",
+      "authorCount": 4,
+      "journal": "PLoS One",
+      "year": 2021,
+      "volume": "16",
+      "pages": "e0257843",
+      "doi": "10.1371/journal.pone.0257843",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34620272": {
+      "pmid": "34620272",
+      "title": "Tacrolimus and herbs interactions: a review",
+      "authors": "Abushammala I",
+      "authorCount": 1,
+      "journal": "Pharmazie",
+      "year": 2021,
+      "volume": "76",
+      "pages": "468-472",
+      "doi": "10.1691/ph.2021.1684",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34626776": {
+      "pmid": "34626776",
+      "title": "Mulberry leaves ameliorate diabetes via regulating metabolic profiling and AGEs/RAGE and p38 MAPK/NF-κB pathway",
+      "authors": "Li JS et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2022,
+      "volume": "283",
+      "pages": "114713",
+      "doi": "10.1016/j.jep.2021.114713",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34652253": {
+      "pmid": "34652253",
+      "title": "Suppressing effect of a saikosaponin-enriched extract of Bupleurum falcatum on alcohol and chocolate self-administration in rats",
+      "authors": "Maccioni P et al.",
+      "authorCount": 7,
+      "journal": "Nat Prod Res",
+      "year": 2022,
+      "volume": "36",
+      "pages": "4502-4505",
+      "doi": "10.1080/14786419.2021.1986816",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34680529": {
+      "pmid": "34680529",
+      "title": "The Pharmacological Effects and Pharmacokinetics of Active Compounds of Artemisia capillaris",
+      "authors": "Hsueh TP et al.",
+      "authorCount": 4,
+      "journal": "Biomedicines",
+      "year": 2021,
+      "volume": "9",
+      "pages": "",
+      "doi": "10.3390/biomedicines9101412",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34718674": {
+      "pmid": "34718674",
+      "title": "Research progress of pharmacological effects of Siraitia grosvenorii extract",
+      "authors": "Li H et al.",
+      "authorCount": 4,
+      "journal": "J Pharm Pharmacol",
+      "year": 2022,
+      "volume": "74",
+      "pages": "953-960",
+      "doi": "10.1093/jpp/rgab150",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34726501": {
+      "pmid": "34726501",
+      "title": "Effect of Banaba (Lagerstroemia speciosa) on Metabolic Syndrome, Insulin Sensitivity, and Insulin Secretion",
+      "authors": "López-Murillo LD et al.",
+      "authorCount": 5,
+      "journal": "J Med Food",
+      "year": 2022,
+      "volume": "25",
+      "pages": "177-182",
+      "doi": "10.1089/jmf.2021.0039",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34755935": {
+      "pmid": "34755935",
+      "title": "Effects of the consumption of guarana on human health: A narrative review",
+      "authors": "Torres EAFS et al.",
+      "authorCount": 10,
+      "journal": "Compr Rev Food Sci Food Saf",
+      "year": 2022,
+      "volume": "21",
+      "pages": "272-295",
+      "doi": "10.1111/1541-4337.12862",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34770801": {
+      "pmid": "34770801",
+      "title": "Clove Essential Oil (Syzygium aromaticum L. Myrtaceae): Extraction, Chemical Composition, Food Applications, and Essential Bioactivity for Human Health",
+      "authors": "Haro-González JN et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2021,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/molecules26216387",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34770940": {
+      "pmid": "34770940",
+      "title": "Huperzine A and Its Neuroprotective Molecular Signaling in Alzheimer's Disease",
+      "authors": "Friedli MJ and Inestrosa NC",
+      "authorCount": 2,
+      "journal": "Molecules",
+      "year": 2021,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/molecules26216531",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34808701": {
+      "pmid": "34808701",
+      "title": "Esculetin: A review of its pharmacology and pharmacokinetics",
+      "authors": "Zhang L et al.",
+      "authorCount": 3,
+      "journal": "Phytother Res",
+      "year": 2022,
+      "volume": "36",
+      "pages": "279-298",
+      "doi": "10.1002/ptr.7311",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34818697": {
+      "pmid": "34818697",
+      "title": "Andrographolide: A review of its pharmacology, pharmacokinetics, toxicity and clinical trials and pharmaceutical researches",
+      "authors": "Zeng B et al.",
+      "authorCount": 9,
+      "journal": "Phytother Res",
+      "year": 2022,
+      "volume": "36",
+      "pages": "336-364",
+      "doi": "10.1002/ptr.7324",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34841626": {
+      "pmid": "34841626",
+      "title": "Social entrepreneurship in obesity prevention: A scoping review",
+      "authors": "Chia A et al.",
+      "authorCount": 4,
+      "journal": "Obes Rev",
+      "year": 2022,
+      "volume": "23",
+      "pages": "e13378",
+      "doi": "10.1111/obr.13378",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Scoping Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34885733": {
+      "pmid": "34885733",
+      "title": "Treatment of Benign Prostatic Hyperplasia by Natural Drugs",
+      "authors": "Csikós E et al.",
+      "authorCount": 14,
+      "journal": "Molecules",
+      "year": 2021,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/molecules26237141",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34946512": {
+      "pmid": "34946512",
+      "title": "Herbal Products Used in Menopause and for Gynecological Disorders",
+      "authors": "Kenda M et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2021,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/molecules26247421",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34946576": {
+      "pmid": "34946576",
+      "title": "The Analgesic Properties of Corydalis yanhusuo",
+      "authors": "Alhassen L et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2021,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/molecules26247498",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34954676": {
+      "pmid": "34954676",
+      "title": "The gender responsiveness of social entrepreneurship in health - A review of initiatives by Ashoka fellows",
+      "authors": "Khalid S et al.",
+      "authorCount": 3,
+      "journal": "Soc Sci Med",
+      "year": 2022,
+      "volume": "293",
+      "pages": "114665",
+      "doi": "10.1016/j.socscimed.2021.114665",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34959738": {
+      "pmid": "34959738",
+      "title": "Pharmacological Activity of Garcinia indica (Kokum): An Updated Review",
+      "authors": "Lim SH et al.",
+      "authorCount": 4,
+      "journal": "Pharmaceuticals (Basel)",
+      "year": 2021,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/ph14121338",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34978226": {
+      "pmid": "34978226",
+      "title": "Plant-derived nootropics and human cognition: A systematic review",
+      "authors": "Lorca C et al.",
+      "authorCount": 11,
+      "journal": "Crit Rev Food Sci Nutr",
+      "year": 2023,
+      "volume": "63",
+      "pages": "5521-5545",
+      "doi": "10.1080/10408398.2021.2021137",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35002589": {
+      "pmid": "35002589",
+      "title": "Old growth forests and large old trees as critical organisms connecting ecosystems and human health. A review",
+      "authors": "Gilhen-Baker M et al.",
+      "authorCount": 4,
+      "journal": "Environ Chem Lett",
+      "year": 2022,
+      "volume": "20",
+      "pages": "1529-1538",
+      "doi": "10.1007/s10311-021-01372-y",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35003289": {
+      "pmid": "35003289",
+      "title": "Processing and Compatibility of Corydalis yanhusuo: Phytochemistry, Pharmacology, Pharmacokinetics, and Safety",
+      "authors": "Wu L et al.",
+      "authorCount": 7,
+      "journal": "Evid Based Complement Alternat Med",
+      "year": 2021,
+      "volume": "2021",
+      "pages": "1271953",
+      "doi": "10.1155/2021/1271953",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35005853": {
+      "pmid": "35005853",
+      "title": "Neuroprotective potential of Celastrus paniculatus seeds against common neurological ailments: a narrative review",
+      "authors": "Sankaramourthy D et al.",
+      "authorCount": 4,
+      "journal": "J Complement Integr Med",
+      "year": 2022,
+      "volume": "20",
+      "pages": "530-536",
+      "doi": "10.1515/jcim-2021-0448",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35009007": {
+      "pmid": "35009007",
+      "title": "Allelopathy of Knotweeds as Invasive Plants",
+      "authors": "Kato-Noguchi H",
+      "authorCount": 1,
+      "journal": "Plants (Basel)",
+      "year": 2021,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/plants11010003",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35095483": {
+      "pmid": "35095483",
+      "title": "Crocetin: A Systematic Review",
+      "authors": "Guo ZL et al.",
+      "authorCount": 10,
+      "journal": "Front Pharmacol",
+      "year": 2022,
+      "volume": "12",
+      "pages": "745683",
+      "doi": "10.3389/fphar.2021.745683",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35118966": {
+      "pmid": "35118966",
+      "title": "Yohimbine as a treatment for erectile dysfunction: A systematic review and meta-analysis",
+      "authors": "Wibowo DNSA et al.",
+      "authorCount": 3,
+      "journal": "Turk J Urol",
+      "year": 2021,
+      "volume": "47",
+      "pages": "482-488",
+      "doi": "10.5152/tud.2021.21206",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35199395": {
+      "pmid": "35199395",
+      "title": "An extensive review on phytochemistry and pharmacological activities of Indian medicinal plant Celastrus paniculatus Willd",
+      "authors": "Nagpal K et al.",
+      "authorCount": 5,
+      "journal": "Phytother Res",
+      "year": 2022,
+      "volume": "36",
+      "pages": "1930-1951",
+      "doi": "10.1002/ptr.7424",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35208993": {
+      "pmid": "35208993",
+      "title": "Pharmacological Activities of Soursop (Annona muricata Lin.)",
+      "authors": "Mutakin M et al.",
+      "authorCount": 6,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27041201",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35276955": {
+      "pmid": "35276955",
+      "title": "Saffron (Crocus sativus L.): A Source of Nutrients for Health and for the Treatment of Neuropsychiatric and Age-Related Diseases",
+      "authors": "El Midaoui A et al.",
+      "authorCount": 19,
+      "journal": "Nutrients",
+      "year": 2022,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/nu14030597",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35294606": {
+      "pmid": "35294606",
+      "title": "St. John's wort (Hypericum perforatum) and depression: what happens to the neurotransmitter systems?",
+      "authors": "Kholghi G et al.",
+      "authorCount": 4,
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "year": 2022,
+      "volume": "395",
+      "pages": "629-642",
+      "doi": "10.1007/s00210-022-02229-z",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35311615": {
+      "pmid": "35311615",
+      "title": "Clinician guidelines for the treatment of psychiatric disorders with nutraceuticals and phytoceuticals: The World Federation of Societies of Biological Psychiatry (WFSBP) and Canadian Network for Mood and Anxiety Treatments (CANMAT) Taskforce",
+      "authors": "Sarris J et al.",
+      "authorCount": 31,
+      "journal": "World J Biol Psychiatry",
+      "year": 2022,
+      "volume": "23",
+      "pages": "424-455",
+      "doi": "10.1080/15622975.2021.2013041",
+      "publicationTypes": [
+        "Meta-Analysis",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35336978": {
+      "pmid": "35336978",
+      "title": "Known and Potential Invertebrate Vectors of Raspberry Viruses",
+      "authors": "Tan JL et al.",
+      "authorCount": 6,
+      "journal": "Viruses",
+      "year": 2022,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/v14030571",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35348337": {
+      "pmid": "35348337",
+      "title": "Elderberry (Sambucus nigra L.): Bioactive Compounds, Health Functions, and Applications",
+      "authors": "Liu D et al.",
+      "authorCount": 7,
+      "journal": "J Agric Food Chem",
+      "year": 2022,
+      "volume": "70",
+      "pages": "4202-4220",
+      "doi": "10.1021/acs.jafc.2c00010",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35349239": {
+      "pmid": "35349239",
+      "title": "Black Pepper",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35349772": {
+      "pmid": "35349772",
+      "title": "Development of EPS-rich herbal shampoo base fermented using Cyclea peltata leaf powder and Lactobacillus plantarum",
+      "authors": "Cheni Cheri D et al.",
+      "authorCount": 4,
+      "journal": "J Cosmet Dermatol",
+      "year": 2022,
+      "volume": "21",
+      "pages": "4999-5009",
+      "doi": "10.1111/jocd.14949",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35372585": {
+      "pmid": "35372585",
+      "title": "Using Network Pharmacology to Explore the Mechanism of Panax notoginseng in the Treatment of Myocardial Fibrosis",
+      "authors": "Han J et al.",
+      "authorCount": 6,
+      "journal": "J Diabetes Res",
+      "year": 2022,
+      "volume": "2022",
+      "pages": "8895950",
+      "doi": "10.1155/2022/8895950",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35378276": {
+      "pmid": "35378276",
+      "title": "Medicinal herbs for the treatment of anxiety: A systematic review and network meta-analysis",
+      "authors": "Zhang W et al.",
+      "authorCount": 11,
+      "journal": "Pharmacol Res",
+      "year": 2022,
+      "volume": "179",
+      "pages": "106204",
+      "doi": "10.1016/j.phrs.2022.106204",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review",
+        "Research Support, Non-U.S. Gov't",
+        "Network Meta-Analysis"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35433636": {
+      "pmid": "35433636",
+      "title": "Research Advances on Matrine",
+      "authors": "Sun XY et al.",
+      "authorCount": 18,
+      "journal": "Front Chem",
+      "year": 2022,
+      "volume": "10",
+      "pages": "867318",
+      "doi": "10.3389/fchem.2022.867318",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35458146": {
+      "pmid": "35458146",
+      "title": "Carica papaya Leaf Juice for Dengue: A Scoping Review",
+      "authors": "Teh BP et al.",
+      "authorCount": 7,
+      "journal": "Nutrients",
+      "year": 2022,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/nu14081584",
+      "publicationTypes": [
+        "Journal Article",
+        "Scoping Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35458696": {
+      "pmid": "35458696",
+      "title": "Health Benefits of Quercetin in Age-Related Diseases",
+      "authors": "Deepika and Maurya PK",
+      "authorCount": 2,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27082498",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35483189": {
+      "pmid": "35483189",
+      "title": "Tetramethylpyrazine: A review on its mechanisms and functions",
+      "authors": "Lin J et al.",
+      "authorCount": 5,
+      "journal": "Biomed Pharmacother",
+      "year": 2022,
+      "volume": "150",
+      "pages": "113005",
+      "doi": "10.1016/j.biopha.2022.113005",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35530094": {
+      "pmid": "35530094",
+      "title": "Polyphenols of Chinese skullcap roots: from chemical profiles to anticancer effects",
+      "authors": "Wang L et al.",
+      "authorCount": 6,
+      "journal": "RSC Adv",
+      "year": 2019,
+      "volume": "9",
+      "pages": "25518-25532",
+      "doi": "10.1039/c9ra03229k",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35567294": {
+      "pmid": "35567294",
+      "title": "Nutmeg (Myristica fragrans Houtt.) essential oil: A review on its composition, biological, and pharmacological activities",
+      "authors": "Ashokkumar K et al.",
+      "authorCount": 5,
+      "journal": "Phytother Res",
+      "year": 2022,
+      "volume": "36",
+      "pages": "2839-2851",
+      "doi": "10.1002/ptr.7491",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35576743": {
+      "pmid": "35576743",
+      "title": "Alkaloids from Dendrobium and their biosynthetic pathway, biological activity and total synthesis",
+      "authors": "Duan H et al.",
+      "authorCount": 6,
+      "journal": "Phytomedicine",
+      "year": 2022,
+      "volume": "102",
+      "pages": "154132",
+      "doi": "10.1016/j.phymed.2022.154132",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35587098": {
+      "pmid": "35587098",
+      "title": "Dermatological uses of rice products: Trend or true?",
+      "authors": "Zamil DH et al.",
+      "authorCount": 4,
+      "journal": "J Cosmet Dermatol",
+      "year": 2022,
+      "volume": "21",
+      "pages": "6056-6060",
+      "doi": "10.1111/jocd.15099",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35620220": {
+      "pmid": "35620220",
+      "title": "Anaesthesia of decapod crustaceans",
+      "authors": "de Souza Valente C",
+      "authorCount": 1,
+      "journal": "Vet Anim Sci",
+      "year": 2022,
+      "volume": "16",
+      "pages": "100252",
+      "doi": "10.1016/j.vas.2022.100252",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35620294": {
+      "pmid": "35620294",
+      "title": "Evidence and Potential Mechanism of Action of Lithospermum erythrorhizon and Its Active Components for Psoriasis",
+      "authors": "Wang J et al.",
+      "authorCount": 14,
+      "journal": "Front Pharmacol",
+      "year": 2022,
+      "volume": "13",
+      "pages": "781850",
+      "doi": "10.3389/fphar.2022.781850",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35662629": {
+      "pmid": "35662629",
+      "title": "Anti-inflammatory and immunomodulatory activity of Mangifera indica L. reveals the modulation of COX-2/mPGES-1 axis and Th17/Treg ratio",
+      "authors": "Saviano A et al.",
+      "authorCount": 18,
+      "journal": "Pharmacol Res",
+      "year": 2022,
+      "volume": "182",
+      "pages": "106283",
+      "doi": "10.1016/j.phrs.2022.106283",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35676785": {
+      "pmid": "35676785",
+      "title": "Anti-inflammatory and immunoregulatory effects of icariin and icaritin",
+      "authors": "Bi Z et al.",
+      "authorCount": 3,
+      "journal": "Biomed Pharmacother",
+      "year": 2022,
+      "volume": "151",
+      "pages": "113180",
+      "doi": "10.1016/j.biopha.2022.113180",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35677108": {
+      "pmid": "35677108",
+      "title": "Diosgenin: An Updated Pharmacological Review and Therapeutic Perspectives",
+      "authors": "Semwal P et al.",
+      "authorCount": 15,
+      "journal": "Oxid Med Cell Longev",
+      "year": 2022,
+      "volume": "2022",
+      "pages": "1035441",
+      "doi": "10.1155/2022/1035441",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35684259": {
+      "pmid": "35684259",
+      "title": "Antiphotoaging Effects of Damiana (Turnera diffusa) Leaves Extract via Regulation AP-1 and Nrf2/ARE Signaling Pathways",
+      "authors": "Kim M et al.",
+      "authorCount": 8,
+      "journal": "Plants (Basel)",
+      "year": 2022,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/plants11111486",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35713852": {
+      "pmid": "35713852",
+      "title": "Astragalus polysaccharide: a review of its immunomodulatory effect",
+      "authors": "Li CX et al.",
+      "authorCount": 5,
+      "journal": "Arch Pharm Res",
+      "year": 2022,
+      "volume": "45",
+      "pages": "367-389",
+      "doi": "10.1007/s12272-022-01393-3",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35721953": {
+      "pmid": "35721953",
+      "title": "Assessment of the CYP1A2 Inhibition-Mediated Drug Interaction Potential for Pinocembrin Using In Silico, In Vitro, and In Vivo Approaches",
+      "authors": "Bhatt S et al.",
+      "authorCount": 8,
+      "journal": "ACS Omega",
+      "year": 2022,
+      "volume": "7",
+      "pages": "20321-20331",
+      "doi": "10.1021/acsomega.2c02315",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35745023": {
+      "pmid": "35745023",
+      "title": "The Effectiveness of Rhodiola rosea L. Preparations in Alleviating Various Aspects of Life-Stress Symptoms and Stress-Induced Conditions-Encouraging Clinical Evidence",
+      "authors": "Ivanova Stojcheva E and Quintela JC",
+      "authorCount": 2,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27123902",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35745040": {
+      "pmid": "35745040",
+      "title": "Green Tea (Camellia sinensis): A Review of Its Phytochemistry, Pharmacology, and Toxicology",
+      "authors": "Zhao T et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27123909",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35807953": {
+      "pmid": "35807953",
+      "title": "Cinnamon as a Complementary Therapeutic Approach for Dysglycemia and Dyslipidemia Control in Type 2 Diabetes Mellitus and Its Molecular Mechanism of Action: A Review",
+      "authors": "Silva ML et al.",
+      "authorCount": 4,
+      "journal": "Nutrients",
+      "year": 2022,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/nu14132773",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35847034": {
+      "pmid": "35847034",
+      "title": "The Angelica dahurica: A Review of Traditional Uses, Phytochemistry and Pharmacology",
+      "authors": "Zhao H et al.",
+      "authorCount": 6,
+      "journal": "Front Pharmacol",
+      "year": 2022,
+      "volume": "13",
+      "pages": "896637",
+      "doi": "10.3389/fphar.2022.896637",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35873376": {
+      "pmid": "35873376",
+      "title": "Mechanistic insights on burdock (Arctium lappa L.) extract effects on diabetes mellitus",
+      "authors": "Mondal SC and Eun JB",
+      "authorCount": 2,
+      "journal": "Food Sci Biotechnol",
+      "year": 2022,
+      "volume": "31",
+      "pages": "999-1008",
+      "doi": "10.1007/s10068-022-01091-2",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35878793": {
+      "pmid": "35878793",
+      "title": "Role of Shankhpushpi (Convolvulus pluricaulis) in neurological disorders: An umbrella review covering evidence from ethnopharmacology to clinical studies",
+      "authors": "Sharma R et al.",
+      "authorCount": 6,
+      "journal": "Neurosci Biobehav Rev",
+      "year": 2022,
+      "volume": "140",
+      "pages": "104795",
+      "doi": "10.1016/j.neubiorev.2022.104795",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35883850": {
+      "pmid": "35883850",
+      "title": "Reviewing the Traditional/Modern Uses, Phytochemistry, Essential Oils/Extracts and Pharmacology of Embelia ribes Burm",
+      "authors": "Sharma V et al.",
+      "authorCount": 6,
+      "journal": "Antioxidants (Basel)",
+      "year": 2022,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/antiox11071359",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35892714": {
+      "pmid": "35892714",
+      "title": "Daphne odora Exerts Depigmenting Effects via Inhibiting CREB/MITF and Activating AKT/ERK-Signaling Pathways",
+      "authors": "Eom YS et al.",
+      "authorCount": 6,
+      "journal": "Curr Issues Mol Biol",
+      "year": 2022,
+      "volume": "44",
+      "pages": "3312-3323",
+      "doi": "10.3390/cimb44080228",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35911428": {
+      "pmid": "35911428",
+      "title": "Complementary and alternative medicine for glycemic control of diabetes mellitus: A systematic review",
+      "authors": "Setiyorini E et al.",
+      "authorCount": 8,
+      "journal": "J Public Health Res",
+      "year": 2022,
+      "volume": "11",
+      "pages": "22799036221106582",
+      "doi": "10.1177/22799036221106582",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35930138": {
+      "pmid": "35930138",
+      "title": "Cistanche Deserticola for Regulation of Bone Metabolism: Therapeutic Potential and Molecular Mechanisms on Postmenopausal Osteoporosis",
+      "authors": "Wang C et al.",
+      "authorCount": 7,
+      "journal": "Chin J Integr Med",
+      "year": 2023,
+      "volume": "29",
+      "pages": "74-80",
+      "doi": "10.1007/s11655-022-3518-z",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35933691": {
+      "pmid": "35933691",
+      "title": "Bioactive compounds, bio-functional properties, and food applications of Garcinia indica: A review",
+      "authors": "Desai S et al.",
+      "authorCount": 5,
+      "journal": "J Food Biochem",
+      "year": 2022,
+      "volume": "46",
+      "pages": "e14344",
+      "doi": "10.1111/jfbc.14344",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "35935936": {
+      "pmid": "35935936",
+      "title": "Efficacy and Safety of Curcumin and Curcuma longa Extract in the Treatment of Arthritis: A Systematic Review and Meta-Analysis of Randomized Controlled Trial",
+      "authors": "Zeng L et al.",
+      "authorCount": 7,
+      "journal": "Front Immunol",
+      "year": 2022,
+      "volume": "13",
+      "pages": "891822",
+      "doi": "10.3389/fimmu.2022.891822",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36013514": {
+      "pmid": "36013514",
+      "title": "Eurycoma longifolia (Jack) Improves Serum Total Testosterone in Men: A Systematic Review and Meta-Analysis of Clinical Trials",
+      "authors": "Leisegang K et al.",
+      "authorCount": 4,
+      "journal": "Medicina (Kaunas)",
+      "year": 2022,
+      "volume": "58",
+      "pages": "",
+      "doi": "10.3390/medicina58081047",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36041061": {
+      "pmid": "36041061",
+      "title": "D-mannose for preventing and treating urinary tract infections",
+      "authors": "Cooper TE et al.",
+      "authorCount": 6,
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2022,
+      "volume": "8",
+      "pages": "CD013608",
+      "doi": "10.1002/14651858.CD013608.pub2",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36061899": {
+      "pmid": "36061899",
+      "title": "Pharmacological attributes of Bacopa monnieri extract: Current updates and clinical manifestation",
+      "authors": "Fatima U et al.",
+      "authorCount": 10,
+      "journal": "Front Nutr",
+      "year": 2022,
+      "volume": "9",
+      "pages": "972379",
+      "doi": "10.3389/fnut.2022.972379",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36070433": {
+      "pmid": "36070433",
+      "title": "Effect of Maitake D-fraction in advanced laryngeal and pharyngeal cancers during concurrent chemoradiotherapy: A randomized clinical trial",
+      "authors": "Hu Q and Xie B",
+      "authorCount": 2,
+      "journal": "Acta Biochim Pol",
+      "year": 2022,
+      "volume": "69",
+      "pages": "625-632",
+      "doi": "10.18388/abp.2020_5996",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36076615": {
+      "pmid": "36076615",
+      "title": "Medicinal uses, pharmacological activities, phytochemistry, and the molecular mechanisms of Punica granatum L. (pomegranate) plant extracts: A review",
+      "authors": "Maphetu N et al.",
+      "authorCount": 5,
+      "journal": "Biomed Pharmacother",
+      "year": 2022,
+      "volume": "153",
+      "pages": "113256",
+      "doi": "10.1016/j.biopha.2022.113256",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36079777": {
+      "pmid": "36079777",
+      "title": "Effects of Resveratrol, Curcumin and Quercetin Supplementation on Bone Metabolism-A Systematic Review",
+      "authors": "Inchingolo AD et al.",
+      "authorCount": 33,
+      "journal": "Nutrients",
+      "year": 2022,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/nu14173519",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36091818": {
+      "pmid": "36091818",
+      "title": "Anti-Inflammatory Effects and Mechanisms of Dandelion in RAW264.7 Macrophages and Zebrafish Larvae",
+      "authors": "Li W et al.",
+      "authorCount": 9,
+      "journal": "Front Pharmacol",
+      "year": 2022,
+      "volume": "13",
+      "pages": "906927",
+      "doi": "10.3389/fphar.2022.906927",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36134975": {
+      "pmid": "36134975",
+      "title": "Japanese Knotweed Rhizome Bark Extract Inhibits Live SARS-CoV-2 In Vitro",
+      "authors": "Jug U et al.",
+      "authorCount": 3,
+      "journal": "Bioengineering (Basel)",
+      "year": 2022,
+      "volume": "9",
+      "pages": "",
+      "doi": "10.3390/bioengineering9090429",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36144755": {
+      "pmid": "36144755",
+      "title": "Medicinal Plants Used for Anxiety, Depression, or Stress Treatment: An Update",
+      "authors": "Kenda M et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27186021",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36176207": {
+      "pmid": "36176207",
+      "title": "Applications of bakuchiol in dermatology: Systematic review of the literature",
+      "authors": "Puyana C et al.",
+      "authorCount": 3,
+      "journal": "J Cosmet Dermatol",
+      "year": 2022,
+      "volume": "21",
+      "pages": "6636-6643",
+      "doi": "10.1111/jocd.15420",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36232220": {
+      "pmid": "36232220",
+      "title": "Inhibition of LPS-Induced Microglial Activation by the Ethyl Acetate Extract of Pueraria mirifica",
+      "authors": "Jantaratnotai N et al.",
+      "authorCount": 5,
+      "journal": "Int J Environ Res Public Health",
+      "year": 2022,
+      "volume": "19",
+      "pages": "",
+      "doi": "10.3390/ijerph191912920",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36235697": {
+      "pmid": "36235697",
+      "title": "Effectivity of Saffron Extract (Saffr'Activ) on Treatment for Children and Adolescents with Attention Deficit/Hyperactivity Disorder (ADHD): A Clinical Effectivity Study",
+      "authors": "Blasco-Fontecilla H et al.",
+      "authorCount": 6,
+      "journal": "Nutrients",
+      "year": 2022,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/nu14194046",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36246064": {
+      "pmid": "36246064",
+      "title": "Hypericum perforatum: Traditional uses, clinical trials, and drug interactions",
+      "authors": "Nobakht SZ et al.",
+      "authorCount": 5,
+      "journal": "Iran J Basic Med Sci",
+      "year": 2022,
+      "volume": "25",
+      "pages": "1045-1058",
+      "doi": "10.22038/IJBMS.2022.65112.14338",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36249817": {
+      "pmid": "36249817",
+      "title": "Epimedium brevicornum Maxim. Extract exhibits pigmentation by melanin biosynthesis and melanosome biogenesis/transfer",
+      "authors": "Hong C et al.",
+      "authorCount": 5,
+      "journal": "Front Pharmacol",
+      "year": 2022,
+      "volume": "13",
+      "pages": "963160",
+      "doi": "10.3389/fphar.2022.963160",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36256521": {
+      "pmid": "36256521",
+      "title": "Piper longum L.: A comprehensive review on traditional uses, phytochemistry, pharmacology, and health-promoting activities",
+      "authors": "Biswas P et al.",
+      "authorCount": 19,
+      "journal": "Phytother Res",
+      "year": 2022,
+      "volume": "36",
+      "pages": "4425-4476",
+      "doi": "10.1002/ptr.7649",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36330891": {
+      "pmid": "36330891",
+      "title": "A review of the botany, ethnopharmacology, phytochemistry, pharmacology, toxicology and quality of Anemarrhena asphodeloides Bunge",
+      "authors": "Liu C et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2023,
+      "volume": "302",
+      "pages": "115857",
+      "doi": "10.1016/j.jep.2022.115857",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36358493": {
+      "pmid": "36358493",
+      "title": "Pharmacological Activity, Pharmacokinetics, and Clinical Research Progress of Puerarin",
+      "authors": "Wang D et al.",
+      "authorCount": 6,
+      "journal": "Antioxidants (Basel)",
+      "year": 2022,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/antiox11112121",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36364048": {
+      "pmid": "36364048",
+      "title": "Effect of Ginger on Inflammatory Diseases",
+      "authors": "Ballester P et al.",
+      "authorCount": 6,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27217223",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36364156": {
+      "pmid": "36364156",
+      "title": "Chemical Profiling and Biological Activity of Extracts from Nine Norwegian Medicinal and Aromatic Plants",
+      "authors": "Slimestad R et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27217335",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36379502": {
+      "pmid": "36379502",
+      "title": "Peripheral Edema: Evaluation and Management in Primary Care",
+      "authors": "Patel H et al.",
+      "authorCount": 3,
+      "journal": "Am Fam Physician",
+      "year": 2022,
+      "volume": "106",
+      "pages": "557-564",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36432799": {
+      "pmid": "36432799",
+      "title": "Exploring Contact Toxicity of Essential Oils against Sitophilus zeamais through a Meta-Analysis Approach",
+      "authors": "Achimón F et al.",
+      "authorCount": 7,
+      "journal": "Plants (Basel)",
+      "year": 2022,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/plants11223070",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36432868": {
+      "pmid": "36432868",
+      "title": "Species-Specific Plant-Derived Nanoparticle Characteristics",
+      "authors": "Viršilė A et al.",
+      "authorCount": 6,
+      "journal": "Plants (Basel)",
+      "year": 2022,
+      "volume": "11",
+      "pages": "",
+      "doi": "10.3390/plants11223139",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36445447": {
+      "pmid": "36445447",
+      "title": "[Phytotherapy in uro-oncology]",
+      "authors": "Bauer-Büntzel C et al.",
+      "authorCount": 4,
+      "journal": "Urologie",
+      "year": 2023,
+      "volume": "62",
+      "pages": "3-10",
+      "doi": "10.1007/s00120-022-01979-1",
+      "publicationTypes": [
+        "English Abstract",
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36513474": {
+      "pmid": "36513474",
+      "title": "What is the efficacy of dietary, nutraceutical, and probiotic interventions for the management of gastroesophageal reflux disease symptoms? A systematic literature review and meta-analysis",
+      "authors": "Martin Z et al.",
+      "authorCount": 7,
+      "journal": "Clin Nutr ESPEN",
+      "year": 2022,
+      "volume": "52",
+      "pages": "340-352",
+      "doi": "10.1016/j.clnesp.2022.09.015",
+      "publicationTypes": [
+        "Systematic Review",
+        "Meta-Analysis",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36558061": {
+      "pmid": "36558061",
+      "title": "Pharmacological Effects and Clinical Prospects of Cepharanthine",
+      "authors": "Liang D et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/molecules27248933",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36596101": {
+      "pmid": "36596101",
+      "title": "Effect of ajwain (Trachyspermum ammi) extract and gamma irradiation on the shelf-life extension of rohu (Labeo rohita) and seer (Scomberomorus guttatus) fish steaks during chilled storage",
+      "authors": "Mishra PK et al.",
+      "authorCount": 6,
+      "journal": "Food Res Int",
+      "year": 2023,
+      "volume": "163",
+      "pages": "112149",
+      "doi": "10.1016/j.foodres.2022.112149",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36606510": {
+      "pmid": "36606510",
+      "title": "A clinical trial about effects of prebiotic and probiotic supplementation on weight loss, psychological profile and metabolic parameters in obese subjects",
+      "authors": "Ben Othman R et al.",
+      "authorCount": 7,
+      "journal": "Endocrinol Diabetes Metab",
+      "year": 2023,
+      "volume": "6",
+      "pages": "e402",
+      "doi": "10.1002/edm2.402",
+      "publicationTypes": [
+        "Clinical Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36615326": {
+      "pmid": "36615326",
+      "title": "Chamomile: A Review of Its Traditional Uses, Chemical Constituents, Pharmacological Activities and Quality Control Studies",
+      "authors": "Dai YL et al.",
+      "authorCount": 9,
+      "journal": "Molecules",
+      "year": 2022,
+      "volume": "28",
+      "pages": "",
+      "doi": "10.3390/molecules28010133",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36634722": {
+      "pmid": "36634722",
+      "title": "Extraction, structure and bioactivities of polysaccharides from Rehmannia glutinosa: A review",
+      "authors": "Bian Z et al.",
+      "authorCount": 8,
+      "journal": "J Ethnopharmacol",
+      "year": 2023,
+      "volume": "305",
+      "pages": "116132",
+      "doi": "10.1016/j.jep.2022.116132",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36650621": {
+      "pmid": "36650621",
+      "title": "Herb-Drug Interactions and Their Impact on Pharmacokinetics: An Update",
+      "authors": "Cheng W et al.",
+      "authorCount": 4,
+      "journal": "Curr Drug Metab",
+      "year": 2023,
+      "volume": "24",
+      "pages": "28-69",
+      "doi": "10.2174/1389200224666230116113240",
+      "publicationTypes": [
+        "Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36671409": {
+      "pmid": "36671409",
+      "title": "A Review of Ganoderma Triterpenoids and Their Bioactivities",
+      "authors": "Galappaththi MCA et al.",
+      "authorCount": 9,
+      "journal": "Biomolecules",
+      "year": 2022,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/biom13010024",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36699694": {
+      "pmid": "36699694",
+      "title": "Pharmacological Activities of Fingerroot Extract and Its Phytoconstituents Against SARS-CoV-2 Infection in Golden Syrian Hamsters",
+      "authors": "Kongratanapasert T et al.",
+      "authorCount": 19,
+      "journal": "J Exp Pharmacol",
+      "year": 2023,
+      "volume": "15",
+      "pages": "13-26",
+      "doi": "10.2147/JEP.S382895",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36732502": {
+      "pmid": "36732502",
+      "title": "Celastrol suppresses colorectal cancer via covalent targeting peroxiredoxin 1",
+      "authors": "Xu H et al.",
+      "authorCount": 14,
+      "journal": "Signal Transduct Target Ther",
+      "year": 2023,
+      "volume": "8",
+      "pages": "51",
+      "doi": "10.1038/s41392-022-01231-4",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36753600": {
+      "pmid": "36753600",
+      "title": "Hawthorn",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2023,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36768300": {
+      "pmid": "36768300",
+      "title": "Eosinophilic Fasciitis: Current and Remaining Challenges",
+      "authors": "Mazilu D et al.",
+      "authorCount": 8,
+      "journal": "Int J Mol Sci",
+      "year": 2023,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/ijms24031982",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36768420": {
+      "pmid": "36768420",
+      "title": "Moringa oleifera: An Updated Comprehensive Review of Its Pharmacological Activities, Ethnomedicinal, Phytopharmaceutical Formulation, Clinical, Phytochemical, and Toxicological Aspects",
+      "authors": "Pareek A et al.",
+      "authorCount": 8,
+      "journal": "Int J Mol Sci",
+      "year": 2023,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/ijms24032098",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36769029": {
+      "pmid": "36769029",
+      "title": "Health Benefits of Coffee Consumption for Cancer and Other Diseases and Mechanisms of Action",
+      "authors": "Safe S et al.",
+      "authorCount": 6,
+      "journal": "Int J Mol Sci",
+      "year": 2023,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/ijms24032706",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36862943": {
+      "pmid": "36862943",
+      "title": "International society of sports nutrition position stand: energy drinks and energy shots",
+      "authors": "Jagim AR et al.",
+      "authorCount": 13,
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2023,
+      "volume": "20",
+      "pages": "2171314",
+      "doi": "10.1080/15502783.2023.2171314",
+      "publicationTypes": [
+        "Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36876591": {
+      "pmid": "36876591",
+      "title": "Inulin: properties and health benefits",
+      "authors": "Qin YQ et al.",
+      "authorCount": 9,
+      "journal": "Food Funct",
+      "year": 2023,
+      "volume": "14",
+      "pages": "2948-2968",
+      "doi": "10.1039/d2fo01096h",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36877269": {
+      "pmid": "36877269",
+      "title": "Morus alba: a comprehensive phytochemical and pharmacological review",
+      "authors": "Batiha GE et al.",
+      "authorCount": 11,
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "year": 2023,
+      "volume": "396",
+      "pages": "1399-1413",
+      "doi": "10.1007/s00210-023-02434-4",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36902200": {
+      "pmid": "36902200",
+      "title": "Depression and Its Phytopharmacotherapy-A Narrative Review",
+      "authors": "Dobrek L and Głowacka K",
+      "authorCount": 2,
+      "journal": "Int J Mol Sci",
+      "year": 2023,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/ijms24054772",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36929344": {
+      "pmid": "36929344",
+      "title": "A Randomized, Double-Blind, Placebo-Controlled, Parallel Study Investigating the Efficacy of a Whole Coffee Cherry Extract and Phosphatidylserine Formulation on Cognitive Performance of Healthy Adults with Self-Perceived Memory Problems",
+      "authors": "Doma KM et al.",
+      "authorCount": 8,
+      "journal": "Neurol Ther",
+      "year": 2023,
+      "volume": "12",
+      "pages": "777-794",
+      "doi": "10.1007/s40120-023-00454-z",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36933876": {
+      "pmid": "36933876",
+      "title": "Therapeutic potential and industrial applications of Terminalia arjuna bark",
+      "authors": "Kumar V et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2023,
+      "volume": "310",
+      "pages": "116352",
+      "doi": "10.1016/j.jep.2023.116352",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36937066": {
+      "pmid": "36937066",
+      "title": "The origin of cultivated mangosteen (Garcinia mangostana L. var. mangostana): Critical assessments and an evolutionary-ecological perspective",
+      "authors": "Yao TL et al.",
+      "authorCount": 5,
+      "journal": "Ecol Evol",
+      "year": 2023,
+      "volume": "13",
+      "pages": "e9792",
+      "doi": "10.1002/ece3.9792",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36938015": {
+      "pmid": "36938015",
+      "title": "California poppy (Eschscholzia californica), the Papaveraceae golden girl model organism for evodevo and specialized metabolism",
+      "authors": "Becker A et al.",
+      "authorCount": 3,
+      "journal": "Front Plant Sci",
+      "year": 2023,
+      "volume": "14",
+      "pages": "1084358",
+      "doi": "10.3389/fpls.2023.1084358",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36987052": {
+      "pmid": "36987052",
+      "title": "Nootropic Herbs, Shrubs, and Trees as Potential Cognitive Enhancers",
+      "authors": "Malík M and Tlustoš P",
+      "authorCount": 2,
+      "journal": "Plants (Basel)",
+      "year": 2023,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/plants12061364",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "36995535": {
+      "pmid": "36995535",
+      "title": "Medicinal Mushroom Supplements in Cancer: A Systematic Review of Clinical Studies",
+      "authors": "Narayanan S et al.",
+      "authorCount": 9,
+      "journal": "Curr Oncol Rep",
+      "year": 2023,
+      "volume": "25",
+      "pages": "569-587",
+      "doi": "10.1007/s11912-023-01408-2",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37026028": {
+      "pmid": "37026028",
+      "title": "Phytochemical and biological review of Aegle marmelos Linn",
+      "authors": "Monika S et al.",
+      "authorCount": 3,
+      "journal": "Future Sci OA",
+      "year": 2023,
+      "volume": "9",
+      "pages": "FSO849",
+      "doi": "10.2144/fsoa-2022-0068",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37043592": {
+      "pmid": "37043592",
+      "title": "Bitter Melon",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2023,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37043739": {
+      "pmid": "37043739",
+      "title": "Modulation of in Vitro SARS-CoV-2 Infection by Stephania tetrandra and Its Alkaloid Constituents",
+      "authors": "Khadilkar A et al.",
+      "authorCount": 17,
+      "journal": "J Nat Prod",
+      "year": 2023,
+      "volume": "86",
+      "pages": "1061-1073",
+      "doi": "10.1021/acs.jnatprod.3c00159",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Research Support, N.I.H., Extramural"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37048268": {
+      "pmid": "37048268",
+      "title": "Soursop (Annona muricata) Properties and Perspectives for Integral Valorization",
+      "authors": "Santos IL et al.",
+      "authorCount": 4,
+      "journal": "Foods",
+      "year": 2023,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/foods12071448",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37062005": {
+      "pmid": "37062005",
+      "title": "Complete genome sequence of daphne virus 1, a novel cytorhabdovirus infecting Daphne odora",
+      "authors": "Belete MT et al.",
+      "authorCount": 7,
+      "journal": "Arch Virol",
+      "year": 2023,
+      "volume": "168",
+      "pages": "141",
+      "doi": "10.1007/s00705-023-05734-5",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37062220": {
+      "pmid": "37062220",
+      "title": "A comprehensive review on celastrol, triptolide and triptonide: Insights on their pharmacological activity, toxicity, combination therapy, new dosage form and novel drug delivery routes",
+      "authors": "Song J et al.",
+      "authorCount": 3,
+      "journal": "Biomed Pharmacother",
+      "year": 2023,
+      "volume": "162",
+      "pages": "114705",
+      "doi": "10.1016/j.biopha.2023.114705",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37068952": {
+      "pmid": "37068952",
+      "title": "Cranberries for preventing urinary tract infections",
+      "authors": "Williams G et al.",
+      "authorCount": 5,
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2023,
+      "volume": "4",
+      "pages": "CD001321",
+      "doi": "10.1002/14651858.CD001321.pub6",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37078654": {
+      "pmid": "37078654",
+      "title": "Effects of dietary fibers or probiotics on functional constipation symptoms and roles of gut microbiota: a double-blinded randomized placebo trial",
+      "authors": "Lai H et al.",
+      "authorCount": 25,
+      "journal": "Gut Microbes",
+      "year": 2023,
+      "volume": "15",
+      "pages": "2197837",
+      "doi": "10.1080/19490976.2023.2197837",
+      "publicationTypes": [
+        "Randomized Controlled Trial",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37120060": {
+      "pmid": "37120060",
+      "title": "Mulberry extract ameliorates T2DM-related symptoms via AMPK pathway in STZ-HFD-induced C57BL/6J mice",
+      "authors": "Zhang L et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2023,
+      "volume": "313",
+      "pages": "116475",
+      "doi": "10.1016/j.jep.2023.116475",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37151166": {
+      "pmid": "37151166",
+      "title": "Natural Compounds Used for Treating Hair Loss",
+      "authors": "Gasmi A et al.",
+      "authorCount": 13,
+      "journal": "Curr Pharm Des",
+      "year": 2023,
+      "volume": "29",
+      "pages": "1231-1244",
+      "doi": "10.2174/1381612829666230505100147",
+      "publicationTypes": [
+        "Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37172085": {
+      "pmid": "37172085",
+      "title": "Electromagnetic fields disrupt the pollination service by honeybees",
+      "authors": "Molina-Montenegro MA et al.",
+      "authorCount": 7,
+      "journal": "Sci Adv",
+      "year": 2023,
+      "volume": "9",
+      "pages": "eadh1455",
+      "doi": "10.1126/sciadv.adh1455",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37184195": {
+      "pmid": "37184195",
+      "title": "Black Cumin Seed",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2023,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37184199": {
+      "pmid": "37184199",
+      "title": "Oregano",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2023,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37192826": {
+      "pmid": "37192826",
+      "title": "Black cohosh extracts in women with menopausal symptoms: an updated pairwise meta-analysis",
+      "authors": "Sadahiro R et al.",
+      "authorCount": 23,
+      "journal": "Menopause",
+      "year": 2023,
+      "volume": "30",
+      "pages": "766-773",
+      "doi": "10.1097/GME.0000000000002196",
+      "publicationTypes": [
+        "Meta-Analysis",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37226859": {
+      "pmid": "37226859",
+      "title": "High-resolution genome mapping and functional dissection of chlorogenic acid production in Lonicera maackii",
+      "authors": "Li R et al.",
+      "authorCount": 20,
+      "journal": "Plant Physiol",
+      "year": 2023,
+      "volume": "192",
+      "pages": "2902-2922",
+      "doi": "10.1093/plphys/kiad295",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37234180": {
+      "pmid": "37234180",
+      "title": "A Comparative Analysis of Effectiveness of Recombinant Interleukin-11 Versus Papaya Leaf Extract for Treatment of Thrombocytopenia: A Review",
+      "authors": "Mishra KP et al.",
+      "authorCount": 5,
+      "journal": "Indian J Clin Biochem",
+      "year": 2023,
+      "volume": "38",
+      "pages": "297-304",
+      "doi": "10.1007/s12291-022-01097-x",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37257051": {
+      "pmid": "37257051",
+      "title": "Integration of molecular docking, molecular dynamics and network pharmacology to explore the multi-target pharmacology of fenugreek against diabetes",
+      "authors": "Luo W et al.",
+      "authorCount": 11,
+      "journal": "J Cell Mol Med",
+      "year": 2023,
+      "volume": "27",
+      "pages": "1959-1974",
+      "doi": "10.1111/jcmm.17787",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37267693": {
+      "pmid": "37267693",
+      "title": "Proteomics and transcriptomics explore the effect of mixture of herbal extract on diabetic wound healing process",
+      "authors": "Liu Y et al.",
+      "authorCount": 9,
+      "journal": "Phytomedicine",
+      "year": 2023,
+      "volume": "116",
+      "pages": "154892",
+      "doi": "10.1016/j.phymed.2023.154892",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37301302": {
+      "pmid": "37301302",
+      "title": "Commiphora mukul (Hook. ex Stocks) Engl.: Historical records, application rules, phytochemistry, pharmacology, clinical research, and adverse reaction",
+      "authors": "Garang Z et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2023,
+      "volume": "317",
+      "pages": "116717",
+      "doi": "10.1016/j.jep.2023.116717",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37313239": {
+      "pmid": "37313239",
+      "title": "Resmetirom: An Orally Administered, Smallmolecule, Liver-directed, β-selective THR Agonist for the Treatment of Non-alcoholic Fatty Liver Disease and Non-alcoholic Steatohepatitis",
+      "authors": "Karim G and Bansal MB",
+      "authorCount": 2,
+      "journal": "touchREV Endocrinol",
+      "year": 2023,
+      "volume": "19",
+      "pages": "60-70",
+      "doi": "10.17925/EE.2023.19.1.60",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37313777": {
+      "pmid": "37313777",
+      "title": "Genome-wide high-throughput chromosome conformation capture analysis reveals hierarchical chromatin interactions during early somatic embryogenesis",
+      "authors": "Chen Y et al.",
+      "authorCount": 14,
+      "journal": "Plant Physiol",
+      "year": 2023,
+      "volume": "193",
+      "pages": "555-577",
+      "doi": "10.1093/plphys/kiad348",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37314054": {
+      "pmid": "37314054",
+      "title": "Update on the treatment of chemotherapy and radiotherapy-induced buccal mucositis: a systematic review",
+      "authors": "Wen S et al.",
+      "authorCount": 4,
+      "journal": "Acta Odontol Latinoam",
+      "year": 2023,
+      "volume": "36",
+      "pages": "3-14",
+      "doi": "10.54589/aol.36/1/3",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37325288": {
+      "pmid": "37325288",
+      "title": "Scalp Seborrheic Dermatitis: What We Know So Far",
+      "authors": "Leroy AK et al.",
+      "authorCount": 5,
+      "journal": "Skin Appendage Disord",
+      "year": 2023,
+      "volume": "9",
+      "pages": "160-164",
+      "doi": "10.1159/000529854",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37337697": {
+      "pmid": "37337697",
+      "title": "Antiproliferative assay of suma or Brazilian ginseng (Hebanthe eriantha) methanolic extract on HCT116 and 4T1 cancer cell lines, in vitro toxicity on Artemia salina larvae, and antibacterial activity",
+      "authors": "Rahamouz-Haghighi S and Sharafi A",
+      "authorCount": 2,
+      "journal": "Nat Prod Res",
+      "year": 2024,
+      "volume": "38",
+      "pages": "1850-1854",
+      "doi": "10.1080/14786419.2023.2225688",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37373268": {
+      "pmid": "37373268",
+      "title": "Anti-Cancer Potential of Edible/Medicinal Mushrooms in Breast Cancer",
+      "authors": "Gariboldi MB et al.",
+      "authorCount": 7,
+      "journal": "Int J Mol Sci",
+      "year": 2023,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/ijms241210120",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37376614": {
+      "pmid": "37376614",
+      "title": "A Narrative Review of Alternative Symptomatic Treatments for Herpes Simplex Virus",
+      "authors": "Chang JY et al.",
+      "authorCount": 4,
+      "journal": "Viruses",
+      "year": 2023,
+      "volume": "15",
+      "pages": "",
+      "doi": "10.3390/v15061314",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37383807": {
+      "pmid": "37383807",
+      "title": "Bangladeshi medicinal plant dataset",
+      "authors": "Borkatulla B et al.",
+      "authorCount": 4,
+      "journal": "Data Brief",
+      "year": 2023,
+      "volume": "48",
+      "pages": "109211",
+      "doi": "10.1016/j.dib.2023.109211",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37385964": {
+      "pmid": "37385964",
+      "title": "Pharmacological Effects of Ginseng: Multiple Constituents and Multiple Actions on Humans",
+      "authors": "Zhou G et al.",
+      "authorCount": 6,
+      "journal": "Am J Chin Med",
+      "year": 2023,
+      "volume": "51",
+      "pages": "1085-1104",
+      "doi": "10.1142/S0192415X23500507",
+      "publicationTypes": [
+        "Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37390875": {
+      "pmid": "37390875",
+      "title": "A comprehensive review on Saraca asoca (Fabaceae) - Historical perspective, traditional uses, biological activities, and conservation",
+      "authors": "Urumarudappa SKJ et al.",
+      "authorCount": 4,
+      "journal": "J Ethnopharmacol",
+      "year": 2023,
+      "volume": "317",
+      "pages": "116861",
+      "doi": "10.1016/j.jep.2023.116861",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37405785": {
+      "pmid": "37405785",
+      "title": "Effect of Fucoxanthin on Metabolic Syndrome, Insulin Sensitivity, and Insulin Secretion",
+      "authors": "López-Ramos A et al.",
+      "authorCount": 4,
+      "journal": "J Med Food",
+      "year": 2023,
+      "volume": "26",
+      "pages": "521-527",
+      "doi": "10.1089/jmf.2022.0103",
+      "publicationTypes": [
+        "Randomized Controlled Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37446683": {
+      "pmid": "37446683",
+      "title": "Dandelion (Taraxacum Genus): A Review of Chemical Constituents and Pharmacological Effects",
+      "authors": "Fan M et al.",
+      "authorCount": 4,
+      "journal": "Molecules",
+      "year": 2023,
+      "volume": "28",
+      "pages": "",
+      "doi": "10.3390/molecules28135022",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37457186": {
+      "pmid": "37457186",
+      "title": "Nutritional, biochemical, and clinical applications of carob: A review",
+      "authors": "Ikram A et al.",
+      "authorCount": 10,
+      "journal": "Food Sci Nutr",
+      "year": 2023,
+      "volume": "11",
+      "pages": "3641-3654",
+      "doi": "10.1002/fsn3.3367",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37493973": {
+      "pmid": "37493973",
+      "title": "Peppers and their constituents against obesity",
+      "authors": "Sirotkin AV",
+      "authorCount": 1,
+      "journal": "Biol Futur",
+      "year": 2023,
+      "volume": "74",
+      "pages": "247-252",
+      "doi": "10.1007/s42977-023-00174-3",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37513187": {
+      "pmid": "37513187",
+      "title": "Coriandrum sativum and Its Utility in Psychiatric Disorders",
+      "authors": "Santibáñez A et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2023,
+      "volume": "28",
+      "pages": "",
+      "doi": "10.3390/molecules28145314",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37513265": {
+      "pmid": "37513265",
+      "title": "Medicinal Mushrooms: Their Bioactive Components, Nutritional Value and Application in Functional Food Production-A Review",
+      "authors": "Łysakowska P et al.",
+      "authorCount": 3,
+      "journal": "Molecules",
+      "year": 2023,
+      "volume": "28",
+      "pages": "",
+      "doi": "10.3390/molecules28145393",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37570851": {
+      "pmid": "37570851",
+      "title": "The Role and Mechanism of Perilla frutescens in Cancer Treatment",
+      "authors": "Huang S et al.",
+      "authorCount": 9,
+      "journal": "Molecules",
+      "year": 2023,
+      "volume": "28",
+      "pages": "",
+      "doi": "10.3390/molecules28155883",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37579922": {
+      "pmid": "37579922",
+      "title": "Rehmannia glutinosa Libosch and Cornus officinalis Sieb herb couple ameliorates renal interstitial fibrosis in CKD rats by inhibiting the TGF-β1/MAPK signaling pathway",
+      "authors": "Zhu JH et al.",
+      "authorCount": 5,
+      "journal": "J Ethnopharmacol",
+      "year": 2024,
+      "volume": "318",
+      "pages": "117039",
+      "doi": "10.1016/j.jep.2023.117039",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37610136": {
+      "pmid": "37610136",
+      "title": "Two new guaiane-type sesquiterpenes from Curcuma wenyujin",
+      "authors": "Jiang XJ et al.",
+      "authorCount": 7,
+      "journal": "J Asian Nat Prod Res",
+      "year": 2024,
+      "volume": "26",
+      "pages": "482-488",
+      "doi": "10.1080/10286020.2023.2249833",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37631007": {
+      "pmid": "37631007",
+      "title": "Antimicrobial and Other Biomedical Properties of Extracts from Plantago major, Plantaginaceae",
+      "authors": "Zhakipbekov K et al.",
+      "authorCount": 15,
+      "journal": "Pharmaceuticals (Basel)",
+      "year": 2023,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/ph16081092",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37673017": {
+      "pmid": "37673017",
+      "title": "Alkaloids in commercial preparations of California poppy - Quantification, intestinal permeability and microbiota interactions",
+      "authors": "Chauveau A et al.",
+      "authorCount": 7,
+      "journal": "Biomed Pharmacother",
+      "year": 2023,
+      "volume": "166",
+      "pages": "115420",
+      "doi": "10.1016/j.biopha.2023.115420",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37682792": {
+      "pmid": "37682792",
+      "title": "Safety and efficacy of zanubrutinib in relapsed/refractory marginal zone lymphoma: final analysis of the MAGNOLIA study",
+      "authors": "Opat S et al.",
+      "authorCount": 26,
+      "journal": "Blood Adv",
+      "year": 2023,
+      "volume": "7",
+      "pages": "6801-6811",
+      "doi": "10.1182/bloodadvances.2023010668",
+      "publicationTypes": [
+        "Clinical Trial, Phase II",
+        "Journal Article",
+        "Multicenter Study",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37701635": {
+      "pmid": "37701635",
+      "title": "A comprehensive review on genomic resources in medicinally and industrially important major spices for future breeding programs: Status, utility and challenges",
+      "authors": "Das P et al.",
+      "authorCount": 7,
+      "journal": "Curr Res Food Sci",
+      "year": 2023,
+      "volume": "7",
+      "pages": "100579",
+      "doi": "10.1016/j.crfs.2023.100579",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37701897": {
+      "pmid": "37701897",
+      "title": "Oxidative stress, hormones, and effects of natural antioxidants on intestinal inflammation in inflammatory bowel disease",
+      "authors": "Sahoo DK et al.",
+      "authorCount": 7,
+      "journal": "Front Endocrinol (Lausanne)",
+      "year": 2023,
+      "volume": "14",
+      "pages": "1217165",
+      "doi": "10.3389/fendo.2023.1217165",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37716049": {
+      "pmid": "37716049",
+      "title": "Recent chemical synthesis of plant polysaccharides",
+      "authors": "Wang X and Xiao G",
+      "authorCount": 2,
+      "journal": "Curr Opin Chem Biol",
+      "year": 2023,
+      "volume": "77",
+      "pages": "102387",
+      "doi": "10.1016/j.cbpa.2023.102387",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37748009": {
+      "pmid": "37748009",
+      "title": "Pomegranate",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2023,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37749449": {
+      "pmid": "37749449",
+      "title": "Review on pharmacological effects of gastrodin",
+      "authors": "Xiao G et al.",
+      "authorCount": 4,
+      "journal": "Arch Pharm Res",
+      "year": 2023,
+      "volume": "46",
+      "pages": "744-770",
+      "doi": "10.1007/s12272-023-01463-0",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37788785": {
+      "pmid": "37788785",
+      "title": "Fuling-Zexie formula attenuates hyperuricemia-induced nephropathy and inhibits JAK2/STAT3 signaling and NLRP3 inflammasome activation in mice",
+      "authors": "Lu M et al.",
+      "authorCount": 16,
+      "journal": "J Ethnopharmacol",
+      "year": 2024,
+      "volume": "319",
+      "pages": "117262",
+      "doi": "10.1016/j.jep.2023.117262",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37814683": {
+      "pmid": "37814683",
+      "title": "Antimicrobial and anti-inflammatory activity of Terminalia arjuna",
+      "authors": "R V et al.",
+      "authorCount": 4,
+      "journal": "Bioinformation",
+      "year": 2023,
+      "volume": "19",
+      "pages": "184-189",
+      "doi": "10.6026/97320630019184",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37818728": {
+      "pmid": "37818728",
+      "title": "The effect of cinnamon supplementation on glycemic control in patients with type 2 diabetes mellitus: An updated systematic review and dose-response meta-analysis of randomized controlled trials",
+      "authors": "Moridpour AH et al.",
+      "authorCount": 7,
+      "journal": "Phytother Res",
+      "year": 2024,
+      "volume": "38",
+      "pages": "117-130",
+      "doi": "10.1002/ptr.8026",
+      "publicationTypes": [
+        "Systematic Review",
+        "Meta-Analysis",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37821383": {
+      "pmid": "37821383",
+      "title": "Efficacy of Andrographis paniculata spray in acute pharyngitis: A randomized controlled trial",
+      "authors": "Okonogi R et al.",
+      "authorCount": 3,
+      "journal": "Drug Discov Ther",
+      "year": 2023,
+      "volume": "17",
+      "pages": "340-345",
+      "doi": "10.5582/ddt.2023.01053",
+      "publicationTypes": [
+        "Randomized Controlled Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37864351": {
+      "pmid": "37864351",
+      "title": "The Effects of Crocus sativus (Saffron) on ADHD: A Systematic Review",
+      "authors": "Seyedi-Sahebari S et al.",
+      "authorCount": 7,
+      "journal": "J Atten Disord",
+      "year": 2024,
+      "volume": "28",
+      "pages": "14-24",
+      "doi": "10.1177/10870547231203176",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37895122": {
+      "pmid": "37895122",
+      "title": "Plant Extracts as Skin Care and Therapeutic Agents",
+      "authors": "Michalak M",
+      "authorCount": 1,
+      "journal": "Int J Mol Sci",
+      "year": 2023,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/ijms242015444",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37901360": {
+      "pmid": "37901360",
+      "title": "Identifying the Potential of miRNAs in Houttuynia cordata-Derived Exosome-Like Nanoparticles Against Respiratory RNA Viruses",
+      "authors": "Zhu H et al.",
+      "authorCount": 6,
+      "journal": "Int J Nanomedicine",
+      "year": 2023,
+      "volume": "18",
+      "pages": "5983-6000",
+      "doi": "10.2147/IJN.S425173",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37907043": {
+      "pmid": "37907043",
+      "title": "Progress of research into the pharmacological effect and clinical application of the traditional Chinese medicine Rehmanniae Radix",
+      "authors": "Jia J et al.",
+      "authorCount": 6,
+      "journal": "Biomed Pharmacother",
+      "year": 2023,
+      "volume": "168",
+      "pages": "115809",
+      "doi": "10.1016/j.biopha.2023.115809",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37915246": {
+      "pmid": "37915246",
+      "title": "Aloe Barbadensis Miller (Aloe Vera)",
+      "authors": "Kaur S and Bains K",
+      "authorCount": 2,
+      "journal": "Int J Vitam Nutr Res",
+      "year": 2024,
+      "volume": "94",
+      "pages": "308-321",
+      "doi": "10.1024/0300-9831/a000797",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37937578": {
+      "pmid": "37937578",
+      "title": "A Comprehensive Review on Phytochemistry and Pharmacology of Rosa Species (Rosaceae)",
+      "authors": "Fayaz F et al.",
+      "authorCount": 5,
+      "journal": "Curr Top Med Chem",
+      "year": 2024,
+      "volume": "24",
+      "pages": "364-378",
+      "doi": "10.2174/0115680266274385231023075011",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37946257": {
+      "pmid": "37946257",
+      "title": "Panax notoginseng: derived exosome-like nanoparticles attenuate ischemia reperfusion injury via altering microglia polarization",
+      "authors": "Li S et al.",
+      "authorCount": 11,
+      "journal": "J Nanobiotechnology",
+      "year": 2023,
+      "volume": "21",
+      "pages": "416",
+      "doi": "10.1186/s12951-023-02161-1",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37958943": {
+      "pmid": "37958943",
+      "title": "Neurotrophic and Neuroprotective Effects of Hericium erinaceus",
+      "authors": "Szućko-Kociuba I et al.",
+      "authorCount": 4,
+      "journal": "Int J Mol Sci",
+      "year": 2023,
+      "volume": "24",
+      "pages": "",
+      "doi": "10.3390/ijms242115960",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38002180": {
+      "pmid": "38002180",
+      "title": "Polyphenols in Agricultural Grassland Crops and Their Health-Promoting Activities-A Review",
+      "authors": "Verhulst EP et al.",
+      "authorCount": 3,
+      "journal": "Foods",
+      "year": 2023,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/foods12224122",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38010396": {
+      "pmid": "38010396",
+      "title": "Therapeutic potential of Lawsonia inermis Linn: a comprehensive overview",
+      "authors": "Batiha GE et al.",
+      "authorCount": 9,
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "year": 2024,
+      "volume": "397",
+      "pages": "3525-3540",
+      "doi": "10.1007/s00210-023-02735-8",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38039759": {
+      "pmid": "38039759",
+      "title": "Cryptotanshinone suppresses ovarian cancer via simultaneous inhibition of glycolysis and oxidative phosphorylation",
+      "authors": "Wang T et al.",
+      "authorCount": 7,
+      "journal": "Biomed Pharmacother",
+      "year": 2024,
+      "volume": "170",
+      "pages": "115956",
+      "doi": "10.1016/j.biopha.2023.115956",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38042505": {
+      "pmid": "38042505",
+      "title": "Nardostachys jatamansi: Phytochemistry, ethnomedicinal uses, and pharmacological activities: A comprehensive review",
+      "authors": "Pathak S and Godela R",
+      "authorCount": 2,
+      "journal": "Fitoterapia",
+      "year": 2024,
+      "volume": "172",
+      "pages": "105764",
+      "doi": "10.1016/j.fitote.2023.105764",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38068631": {
+      "pmid": "38068631",
+      "title": "Latin American Plants against Microorganisms",
+      "authors": "Cuevas-Cianca SI et al.",
+      "authorCount": 6,
+      "journal": "Plants (Basel)",
+      "year": 2023,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/plants12233997",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38068651": {
+      "pmid": "38068651",
+      "title": "Unraveling the Potential of Organic Oregano and Tarragon Essential Oils: Profiling Composition, FT-IR and Bioactivities",
+      "authors": "Vârban D et al.",
+      "authorCount": 14,
+      "journal": "Plants (Basel)",
+      "year": 2023,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/plants12234017",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38068725": {
+      "pmid": "38068725",
+      "title": "A Scoping Review of the Clinical Evidence for the Health Benefits of Culinary Doses of Herbs and Spices for the Prevention and Treatment of Metabolic Syndrome",
+      "authors": "Mackonochie M et al.",
+      "authorCount": 4,
+      "journal": "Nutrients",
+      "year": 2023,
+      "volume": "15",
+      "pages": "",
+      "doi": "10.3390/nu15234867",
+      "publicationTypes": [
+        "Journal Article",
+        "Scoping Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38111697": {
+      "pmid": "38111697",
+      "title": "Cornus officinalis: a potential herb for treatment of osteoporosis",
+      "authors": "Tang X et al.",
+      "authorCount": 7,
+      "journal": "Front Med (Lausanne)",
+      "year": 2023,
+      "volume": "10",
+      "pages": "1289144",
+      "doi": "10.3389/fmed.2023.1289144",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38116085": {
+      "pmid": "38116085",
+      "title": "Chaga mushroom: a super-fungus with countless facets and untapped potential",
+      "authors": "Fordjour E et al.",
+      "authorCount": 7,
+      "journal": "Front Pharmacol",
+      "year": 2023,
+      "volume": "14",
+      "pages": "1273786",
+      "doi": "10.3389/fphar.2023.1273786",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38140277": {
+      "pmid": "38140277",
+      "title": "Acute Effects of Naturally Occurring Guayusa Tea and Nordic Lion's Mane Extracts on Cognitive Performance",
+      "authors": "La Monica MB et al.",
+      "authorCount": 8,
+      "journal": "Nutrients",
+      "year": 2023,
+      "volume": "15",
+      "pages": "",
+      "doi": "10.3390/nu15245018",
+      "publicationTypes": [
+        "Randomized Controlled Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38148708": {
+      "pmid": "38148708",
+      "title": "Current stage of preclinical and clinical development of guggulsterone in cancers: Challenges and promises",
+      "authors": "Ijaz S et al.",
+      "authorCount": 15,
+      "journal": "Cell Biol Int",
+      "year": 2024,
+      "volume": "48",
+      "pages": "128-142",
+      "doi": "10.1002/cbin.12112",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38149060": {
+      "pmid": "38149060",
+      "title": "Mechanistic engineering of celastrol liposomes induces ferroptosis and apoptosis by directly targeting VDAC2 in hepatocellular carcinoma",
+      "authors": "Luo P et al.",
+      "authorCount": 17,
+      "journal": "Asian J Pharm Sci",
+      "year": 2023,
+      "volume": "18",
+      "pages": "100874",
+      "doi": "10.1016/j.ajps.2023.100874",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38158101": {
+      "pmid": "38158101",
+      "title": "Piperine promotes PI3K/AKT/mTOR-mediated gut-brain autophagy to degrade α-Synuclein in Parkinson's disease rats",
+      "authors": "Yu L et al.",
+      "authorCount": 13,
+      "journal": "J Ethnopharmacol",
+      "year": 2024,
+      "volume": "322",
+      "pages": "117628",
+      "doi": "10.1016/j.jep.2023.117628",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38165423": {
+      "pmid": "38165423",
+      "title": "Gastrodin: a comprehensive pharmacological review",
+      "authors": "Wang Y et al.",
+      "authorCount": 9,
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "year": 2024,
+      "volume": "397",
+      "pages": "3781-3802",
+      "doi": "10.1007/s00210-023-02920-9",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38170849": {
+      "pmid": "38170849",
+      "title": "Medicine for chronic atrophic gastritis: a systematic review, meta- and network pharmacology analysis",
+      "authors": "Weng J et al.",
+      "authorCount": 5,
+      "journal": "Ann Med",
+      "year": 2023,
+      "volume": "55",
+      "pages": "2299352",
+      "doi": "10.1080/07853890.2023.2299352",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Network Meta-Analysis"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38174012": {
+      "pmid": "38174012",
+      "title": "Complementary and alternative supplements: a review of dermatologic effectiveness for androgenetic alopecia",
+      "authors": "Ufomadu P",
+      "authorCount": 1,
+      "journal": "Proc (Bayl Univ Med Cent)",
+      "year": 2023,
+      "volume": "37",
+      "pages": "111-117",
+      "doi": "10.1080/08998280.2023.2263829",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38232876": {
+      "pmid": "38232876",
+      "title": "Purification and structural characterization of two polysaccharides with anti-inflammatory activities from Plumbago zeylanica L",
+      "authors": "Zhang X et al.",
+      "authorCount": 7,
+      "journal": "Int J Biol Macromol",
+      "year": 2024,
+      "volume": "260",
+      "pages": "129455",
+      "doi": "10.1016/j.ijbiomac.2024.129455",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38254493": {
+      "pmid": "38254493",
+      "title": "A Literature Review of the Pharmacological Effects of Jujube",
+      "authors": "Zhu D et al.",
+      "authorCount": 5,
+      "journal": "Foods",
+      "year": 2024,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/foods13020193",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38256329": {
+      "pmid": "38256329",
+      "title": "Nutritional Supplements for Skin Health-A Review of What Should Be Chosen and Why",
+      "authors": "Januszewski J et al.",
+      "authorCount": 9,
+      "journal": "Medicina (Kaunas)",
+      "year": 2023,
+      "volume": "60",
+      "pages": "",
+      "doi": "10.3390/medicina60010068",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38257301": {
+      "pmid": "38257301",
+      "title": "Antimicrobial and Other Pharmacological Properties of Ocimum basilicum, Lamiaceae",
+      "authors": "Zhakipbekov K et al.",
+      "authorCount": 14,
+      "journal": "Molecules",
+      "year": 2024,
+      "volume": "29",
+      "pages": "",
+      "doi": "10.3390/molecules29020388",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38285776": {
+      "pmid": "38285776",
+      "title": "The Apoptotic Property of Nymphaea Caerulea Flower Extract on Acute Myeloid Leukaemia Cell Line, THP-1",
+      "authors": "Chatterjee D et al.",
+      "authorCount": 4,
+      "journal": "Asian Pac J Cancer Prev",
+      "year": 2024,
+      "volume": "25",
+      "pages": "123-137",
+      "doi": "10.31557/APJCP.2024.25.1.123",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38289992": {
+      "pmid": "38289992",
+      "title": "Lion’s Mane",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38290997": {
+      "pmid": "38290997",
+      "title": "Phytotherapy in periodontics as an effective and sustainable supplemental treatment: a narrative review",
+      "authors": "Gawish AS et al.",
+      "authorCount": 6,
+      "journal": "J Periodontal Implant Sci",
+      "year": 2024,
+      "volume": "54",
+      "pages": "209-223",
+      "doi": "10.5051/jpis.2301420071",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38301993": {
+      "pmid": "38301993",
+      "title": "The double-edged sword effect of indigo naturalis",
+      "authors": "Xu Y et al.",
+      "authorCount": 4,
+      "journal": "Food Chem Toxicol",
+      "year": 2024,
+      "volume": "185",
+      "pages": "114476",
+      "doi": "10.1016/j.fct.2024.114476",
+      "publicationTypes": [
+        "Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38318825": {
+      "pmid": "38318825",
+      "title": "Valeriana jatamansi: Bioactive Compounds and their Medicinal Uses",
+      "authors": "Maurya AK and Agnihotri VK",
+      "authorCount": 2,
+      "journal": "Curr Top Med Chem",
+      "year": 2024,
+      "volume": "24",
+      "pages": "757-796",
+      "doi": "10.2174/0115680266273617240129042653",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38319742": {
+      "pmid": "38319742",
+      "title": "MYB transcription factors encoded by diversified tandem gene clusters cause varied Morella rubra fruit color",
+      "authors": "Xue L et al.",
+      "authorCount": 11,
+      "journal": "Plant Physiol",
+      "year": 2024,
+      "volume": "195",
+      "pages": "598-616",
+      "doi": "10.1093/plphys/kiae063",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38326604": {
+      "pmid": "38326604",
+      "title": "Salacia spp.: recent insights on biotechnological interventions and future perspectives",
+      "authors": "Chavan J et al.",
+      "authorCount": 15,
+      "journal": "Appl Microbiol Biotechnol",
+      "year": 2024,
+      "volume": "108",
+      "pages": "200",
+      "doi": "10.1007/s00253-023-12998-z",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38328737": {
+      "pmid": "38328737",
+      "title": "Oral sub-chronic toxicity of fingerroot (Boesenbergia rotunda) rhizome extract formulation in Wistar rats",
+      "authors": "Techapichetvanich P et al.",
+      "authorCount": 6,
+      "journal": "Toxicol Rep",
+      "year": 2024,
+      "volume": "12",
+      "pages": "224-233",
+      "doi": "10.1016/j.toxrep.2024.01.013",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38338400": {
+      "pmid": "38338400",
+      "title": "The Extraction, Determination, and Bioactivity of Curcumenol: A Comprehensive Review",
+      "authors": "Li J et al.",
+      "authorCount": 6,
+      "journal": "Molecules",
+      "year": 2024,
+      "volume": "29",
+      "pages": "",
+      "doi": "10.3390/molecules29030656",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38358164": {
+      "pmid": "38358164",
+      "title": "Alternative first-line malaria treatment",
+      "authors": "Maafoh C and Onyedibe K",
+      "authorCount": 2,
+      "journal": "Ann Afr Med",
+      "year": 2024,
+      "volume": "23",
+      "pages": "5-12",
+      "doi": "10.4103/aam.aam_35_23",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38381605": {
+      "pmid": "38381605",
+      "title": "The genome of Stephania japonica provides insights into the biosynthesis of cepharanthine",
+      "authors": "Liu Z et al.",
+      "authorCount": 13,
+      "journal": "Cell Rep",
+      "year": 2024,
+      "volume": "43",
+      "pages": "113832",
+      "doi": "10.1016/j.celrep.2024.113832",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38396766": {
+      "pmid": "38396766",
+      "title": "Acerola (Malpighia emarginata) Anti-Inflammatory Activity-A Review",
+      "authors": "Olędzki R and Harasym J",
+      "authorCount": 2,
+      "journal": "Int J Mol Sci",
+      "year": 2024,
+      "volume": "25",
+      "pages": "",
+      "doi": "10.3390/ijms25042089",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38398854": {
+      "pmid": "38398854",
+      "title": "Not All Maca Is Created Equal: A Review of Colors, Nutrition, Phytochemicals, and Clinical Uses",
+      "authors": "Minich DM et al.",
+      "authorCount": 6,
+      "journal": "Nutrients",
+      "year": 2024,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/nu16040530",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38432993": {
+      "pmid": "38432993",
+      "title": "The Potential of Roselle (Hibiscus sabdariffa) Plant in Industrial Applications: A Promising Source of Functional Compounds",
+      "authors": "Chew LY et al.",
+      "authorCount": 5,
+      "journal": "J Oleo Sci",
+      "year": 2024,
+      "volume": "73",
+      "pages": "275-292",
+      "doi": "10.5650/jos.ess23111",
+      "publicationTypes": [
+        "Review",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38433659": {
+      "pmid": "38433659",
+      "title": "Sweet basil (Ocimum basilicum) leaf and seed extracts alleviate neuronal dysfunction in aluminum chloride-induced neurotoxicity in Drosophila melanogaster Meigen model",
+      "authors": "Oyeniran OH et al.",
+      "authorCount": 4,
+      "journal": "Drug Chem Toxicol",
+      "year": 2024,
+      "volume": "47",
+      "pages": "949-959",
+      "doi": "10.1080/01480545.2024.2317828",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38435393": {
+      "pmid": "38435393",
+      "title": "Essential oils: a systematic review on revolutionizing health, nutrition, and omics for optimal well-being",
+      "authors": "Pezantes-Orellana C et al.",
+      "authorCount": 5,
+      "journal": "Front Med (Lausanne)",
+      "year": 2024,
+      "volume": "11",
+      "pages": "1337785",
+      "doi": "10.3389/fmed.2024.1337785",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38440178": {
+      "pmid": "38440178",
+      "title": "Exploring the chemical and pharmacological variability of Lepidium meyenii: a comprehensive review of the effects of maca",
+      "authors": "Ulloa Del Carpio N et al.",
+      "authorCount": 8,
+      "journal": "Front Pharmacol",
+      "year": 2024,
+      "volume": "15",
+      "pages": "1360422",
+      "doi": "10.3389/fphar.2024.1360422",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38465436": {
+      "pmid": "38465436",
+      "title": "Safety Issues of Herb-Warfarin Interactions",
+      "authors": "Hazra S et al.",
+      "authorCount": 3,
+      "journal": "Curr Drug Metab",
+      "year": 2024,
+      "volume": "25",
+      "pages": "13-27",
+      "doi": "10.2174/0113892002290846240228061506",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38471319": {
+      "pmid": "38471319",
+      "title": "Esculin inhibits hepatic stellate cell activation and CCl(4)-induced liver fibrosis by activating the Nrf2/GPX4 signaling pathway",
+      "authors": "Xu S et al.",
+      "authorCount": 9,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "128",
+      "pages": "155465",
+      "doi": "10.1016/j.phymed.2024.155465",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38490155": {
+      "pmid": "38490155",
+      "title": "Cynaroside improved depressive-like behavior in CUMS mice by suppressing microglial inflammation and ferroptosis",
+      "authors": "Zhou Y et al.",
+      "authorCount": 5,
+      "journal": "Biomed Pharmacother",
+      "year": 2024,
+      "volume": "173",
+      "pages": "116425",
+      "doi": "10.1016/j.biopha.2024.116425",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38495279": {
+      "pmid": "38495279",
+      "title": "Insights into skullcap herb-induced liver injury",
+      "authors": "Soldera J",
+      "authorCount": 1,
+      "journal": "World J Hepatol",
+      "year": 2024,
+      "volume": "16",
+      "pages": "120-122",
+      "doi": "10.4254/wjh.v16.i2.120",
+      "publicationTypes": [
+        "Editorial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38518640": {
+      "pmid": "38518640",
+      "title": "Aqueous extract of fermented Eucommia ulmoides leaves alleviates hyperlipidemia by maintaining gut homeostasis and modulating metabolism in high-fat diet fed rats",
+      "authors": "Duan Y et al.",
+      "authorCount": 12,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "128",
+      "pages": "155291",
+      "doi": "10.1016/j.phymed.2023.155291",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38539824": {
+      "pmid": "38539824",
+      "title": "Dietary Puerarin Supplementation Improves Immune Response and Antioxidant Capacity of Sows",
+      "authors": "Cao S et al.",
+      "authorCount": 5,
+      "journal": "Antioxidants (Basel)",
+      "year": 2024,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/antiox13030290",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38542782": {
+      "pmid": "38542782",
+      "title": "Functional and Therapeutic Potential of Cynara scolymus in Health Benefits",
+      "authors": "Porro C et al.",
+      "authorCount": 7,
+      "journal": "Nutrients",
+      "year": 2024,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/nu16060872",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38551844": {
+      "pmid": "38551844",
+      "title": "Corynoline Suppresses Osteoclastogenesis and Attenuates ROS Activities by Regulating NF-κB/MAPKs and Nrf2 Signaling Pathways",
+      "authors": "Jin C et al.",
+      "authorCount": 14,
+      "journal": "J Agric Food Chem",
+      "year": 2024,
+      "volume": "72",
+      "pages": "8149-8166",
+      "doi": "10.1021/acs.jafc.3c07088",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38552431": {
+      "pmid": "38552431",
+      "title": "Gastrodin regulates the TLR4/TRAF6/NF-κB pathway to reduce neuroinflammation and microglial activation in an AD model",
+      "authors": "Wang W et al.",
+      "authorCount": 9,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "128",
+      "pages": "155518",
+      "doi": "10.1016/j.phymed.2024.155518",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38558676": {
+      "pmid": "38558676",
+      "title": "Ayurvedic Herbal Medicines: A Literature Review of Their Applications in Female Reproductive Health",
+      "authors": "Patibandla S et al.",
+      "authorCount": 6,
+      "journal": "Cureus",
+      "year": 2024,
+      "volume": "16",
+      "pages": "e55240",
+      "doi": "10.7759/cureus.55240",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38561058": {
+      "pmid": "38561058",
+      "title": "Esculin induces endoplasmic reticulum stress and drives apoptosis and ferroptosis in colorectal cancer via PERK regulating eIF2α/CHOP and Nrf2/HO-1 cascades",
+      "authors": "Ji X et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2024,
+      "volume": "328",
+      "pages": "118139",
+      "doi": "10.1016/j.jep.2024.118139",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38561618": {
+      "pmid": "38561618",
+      "title": "The Effects of Curcumin Plus Piperine Co-administration on Inflammation and Oxidative Stress: A Systematic Review and Meta-analysis of Randomized Controlled Trials",
+      "authors": "Hosseini H et al.",
+      "authorCount": 6,
+      "journal": "Curr Med Chem",
+      "year": 2025,
+      "volume": "32",
+      "pages": "4078-4094",
+      "doi": "10.2174/0109298673260515240322074849",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review",
+        "Meta-Analysis"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38565924": {
+      "pmid": "38565924",
+      "title": "Rosemary and neem: an insight into their combined anti-dandruff and anti-hair loss efficacy",
+      "authors": "Hashem MM et al.",
+      "authorCount": 7,
+      "journal": "Sci Rep",
+      "year": 2024,
+      "volume": "14",
+      "pages": "7780",
+      "doi": "10.1038/s41598-024-57838-w",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38572469": {
+      "pmid": "38572469",
+      "title": "Geographic-Scale Coffee Cherry Counting with Smartphones and Deep Learning",
+      "authors": "Palacio JCR et al.",
+      "authorCount": 6,
+      "journal": "Plant Phenomics",
+      "year": 2024,
+      "volume": "6",
+      "pages": "0165",
+      "doi": "10.34133/plantphenomics.0165",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38604260": {
+      "pmid": "38604260",
+      "title": "Curcuma wenyujin rhizomes extract ameliorates lipid accumulation",
+      "authors": "Wang H et al.",
+      "authorCount": 6,
+      "journal": "Fitoterapia",
+      "year": 2024,
+      "volume": "175",
+      "pages": "105957",
+      "doi": "10.1016/j.fitote.2024.105957",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38616734": {
+      "pmid": "38616734",
+      "title": "Effects of Artemisia absinthium on broiler chicken coccidiosis: a systematic review and meta-analysis",
+      "authors": "Hezil N et al.",
+      "authorCount": 8,
+      "journal": "Avian Pathol",
+      "year": 2024,
+      "volume": "53",
+      "pages": "350-358",
+      "doi": "10.1080/03079457.2024.2342882",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38625264": {
+      "pmid": "38625264",
+      "title": "Myrtle: a versatile medicinal plant",
+      "authors": "Gorjian H and Khaligh NG",
+      "authorCount": 2,
+      "journal": "Nutrire",
+      "year": 2023,
+      "volume": "48",
+      "pages": "10",
+      "doi": "10.1186/s41110-023-00194-y",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38746009": {
+      "pmid": "38746009",
+      "title": "A review on the pharmacology, pharmacokinetics and toxicity of sophocarpine",
+      "authors": "Wei S et al.",
+      "authorCount": 5,
+      "journal": "Front Pharmacol",
+      "year": 2024,
+      "volume": "15",
+      "pages": "1353234",
+      "doi": "10.3389/fphar.2024.1353234",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38754041": {
+      "pmid": "38754041",
+      "title": "Management of Fatigue in Adult Survivors of Cancer: ASCO-Society for Integrative Oncology Guideline Update",
+      "authors": "Bower JE et al.",
+      "authorCount": 18,
+      "journal": "J Clin Oncol",
+      "year": 2024,
+      "volume": "42",
+      "pages": "2456-2487",
+      "doi": "10.1200/JCO.24.00541",
+      "publicationTypes": [
+        "Journal Article",
+        "Practice Guideline",
+        "Systematic Review",
+        "Research Support, N.I.H., Extramural",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38797379": {
+      "pmid": "38797379",
+      "title": "Beneficial effects of oxymatrine from Sophora flavescens on alleviating Ulcerative colitis by improving inflammation and ferroptosis",
+      "authors": "Gao BB et al.",
+      "authorCount": 9,
+      "journal": "J Ethnopharmacol",
+      "year": 2024,
+      "volume": "332",
+      "pages": "118385",
+      "doi": "10.1016/j.jep.2024.118385",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38813471": {
+      "pmid": "38813471",
+      "title": "Therapeutic properties of Inonotus obliquus (Chaga mushroom): A review",
+      "authors": "Ern PTY et al.",
+      "authorCount": 4,
+      "journal": "Mycology",
+      "year": 2023,
+      "volume": "15",
+      "pages": "144-161",
+      "doi": "10.1080/21501203.2023.2260408",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38831870": {
+      "pmid": "38831870",
+      "title": "Physicochemistry, Nutritional, and Therapeutic Potential of Ficus carica - A Promising Nutraceutical",
+      "authors": "Fazel MF et al.",
+      "authorCount": 12,
+      "journal": "Drug Des Devel Ther",
+      "year": 2024,
+      "volume": "18",
+      "pages": "1947-1968",
+      "doi": "10.2147/DDDT.S436446",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38876007": {
+      "pmid": "38876007",
+      "title": "Chemical composition, pharmacological effects, and parasitic mechanisms of Cistanche deserticola: An update",
+      "authors": "Zhang S et al.",
+      "authorCount": 9,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "132",
+      "pages": "155808",
+      "doi": "10.1016/j.phymed.2024.155808",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38892603": {
+      "pmid": "38892603",
+      "title": "Understanding the Impact of Different Doses of Reducose(®) Mulberry Leaf Extract on Blood Glucose and Insulin Responses after Eating a Complex Meal: Results from a Double-Blind, Randomised, Crossover Trial",
+      "authors": "Thondre PS et al.",
+      "authorCount": 7,
+      "journal": "Nutrients",
+      "year": 2024,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/nu16111670",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38903613": {
+      "pmid": "38903613",
+      "title": "A critical review of Ginger's (Zingiber officinale) antioxidant, anti-inflammatory, and immunomodulatory activities",
+      "authors": "Ayustaningwarno F et al.",
+      "authorCount": 4,
+      "journal": "Front Nutr",
+      "year": 2024,
+      "volume": "11",
+      "pages": "1364836",
+      "doi": "10.3389/fnut.2024.1364836",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38920890": {
+      "pmid": "38920890",
+      "title": "Evaluation of Ilex guayusa and Piper marginatum Extract Cytotoxicity on Human Dental Pulp Mesenchymal Stem Cells",
+      "authors": "Sequeda-Castañeda LG et al.",
+      "authorCount": 5,
+      "journal": "Dent J (Basel)",
+      "year": 2024,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/dj12060189",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38972239": {
+      "pmid": "38972239",
+      "title": "Polygala tenuifolia willd. Extract alleviates LPS-induced acute lung injury in rats via TLR4/NF-κB pathway and NLRP3 inflammasome suppression",
+      "authors": "Guo S et al.",
+      "authorCount": 14,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "132",
+      "pages": "155859",
+      "doi": "10.1016/j.phymed.2024.155859",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38990057": {
+      "pmid": "38990057",
+      "title": "Plumbagin ameliorates LPS-induced acute lung injury by regulating PI3K/AKT/mTOR and Keap1-Nrf2/HO-1 signalling pathways",
+      "authors": "Liu Z et al.",
+      "authorCount": 4,
+      "journal": "J Cell Mol Med",
+      "year": 2024,
+      "volume": "28",
+      "pages": "e18386",
+      "doi": "10.1111/jcmm.18386",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38998660": {
+      "pmid": "38998660",
+      "title": "Aloe vera-An Extensive Review Focused on Recent Studies",
+      "authors": "Catalano A et al.",
+      "authorCount": 9,
+      "journal": "Foods",
+      "year": 2024,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/foods13132155",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39000214": {
+      "pmid": "39000214",
+      "title": "Plantago major and Plantago lanceolata Exhibit Antioxidant and Borrelia burgdorferi Inhibiting Activities",
+      "authors": "Laanet PR et al.",
+      "authorCount": 4,
+      "journal": "Int J Mol Sci",
+      "year": 2024,
+      "volume": "25",
+      "pages": "",
+      "doi": "10.3390/ijms25137112",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39004032": {
+      "pmid": "39004032",
+      "title": "Elucidating the mechanisms of Buyang Huanwu Decoction in treating chronic cerebral ischemia: A combined approach using network pharmacology, molecular docking, and in vivo validation",
+      "authors": "Cao Y et al.",
+      "authorCount": 11,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "132",
+      "pages": "155820",
+      "doi": "10.1016/j.phymed.2024.155820",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39026367": {
+      "pmid": "39026367",
+      "title": "Adipose-derived stem cell exosomes loaded with icariin alleviates rheumatoid arthritis by modulating macrophage polarization in rats",
+      "authors": "Yan Q et al.",
+      "authorCount": 11,
+      "journal": "J Nanobiotechnology",
+      "year": 2024,
+      "volume": "22",
+      "pages": "423",
+      "doi": "10.1186/s12951-024-02711-1",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39064820": {
+      "pmid": "39064820",
+      "title": "Selaginella tamariscina Ethanol Extract Attenuates Influenza A Virus Infection by Inhibiting Hemagglutinin and Neuraminidase",
+      "authors": "Cho WK et al.",
+      "authorCount": 3,
+      "journal": "Nutrients",
+      "year": 2024,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/nu16142377",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39068762": {
+      "pmid": "39068762",
+      "title": "Berberine alleviates ulcerative colitis by inhibiting inflammation through targeting IRGM1",
+      "authors": "Meng G et al.",
+      "authorCount": 5,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "133",
+      "pages": "155909",
+      "doi": "10.1016/j.phymed.2024.155909",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39072200": {
+      "pmid": "39072200",
+      "title": "Ethnopharmacology, chemical composition and functions of Cymbopogon citratus",
+      "authors": "Du X et al.",
+      "authorCount": 6,
+      "journal": "Chin Herb Med",
+      "year": 2023,
+      "volume": "16",
+      "pages": "358-374",
+      "doi": "10.1016/j.chmed.2023.07.002",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39101149": {
+      "pmid": "39101149",
+      "title": "Ophiopogonin D: review of pharmacological activity",
+      "authors": "Chen KQ et al.",
+      "authorCount": 4,
+      "journal": "Front Pharmacol",
+      "year": 2024,
+      "volume": "15",
+      "pages": "1401627",
+      "doi": "10.3389/fphar.2024.1401627",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39170416": {
+      "pmid": "39170416",
+      "title": "Mangosteen extract reduces the bacterial load of eggshell and improves egg quality",
+      "authors": "Zhu J et al.",
+      "authorCount": 7,
+      "journal": "Heliyon",
+      "year": 2024,
+      "volume": "10",
+      "pages": "e35857",
+      "doi": "10.1016/j.heliyon.2024.e35857",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39171117": {
+      "pmid": "39171117",
+      "title": "Soursop leaf extract and fractions protects against L-NAME-induced hypertension and hyperlipidemia",
+      "authors": "Nsor OO et al.",
+      "authorCount": 6,
+      "journal": "Front Nutr",
+      "year": 2024,
+      "volume": "11",
+      "pages": "1437101",
+      "doi": "10.3389/fnut.2024.1437101",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39180449": {
+      "pmid": "39180449",
+      "title": "Ligusticum chuanxiong Hort.: a review of its phytochemistry, pharmacology, and toxicology",
+      "authors": "Kong Q et al.",
+      "authorCount": 10,
+      "journal": "J Pharm Pharmacol",
+      "year": 2024,
+      "volume": "76",
+      "pages": "1404-1430",
+      "doi": "10.1093/jpp/rgae105",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39186724": {
+      "pmid": "39186724",
+      "title": "Exploration of the potential mechanism of aqueous extract of Artemisia capillaris for the treatment of non-alcoholic fatty liver disease based on network pharmacology and experimental verification",
+      "authors": "Liang M et al.",
+      "authorCount": 8,
+      "journal": "J Pharm Pharmacol",
+      "year": 2024,
+      "volume": "76",
+      "pages": "1328-1339",
+      "doi": "10.1093/jpp/rgae061",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39202761": {
+      "pmid": "39202761",
+      "title": "New Insights Concerning Phytophotodermatitis Induced by Phototoxic Plants",
+      "authors": "Grosu Dumitrescu C et al.",
+      "authorCount": 9,
+      "journal": "Life (Basel)",
+      "year": 2024,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/life14081019",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39202965": {
+      "pmid": "39202965",
+      "title": "Artemisinin and Its Derivatives as Potential Anticancer Agents",
+      "authors": "Wen L et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2024,
+      "volume": "29",
+      "pages": "",
+      "doi": "10.3390/molecules29163886",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39215362": {
+      "pmid": "39215362",
+      "title": "Astragali radix (Huangqi): a time-honored nourishing herbal medicine",
+      "authors": "Zhang Y et al.",
+      "authorCount": 16,
+      "journal": "Chin Med",
+      "year": 2024,
+      "volume": "19",
+      "pages": "119",
+      "doi": "10.1186/s13020-024-00977-z",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39227108": {
+      "pmid": "39227108",
+      "title": "Composite microneedles loaded with Astragalus membranaceus polysaccharide nanoparticles promote wound healing by curbing the ROS/NF-κB pathway to regulate macrophage polarization",
+      "authors": "Liu X et al.",
+      "authorCount": 13,
+      "journal": "Carbohydr Polym",
+      "year": 2024,
+      "volume": "345",
+      "pages": "122574",
+      "doi": "10.1016/j.carbpol.2024.122574",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39253925": {
+      "pmid": "39253925",
+      "title": "Murraya koenigii (L.) Spreng. as a Natural Intervention for Diabesity: A Review",
+      "authors": "Jachak SM et al.",
+      "authorCount": 4,
+      "journal": "Curr Pharm Des",
+      "year": 2024,
+      "volume": "30",
+      "pages": "3255-3275",
+      "doi": "10.2174/0113816128304471240801183021",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39258186": {
+      "pmid": "39258186",
+      "title": "Amentoflavone from Selaginella tamariscina inhibits SARS-CoV-2 RNA-dependent RNA polymerase",
+      "authors": "Youn KW et al.",
+      "authorCount": 8,
+      "journal": "Heliyon",
+      "year": 2024,
+      "volume": "10",
+      "pages": "e36568",
+      "doi": "10.1016/j.heliyon.2024.e36568",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39275022": {
+      "pmid": "39275022",
+      "title": "Pomegranate (Punica granatum L.) Extract Effects on Inflammaging",
+      "authors": "Cordiano R et al.",
+      "authorCount": 5,
+      "journal": "Molecules",
+      "year": 2024,
+      "volume": "29",
+      "pages": "",
+      "doi": "10.3390/molecules29174174",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39275211": {
+      "pmid": "39275211",
+      "title": "Garlic and Hypertension: Efficacy, Mechanism of Action, and Clinical Implications",
+      "authors": "Sleiman C et al.",
+      "authorCount": 7,
+      "journal": "Nutrients",
+      "year": 2024,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/nu16172895",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39286661": {
+      "pmid": "39286661",
+      "title": "Effectiveness of Lemon Verbena (Cymbopogon citratus) in Oral Candidiasis: A Systematic Review",
+      "authors": "Cuenca-León K et al.",
+      "authorCount": 5,
+      "journal": "Clin Cosmet Investig Dent",
+      "year": 2024,
+      "volume": "16",
+      "pages": "295-305",
+      "doi": "10.2147/CCIDE.S478181",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39296670": {
+      "pmid": "39296670",
+      "title": "Huangqi-Danshen Decoction Against Renal Fibrosis in UUO Mice via TGF-β1 Induced Downstream Signaling Pathway",
+      "authors": "Huang X et al.",
+      "authorCount": 7,
+      "journal": "Drug Des Devel Ther",
+      "year": 2024,
+      "volume": "18",
+      "pages": "4119-4134",
+      "doi": "10.2147/DDDT.S457100",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39303542": {
+      "pmid": "39303542",
+      "title": "Synthesis and pharmacological evaluation of Andrographolide and Ajwain as promising alternatives to antibiotics for treating Salmonella gallinarum infection in chicken",
+      "authors": "Mudasir Ahmad S et al.",
+      "authorCount": 10,
+      "journal": "Int Immunopharmacol",
+      "year": 2024,
+      "volume": "142",
+      "pages": "113163",
+      "doi": "10.1016/j.intimp.2024.113163",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39312451": {
+      "pmid": "39312451",
+      "title": "Discovery of Natural Products for Cancer Prevention",
+      "authors": "Blanco Carcache PJ et al.",
+      "authorCount": 3,
+      "journal": "Cancer J",
+      "year": 2024,
+      "volume": "30",
+      "pages": "313-319",
+      "doi": "10.1097/PPO.0000000000000745",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39326132": {
+      "pmid": "39326132",
+      "title": "Puerarin ameliorates colitis by direct suppression of macrophage M1 polarization in DSS mice",
+      "authors": "Tao Q et al.",
+      "authorCount": 14,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "135",
+      "pages": "156048",
+      "doi": "10.1016/j.phymed.2024.156048",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39348746": {
+      "pmid": "39348746",
+      "title": "Effects of Ashwagandha (Withania Somnifera) on stress and anxiety: A systematic review and meta-analysis",
+      "authors": "Arumugam V et al.",
+      "authorCount": 8,
+      "journal": "Explore (NY)",
+      "year": 2024,
+      "volume": "20",
+      "pages": "103062",
+      "doi": "10.1016/j.explore.2024.103062",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article",
+        "Meta-Analysis"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39353308": {
+      "pmid": "39353308",
+      "title": "Insights into the anticancer effects of galangal and galangin: A comprehensive review",
+      "authors": "Wu Y et al.",
+      "authorCount": 3,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "135",
+      "pages": "156085",
+      "doi": "10.1016/j.phymed.2024.156085",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39368758": {
+      "pmid": "39368758",
+      "title": "Exploring the liver toxicity mechanism of Tripterygium wilfordii extract based on metabolomics, network pharmacological analysis and experimental validation",
+      "authors": "Zhou GL et al.",
+      "authorCount": 7,
+      "journal": "J Ethnopharmacol",
+      "year": 2025,
+      "volume": "337",
+      "pages": "118888",
+      "doi": "10.1016/j.jep.2024.118888",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39378978": {
+      "pmid": "39378978",
+      "title": "Alleviation of colitis by honeysuckle MIR2911 via direct regulation of gut microbiota",
+      "authors": "Li W et al.",
+      "authorCount": 20,
+      "journal": "J Control Release",
+      "year": 2024,
+      "volume": "376",
+      "pages": "123-137",
+      "doi": "10.1016/j.jconrel.2024.09.050",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39379937": {
+      "pmid": "39379937",
+      "title": "Oral administration of Sophora Flavescens-derived exosomes-like nanovesicles carrying CX5461 ameliorates DSS-induced colitis in mice",
+      "authors": "Zhang M et al.",
+      "authorCount": 16,
+      "journal": "J Nanobiotechnology",
+      "year": 2024,
+      "volume": "22",
+      "pages": "607",
+      "doi": "10.1186/s12951-024-02856-z",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39408204": {
+      "pmid": "39408204",
+      "title": "Effects of Acute Citrulline Malate Supplementation on CrossFit(®) Exercise Performance: A Randomized, Double-Blind, Placebo-Controlled, Cross-Over Study",
+      "authors": "Devrim-Lanpir A et al.",
+      "authorCount": 14,
+      "journal": "Nutrients",
+      "year": 2024,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/nu16193235",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39408345": {
+      "pmid": "39408345",
+      "title": "Potential Neuroprotective Effects of Alpinia officinarum Hance (Galangal): A Review",
+      "authors": "Abd Rahman IZ et al.",
+      "authorCount": 8,
+      "journal": "Nutrients",
+      "year": 2024,
+      "volume": "16",
+      "pages": "",
+      "doi": "10.3390/nu16193378",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39409183": {
+      "pmid": "39409183",
+      "title": "Advances in Gouty Arthritis Management: Integration of Established Therapies, Emerging Treatments, and Lifestyle Interventions",
+      "authors": "Yao TK et al.",
+      "authorCount": 6,
+      "journal": "Int J Mol Sci",
+      "year": 2024,
+      "volume": "25",
+      "pages": "",
+      "doi": "10.3390/ijms251910853",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39445611": {
+      "pmid": "39445611",
+      "title": "Nuciferine Alleviates High-Fat Diet- and ApoE(-/-)-Induced Hepatic Steatosis and Ferroptosis in NAFLD Mice via the PPARα Signaling Pathway",
+      "authors": "Qiu J et al.",
+      "authorCount": 11,
+      "journal": "J Agric Food Chem",
+      "year": 2024,
+      "volume": "72",
+      "pages": "24417-24431",
+      "doi": "10.1021/acs.jafc.4c04929",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39447789": {
+      "pmid": "39447789",
+      "title": "Endoperoxidases in biosynthesis of endoperoxide bonds",
+      "authors": "Zhang S et al.",
+      "authorCount": 11,
+      "journal": "Int J Biol Macromol",
+      "year": 2024,
+      "volume": "282",
+      "pages": "136806",
+      "doi": "10.1016/j.ijbiomac.2024.136806",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39458790": {
+      "pmid": "39458790",
+      "title": "Regeneration and Genetic Transformation in Eucalyptus Species, Current Research and Future Perspectives",
+      "authors": "Wang Y et al.",
+      "authorCount": 4,
+      "journal": "Plants (Basel)",
+      "year": 2024,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/plants13202843",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39476924": {
+      "pmid": "39476924",
+      "title": "Advances in the study of polysaccharides from Anemarrhena asphodeloides Bge.: A review",
+      "authors": "An H et al.",
+      "authorCount": 4,
+      "journal": "Int J Biol Macromol",
+      "year": 2024,
+      "volume": "282",
+      "pages": "136999",
+      "doi": "10.1016/j.ijbiomac.2024.136999",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39477563": {
+      "pmid": "39477563",
+      "title": "Complementary and Alternative Medicine for Menopause",
+      "authors": "Smith-Francis MJ",
+      "authorCount": 1,
+      "journal": "Nurs Clin North Am",
+      "year": 2024,
+      "volume": "59",
+      "pages": "551-562",
+      "doi": "10.1016/j.cnur.2024.08.001",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39477683": {
+      "pmid": "39477683",
+      "title": "Atractylenolide I inhibits angiogenesis and reverses sunitinib resistance in clear cell renal cell carcinoma through ATP6V0D2-mediated autophagic degradation of EPAS1/HIF2α",
+      "authors": "Li Q et al.",
+      "authorCount": 11,
+      "journal": "Autophagy",
+      "year": 2025,
+      "volume": "21",
+      "pages": "619-638",
+      "doi": "10.1080/15548627.2024.2421699",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39482471": {
+      "pmid": "39482471",
+      "title": "Poria cocos: traditional uses, triterpenoid components and their renoprotective pharmacology",
+      "authors": "Guo ZY et al.",
+      "authorCount": 6,
+      "journal": "Acta Pharmacol Sin",
+      "year": 2025,
+      "volume": "46",
+      "pages": "836-851",
+      "doi": "10.1038/s41401-024-01404-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39500772": {
+      "pmid": "39500772",
+      "title": "Aromatic plants as cosmeceuticals: benefits and applications for skin health",
+      "authors": "Olivero-Verbel J et al.",
+      "authorCount": 3,
+      "journal": "Planta",
+      "year": 2024,
+      "volume": "260",
+      "pages": "132",
+      "doi": "10.1007/s00425-024-04550-8",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39520951": {
+      "pmid": "39520951",
+      "title": "Kaixinsan regulates neuronal mitochondrial homeostasis to improve the cognitive function of Alzheimer's disease by activating CaMKKβ-AMPK-PGC-1α signaling axis",
+      "authors": "Ren J et al.",
+      "authorCount": 9,
+      "journal": "Phytomedicine",
+      "year": 2024,
+      "volume": "135",
+      "pages": "156170",
+      "doi": "10.1016/j.phymed.2024.156170",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39527684": {
+      "pmid": "39527684",
+      "title": "Tongkat Ali",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39544693": {
+      "pmid": "39544693",
+      "title": "Morus alba: natural and valuable effects in weight loss management",
+      "authors": "Ntalouka F and Tsirivakou A",
+      "authorCount": 2,
+      "journal": "Front Clin Diabetes Healthc",
+      "year": 2024,
+      "volume": "5",
+      "pages": "1395688",
+      "doi": "10.3389/fcdhc.2024.1395688",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39567970": {
+      "pmid": "39567970",
+      "title": "Potential of natural products and gut microbiome in tumor immunotherapy",
+      "authors": "Cao L et al.",
+      "authorCount": 5,
+      "journal": "Chin Med",
+      "year": 2024,
+      "volume": "19",
+      "pages": "161",
+      "doi": "10.1186/s13020-024-01032-7",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39597571": {
+      "pmid": "39597571",
+      "title": "Ingesting Stellera chamaejasme Significantly Impacts the Gastrointestinal Tract Bacterial Community and Diversity in Plateau Zokors (Eospalax baileyi)",
+      "authors": "Guo J et al.",
+      "authorCount": 4,
+      "journal": "Microorganisms",
+      "year": 2024,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/microorganisms12112182",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39612339": {
+      "pmid": "39612339",
+      "title": "Convergent evolution of berberine biosynthesis",
+      "authors": "Xu Z et al.",
+      "authorCount": 26,
+      "journal": "Sci Adv",
+      "year": 2024,
+      "volume": "10",
+      "pages": "eads3596",
+      "doi": "10.1126/sciadv.ads3596",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39616734": {
+      "pmid": "39616734",
+      "title": "Plumbagin alleviates muscle atrophy in female mice through inhibiting the DANCR/NF-κB axis",
+      "authors": "Liu Y et al.",
+      "authorCount": 18,
+      "journal": "Phytomedicine",
+      "year": 2025,
+      "volume": "136",
+      "pages": "156282",
+      "doi": "10.1016/j.phymed.2024.156282",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39620580": {
+      "pmid": "39620580",
+      "title": "Control and Disposal of Invasive Japanese Knotweed Reynoutria japonica Houtt. Using Microwave Treatment",
+      "authors": "Słowiński K et al.",
+      "authorCount": 5,
+      "journal": "J Vis Exp",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "10.3791/67660",
+      "publicationTypes": [
+        "Journal Article",
+        "Video-Audio Media",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39666848": {
+      "pmid": "39666848",
+      "title": "Gymnema",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2024,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39719741": {
+      "pmid": "39719741",
+      "title": "Olive leaf extract (OLE) reduces mast cell-mediated allergic inflammation",
+      "authors": "Somma F et al.",
+      "authorCount": 7,
+      "journal": "Biomed Pharmacother",
+      "year": 2025,
+      "volume": "182",
+      "pages": "117784",
+      "doi": "10.1016/j.biopha.2024.117784",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39731715": {
+      "pmid": "39731715",
+      "title": "Beverages developed from pseudocereals (quinoa, buckwheat, and amaranth): Nutritional and functional properties",
+      "authors": "Li H et al.",
+      "authorCount": 3,
+      "journal": "Compr Rev Food Sci Food Saf",
+      "year": 2025,
+      "volume": "24",
+      "pages": "e70081",
+      "doi": "10.1111/1541-4337.70081",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39742094": {
+      "pmid": "39742094",
+      "title": "Houttuynia cordata-Derived Exosome-Like Nanoparticles Mitigate Colitis in Mice via Inhibition of the NLRP3 Signaling Pathway and Modulation of the Gut Microbiota",
+      "authors": "Li JH et al.",
+      "authorCount": 13,
+      "journal": "Int J Nanomedicine",
+      "year": 2024,
+      "volume": "19",
+      "pages": "13991-14018",
+      "doi": "10.2147/IJN.S493434",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39769174": {
+      "pmid": "39769174",
+      "title": "Nigella sativa: A Comprehensive Review of Its Therapeutic Potential, Pharmacological Properties, and Clinical Applications",
+      "authors": "Alberts A et al.",
+      "authorCount": 4,
+      "journal": "Int J Mol Sci",
+      "year": 2024,
+      "volume": "25",
+      "pages": "",
+      "doi": "10.3390/ijms252413410",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39845379": {
+      "pmid": "39845379",
+      "title": "Nutraceutical and low energy shockwave treatments improved sexual function recovery in a rat pelvic neurovascular injury model",
+      "authors": "Crisostomo-Wynne TC et al.",
+      "authorCount": 5,
+      "journal": "Sex Med",
+      "year": 2025,
+      "volume": "12",
+      "pages": "qfaf001",
+      "doi": "10.1093/sexmed/qfaf001",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39853578": {
+      "pmid": "39853578",
+      "title": "Nutraceuticals and Headache 2024: Riboflavin, Coenzyme Q10, Feverfew, Magnesium, Melatonin, and Butterbur",
+      "authors": "Tepper SJ and Tepper K",
+      "authorCount": 2,
+      "journal": "Curr Pain Headache Rep",
+      "year": 2025,
+      "volume": "29",
+      "pages": "33",
+      "doi": "10.1007/s11916-025-01358-3",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39904199": {
+      "pmid": "39904199",
+      "title": "Exploring the active components and potential mechanisms of Zhimu-Huangbai herb-pair in the treatment of depression",
+      "authors": "Lei X et al.",
+      "authorCount": 8,
+      "journal": "Phytomedicine",
+      "year": 2025,
+      "volume": "138",
+      "pages": "156365",
+      "doi": "10.1016/j.phymed.2025.156365",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39940699": {
+      "pmid": "39940699",
+      "title": "Network Pharmacology and Bioinformatics Study of Six Medicinal Food Homologous Plants Against Colorectal Cancer",
+      "authors": "Zhao X et al.",
+      "authorCount": 5,
+      "journal": "Int J Mol Sci",
+      "year": 2025,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/ijms26030930",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39942757": {
+      "pmid": "39942757",
+      "title": "Epigallocatechin Gallate (EGCG): Pharmacological Properties, Biological Activities and Therapeutic Potential",
+      "authors": "Capasso L et al.",
+      "authorCount": 8,
+      "journal": "Molecules",
+      "year": 2025,
+      "volume": "30",
+      "pages": "",
+      "doi": "10.3390/molecules30030654",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39942962": {
+      "pmid": "39942962",
+      "title": "Aromatherapy and Essential Oils: Holistic Strategies in Complementary and Alternative Medicine for Integral Wellbeing",
+      "authors": "Caballero-Gallardo K et al.",
+      "authorCount": 3,
+      "journal": "Plants (Basel)",
+      "year": 2025,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/plants14030400",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39954619": {
+      "pmid": "39954619",
+      "title": "Curcuma wenyujin extract alleviates cognitive deficits and restrains pyroptosis through PINK1/Parkin mediated autophagy in Alzheimer's disease",
+      "authors": "Qi Y et al.",
+      "authorCount": 13,
+      "journal": "Phytomedicine",
+      "year": 2025,
+      "volume": "139",
+      "pages": "156482",
+      "doi": "10.1016/j.phymed.2025.156482",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40050867": {
+      "pmid": "40050867",
+      "title": "Antiviral treatment for viral pneumonia: current drugs and natural compounds",
+      "authors": "Zhang H et al.",
+      "authorCount": 11,
+      "journal": "Virol J",
+      "year": 2025,
+      "volume": "22",
+      "pages": "62",
+      "doi": "10.1186/s12985-025-02666-1",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40089686": {
+      "pmid": "40089686",
+      "title": "Epimedium brevicornum Maxim alleviates diabetes osteoporosis by regulating AGE-RAGE signaling pathway",
+      "authors": "Lei SS et al.",
+      "authorCount": 6,
+      "journal": "Mol Med",
+      "year": 2025,
+      "volume": "31",
+      "pages": "101",
+      "doi": "10.1186/s10020-025-01152-2",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40115263": {
+      "pmid": "40115263",
+      "title": "Paeonia suffruticosa Andrews root extract ameliorates photoaging via regulating IRS1/PI3K/FOXO pathway",
+      "authors": "Liu J et al.",
+      "authorCount": 6,
+      "journal": "Front Pharmacol",
+      "year": 2025,
+      "volume": "16",
+      "pages": "1520392",
+      "doi": "10.3389/fphar.2025.1520392",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40125913": {
+      "pmid": "40125913",
+      "title": "Damiana (Turnera diffusa) Reduces Adipocyte Cell Differentiation and Ameliorates Myocyte Glucose Uptake",
+      "authors": "Chae HS et al.",
+      "authorCount": 6,
+      "journal": "J Diet Suppl",
+      "year": 2025,
+      "volume": "22",
+      "pages": "401-416",
+      "doi": "10.1080/19390211.2025.2480582",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40143483": {
+      "pmid": "40143483",
+      "title": "A narrative review on the role of traditional Chinese medicine (TCM) in treating coronary artery disease",
+      "authors": "Zhang A et al.",
+      "authorCount": 5,
+      "journal": "J Pak Med Assoc",
+      "year": 2025,
+      "volume": "75",
+      "pages": "462-468",
+      "doi": "10.47391/JPMA.11610",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40176912": {
+      "pmid": "40176912",
+      "title": "Traditional usages, chemical metabolites, pharmacological activities, and pharmacokinetics of Boesenbergia rotunda (L.) Mansf.: a comprehensive review",
+      "authors": "Wang Y et al.",
+      "authorCount": 7,
+      "journal": "Front Pharmacol",
+      "year": 2025,
+      "volume": "16",
+      "pages": "1527210",
+      "doi": "10.3389/fphar.2025.1527210",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40205009": {
+      "pmid": "40205009",
+      "title": "Wogonin attenuates septic cardiomyopathy by suppressing ALOX15-mediated ferroptosis",
+      "authors": "Ye H et al.",
+      "authorCount": 7,
+      "journal": "Acta Pharmacol Sin",
+      "year": 2025,
+      "volume": "46",
+      "pages": "2407-2422",
+      "doi": "10.1038/s41401-025-01547-1",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40214514": {
+      "pmid": "40214514",
+      "title": "Somatostatin and Mannooligosaccharide Modified Selenium Nanoparticles with Dual-Targeting for Ulcerative Colitis Treatment",
+      "authors": "Ye R et al.",
+      "authorCount": 7,
+      "journal": "ACS Nano",
+      "year": 2025,
+      "volume": "19",
+      "pages": "14914-14930",
+      "doi": "10.1021/acsnano.5c00355",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40220415": {
+      "pmid": "40220415",
+      "title": "Scutellaria baicalensis Extracts Restrict Intestinal Epithelial Cell Ferroptosis by Regulating Lipid Peroxidation and GPX4/ACSL4 in Colitis",
+      "authors": "Zhang J et al.",
+      "authorCount": 8,
+      "journal": "Phytomedicine",
+      "year": 2025,
+      "volume": "141",
+      "pages": "156708",
+      "doi": "10.1016/j.phymed.2025.156708",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40235541": {
+      "pmid": "40235541",
+      "title": "Ligusticum chuanxiong: a chemical, pharmacological and clinical review",
+      "authors": "Wang Y et al.",
+      "authorCount": 11,
+      "journal": "Front Pharmacol",
+      "year": 2025,
+      "volume": "16",
+      "pages": "1523176",
+      "doi": "10.3389/fphar.2025.1523176",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40248109": {
+      "pmid": "40248109",
+      "title": "Perilla frutescens Leaf-Derived Extracellular Vesicle-Like Particles Carry Pab-miR-396a-5p to Alleviate Psoriasis by Modulating IL-17 Signaling",
+      "authors": "Liu Y et al.",
+      "authorCount": 11,
+      "journal": "Research (Wash D C)",
+      "year": 2025,
+      "volume": "8",
+      "pages": "0675",
+      "doi": "10.34133/research.0675",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40256714": {
+      "pmid": "40256714",
+      "title": "Osthole ameliorates chronic pruritus in 2,4-dichloronitrobenzene-induced atopic dermatitis by inhibiting IL-31 production",
+      "authors": "He S et al.",
+      "authorCount": 12,
+      "journal": "Chin Herb Med",
+      "year": 2024,
+      "volume": "17",
+      "pages": "368-379",
+      "doi": "10.1016/j.chmed.2024.01.003",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40284172": {
+      "pmid": "40284172",
+      "title": "Lion's Mane Mushroom (Hericium erinaceus): A Neuroprotective Fungus with Antioxidant, Anti-Inflammatory, and Antimicrobial Potential-A Narrative Review",
+      "authors": "Contato AG and Conte-Junior CA",
+      "authorCount": 2,
+      "journal": "Nutrients",
+      "year": 2025,
+      "volume": "17",
+      "pages": "",
+      "doi": "10.3390/nu17081307",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40302443": {
+      "pmid": "40302443",
+      "title": "Huntington's disease clinical trials update: March 2025",
+      "authors": "Farag M et al.",
+      "authorCount": 3,
+      "journal": "J Huntingtons Dis",
+      "year": 2025,
+      "volume": "14",
+      "pages": "191-206",
+      "doi": "10.1177/18796397251337000",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40317096": {
+      "pmid": "40317096",
+      "title": "Nutritional and herbal interventions for polycystic ovary syndrome (PCOS): a comprehensive review of dietary approaches, macronutrient impact, and herbal medicine in management",
+      "authors": "Muhammed Saeed AA et al.",
+      "authorCount": 8,
+      "journal": "J Health Popul Nutr",
+      "year": 2025,
+      "volume": "44",
+      "pages": "143",
+      "doi": "10.1186/s41043-025-00899-y",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40321800": {
+      "pmid": "40321800",
+      "title": "Mechanistic Insights into the Anti-Glioma Effects of Exosome-Like Nanoparticles Derived from Garcinia Mangostana L.: A Metabolomics, Network Pharmacology, and Experimental Study",
+      "authors": "Luo X et al.",
+      "authorCount": 10,
+      "journal": "Int J Nanomedicine",
+      "year": 2025,
+      "volume": "20",
+      "pages": "5407-5427",
+      "doi": "10.2147/IJN.S514930",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40332350": {
+      "pmid": "40332350",
+      "title": "Maral Root Extract and Its Main Constituent 20-Hydroxyecdysone Enhance Stress Resilience in Caenorhabditis elegans",
+      "authors": "Todorova V et al.",
+      "authorCount": 6,
+      "journal": "Int J Mol Sci",
+      "year": 2025,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/ijms26083739",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40348378": {
+      "pmid": "40348378",
+      "title": "The role of venoactive compounds in the treatment of chronic venous disease",
+      "authors": "Gloviczki ML et al.",
+      "authorCount": 5,
+      "journal": "J Vasc Surg Venous Lymphat Disord",
+      "year": 2025,
+      "volume": "13",
+      "pages": "102258",
+      "doi": "10.1016/j.jvsv.2025.102258",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40362563": {
+      "pmid": "40362563",
+      "title": "Peumus boldus Extract Inhibits Lipid Accumulation in 3T3-L1 Adipocytes",
+      "authors": "Montaldo L et al.",
+      "authorCount": 4,
+      "journal": "Int J Mol Sci",
+      "year": 2025,
+      "volume": "26",
+      "pages": "",
+      "doi": "10.3390/ijms26094326",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40370689": {
+      "pmid": "40370689",
+      "title": "Neuroprotective Mushrooms",
+      "authors": "Abdelmoaty MM et al.",
+      "authorCount": 4,
+      "journal": "NeuroImmune Pharm Ther",
+      "year": 2024,
+      "volume": "3",
+      "pages": "129-137",
+      "doi": "10.1515/nipt-2024-0004",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40375936": {
+      "pmid": "40375936",
+      "title": "Unlocking the potential of Artemisia annua for artemisinin production: current insights and emerging strategies",
+      "authors": "Vashisth D and Mishra S",
+      "authorCount": 2,
+      "journal": "3 Biotech",
+      "year": 2025,
+      "volume": "15",
+      "pages": "164",
+      "doi": "10.1007/s13205-025-04332-3",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40378325": {
+      "pmid": "40378325",
+      "title": "Migraine Headache Prophylaxis",
+      "authors": "Moreland P et al.",
+      "authorCount": 3,
+      "journal": "Am Fam Physician",
+      "year": 2025,
+      "volume": "111",
+      "pages": "443-450",
+      "doi": "",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40490795": {
+      "pmid": "40490795",
+      "title": "Atractylodes macrocephala-derived extracellular vesicles-like particles enhance the recovery of ulcerative colitis by remodeling intestinal microecological balance",
+      "authors": "Tan X et al.",
+      "authorCount": 11,
+      "journal": "J Nanobiotechnology",
+      "year": 2025,
+      "volume": "23",
+      "pages": "433",
+      "doi": "10.1186/s12951-025-03506-8",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40512457": {
+      "pmid": "40512457",
+      "title": "Natural antitussive products for children and adolescents: darkness and shadow",
+      "authors": "Ciprandi G",
+      "authorCount": 1,
+      "journal": "Minerva Pediatr (Torino)",
+      "year": 2025,
+      "volume": "",
+      "pages": "",
+      "doi": "10.23736/S2724-5276.25.07848-6",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40527063": {
+      "pmid": "40527063",
+      "title": "Mulberry leaf improves type 2 diabetes in mice via gut microbiota-SCFAs-GPRs axis and AMPK signaling pathway",
+      "authors": "Zhang Y et al.",
+      "authorCount": 10,
+      "journal": "Phytomedicine",
+      "year": 2025,
+      "volume": "145",
+      "pages": "156970",
+      "doi": "10.1016/j.phymed.2025.156970",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40527613": {
+      "pmid": "40527613",
+      "title": "Galangin alleviates vitiligo by targeting ANXA2 degradation in macrophages",
+      "authors": "Wei W et al.",
+      "authorCount": 11,
+      "journal": "Br J Pharmacol",
+      "year": 2025,
+      "volume": "182",
+      "pages": "4647-4667",
+      "doi": "10.1111/bph.70103",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40554037": {
+      "pmid": "40554037",
+      "title": "Effect of a combination of C. longa and B. serrata extracts on hand osteoarthritis. Results of a double-blind, randomized, placebo-controlled, multicenter trial",
+      "authors": "Henrotin Y et al.",
+      "authorCount": 12,
+      "journal": "Osteoarthritis Cartilage",
+      "year": 2025,
+      "volume": "33",
+      "pages": "1404-1411",
+      "doi": "10.1016/j.joca.2025.06.005",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial",
+        "Multicenter Study",
+        "Research Support, Non-U.S. Gov't"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40613623": {
+      "pmid": "40613623",
+      "title": "Exploring nutraceutical solutions for prediabetes: a narrative review on the effects of banaba and chromium picolinate",
+      "authors": "Derosa G et al.",
+      "authorCount": 8,
+      "journal": "Eur Rev Med Pharmacol Sci",
+      "year": 2025,
+      "volume": "29",
+      "pages": "324-338",
+      "doi": "10.26355/eurrev_202506_37275",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40706130": {
+      "pmid": "40706130",
+      "title": "Antiviral activity of Stephania japonica extract against porcine epidemic diarrhea virus infection",
+      "authors": "Zhao Y et al.",
+      "authorCount": 8,
+      "journal": "Vet Microbiol",
+      "year": 2025,
+      "volume": "308",
+      "pages": "110647",
+      "doi": "10.1016/j.vetmic.2025.110647",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40708494": {
+      "pmid": "40708494",
+      "title": "The Role of Chinese Medicine in the Treatment of Chronic Hepatitis B",
+      "authors": "Zheng S et al.",
+      "authorCount": 8,
+      "journal": "Am J Chin Med",
+      "year": 2025,
+      "volume": "53",
+      "pages": "1285-1307",
+      "doi": "10.1142/S0192415X25500508",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40751788": {
+      "pmid": "40751788",
+      "title": "Metabolism of coclaurine into the WADA-banned substance higenamine: a doping-relevant analytical evaluation of Kampo extracts",
+      "authors": "Sakamoto S et al.",
+      "authorCount": 9,
+      "journal": "J Nat Med",
+      "year": 2025,
+      "volume": "79",
+      "pages": "1140-1153",
+      "doi": "10.1007/s11418-025-01940-4",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40808332": {
+      "pmid": "40808332",
+      "title": "Levodopa and Plant-Derived Bioactive Compounds in Parkinson's Disease: Mechanisms, Efficacy, and Future Perspectives",
+      "authors": "Aktaş E et al.",
+      "authorCount": 3,
+      "journal": "CNS Neurosci Ther",
+      "year": 2025,
+      "volume": "31",
+      "pages": "e70540",
+      "doi": "10.1111/cns.70540",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40918053": {
+      "pmid": "40918053",
+      "title": "Magnesium Bisglycinate Supplementation in Healthy Adults Reporting Poor Sleep: A Randomized, Placebo-Controlled Trial",
+      "authors": "Schuster J et al.",
+      "authorCount": 4,
+      "journal": "Nat Sci Sleep",
+      "year": 2025,
+      "volume": "17",
+      "pages": "2027-2040",
+      "doi": "10.2147/NSS.S524348",
+      "publicationTypes": [
+        "Case Reports",
+        "Clinical Trial",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40941781": {
+      "pmid": "40941781",
+      "title": "Identification of Daphnane Diterpenoids from Flower Buds and Blooming Flowers of Daphne odora Using UHPLC-Q-Exactive-Orbitrap MS",
+      "authors": "Otsuki K et al.",
+      "authorCount": 6,
+      "journal": "Plants (Basel)",
+      "year": 2025,
+      "volume": "14",
+      "pages": "",
+      "doi": "10.3390/plants14172616",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "40986632": {
+      "pmid": "40986632",
+      "title": "A Canadian Consensus on Androgenetic Alopecia: Approach and Management",
+      "authors": "Landells I et al.",
+      "authorCount": 15,
+      "journal": "J Cutan Med Surg",
+      "year": 2025,
+      "volume": "29",
+      "pages": "5S-14S",
+      "doi": "10.1177/12034754251368849",
+      "publicationTypes": [
+        "Consensus Statement",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41031161": {
+      "pmid": "41031161",
+      "title": "Stephania tetrandra S. Moore: a promising candidate drug for treating diabetic kidney disease",
+      "authors": "Wang W et al.",
+      "authorCount": 8,
+      "journal": "Front Pharmacol",
+      "year": 2025,
+      "volume": "16",
+      "pages": "1651023",
+      "doi": "10.3389/fphar.2025.1651023",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41052496": {
+      "pmid": "41052496",
+      "title": "Integrated breeding strategies for blue lotus based on petal pH, anthocyanin profiling, and gene expression analysis",
+      "authors": "Liu Q et al.",
+      "authorCount": 11,
+      "journal": "Plant Physiol Biochem",
+      "year": 2025,
+      "volume": "229",
+      "pages": "110583",
+      "doi": "10.1016/j.plaphy.2025.110583",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41106096": {
+      "pmid": "41106096",
+      "title": "Cistanche deserticola extract and its active components, echinacoside, ameliorate sarcopenia by activating the IGF-1/PI3K-AKT pathway to modulate ferroptosis",
+      "authors": "Wang X et al.",
+      "authorCount": 14,
+      "journal": "Phytomedicine",
+      "year": 2025,
+      "volume": "148",
+      "pages": "157378",
+      "doi": "10.1016/j.phymed.2025.157378",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41150909": {
+      "pmid": "41150909",
+      "title": "Trunk Injection of a Curry Leaf Extract to Promote Citrus Tree Health in Huanglongbing-Endemic Regions",
+      "authors": "Aglave T et al.",
+      "authorCount": 4,
+      "journal": "Plant Dis",
+      "year": 2026,
+      "volume": "110",
+      "pages": "2024-2028",
+      "doi": "10.1094/PDIS-10-25-2132-SC",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41155688": {
+      "pmid": "41155688",
+      "title": "A Review on Phytochemistry, Ethnopharmacology, and Antiparasitic Potential of Mangifera indica L",
+      "authors": "Mendonça D et al.",
+      "authorCount": 21,
+      "journal": "Pharmaceuticals (Basel)",
+      "year": 2025,
+      "volume": "18",
+      "pages": "",
+      "doi": "10.3390/ph18101576",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41272020": {
+      "pmid": "41272020",
+      "title": "Exploring the potential mechanisms of anti-pulmonary fibrosis effects of Luo Han Guo via network pharmacology, molecular docking, and experimental validation",
+      "authors": "Cui Q et al.",
+      "authorCount": 12,
+      "journal": "Sci Rep",
+      "year": 2025,
+      "volume": "15",
+      "pages": "41345",
+      "doi": "10.1038/s41598-025-25270-3",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41288788": {
+      "pmid": "41288788",
+      "title": "Eucommia ulmoides Oliver (Duzhong) extract ameliorates cerebral ischemic stroke in mice by remodeling intestinal microbiota and metabolites",
+      "authors": "Qi X et al.",
+      "authorCount": 5,
+      "journal": "Metab Brain Dis",
+      "year": 2025,
+      "volume": "40",
+      "pages": "325",
+      "doi": "10.1007/s11011-025-01750-3",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41353162": {
+      "pmid": "41353162",
+      "title": "Boldo leaves reduce seizures, neuroinflammation, and hemichannel activity in a murine model of chronic epilepsy",
+      "authors": "García-Rodríguez C et al.",
+      "authorCount": 7,
+      "journal": "Biol Res",
+      "year": 2025,
+      "volume": "58",
+      "pages": "72",
+      "doi": "10.1186/s40659-025-00647-w",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41498029": {
+      "pmid": "41498029",
+      "title": "Immunomodulatory Mechanisms of Rehmanniae Radix Praeparata-Achyranthes Root-Chinese Angelica Root Combination in Nontraumatic Osteonecrosis of the Femoral Head: A Comprehensive Network Pharmacology and Molecular Docking Study Focusing on Immunological Pathways",
+      "authors": "Li X et al.",
+      "authorCount": 10,
+      "journal": "Mediators Inflamm",
+      "year": 2025,
+      "volume": "2025",
+      "pages": "e2808908",
+      "doi": "10.1155/mi/2808908",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41500295": {
+      "pmid": "41500295",
+      "title": "Fig-derived exosome-like nanoparticles attenuating bone metastasis of breast cancer through establishing an anti-tumor microenvironment",
+      "authors": "Wang DD et al.",
+      "authorCount": 17,
+      "journal": "Pharmacol Res",
+      "year": 2026,
+      "volume": "224",
+      "pages": "108088",
+      "doi": "10.1016/j.phrs.2026.108088",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41515938": {
+      "pmid": "41515938",
+      "title": "Effects of Common Fig (Ficus carica L.) and Its Extracts on Certain Cancer Types: Focusing on the Mechanism of Action",
+      "authors": "Gökçen EN et al.",
+      "authorCount": 6,
+      "journal": "Int J Mol Sci",
+      "year": 2025,
+      "volume": "27",
+      "pages": "",
+      "doi": "10.3390/ijms27010056",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41554764": {
+      "pmid": "41554764",
+      "title": "Lactiplantibacillus plantarum Lp815 improves sleep and increases urinary GABA in a randomized, double-blind, placebo-controlled study of sleep disturbance",
+      "authors": "Grant AD et al.",
+      "authorCount": 10,
+      "journal": "Sci Rep",
+      "year": 2026,
+      "volume": "16",
+      "pages": "644",
+      "doi": "10.1038/s41598-025-27861-6",
+      "publicationTypes": [
+        "Journal Article",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41655513": {
+      "pmid": "41655513",
+      "title": "Transcriptome analysis of Stephania cepharantha and characterization of two CYP80B genes involved in the benzylisoquinoline alkaloid biosynthesis",
+      "authors": "Feng Y et al.",
+      "authorCount": 10,
+      "journal": "Plant Physiol Biochem",
+      "year": 2026,
+      "volume": "232",
+      "pages": "111088",
+      "doi": "10.1016/j.plaphy.2026.111088",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41696952": {
+      "pmid": "41696952",
+      "title": "Buckwheat allergy",
+      "authors": "Chen F et al.",
+      "authorCount": 5,
+      "journal": "Asian Pac J Allergy Immunol",
+      "year": 2025,
+      "volume": "43",
+      "pages": "753-761",
+      "doi": "10.12932/AP-171025-2165",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41800803": {
+      "pmid": "41800803",
+      "title": "Methylophiopogonanone a attenuates pulmonary fibrosis by inhibiting SPP1-mediated macrophage polarization via the PI3K/Akt pathway",
+      "authors": "Yang F et al.",
+      "authorCount": 11,
+      "journal": "Animal Model Exp Med",
+      "year": 2026,
+      "volume": "9",
+      "pages": "520-536",
+      "doi": "10.1002/ame2.70157",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41841386": {
+      "pmid": "41841386",
+      "title": "Divergent Synthesis of Mogrosides",
+      "authors": "Petrović G et al.",
+      "authorCount": 5,
+      "journal": "J Org Chem",
+      "year": 2026,
+      "volume": "91",
+      "pages": "4407-4421",
+      "doi": "10.1021/acs.joc.6c00056",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41855365": {
+      "pmid": "41855365",
+      "title": "Broccoli",
+      "authors": "",
+      "authorCount": 0,
+      "journal": "",
+      "year": 2026,
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "publicationTypes": [
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "41875856": {
+      "pmid": "41875856",
+      "title": "Noni Franklin-Tong",
+      "authors": "Franklin-Tong N",
+      "authorCount": 1,
+      "journal": "Curr Biol",
+      "year": 2026,
+      "volume": "36",
+      "pages": "R235-R237",
+      "doi": "10.1016/j.cub.2026.01.057",
+      "publicationTypes": [
+        "Interview",
+        "Historical Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "42196951": {
+      "pmid": "42196951",
+      "title": "Characterization of Isoorientin and Paeoniflorin as Botanical Glucocorticoid Receptor Modulators from White Peony and Chasteberry",
+      "authors": "Bashatwah RM et al.",
+      "authorCount": 7,
+      "journal": "Nutrients",
+      "year": 2026,
+      "volume": "18",
+      "pages": "",
+      "doi": "10.3390/nu18101491",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "gate:content-quality": "node scripts/ci/validate-content-quality-gate.mjs",
     "validate:dose-fields": "tsx scripts/ci/validate-dose-fields.ts",
     "validate:citation-identifiers": "node scripts/ci/validate-citation-identifiers.mjs",
+    "citations:fetch-pubmed": "node scripts/data/fetch-pubmed-metadata.mjs",
+    "citations:apply-pubmed": "tsx scripts/data/apply-pubmed-metadata.ts",
     "data:repair-packed-citations": "node scripts/data/repair-packed-citations.mjs",
     "validate:evidence-grades": "tsx scripts/ci/validate-evidence-grade-consistency.ts",
     "data:normalize-evidence": "tsx scripts/data/normalize-evidence-grades.ts --data-dir=public/data",

--- a/public/data/compounds-detail/11-keto-beta-boswellic-acid.json
+++ b/public/data/compounds-detail/11-keto-beta-boswellic-acid.json
@@ -135,7 +135,12 @@
       "url": "https://pubmed.ncbi.nlm.nih.gov/15070181/",
       "pmid": "15070181",
       "note": "human_pk",
-      "reviewStatus": "pending"
+      "reviewStatus": "pending",
+      "journal": "Phytomedicine",
+      "year": 2004,
+      "authors": "Sharma S et al.",
+      "doi": "10.1078/0944-7113-00290",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_3bc3ceb5a629-2",
@@ -143,7 +148,14 @@
       "url": "https://pubmed.ncbi.nlm.nih.gov/22167571/",
       "pmid": "22167571",
       "note": "human_pk",
-      "reviewStatus": "pending"
+      "reviewStatus": "pending",
+      "journal": "J Clin Pharmacol",
+      "year": 2012,
+      "authors": "Skarke C et al.",
+      "doi": "10.1177/0091270011422811",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract or essential-oil-free preparation when oral use is intended",

--- a/public/data/compounds-detail/23-epi-26-deoxyactein.json
+++ b/public/data/compounds-detail/23-epi-26-deoxyactein.json
@@ -86,7 +86,11 @@
       "journal": "Clin Pharmacol Ther",
       "citation": "Author not retrieved (2010). Clin Pharmacol Ther. PMID: 20032972. DOI: 10.1038/clpt.2009.251.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "van Breemen RB et al.",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract or essential-oil-free preparation when oral use is intended",

--- a/public/data/compounds-detail/acarbose.json
+++ b/public/data/compounds-detail/acarbose.json
@@ -112,13 +112,19 @@
   "sources": [
     {
       "id": "src_785db79c7b8b",
-      "title": "PubMed PMID 10372249. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A randomized double-blind trial of acarbose in type 2 diabetes shows improved glycemic control over 3 years (U.K. Prospective Diabetes Study 44)",
       "url": "https://pubmed.ncbi.nlm.nih.gov/10372249/",
       "pmid": "10372249",
       "authors": "PubMed",
       "citation": "PubMed PMID 10372249. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Diabetes Care",
+      "year": 1999,
+      "doi": "10.2337/diacare.22.6.960",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "long",

--- a/public/data/compounds-detail/alpha-asarone.json
+++ b/public/data/compounds-detail/alpha-asarone.json
@@ -140,7 +140,11 @@
       "journal": "Phytomedicine",
       "citation": "Author not retrieved (2017). Phytomedicine. PMID: 28732807. DOI: 10.1016/j.phymed.2017.04.003.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Chellian R et al.",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/alpha-gpc.json
+++ b/public/data/compounds-detail/alpha-gpc.json
@@ -85,13 +85,17 @@
   "sources": [
     {
       "id": "src_27246dab02a6",
-      "title": "PubMed PMID 14767959. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Disclosing new inhibitors by finding similarities in three-dimensional active-site architectures of polynuclear zinc phospholipases and aminopeptidases",
       "url": "https://pubmed.ncbi.nlm.nih.gov/14767959/",
       "pmid": "14767959",
       "authors": "PubMed",
       "citation": "PubMed PMID 14767959. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Angew Chem Int Ed Engl",
+      "year": 2004,
+      "doi": "10.1002/anie.200352241",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/alpha-lipoic-acid.json
+++ b/public/data/compounds-detail/alpha-lipoic-acid.json
@@ -66,13 +66,17 @@
   "sources": [
     {
       "id": "src_7a5eca313ce8",
-      "title": "PubMed PMID 12874400. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Abeta1-42 promotes cholinergic sprouting in patients with AD and Lewy body variant of AD",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12874400/",
       "pmid": "12874400",
       "authors": "PubMed",
       "citation": "PubMed PMID 12874400. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Neurology",
+      "year": 2003,
+      "doi": "10.1212/01.wnl.0000073987.79060.4b",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/alpha-mangostin.json
+++ b/public/data/compounds-detail/alpha-mangostin.json
@@ -142,7 +142,9 @@
       "journal": "Mol Nutr Food Res",
       "citation": "Author not retrieved (2011). Mol Nutr Food Res. PMID: 21254395. DOI: 10.1002/mnfr.201000511.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Li L et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract capsule",

--- a/public/data/compounds-detail/american-ginseng-extract.json
+++ b/public/data/compounds-detail/american-ginseng-extract.json
@@ -66,13 +66,17 @@
   "sources": [
     {
       "id": "src_6563b3b488ec",
-      "title": "PubMed PMID 16332936. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Testosterone, dehydroepiandrosterone, and physical performance in older men: results from the Massachusetts Male Aging Study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/16332936/",
       "pmid": "16332936",
       "authors": "PubMed",
       "citation": "PubMed PMID 16332936. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Clin Endocrinol Metab",
+      "year": 2006,
+      "doi": "10.1210/jc.2005-1227",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/andrographis.json
+++ b/public/data/compounds-detail/andrographis.json
@@ -111,13 +111,19 @@
   "sources": [
     {
       "id": "src_21d61628ee99",
-      "title": "PubMed PMID 15095142. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Andrographis paniculata in the treatment of upper respiratory tract infections: a systematic review of safety and efficacy",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15095142/",
       "pmid": "15095142",
       "authors": "PubMed",
       "citation": "PubMed PMID 15095142. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Planta Med",
+      "year": 2004,
+      "doi": "10.1055/s-2004-818938",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/andrographolide.json
+++ b/public/data/compounds-detail/andrographolide.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_21d61628ee99",
-      "title": "PubMed PMID 15095142. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Andrographis paniculata in the treatment of upper respiratory tract infections: a systematic review of safety and efficacy",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15095142/",
       "pmid": "15095142",
       "authors": "PubMed",
       "citation": "PubMed PMID 15095142. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Planta Med",
+      "year": 2004,
+      "doi": "10.1055/s-2004-818938",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/arabinoxylan.json
+++ b/public/data/compounds-detail/arabinoxylan.json
@@ -62,13 +62,17 @@
   "sources": [
     {
       "id": "src_0d867f116292",
-      "title": "PubMed PMID 29456638. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Biobran/MGN-3, an arabinoxylan rice bran, enhances NK cell activity in geriatric subjects: A randomized, double-blind, placebo-controlled clinical trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/29456638/",
       "pmid": "29456638",
       "authors": "PubMed",
       "citation": "PubMed PMID 29456638. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Exp Ther Med",
+      "year": 2018,
+      "doi": "10.3892/etm.2018.5713",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "powder or capsule",

--- a/public/data/compounds-detail/artichoke-extract.json
+++ b/public/data/compounds-detail/artichoke-extract.json
@@ -67,13 +67,19 @@
   "sources": [
     {
       "id": "src_38b3994acf96",
-      "title": "PubMed PMID 22746542. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Beneficial effects of artichoke leaf extract supplementation on increasing HDL-cholesterol in subjects with primary mild hypercholesterolaemia: a double-blind, randomized, placebo-controlled trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/22746542/",
       "pmid": "22746542",
       "authors": "PubMed",
       "citation": "PubMed PMID 22746542. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int J Food Sci Nutr",
+      "year": 2013,
+      "doi": "10.3109/09637486.2012.700920",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/astaxanthin.json
+++ b/public/data/compounds-detail/astaxanthin.json
@@ -67,13 +67,17 @@
   "sources": [
     {
       "id": "src_96a391c482c6",
-      "title": "PubMed PMID 34376917. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of anthocyanin, astaxanthin, and lutein on eye functions: a randomized, double-blind, placebo-controlled study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/34376917/",
       "pmid": "34376917",
       "authors": "PubMed",
       "citation": "PubMed PMID 34376917. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Clin Biochem Nutr",
+      "year": 2021,
+      "doi": "10.3164/jcbn.20-149",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/atractylenolide-i.json
+++ b/public/data/compounds-detail/atractylenolide-i.json
@@ -135,7 +135,11 @@
       "journal": "Arch Pharm Res",
       "citation": "Author not retrieved (2021). Arch Pharm Res. PMID: 34269984. DOI: 10.1007/s12272-021-01342-6.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Deng M et al.",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/atractylenolide-ii.json
+++ b/public/data/compounds-detail/atractylenolide-ii.json
@@ -131,7 +131,11 @@
       "journal": "Arch Pharm Res",
       "citation": "Author not retrieved (2021). Arch Pharm Res. PMID: 34269984. DOI: 10.1007/s12272-021-01342-6.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Deng M et al.",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract or essential-oil-free preparation when oral use is intended",

--- a/public/data/compounds-detail/atractylenolide-iii.json
+++ b/public/data/compounds-detail/atractylenolide-iii.json
@@ -138,7 +138,9 @@
       "journal": "Phytomedicine",
       "citation": "Author not retrieved (2019). Phytomedicine. PMID: 30981186. DOI: 10.1016/j.phymed.2019.152922.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Zhou K et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/aucubin.json
+++ b/public/data/compounds-detail/aucubin.json
@@ -145,7 +145,9 @@
       "journal": "Pharm Res",
       "citation": "Author not retrieved (1991). Pharm Res. PMID: 1924160. DOI: 10.1023/a:1015821527621.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Suh NJ et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized botanical extract capsule",

--- a/public/data/compounds-detail/bacopaside-ii.json
+++ b/public/data/compounds-detail/bacopaside-ii.json
@@ -92,7 +92,9 @@
       "citation": "Author not retrieved (2018). Cells. PMID: 30037060. DOI: 10.3390/cells7070081.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
       "studyType": "Mechanistic",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Smith E et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized botanical extract capsule",

--- a/public/data/compounds-detail/banaba-leaf-extract.json
+++ b/public/data/compounds-detail/banaba-leaf-extract.json
@@ -64,13 +64,19 @@
   "sources": [
     {
       "id": "src_681b9bde8e6f",
-      "title": "PubMed PMID 34726501. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effect of Banaba (Lagerstroemia speciosa) on Metabolic Syndrome, Insulin Sensitivity, and Insulin Secretion",
       "url": "https://pubmed.ncbi.nlm.nih.gov/34726501/",
       "pmid": "34726501",
       "authors": "PubMed",
       "citation": "PubMed PMID 34726501. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Med Food",
+      "year": 2022,
+      "doi": "10.1089/jmf.2021.0039",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "medium",

--- a/public/data/compounds-detail/bcaas.json
+++ b/public/data/compounds-detail/bcaas.json
@@ -64,13 +64,19 @@
   "sources": [
     {
       "id": "src_215b4cf4fb91",
-      "title": "PubMed PMID 17095909. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Reassessment of cardiovascular risk in diabetes",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17095909/",
       "pmid": "17095909",
       "authors": "PubMed",
       "citation": "PubMed PMID 17095909. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Curr Opin Lipidol",
+      "year": 2006,
+      "doi": "10.1097/MOL.0b013e3280106208",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/berberine.json
+++ b/public/data/compounds-detail/berberine.json
@@ -127,43 +127,62 @@
   "sources": [
     {
       "id": "src_3360127d4eb9",
-      "title": "PubMed PMID 25676062. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Association of human papillomavirus type 58 with breast cancer in Shaanxi province of China",
       "url": "https://pubmed.ncbi.nlm.nih.gov/25676062/",
       "pmid": "25676062",
       "authors": "PubMed",
       "citation": "PubMed PMID 25676062. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Med Virol",
+      "year": 2015,
+      "doi": "10.1002/jmv.24142",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_46d014a9f663",
-      "title": "PubMed PMID 21346706. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Fatal laboratory-acquired infection with an attenuated Yersinia pestis Strain--Chicago, Illinois, 2009",
       "url": "https://pubmed.ncbi.nlm.nih.gov/21346706/",
       "pmid": "21346706",
       "authors": "PubMed",
       "citation": "PubMed PMID 21346706. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "MMWR Morb Mortal Wkly Rep",
+      "year": 2011,
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_5ec9a8f4ea44",
-      "title": "PubMed PMID 18442638. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy of berberine in patients with type 2 diabetes mellitus",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18442638/",
       "pmid": "18442638",
       "authors": "PubMed",
       "citation": "PubMed PMID 18442638. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Metabolism",
+      "year": 2008,
+      "doi": "10.1016/j.metabol.2008.01.013",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_fe3eabf330c8",
-      "title": "PubMed PMID 22739410. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Lipid-lowering effect of berberine in human subjects and rats",
       "url": "https://pubmed.ncbi.nlm.nih.gov/22739410/",
       "pmid": "22739410",
       "authors": "PubMed",
       "citation": "PubMed PMID 22739410. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytomedicine",
+      "year": 2012,
+      "doi": "10.1016/j.phymed.2012.05.009",
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/beta-alanine.json
+++ b/public/data/compounds-detail/beta-alanine.json
@@ -66,13 +66,19 @@
   "sources": [
     {
       "id": "src_5fb27681f298",
-      "title": "PubMed PMID 17194255. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of twenty-eight days of beta-alanine and creatine monohydrate supplementation on the physical working capacity at neuromuscular fatigue threshold",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17194255/",
       "pmid": "17194255",
       "authors": "PubMed",
       "citation": "PubMed PMID 17194255. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Strength Cond Res",
+      "year": 2006,
+      "doi": "10.1519/R-19655.1",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "powder or capsule",

--- a/public/data/compounds-detail/beta-glucans.json
+++ b/public/data/compounds-detail/beta-glucans.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_320c9c51472e",
-      "title": "PubMed PMID 30198828. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of Yeast (1,3)-(1,6)-Beta-Glucan on Severity of Upper Respiratory Tract Infections: A Double-Blind, Randomized, Placebo-Controlled Study in Healthy Subjects",
       "url": "https://pubmed.ncbi.nlm.nih.gov/30198828/",
       "pmid": "30198828",
       "authors": "PubMed",
       "citation": "PubMed PMID 30198828. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Am Coll Nutr",
+      "year": 2019,
+      "doi": "10.1080/07315724.2018.1478339",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/beta-sitosterol.json
+++ b/public/data/compounds-detail/beta-sitosterol.json
@@ -64,13 +64,18 @@
   "sources": [
     {
       "id": "src_ad26988bf771",
-      "title": "PubMed PMID 9313662. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A multicentric, placebo-controlled, double-blind clinical trial of beta-sitosterol (phytosterol) for the treatment of benign prostatic hyperplasia. German BPH-Phyto Study group",
       "url": "https://pubmed.ncbi.nlm.nih.gov/9313662/",
       "pmid": "9313662",
       "authors": "PubMed",
       "citation": "PubMed PMID 9313662. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Br J Urol",
+      "year": 1997,
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/bicarbonate.json
+++ b/public/data/compounds-detail/bicarbonate.json
@@ -106,13 +106,19 @@
   "sources": [
     {
       "id": "src_005702379a61",
-      "title": "PubMed PMID 34503527. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "International Society of Sports Nutrition position stand: sodium bicarbonate and exercise performance",
       "url": "https://pubmed.ncbi.nlm.nih.gov/34503527/",
       "pmid": "34503527",
       "authors": "PubMed",
       "citation": "PubMed PMID 34503527. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2021,
+      "doi": "10.1186/s12970-021-00458-w",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/boron.json
+++ b/public/data/compounds-detail/boron.json
@@ -64,13 +64,17 @@
   "sources": [
     {
       "id": "src_6bc0961b2000",
-      "title": "PubMed PMID 21129941. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Comparative effects of daily and weekly boron supplementation on plasma steroid hormones and proinflammatory cytokines",
       "url": "https://pubmed.ncbi.nlm.nih.gov/21129941/",
       "pmid": "21129941",
       "authors": "PubMed",
       "citation": "PubMed PMID 21129941. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Trace Elem Med Biol",
+      "year": 2011,
+      "doi": "10.1016/j.jtemb.2010.10.001",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or softgel",

--- a/public/data/compounds-detail/boswellia.json
+++ b/public/data/compounds-detail/boswellia.json
@@ -84,23 +84,32 @@
   "sources": [
     {
       "id": "src_51f7a63c92af",
-      "title": "PubMed PMID 32848497. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Scientific Rigour in the Assessment and Interpretation of Youth Cardiopulmonary Fitness: A Response to the Paper 'Normative Reference Values and International Comparisons for the 20-Metre Shuttle Run Test: Analysis of 69,960 Test Results among Chinese Children and Youth'",
       "url": "https://pubmed.ncbi.nlm.nih.gov/32848497/",
       "pmid": "32848497",
       "authors": "PubMed",
       "citation": "PubMed PMID 32848497. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Sports Sci Med",
+      "year": 2020,
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_8cf793becc9b",
-      "title": "PubMed PMID 40554037. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effect of a combination of C. longa and B. serrata extracts on hand osteoarthritis. Results of a double-blind, randomized, placebo-controlled, multicenter trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/40554037/",
       "pmid": "40554037",
       "authors": "PubMed",
       "citation": "PubMed PMID 40554037. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Osteoarthritis Cartilage",
+      "year": 2025,
+      "doi": "10.1016/j.joca.2025.06.005",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/bromelain.json
+++ b/public/data/compounds-detail/bromelain.json
@@ -64,13 +64,19 @@
   "sources": [
     {
       "id": "src_1897dff526db",
-      "title": "PubMed PMID 17121765. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Bromelain as an adjunctive treatment for moderate-to-severe osteoarthritis of the knee: a randomized placebo-controlled pilot study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17121765/",
       "pmid": "17121765",
       "authors": "PubMed",
       "citation": "PubMed PMID 17121765. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "QJM",
+      "year": 2006,
+      "doi": "10.1093/qjmed/hcl118",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/caffeine-l-theanine.json
+++ b/public/data/compounds-detail/caffeine-l-theanine.json
@@ -85,13 +85,19 @@
   "sources": [
     {
       "id": "src_e2df05e4dcb4",
-      "title": "PubMed PMID 18681988. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The combined effects of L-theanine and caffeine on cognitive performance and mood",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18681988/",
       "pmid": "18681988",
       "authors": "PubMed",
       "citation": "PubMed PMID 18681988. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Nutr Neurosci",
+      "year": 2008,
+      "doi": "10.1179/147683008X301513",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_a051bced3154",

--- a/public/data/compounds-detail/caffeine.json
+++ b/public/data/compounds-detail/caffeine.json
@@ -86,13 +86,19 @@
   "sources": [
     {
       "id": "src_5de80572b86c",
-      "title": "PubMed PMID 20182035. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Is caffeine a cognitive enhancer?",
       "url": "https://pubmed.ncbi.nlm.nih.gov/20182035/",
       "pmid": "20182035",
       "authors": "PubMed",
       "citation": "PubMed PMID 20182035. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Alzheimers Dis",
+      "year": 2010,
+      "doi": "10.3233/JAD-2010-091315",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/calcium.json
+++ b/public/data/compounds-detail/calcium.json
@@ -124,13 +124,19 @@
   "sources": [
     {
       "id": "src_738081654367",
-      "title": "PubMed PMID 31860103. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Vitamin D and Calcium for the Prevention of Fracture: A Systematic Review and Meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/31860103/",
       "pmid": "31860103",
       "authors": "PubMed",
       "citation": "PubMed PMID 31860103. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "JAMA Netw Open",
+      "year": 2019,
+      "doi": "10.1001/jamanetworkopen.2019.17789",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_e60ce5d9aaa2",

--- a/public/data/compounds-detail/capsaicin.json
+++ b/public/data/compounds-detail/capsaicin.json
@@ -67,13 +67,19 @@
   "sources": [
     {
       "id": "src_ac7187de89a0",
-      "title": "PubMed PMID 24941673. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Capsaicin for osteoarthritis pain",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24941673/",
       "pmid": "24941673",
       "authors": "PubMed",
       "citation": "PubMed PMID 24941673. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Prog Drug Res",
+      "year": 2014,
+      "doi": "10.1007/978-3-0348-0828-6_11",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/carnitine-l-tartrate.json
+++ b/public/data/compounds-detail/carnitine-l-tartrate.json
@@ -113,13 +113,19 @@
   "sources": [
     {
       "id": "src_9b85ebb8daf4",
-      "title": "PubMed PMID 12930169. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effects of L-carnitine L-tartrate supplementation on hormonal responses to resistance exercise and recovery",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12930169/",
       "pmid": "12930169",
       "authors": "PubMed",
       "citation": "PubMed PMID 12930169. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Strength Cond Res",
+      "year": 2003,
+      "doi": "10.1519/1533-4287(2003)017<0455:teolls>2.0.co;2",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/cdp-choline.json
+++ b/public/data/compounds-detail/cdp-choline.json
@@ -84,13 +84,19 @@
   "sources": [
     {
       "id": "src_ad8ff3b198d3",
-      "title": "PubMed PMID 33978188. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Citicoline and Memory Function in Healthy Older Adults: A Randomized, Double-Blind, Placebo-Controlled Clinical Trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/33978188/",
       "pmid": "33978188",
       "authors": "PubMed",
       "citation": "PubMed PMID 33978188. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Nutr",
+      "year": 2021,
+      "doi": "10.1093/jn/nxab119",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/chamomile.json
+++ b/public/data/compounds-detail/chamomile.json
@@ -114,13 +114,19 @@
   "sources": [
     {
       "id": "src_2ab07cb6684b",
-      "title": "PubMed PMID 19593179. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A randomized, double-blind, placebo-controlled trial of oral Matricaria recutita (chamomile) extract therapy for generalized anxiety disorder",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19593179/",
       "pmid": "19593179",
       "authors": "PubMed",
       "citation": "PubMed PMID 19593179. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Clin Psychopharmacol",
+      "year": 2009,
+      "doi": "10.1097/JCP.0b013e3181ac935c",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract capsule",

--- a/public/data/compounds-detail/chondroitin.json
+++ b/public/data/compounds-detail/chondroitin.json
@@ -62,13 +62,17 @@
   "sources": [
     {
       "id": "src_36895c5bc0d1",
-      "title": "PubMed PMID 17470980. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Esophageal temperature monitoring during radiofrequency catheter ablation: experimental study based on an agar phantom model",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17470980/",
       "pmid": "17470980",
       "authors": "PubMed",
       "citation": "PubMed PMID 17470980. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Physiol Meas",
+      "year": 2007,
+      "doi": "10.1088/0967-3334/28/5/001",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/chromium-picolinate.json
+++ b/public/data/compounds-detail/chromium-picolinate.json
@@ -64,13 +64,18 @@
   "sources": [
     {
       "id": "src_8799e0f58983",
-      "title": "PubMed PMID 15208835. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A scientific review: the role of chromium in insulin resistance",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15208835/",
       "pmid": "15208835",
       "authors": "PubMed",
       "citation": "PubMed PMID 15208835. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Diabetes Educ",
+      "year": 2004,
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/compounds-detail/chromium.json
+++ b/public/data/compounds-detail/chromium.json
@@ -83,23 +83,34 @@
   "sources": [
     {
       "id": "src_77b5365e4e0b",
-      "title": "PubMed PMID 12612144. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The consumption of processed tomato products enhances plasma lycopene concentrations in association with a reduced lipoprotein sensitivity to oxidative damage",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12612144/",
       "pmid": "12612144",
       "authors": "PubMed",
       "citation": "PubMed PMID 12612144. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Nutr",
+      "year": 2003,
+      "doi": "10.1093/jn/133.3.727",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_8799e0f58983",
-      "title": "PubMed PMID 15208835. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A scientific review: the role of chromium in insulin resistance",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15208835/",
       "pmid": "15208835",
       "authors": "PubMed",
       "citation": "PubMed PMID 15208835. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Diabetes Educ",
+      "year": 2004,
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/compounds-detail/cinnamon-extract.json
+++ b/public/data/compounds-detail/cinnamon-extract.json
@@ -67,13 +67,19 @@
   "sources": [
     {
       "id": "src_7895c4d03ee1",
-      "title": "PubMed PMID 37818728. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effect of cinnamon supplementation on glycemic control in patients with type 2 diabetes mellitus: An updated systematic review and dose-response meta-analysis of randomized controlled trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/37818728/",
       "pmid": "37818728",
       "authors": "PubMed",
       "citation": "PubMed PMID 37818728. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytother Res",
+      "year": 2024,
+      "doi": "10.1002/ptr.8026",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/citrulline-malate.json
+++ b/public/data/compounds-detail/citrulline-malate.json
@@ -62,13 +62,19 @@
   "sources": [
     {
       "id": "src_518c663921d5",
-      "title": "PubMed PMID 39408204. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of Acute Citrulline Malate Supplementation on CrossFit(®) Exercise Performance: A Randomized, Double-Blind, Placebo-Controlled, Cross-Over Study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/39408204/",
       "pmid": "39408204",
       "authors": "PubMed",
       "citation": "PubMed PMID 39408204. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Nutrients",
+      "year": 2024,
+      "doi": "10.3390/nu16193235",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "powder or capsule",

--- a/public/data/compounds-detail/collagen-peptides.json
+++ b/public/data/compounds-detail/collagen-peptides.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_e613cf0b61e3",
-      "title": "PubMed PMID 23949208. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Oral supplementation of specific collagen peptides has beneficial effects on human skin physiology: a double-blind, placebo-controlled study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23949208/",
       "pmid": "23949208",
       "authors": "PubMed",
       "citation": "PubMed PMID 23949208. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Skin Pharmacol Physiol",
+      "year": 2014,
+      "doi": "10.1159/000351376",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "powder or capsule",

--- a/public/data/compounds-detail/coq10.json
+++ b/public/data/compounds-detail/coq10.json
@@ -85,23 +85,33 @@
   "sources": [
     {
       "id": "src_131a3ccd6bf5",
-      "title": "PubMed PMID 25282031. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effect of coenzyme Q10 on morbidity and mortality in chronic heart failure: results from Q-SYMBIO: a randomized double-blind trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/25282031/",
       "pmid": "25282031",
       "authors": "PubMed",
       "citation": "PubMed PMID 25282031. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "JACC Heart Fail",
+      "year": 2014,
+      "doi": "10.1016/j.jchf.2014.06.008",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_ad46e361d8f8",
-      "title": "PubMed PMID 25174896. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "New insights into the development of infantile intraocular medulloepithelioma",
       "url": "https://pubmed.ncbi.nlm.nih.gov/25174896/",
       "pmid": "25174896",
       "authors": "PubMed",
       "citation": "PubMed PMID 25174896. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Ophthalmol",
+      "year": 2014,
+      "doi": "10.1016/j.ajo.2014.08.036",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/creatine.json
+++ b/public/data/compounds-detail/creatine.json
@@ -163,33 +163,51 @@
   "sources": [
     {
       "id": "src_319bf8dafaf1",
-      "title": "PubMed PMID 19773644. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Cognitive effects of creatine ethyl ester supplementation",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19773644/",
       "pmid": "19773644",
       "authors": "PubMed",
       "citation": "PubMed PMID 19773644. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Behav Pharmacol",
+      "year": 2009,
+      "doi": "10.1097/FBP.0b013e3283323c2a",
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_9ba65a7d6204",
-      "title": "PubMed PMID 16416332. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effect of creatine supplementation and sleep deprivation, with mild exercise, on cognitive and psychomotor performance, mood state, and plasma concentrations of catecholamines and cortisol",
       "url": "https://pubmed.ncbi.nlm.nih.gov/16416332/",
       "pmid": "16416332",
       "authors": "PubMed",
       "citation": "PubMed PMID 16416332. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Psychopharmacology (Berl)",
+      "year": 2006,
+      "doi": "10.1007/s00213-005-0269-z",
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_b08316272e24",
-      "title": "PubMed PMID 28615996. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "International Society of Sports Nutrition position stand: safety and efficacy of creatine supplementation in exercise, sport, and medicine",
       "url": "https://pubmed.ncbi.nlm.nih.gov/28615996/",
       "pmid": "28615996",
       "authors": "PubMed",
       "citation": "PubMed PMID 28615996. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2017,
+      "doi": "10.1186/s12970-017-0173-z",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_da5119881f63",

--- a/public/data/compounds-detail/crocetin.json
+++ b/public/data/compounds-detail/crocetin.json
@@ -159,8 +159,11 @@
       "journal": "Front Pharmacol",
       "citation": "Author not retrieved (2021). Front Pharmacol. PMID: 35095483. DOI: 10.3389/fphar.2021.745683.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "studyType": "Systematic review",
-      "reviewStatus": "approved"
+      "studyType": "Narrative review",
+      "reviewStatus": "approved",
+      "authors": "Guo ZL et al.",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/crocin.json
+++ b/public/data/compounds-detail/crocin.json
@@ -157,7 +157,9 @@
       "citation": "Author not retrieved (2015). J Affect Disord. PMID: 25484177. DOI: 10.1016/j.jad.2014.11.035.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
       "studyType": "Randomized controlled trial",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Talaei A et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized botanical extract capsule",

--- a/public/data/compounds-detail/cryptotanshinone.json
+++ b/public/data/compounds-detail/cryptotanshinone.json
@@ -138,7 +138,9 @@
       "journal": "Biomed Pharmacother",
       "citation": "Author not retrieved (2024). Biomed Pharmacother. PMID: 38039759. DOI: 10.1016/j.biopha.2023.115956.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Wang T et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/curcumin-piperine.json
+++ b/public/data/compounds-detail/curcumin-piperine.json
@@ -89,7 +89,9 @@
       "citation": "Author not retrieved (2025). Curr Med Chem. PMID: 38561618. DOI: 10.2174/0109298673260515240322074849.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Hosseini H et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/d-chiro-inositol.json
+++ b/public/data/compounds-detail/d-chiro-inositol.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_f7ab63c70d7e",
-      "title": "PubMed PMID 29498933. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Management of women with PCOS using myo-inositol and folic acid. New clinical data and review of the literature",
       "url": "https://pubmed.ncbi.nlm.nih.gov/29498933/",
       "pmid": "29498933",
       "authors": "PubMed",
       "citation": "PubMed PMID 29498933. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Horm Mol Biol Clin Investig",
+      "year": 2018,
+      "doi": "10.1515/hmbci-2017-0067",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/devils-claw.json
+++ b/public/data/compounds-detail/devils-claw.json
@@ -124,23 +124,33 @@
   "sources": [
     {
       "id": "src_8b0e655d4aa1",
-      "title": "PubMed PMID 11406863. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Mutagenicity and antioxidant assessment of Stachitarpheta jamaicensis (L.) Vahl",
       "url": "https://pubmed.ncbi.nlm.nih.gov/11406863/",
       "pmid": "11406863",
       "authors": "PubMed",
       "citation": "PubMed PMID 11406863. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytother Res",
+      "year": 2001,
+      "doi": "10.1002/ptr.708",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_d9d362d72071",
-      "title": "PubMed PMID 17212570. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Devil's Claw (Harpagophytum procumbens) as a treatment for osteoarthritis: a review of efficacy and safety",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17212570/",
       "pmid": "17212570",
       "authors": "PubMed",
       "citation": "PubMed PMID 17212570. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Altern Complement Med",
+      "year": 2006,
+      "doi": "10.1089/acm.2006.12.981",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "medium",

--- a/public/data/compounds-detail/dihydrokavain.json
+++ b/public/data/compounds-detail/dihydrokavain.json
@@ -87,7 +87,9 @@
       "citation": "Author not retrieved (2002). Planta Med. PMID: 12494336. DOI: 10.1055/s-2002-36338.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
       "studyType": "Animal",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Yuan CS et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/dihydromethysticin.json
+++ b/public/data/compounds-detail/dihydromethysticin.json
@@ -139,7 +139,9 @@
       "journal": "Toxicol Sci",
       "citation": "Author not retrieved (2011). Toxicol Sci. PMID: 21908763. DOI: 10.1093/toxsci/kfr235.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Li Y et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/diosgenin.json
+++ b/public/data/compounds-detail/diosgenin.json
@@ -140,7 +140,11 @@
       "journal": "Oxid Med Cell Longev",
       "citation": "Author not retrieved (2022). Oxid Med Cell Longev. PMID: 35677108. DOI: 10.1155/2022/1035441.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Semwal P et al.",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/echinacea.json
+++ b/public/data/compounds-detail/echinacea.json
@@ -64,13 +64,19 @@
   "sources": [
     {
       "id": "src_4dd8f9af54c4",
-      "title": "PubMed PMID 24554461. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Echinacea for preventing and treating the common cold",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24554461/",
       "pmid": "24554461",
       "authors": "PubMed",
       "citation": "PubMed PMID 24554461. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2014,
+      "doi": "10.1002/14651858.CD000530.pub3",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/egcg-caffeine.json
+++ b/public/data/compounds-detail/egcg-caffeine.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_72eadc586f7b",
-      "title": "PubMed PMID 19597519. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effects of green tea on weight loss and weight maintenance: a meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19597519/",
       "pmid": "19597519",
       "authors": "PubMed",
       "citation": "PubMed PMID 19597519. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int J Obes (Lond)",
+      "year": 2009,
+      "doi": "10.1038/ijo.2009.135",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/fadogia-agrestis.json
+++ b/public/data/compounds-detail/fadogia-agrestis.json
@@ -104,7 +104,9 @@
       "journal": "Asian J Androl",
       "citation": "Author not retrieved (2005). Asian J Androl. PMID: 16281088. DOI: 10.1111/j.1745-7262.2005.00052.x.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Yakubu MT et al.",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_b5b0b0a73b41",

--- a/public/data/compounds-detail/farnesol.json
+++ b/public/data/compounds-detail/farnesol.json
@@ -143,7 +143,11 @@
       "journal": "Expert Opin Ther Pat",
       "citation": "Author not retrieved (2020). Expert Opin Ther Pat. PMID: 31958255. DOI: 10.1080/13543776.2020.1718653.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Delmondes GA et al.",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "softgel or liquid oil",

--- a/public/data/compounds-detail/fenugreek-extract.json
+++ b/public/data/compounds-detail/fenugreek-extract.json
@@ -89,7 +89,9 @@
       "citation": "Author not retrieved (2020). Phytother Res. PMID: 32048383. DOI: 10.1002/ptr.6627.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Mansoori A et al.",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/fenugreek.json
+++ b/public/data/compounds-detail/fenugreek.json
@@ -64,13 +64,19 @@
   "sources": [
     {
       "id": "src_8fc841bf5035",
-      "title": "PubMed PMID 28266134. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A small plant with big benefits: Fenugreek (Trigonella foenum-graecum Linn.) for disease prevention and health promotion",
       "url": "https://pubmed.ncbi.nlm.nih.gov/28266134/",
       "pmid": "28266134",
       "authors": "PubMed",
       "citation": "PubMed PMID 28266134. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Mol Nutr Food Res",
+      "year": 2017,
+      "doi": "10.1002/mnfr.201600950",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized botanical extract capsule",

--- a/public/data/compounds-detail/ferulic-acid.json
+++ b/public/data/compounds-detail/ferulic-acid.json
@@ -162,7 +162,9 @@
       "journal": "Biochem Biophys Res Commun",
       "citation": "Author not retrieved (1998). Biochem Biophys Res Commun. PMID: 9878519. DOI: 10.1006/bbrc.1998.9681.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Bourne LC and Rice-Evans C",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract capsule",

--- a/public/data/compounds-detail/folate.json
+++ b/public/data/compounds-detail/folate.json
@@ -64,13 +64,19 @@
   "sources": [
     {
       "id": "src_6833b35c98eb",
-      "title": "PubMed PMID 15671130. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Treatment of depression: time to consider folic acid and vitamin B12",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15671130/",
       "pmid": "15671130",
       "authors": "PubMed",
       "citation": "PubMed PMID 15671130. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Psychopharmacol",
+      "year": 2005,
+      "doi": "10.1177/0269881105048899",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "softgel or liquid oil",

--- a/public/data/compounds-detail/forskolin.json
+++ b/public/data/compounds-detail/forskolin.json
@@ -100,13 +100,19 @@
   "sources": [
     {
       "id": "src_786acb726fa1",
-      "title": "PubMed PMID 16129715. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Body composition and hormonal adaptations associated with forskolin consumption in overweight and obese men",
       "url": "https://pubmed.ncbi.nlm.nih.gov/16129715/",
       "pmid": "16129715",
       "authors": "PubMed",
       "citation": "PubMed PMID 16129715. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Obes Res",
+      "year": 2005,
+      "doi": "10.1038/oby.2005.162",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract or essential-oil-free preparation when oral use is intended",

--- a/public/data/compounds-detail/fucoxanthin.json
+++ b/public/data/compounds-detail/fucoxanthin.json
@@ -108,13 +108,19 @@
   "sources": [
     {
       "id": "src_10624494092d",
-      "title": "PubMed PMID 37405785. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effect of Fucoxanthin on Metabolic Syndrome, Insulin Sensitivity, and Insulin Secretion",
       "url": "https://pubmed.ncbi.nlm.nih.gov/37405785/",
       "pmid": "37405785",
       "authors": "PubMed",
       "citation": "PubMed PMID 37405785. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Med Food",
+      "year": 2023,
+      "doi": "10.1089/jmf.2022.0103",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract",

--- a/public/data/compounds-detail/gaba.json
+++ b/public/data/compounds-detail/gaba.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_1ea4b8e52a2c",
-      "title": "PubMed PMID 41554764. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Lactiplantibacillus plantarum Lp815 improves sleep and increases urinary GABA in a randomized, double-blind, placebo-controlled study of sleep disturbance",
       "url": "https://pubmed.ncbi.nlm.nih.gov/41554764/",
       "pmid": "41554764",
       "authors": "PubMed",
       "citation": "PubMed PMID 41554764. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Sci Rep",
+      "year": 2026,
+      "doi": "10.1038/s41598-025-27861-6",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "powder or capsule",

--- a/public/data/compounds-detail/galantamine.json
+++ b/public/data/compounds-detail/galantamine.json
@@ -105,13 +105,19 @@
   "sources": [
     {
       "id": "src_29540e3aa4cd",
-      "title": "PubMed PMID 10881250. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Galantamine in AD: A 6-month randomized, placebo-controlled trial with a 6-month extension. The Galantamine USA-1 Study Group",
       "url": "https://pubmed.ncbi.nlm.nih.gov/10881250/",
       "pmid": "10881250",
       "authors": "PubMed",
       "citation": "PubMed PMID 10881250. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Neurology",
+      "year": 2000,
+      "doi": "10.1212/wnl.54.12.2261",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "prescription tablet",

--- a/public/data/compounds-detail/garcinia-cambogia-extract.json
+++ b/public/data/compounds-detail/garcinia-cambogia-extract.json
@@ -106,13 +106,19 @@
   "sources": [
     {
       "id": "src_36a6058bc2c4",
-      "title": "PubMed PMID 9820262. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Garcinia cambogia (hydroxycitric acid) as a potential antiobesity agent: a randomized controlled trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/9820262/",
       "pmid": "9820262",
       "authors": "PubMed",
       "citation": "PubMed PMID 9820262. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "JAMA",
+      "year": 1998,
+      "doi": "10.1001/jama.280.18.1596",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract",

--- a/public/data/compounds-detail/garcinol.json
+++ b/public/data/compounds-detail/garcinol.json
@@ -138,7 +138,14 @@
       "url": "https://pubmed.ncbi.nlm.nih.gov/33799504/",
       "pmid": "33799504",
       "note": "needs_classification",
-      "reviewStatus": "pending"
+      "reviewStatus": "pending",
+      "journal": "Int J Mol Sci",
+      "year": 2021,
+      "authors": "Kopytko P et al.",
+      "doi": "10.3390/ijms22062828",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_2da296428064-2",
@@ -146,7 +153,12 @@
       "url": "https://pubmed.ncbi.nlm.nih.gov/33034447/",
       "pmid": "33034447",
       "note": "needs_classification",
-      "reviewStatus": "pending"
+      "reviewStatus": "pending",
+      "journal": "ACS Chem Biol",
+      "year": 2020,
+      "authors": "Son SI et al.",
+      "doi": "10.1021/acschembio.0c00719",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract capsule",

--- a/public/data/compounds-detail/ginsenoside-rg3.json
+++ b/public/data/compounds-detail/ginsenoside-rg3.json
@@ -144,7 +144,11 @@
       "journal": "Int J Mol Med",
       "citation": "Author not retrieved (2017). Int J Mol Med. PMID: 28098857. DOI: 10.3892/ijmm.2017.2857.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Sun M et al.",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized botanical extract capsule",

--- a/public/data/compounds-detail/glucomannan.json
+++ b/public/data/compounds-detail/glucomannan.json
@@ -109,17 +109,25 @@
       "citation": "Author not retrieved (2014). J Am Coll Nutr. PMID: 24533610. DOI: 10.1080/07315724.2014.870013.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Onakpoya I et al.",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_cc31fbab8401",
-      "title": "PubMed PMID 18842808. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effect of glucomannan on plasma lipid and glucose concentrations, body weight, and blood pressure: systematic review and meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18842808/",
       "pmid": "18842808",
       "authors": "PubMed",
       "citation": "PubMed PMID 18842808. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Clin Nutr",
+      "year": 2008,
+      "doi": "10.1093/ajcn/88.4.1167",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/glucosamine.json
+++ b/public/data/compounds-detail/glucosamine.json
@@ -64,13 +64,17 @@
   "sources": [
     {
       "id": "src_36895c5bc0d1",
-      "title": "PubMed PMID 17470980. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Esophageal temperature monitoring during radiofrequency catheter ablation: experimental study based on an agar phantom model",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17470980/",
       "pmid": "17470980",
       "authors": "PubMed",
       "citation": "PubMed PMID 17470980. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Physiol Meas",
+      "year": 2007,
+      "doi": "10.1088/0967-3334/28/5/001",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/glycinate-magnesium-complex.json
+++ b/public/data/compounds-detail/glycinate-magnesium-complex.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_783236db1529",
-      "title": "PubMed PMID 40918053. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Magnesium Bisglycinate Supplementation in Healthy Adults Reporting Poor Sleep: A Randomized, Placebo-Controlled Trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/40918053/",
       "pmid": "40918053",
       "authors": "PubMed",
       "citation": "PubMed PMID 40918053. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Nat Sci Sleep",
+      "year": 2025,
+      "doi": "10.2147/NSS.S524348",
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral",

--- a/public/data/compounds-detail/green-tea-extract-egcg.json
+++ b/public/data/compounds-detail/green-tea-extract-egcg.json
@@ -88,7 +88,11 @@
       "journal": "Molecules",
       "citation": "Author not retrieved (2025). Molecules. PMID: 39942757. DOI: 10.3390/molecules30030654.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Capasso L et al.",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/guggulsterone.json
+++ b/public/data/compounds-detail/guggulsterone.json
@@ -158,7 +158,11 @@
       "journal": "Adv Exp Med Biol",
       "citation": "Author not retrieved (2016). Adv Exp Med Biol. PMID: 27771932. DOI: 10.1007/978-3-319-41342-6_15.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Yamada T and Sugimoto K",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized botanical extract capsule",

--- a/public/data/compounds-detail/hawthorn-extract.json
+++ b/public/data/compounds-detail/hawthorn-extract.json
@@ -106,17 +106,25 @@
       "journal": "Int J Urol",
       "citation": "Author not retrieved (2007). Int J Urol. PMID: 17470176. DOI: 10.1111/j.1442-2042.2007.01576.x.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Suzuki K et al.",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_63a59e474b8d",
-      "title": "PubMed PMID 19789403. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Hawthorn Extract Randomized Blinded Chronic Heart Failure (HERB CHF) trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19789403/",
       "pmid": "19789403",
       "authors": "PubMed",
       "citation": "PubMed PMID 19789403. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Eur J Heart Fail",
+      "year": 2009,
+      "doi": "10.1093/eurjhf/hfp116",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract",

--- a/public/data/compounds-detail/hesperidin.json
+++ b/public/data/compounds-detail/hesperidin.json
@@ -89,7 +89,11 @@
       "journal": "New Phytol",
       "citation": "Author not retrieved (2020). New Phytol. PMID: 32353900. DOI: 10.1111/nph.16632.",
       "note": "source-backed gap-fill audit only; not a full monograph field extraction",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "authors": "Gagliardi D and Manavella PA",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized botanical extract capsule",

--- a/public/data/compounds-detail/hmb.json
+++ b/public/data/compounds-detail/hmb.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_0b430227bf79",
-      "title": "PubMed PMID 10410847. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Creatine supplementation. Its role in human performance",
       "url": "https://pubmed.ncbi.nlm.nih.gov/10410847/",
       "pmid": "10410847",
       "authors": "PubMed",
       "citation": "PubMed PMID 10410847. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Clin Sports Med",
+      "year": 1999,
+      "doi": "10.1016/s0278-5919(05)70174-5",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/hyaluronic-acid.json
+++ b/public/data/compounds-detail/hyaluronic-acid.json
@@ -63,13 +63,17 @@
   "sources": [
     {
       "id": "src_d0eb5bce755f",
-      "title": "PubMed PMID 32650511. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Short-Term Effect of a New Oral Sodium Hyaluronate Formulation on Knee Osteoarthritis: A Double-Blind, Randomized, Placebo-Controlled Clinical Trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/32650511/",
       "pmid": "32650511",
       "authors": "PubMed",
       "citation": "PubMed PMID 32650511. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Diseases",
+      "year": 2020,
+      "doi": "10.3390/diseases8030026",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/iberogast.json
+++ b/public/data/compounds-detail/iberogast.json
@@ -105,13 +105,18 @@
   "sources": [
     {
       "id": "src_589c4ec4e87b",
-      "title": "PubMed PMID 15927925. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Iberis amara L. and Iberogast--results of a systematic review concerning functional dyspepsia",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15927925/",
       "pmid": "15927925",
       "authors": "PubMed",
       "citation": "PubMed PMID 15927925. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Herb Pharmacother",
+      "year": 2004,
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "short-to-medium",

--- a/public/data/compounds-detail/iodine.json
+++ b/public/data/compounds-detail/iodine.json
@@ -120,13 +120,18 @@
   "sources": [
     {
       "id": "src_0abece3aa01b",
-      "title": "PubMed PMID 15734706. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effects of iodine on intelligence in children: a meta-analysis of studies conducted in China",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15734706/",
       "pmid": "15734706",
       "authors": "PubMed",
       "citation": "PubMed PMID 15734706. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Asia Pac J Clin Nutr",
+      "year": 2005,
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_991903c9ff62",

--- a/public/data/compounds-detail/iron.json
+++ b/public/data/compounds-detail/iron.json
@@ -149,33 +149,47 @@
   "sources": [
     {
       "id": "src_2c881e8d3299",
-      "title": "PubMed PMID 17344500. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Iron treatment normalizes cognitive functioning in young women",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17344500/",
       "pmid": "17344500",
       "authors": "PubMed",
       "citation": "PubMed PMID 17344500. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Clin Nutr",
+      "year": 2007,
+      "doi": "10.1093/ajcn/85.3.778",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_35249a83e723",
-      "title": "PubMed PMID 12706309. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Occurrence of oxygen desaturation events during preterm infant bottle feeding near discharge",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12706309/",
       "pmid": "12706309",
       "authors": "PubMed",
       "citation": "PubMed PMID 12706309. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Early Hum Dev",
+      "year": 2003,
+      "doi": "10.1016/s0378-3782(03)00008-2",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_4a32a37af842",
-      "title": "PubMed PMID 18711167. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Why choose serum cystatin C levels over serum creatinine levels as a serologic marker of kidney function?",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18711167/",
       "pmid": "18711167",
       "authors": "PubMed",
       "citation": "PubMed PMID 18711167. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Ann Intern Med",
+      "year": 2008,
+      "doi": "10.7326/0003-4819-149-4-200808190-00016",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/compounds-detail/kava.json
+++ b/public/data/compounds-detail/kava.json
@@ -63,13 +63,19 @@
   "sources": [
     {
       "id": "src_203bc87edd2e",
-      "title": "PubMed PMID 12131602. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A placebo-controlled study of Kava kava in generalized anxiety disorder",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12131602/",
       "pmid": "12131602",
       "authors": "PubMed",
       "citation": "PubMed PMID 12131602. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int Clin Psychopharmacol",
+      "year": 2002,
+      "doi": "10.1097/00004850-200207000-00005",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/l-carnitine.json
+++ b/public/data/compounds-detail/l-carnitine.json
@@ -65,13 +65,17 @@
   "sources": [
     {
       "id": "src_6f68e9784e5a",
-      "title": "PubMed PMID 15607555. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A novel therapeutic strategy for Ehlers-Danlos syndrome based on nutritional supplements",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15607555/",
       "pmid": "15607555",
       "authors": "PubMed",
       "citation": "PubMed PMID 15607555. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Med Hypotheses",
+      "year": 2005,
+      "doi": "10.1016/j.mehy.2004.07.023",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "softgel or liquid oil",

--- a/public/data/compounds-detail/lavender-extract.json
+++ b/public/data/compounds-detail/lavender-extract.json
@@ -133,23 +133,35 @@
   "sources": [
     {
       "id": "src_724799cfc414",
-      "title": "PubMed PMID 24456909. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Lavender oil preparation Silexan is effective in generalized anxiety disorder--a randomized, double-blind comparison to placebo and paroxetine",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24456909/",
       "pmid": "24456909",
       "authors": "PubMed",
       "citation": "PubMed PMID 24456909. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int J Neuropsychopharmacol",
+      "year": 2014,
+      "doi": "10.1017/S1461145714000017",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_d0f31504cef6",
-      "title": "PubMed PMID 21170695. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy and safety of silexan, a new, orally administered lavender oil preparation, in subthreshold anxiety disorder - evidence from clinical trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/21170695/",
       "pmid": "21170695",
       "authors": "PubMed",
       "citation": "PubMed PMID 21170695. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Wien Med Wochenschr",
+      "year": 2010,
+      "doi": "10.1007/s10354-010-0845-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "oral lavender oil",

--- a/public/data/compounds-detail/lavender.json
+++ b/public/data/compounds-detail/lavender.json
@@ -146,13 +146,19 @@
   "sources": [
     {
       "id": "src_724799cfc414",
-      "title": "PubMed PMID 24456909. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Lavender oil preparation Silexan is effective in generalized anxiety disorder--a randomized, double-blind comparison to placebo and paroxetine",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24456909/",
       "pmid": "24456909",
       "authors": "PubMed",
       "citation": "PubMed PMID 24456909. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int J Neuropsychopharmacol",
+      "year": 2014,
+      "doi": "10.1017/S1461145714000017",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_941e08f798f5",

--- a/public/data/compounds-detail/lemon-balm.json
+++ b/public/data/compounds-detail/lemon-balm.json
@@ -121,13 +121,19 @@
   "sources": [
     {
       "id": "src_826d7cae36e1",
-      "title": "PubMed PMID 34449930. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effects of lemon balm (Melissa officinalis L.) on depression and anxiety in clinical trials: A systematic review and meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/34449930/",
       "pmid": "34449930",
       "authors": "PubMed",
       "citation": "PubMed PMID 34449930. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytother Res",
+      "year": 2021,
+      "doi": "10.1002/ptr.7252",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract capsule",

--- a/public/data/compounds-detail/lutein.json
+++ b/public/data/compounds-detail/lutein.json
@@ -99,13 +99,19 @@
   "sources": [
     {
       "id": "src_56cc494303b2",
-      "title": "PubMed PMID 23644932. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Lutein + zeaxanthin and omega-3 fatty acids for age-related macular degeneration: the Age-Related Eye Disease Study 2 (AREDS2) randomized clinical trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23644932/",
       "pmid": "23644932",
       "authors": "PubMed",
       "citation": "PubMed PMID 23644932. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "JAMA",
+      "year": 2013,
+      "doi": "10.1001/jama.2013.4997",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_926aac42dc97",

--- a/public/data/compounds-detail/magnesium.json
+++ b/public/data/compounds-detail/magnesium.json
@@ -184,43 +184,60 @@
   "sources": [
     {
       "id": "src_1db911595120",
-      "title": "PubMed PMID 23853635. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effect of magnesium supplementation on primary insomnia in elderly: A double-blind placebo-controlled clinical trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23853635/",
       "pmid": "23853635",
       "authors": "PubMed",
       "citation": "PubMed PMID 23853635. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Res Med Sci",
+      "year": 2012,
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_46b64396df5a",
-      "title": "PubMed PMID 28471760. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Magnesium Supplementation in Vitamin D Deficiency",
       "url": "https://pubmed.ncbi.nlm.nih.gov/28471760/",
       "pmid": "28471760",
       "authors": "PubMed",
       "citation": "PubMed PMID 28471760. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Ther",
+      "year": 2019,
+      "doi": "10.1097/MJT.0000000000000538",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_972d09376205",
-      "title": "PubMed PMID 29679349. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Timeline (Bioavailability) of Magnesium Compounds in Hours: Which Magnesium Compound Works Best?",
       "url": "https://pubmed.ncbi.nlm.nih.gov/29679349/",
       "pmid": "29679349",
       "authors": "PubMed",
       "citation": "PubMed PMID 29679349. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Biol Trace Elem Res",
+      "year": 2019,
+      "doi": "10.1007/s12011-018-1351-9",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_a8cddfb5c4db",
-      "title": "PubMed PMID 31654344. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Trends in Drain Utilization in Bariatric Surgery: an Analysis of the MBSAQIP Database 2015-2017",
       "url": "https://pubmed.ncbi.nlm.nih.gov/31654344/",
       "pmid": "31654344",
       "authors": "PubMed",
       "citation": "PubMed PMID 31654344. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Obes Surg",
+      "year": 2020,
+      "doi": "10.1007/s11695-019-04215-6",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_7e4a317262c5",

--- a/public/data/compounds-detail/mct-oil.json
+++ b/public/data/compounds-detail/mct-oil.json
@@ -111,13 +111,19 @@
   "sources": [
     {
       "id": "src_0071dad30187",
-      "title": "PubMed PMID 18326600. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Weight-loss diet that includes consumption of medium-chain triacylglycerol oil leads to a greater rate of weight and fat mass loss than does olive oil",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18326600/",
       "pmid": "18326600",
       "authors": "PubMed",
       "citation": "PubMed PMID 18326600. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Clin Nutr",
+      "year": 2008,
+      "doi": "10.1093/ajcn/87.3.621",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/melatonin.json
+++ b/public/data/compounds-detail/melatonin.json
@@ -204,43 +204,63 @@
   "sources": [
     {
       "id": "src_0e38d20729ea",
-      "title": "PubMed PMID 20091037. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Biopsychosocial determinants of physical and mental fatigue in patients with spondyloarthropathy",
       "url": "https://pubmed.ncbi.nlm.nih.gov/20091037/",
       "pmid": "20091037",
       "authors": "PubMed",
       "citation": "PubMed PMID 20091037. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Rheumatol Int",
+      "year": 2011,
+      "doi": "10.1007/s00296-009-1250-7",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_4fd666ecb3cf",
-      "title": "PubMed PMID 23691095. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Meta-analysis: melatonin for the treatment of primary sleep disorders",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23691095/",
       "pmid": "23691095",
       "authors": "PubMed",
       "citation": "PubMed PMID 23691095. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "PLoS One",
+      "year": 2013,
+      "doi": "10.1371/journal.pone.0063773",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_529bc3e73238",
-      "title": "PubMed PMID 25128263. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Wound ballistics of firearm-related injuries--part 2: mechanisms of skeletal injury and characteristics of maxillofacial ballistic trauma",
       "url": "https://pubmed.ncbi.nlm.nih.gov/25128263/",
       "pmid": "25128263",
       "authors": "PubMed",
       "citation": "PubMed PMID 25128263. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int J Oral Maxillofac Surg",
+      "year": 2015,
+      "doi": "10.1016/j.ijom.2014.07.012",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_ac1716c7775d",
-      "title": "PubMed PMID 12467979. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A putative novel nuclear-encoded subunit of the cytochrome c oxidase complex in trypanosomatids",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12467979/",
       "pmid": "12467979",
       "authors": "PubMed",
       "citation": "PubMed PMID 12467979. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Mol Biochem Parasitol",
+      "year": 2002,
+      "doi": "10.1016/s0166-6851(02)00235-9",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_070f1c3027c3",

--- a/public/data/compounds-detail/msm.json
+++ b/public/data/compounds-detail/msm.json
@@ -110,13 +110,19 @@
   "sources": [
     {
       "id": "src_0101f16f4835",
-      "title": "PubMed PMID 21708034. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy of methylsulfonylmethane supplementation on osteoarthritis of the knee: a randomized controlled study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/21708034/",
       "pmid": "21708034",
       "authors": "PubMed",
       "citation": "PubMed PMID 21708034. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "BMC Complement Altern Med",
+      "year": 2011,
+      "doi": "10.1186/1472-6882-11-50",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/mucuna-pruriens.json
+++ b/public/data/compounds-detail/mucuna-pruriens.json
@@ -62,13 +62,19 @@
   "sources": [
     {
       "id": "src_5f66f401acda",
-      "title": "PubMed PMID 15548480. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Mucuna pruriens in Parkinson's disease: a double blind clinical and pharmacological study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15548480/",
       "pmid": "15548480",
       "authors": "PubMed",
       "citation": "PubMed PMID 15548480. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Neurol Neurosurg Psychiatry",
+      "year": 2004,
+      "doi": "10.1136/jnnp.2003.028761",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/nattokinase.json
+++ b/public/data/compounds-detail/nattokinase.json
@@ -63,13 +63,19 @@
   "sources": [
     {
       "id": "src_0140e760e912",
-      "title": "PubMed PMID 18971533. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of nattokinase on blood pressure: a randomized, controlled trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18971533/",
       "pmid": "18971533",
       "authors": "PubMed",
       "citation": "PubMed PMID 18971533. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Hypertens Res",
+      "year": 2008,
+      "doi": "10.1291/hypres.31.1583",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/olive-leaf-extract.json
+++ b/public/data/compounds-detail/olive-leaf-extract.json
@@ -68,13 +68,19 @@
   "sources": [
     {
       "id": "src_7ae7a5ea3481",
-      "title": "PubMed PMID 21443487. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Molecular mechanisms of inflammation. Anti-inflammatory benefits of virgin olive oil and the phenolic compound oleocanthal",
       "url": "https://pubmed.ncbi.nlm.nih.gov/21443487/",
       "pmid": "21443487",
       "authors": "PubMed",
       "citation": "PubMed PMID 21443487. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Curr Pharm Des",
+      "year": 2011,
+      "doi": "10.2174/138161211795428911",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/omega-3.json
+++ b/public/data/compounds-detail/omega-3.json
@@ -148,53 +148,74 @@
   "sources": [
     {
       "id": "src_04928558bfad",
-      "title": "PubMed PMID 18497367. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Adaptation of orientation vectors of otolith-related central vestibular neurons to gravity",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18497367/",
       "pmid": "18497367",
       "authors": "PubMed",
       "citation": "PubMed PMID 18497367. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Neurophysiol",
+      "year": 2008,
+      "doi": "10.1152/jn.90289.2008",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_4431416626da",
-      "title": "PubMed PMID 30415628. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Cardiovascular Risk Reduction with Icosapent Ethyl for Hypertriglyceridemia",
       "url": "https://pubmed.ncbi.nlm.nih.gov/30415628/",
       "pmid": "30415628",
       "authors": "PubMed",
       "citation": "PubMed PMID 30415628. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "N Engl J Med",
+      "year": 2019,
+      "doi": "10.1056/NEJMoa1812792",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_938e1bdb63fd",
-      "title": "PubMed PMID 25287985. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Blue blocker glasses as a countermeasure for alerting effects of evening light-emitting diode screen exposure in male teenagers",
       "url": "https://pubmed.ncbi.nlm.nih.gov/25287985/",
       "pmid": "25287985",
       "authors": "PubMed",
       "citation": "PubMed PMID 25287985. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Adolesc Health",
+      "year": 2015,
+      "doi": "10.1016/j.jadohealth.2014.08.002",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_a190dcbbb452",
-      "title": "PubMed PMID 27132744. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Manjunath",
       "url": "https://pubmed.ncbi.nlm.nih.gov/27132744/",
       "pmid": "27132744",
       "authors": "PubMed",
       "citation": "PubMed PMID 27132744. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Natl Med J India",
+      "year": 2015,
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_aef42e549429",
-      "title": "PubMed PMID 30686880. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Progress in Fetal Surgery: A Buoyant Start or Watchful Reluctance? Perspectives for India",
       "url": "https://pubmed.ncbi.nlm.nih.gov/30686880/",
       "pmid": "30686880",
       "authors": "PubMed",
       "citation": "PubMed PMID 30686880. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Indian Assoc Pediatr Surg",
+      "year": 2019,
+      "doi": "10.4103/jiaps.JIAPS_84_18",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "softgel or liquid oil",

--- a/public/data/compounds-detail/passionflower-extract.json
+++ b/public/data/compounds-detail/passionflower-extract.json
@@ -112,13 +112,19 @@
   "sources": [
     {
       "id": "src_037925910c28",
-      "title": "PubMed PMID 31714321. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of Passiflora incarnata Linnaeus on polysomnographic sleep parameters in subjects with insomnia disorder: a double-blind randomized placebo-controlled study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/31714321/",
       "pmid": "31714321",
       "authors": "PubMed",
       "citation": "PubMed PMID 31714321. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int Clin Psychopharmacol",
+      "year": 2020,
+      "doi": "10.1097/YIC.0000000000000291",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "extract",

--- a/public/data/compounds-detail/passionflower.json
+++ b/public/data/compounds-detail/passionflower.json
@@ -109,13 +109,19 @@
   "sources": [
     {
       "id": "src_3213bd269e3f",
-      "title": "PubMed PMID 18499602. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Preoperative oral Passiflora incarnata reduces anxiety in ambulatory surgery patients: a double-blind, placebo-controlled study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18499602/",
       "pmid": "18499602",
       "authors": "PubMed",
       "citation": "PubMed PMID 18499602. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Anesth Analg",
+      "year": 2008,
+      "doi": "10.1213/ane.0b013e318172c3f9",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract capsule",

--- a/public/data/compounds-detail/peppermint-oil.json
+++ b/public/data/compounds-detail/peppermint-oil.json
@@ -105,13 +105,19 @@
   "sources": [
     {
       "id": "src_e4c8a349570e",
-      "title": "PubMed PMID 19507027. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effect of enteric-coated, delayed-release peppermint oil on irritable bowel syndrome",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19507027/",
       "pmid": "19507027",
       "authors": "PubMed",
       "citation": "PubMed PMID 19507027. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Dig Dis Sci",
+      "year": 2010,
+      "doi": "10.1007/s10620-009-0854-9",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_8e18d4094410",

--- a/public/data/compounds-detail/plant-sterols.json
+++ b/public/data/compounds-detail/plant-sterols.json
@@ -62,13 +62,19 @@
   "sources": [
     {
       "id": "src_dc5e91c8cd2f",
-      "title": "PubMed PMID 24780090. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "LDL-cholesterol-lowering effect of plant sterols and stanols across different dose ranges: a meta-analysis of randomised controlled studies",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24780090/",
       "pmid": "24780090",
       "authors": "PubMed",
       "citation": "PubMed PMID 24780090. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Br J Nutr",
+      "year": 2014,
+      "doi": "10.1017/S0007114514000750",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/pomegranate-extract.json
+++ b/public/data/compounds-detail/pomegranate-extract.json
@@ -66,13 +66,19 @@
   "sources": [
     {
       "id": "src_a269a9f84c29",
-      "title": "PubMed PMID 27888156. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of pomegranate juice on blood pressure: A systematic review and meta-analysis of randomized controlled trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/27888156/",
       "pmid": "27888156",
       "authors": "PubMed",
       "citation": "PubMed PMID 27888156. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Pharmacol Res",
+      "year": 2017,
+      "doi": "10.1016/j.phrs.2016.11.018",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/potassium.json
+++ b/public/data/compounds-detail/potassium.json
@@ -64,13 +64,17 @@
   "sources": [
     {
       "id": "src_06d69ae03171",
-      "title": "PubMed PMID 25059961. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "One Health: time to move on from just talking",
       "url": "https://pubmed.ncbi.nlm.nih.gov/25059961/",
       "pmid": "25059961",
       "authors": "PubMed",
       "citation": "PubMed PMID 25059961. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Vet Rec",
+      "year": 2014,
+      "doi": "10.1136/vr.g4746",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/compounds-detail/probiotics.json
+++ b/public/data/compounds-detail/probiotics.json
@@ -86,23 +86,31 @@
   "sources": [
     {
       "id": "src_74aff507b53f",
-      "title": "PubMed PMID 25808252. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Celebrate World Hypertension Day (WHD) on May 17, 2015, and contribute to improving awareness of hypertension",
       "url": "https://pubmed.ncbi.nlm.nih.gov/25808252/",
       "pmid": "25808252",
       "authors": "PubMed",
       "citation": "PubMed PMID 25808252. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Clin Hypertens (Greenwich)",
+      "year": 2015,
+      "doi": "10.1111/jch.12542",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_c0401bbdfecb",
-      "title": "PubMed PMID 24912386. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Expert consensus document. The International Scientific Association for Probiotics and Prebiotics consensus statement on the scope and appropriate use of the term probiotic",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24912386/",
       "pmid": "24912386",
       "authors": "PubMed",
       "citation": "PubMed PMID 24912386. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Nat Rev Gastroenterol Hepatol",
+      "year": 2014,
+      "doi": "10.1038/nrgastro.2014.66",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/psyllium-husk.json
+++ b/public/data/compounds-detail/psyllium-husk.json
@@ -66,13 +66,19 @@
   "sources": [
     {
       "id": "src_b88cf6d3636d",
-      "title": "PubMed PMID 30239559. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effect of psyllium (Plantago ovata) fiber on LDL cholesterol and alternative lipid targets, non-HDL cholesterol and apolipoprotein B: a systematic review and meta-analysis of randomized controlled trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/30239559/",
       "pmid": "30239559",
       "authors": "PubMed",
       "citation": "PubMed PMID 30239559. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Clin Nutr",
+      "year": 2018,
+      "doi": "10.1093/ajcn/nqy115",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "powder or capsule",

--- a/public/data/compounds-detail/pycnogenol.json
+++ b/public/data/compounds-detail/pycnogenol.json
@@ -118,13 +118,19 @@
   "sources": [
     {
       "id": "src_4a4d5861f666",
-      "title": "PubMed PMID 31763928. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effect of Pycnogenol on Blood Pressure: Findings From a PRISMA Compliant Systematic Review and Meta-Analysis of Randomized, Double-Blind, Placebo-Controlled, Clinical Studies",
       "url": "https://pubmed.ncbi.nlm.nih.gov/31763928/",
       "pmid": "31763928",
       "authors": "PubMed",
       "citation": "PubMed PMID 31763928. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Angiology",
+      "year": 2020,
+      "doi": "10.1177/0003319719889428",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/pygeum.json
+++ b/public/data/compounds-detail/pygeum.json
@@ -105,13 +105,16 @@
   "sources": [
     {
       "id": "src_dd5ae5c1300e",
-      "title": "PubMed PMID 15748367. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Evaluating the efficiency of a combination of Pygeum africanum and stinging nettle (Urtica dioica) extracts in treating benign prostatic hyperplasia (BPH): double-blind, randomized, placebo controlled trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15748367/",
       "pmid": "15748367",
       "authors": "PubMed",
       "citation": "PubMed PMID 15748367. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Int Braz J Urol",
+      "year": 2002,
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/red-yeast-rice.json
+++ b/public/data/compounds-detail/red-yeast-rice.json
@@ -62,13 +62,17 @@
   "sources": [
     {
       "id": "src_3aa4c686d649",
-      "title": "PubMed PMID 27282571. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Molecular characterization of six new cases of red blood cell hexokinase deficiency yields four novel mutations in HK1",
       "url": "https://pubmed.ncbi.nlm.nih.gov/27282571/",
       "pmid": "27282571",
       "authors": "PubMed",
       "citation": "PubMed PMID 27282571. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Blood Cells Mol Dis",
+      "year": 2016,
+      "doi": "10.1016/j.bcmd.2016.04.002",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "tested extract",

--- a/public/data/compounds-detail/saccharomyces-boulardii.json
+++ b/public/data/compounds-detail/saccharomyces-boulardii.json
@@ -83,13 +83,19 @@
   "sources": [
     {
       "id": "src_d6bd0ab16fed",
-      "title": "PubMed PMID 20458757. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Systematic review and meta-analysis of Saccharomyces boulardii in adult patients",
       "url": "https://pubmed.ncbi.nlm.nih.gov/20458757/",
       "pmid": "20458757",
       "authors": "PubMed",
       "citation": "PubMed PMID 20458757. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "World J Gastroenterol",
+      "year": 2010,
+      "doi": "10.3748/wjg.v16.i18.2202",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_87430c135287",

--- a/public/data/compounds-detail/saffron-extract.json
+++ b/public/data/compounds-detail/saffron-extract.json
@@ -65,13 +65,19 @@
   "sources": [
     {
       "id": "src_9f508d2c359c",
-      "title": "PubMed PMID 28735826. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "affron(®) a novel saffron extract (Crocus sativus L.) improves mood in healthy adults over 4 weeks in a double-blind, parallel, randomized, placebo-controlled clinical trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/28735826/",
       "pmid": "28735826",
       "authors": "PubMed",
       "citation": "PubMed PMID 28735826. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Complement Ther Med",
+      "year": 2017,
+      "doi": "10.1016/j.ctim.2017.06.001",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract capsule",

--- a/public/data/compounds-detail/selenium.json
+++ b/public/data/compounds-detail/selenium.json
@@ -87,23 +87,35 @@
   "sources": [
     {
       "id": "src_aa51526269ce",
-      "title": "PubMed PMID 14668278. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Water-miscible, emulsified, and solid forms of retinol supplements are more toxic than oil-based preparations",
       "url": "https://pubmed.ncbi.nlm.nih.gov/14668278/",
       "pmid": "14668278",
       "authors": "PubMed",
       "citation": "PubMed PMID 14668278. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Clin Nutr",
+      "year": 2003,
+      "doi": "10.1093/ajcn/78.6.1152",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_dfe6dba7f842",
-      "title": "PubMed PMID 19926708. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Apoptosis by dietary agents for prevention and treatment of prostate cancer",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19926708/",
       "pmid": "19926708",
       "authors": "PubMed",
       "citation": "PubMed PMID 19926708. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Endocr Relat Cancer",
+      "year": 2010,
+      "doi": "10.1677/ERC-09-0262",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/compounds-detail/shilajit.json
+++ b/public/data/compounds-detail/shilajit.json
@@ -63,13 +63,19 @@
   "sources": [
     {
       "id": "src_f88a60c3992b",
-      "title": "PubMed PMID 26395129. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Clinical evaluation of purified Shilajit on testosterone levels in healthy volunteers",
       "url": "https://pubmed.ncbi.nlm.nih.gov/26395129/",
       "pmid": "26395129",
       "authors": "PubMed",
       "citation": "PubMed PMID 26395129. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Andrologia",
+      "year": 2016,
+      "doi": "10.1111/and.12482",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/compounds-detail/spirulina.json
+++ b/public/data/compounds-detail/spirulina.json
@@ -64,13 +64,17 @@
   "sources": [
     {
       "id": "src_b06318b9c33e",
-      "title": "PubMed PMID 20301409. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Isolated Methylmalonic Acidemia",
       "url": "https://pubmed.ncbi.nlm.nih.gov/20301409/",
       "pmid": "20301409",
       "authors": "PubMed",
       "citation": "PubMed PMID 20301409. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "year": 2022,
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/taurine.json
+++ b/public/data/compounds-detail/taurine.json
@@ -72,13 +72,19 @@
   "sources": [
     {
       "id": "src_cab5f6b21f4c",
-      "title": "PubMed PMID 20386132. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Citrulline malate enhances athletic anaerobic performance and relieves muscle soreness",
       "url": "https://pubmed.ncbi.nlm.nih.gov/20386132/",
       "pmid": "20386132",
       "authors": "PubMed",
       "citation": "PubMed PMID 20386132. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Strength Cond Res",
+      "year": 2010,
+      "doi": "10.1519/JSC.0b013e3181cb28e0",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "powder or capsule",

--- a/public/data/compounds-detail/uc-ii-collagen.json
+++ b/public/data/compounds-detail/uc-ii-collagen.json
@@ -86,23 +86,31 @@
   "sources": [
     {
       "id": "src_91b6fafc762c",
-      "title": "PubMed PMID 27551171. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of Native Type II Collagen Treatment on Knee Osteoarthritis: A Randomized Controlled Trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/27551171/",
       "pmid": "27551171",
       "authors": "PubMed",
       "citation": "PubMed PMID 27551171. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Eurasian J Med",
+      "year": 2016,
+      "doi": "10.5152/eurasianjmed.2015.15030",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_d7b833562a9a",
-      "title": "PubMed PMID 24153020. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Undenatured type II collagen (UC-II®) for joint support: a randomized, double-blind, placebo-controlled study in healthy volunteers",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24153020/",
       "pmid": "24153020",
       "authors": "PubMed",
       "citation": "PubMed PMID 24153020. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Int Soc Sports Nutr",
+      "year": 2013,
+      "doi": "10.1186/1550-2783-10-48",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "long",

--- a/public/data/compounds-detail/valerian-root-extract.json
+++ b/public/data/compounds-detail/valerian-root-extract.json
@@ -68,13 +68,19 @@
   "sources": [
     {
       "id": "src_63fe90f947a8",
-      "title": "PubMed PMID 17145239. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Valerian for sleep: a systematic review and meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17145239/",
       "pmid": "17145239",
       "authors": "PubMed",
       "citation": "PubMed PMID 17145239. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Med",
+      "year": 2006,
+      "doi": "10.1016/j.amjmed.2006.02.026",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "standardized extract",

--- a/public/data/compounds-detail/vitamin-a.json
+++ b/public/data/compounds-detail/vitamin-a.json
@@ -124,13 +124,17 @@
   "sources": [
     {
       "id": "src_a44ba08ccc12",
-      "title": "PubMed PMID 11311045. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effect of aging on glutathione peroxidase-i knockout mice-resistance of the lens to oxidative stress",
       "url": "https://pubmed.ncbi.nlm.nih.gov/11311045/",
       "pmid": "11311045",
       "authors": "PubMed",
       "citation": "PubMed PMID 11311045. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Exp Eye Res",
+      "year": 2001,
+      "doi": "10.1006/exer.2001.0980",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_c8f67d93ed2d",

--- a/public/data/compounds-detail/vitamin-c.json
+++ b/public/data/compounds-detail/vitamin-c.json
@@ -90,23 +90,33 @@
   "sources": [
     {
       "id": "src_2e1f6ee2f631",
-      "title": "PubMed PMID 19147492. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Oxidative stress-induced peptidoglycan deacetylase in Helicobacter pylori",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19147492/",
       "pmid": "19147492",
       "authors": "PubMed",
       "citation": "PubMed PMID 19147492. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Biol Chem",
+      "year": 2009,
+      "doi": "10.1074/jbc.M808071200",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_698caa1f98a9",
-      "title": "PubMed PMID 23440782. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Vitamin C for preventing and treating the common cold",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23440782/",
       "pmid": "23440782",
       "authors": "PubMed",
       "citation": "PubMed PMID 23440782. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2013,
+      "doi": "10.1002/14651858.CD000980.pub4",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/compounds-detail/vitamin-d.json
+++ b/public/data/compounds-detail/vitamin-d.json
@@ -126,33 +126,47 @@
   "sources": [
     {
       "id": "src_82e00c572398",
-      "title": "PubMed PMID 24191306. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Response to: 'Trends in cardiovascular diseases and cancer mortality in 45 countries from five continents (1980-2010)', by, Araújo F, Gouvinhas C, Fontes F, et al",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24191306/",
       "pmid": "24191306",
       "authors": "PubMed",
       "citation": "PubMed PMID 24191306. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Eur J Prev Cardiol",
+      "year": 2015,
+      "doi": "10.1177/2047487313510894",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_841c78d0905c",
-      "title": "PubMed PMID 22736219. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Who should be included in a clinical trial of screening for bladder cancer?: a decision analysis of data from the Prostate, Lung, Colorectal and Ovarian Cancer Screening Trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/22736219/",
       "pmid": "22736219",
       "authors": "PubMed",
       "citation": "PubMed PMID 22736219. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Cancer",
+      "year": 2013,
+      "doi": "10.1002/cncr.27692",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_f29ea2c68e0c",
-      "title": "PubMed PMID 28202713. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Vitamin D supplementation to prevent acute respiratory tract infections: systematic review and meta-analysis of individual participant data",
       "url": "https://pubmed.ncbi.nlm.nih.gov/28202713/",
       "pmid": "28202713",
       "authors": "PubMed",
       "citation": "PubMed PMID 28202713. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "BMJ",
+      "year": 2017,
+      "doi": "10.1136/bmj.i6583",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or softgel",

--- a/public/data/compounds-detail/willow-bark-extract.json
+++ b/public/data/compounds-detail/willow-bark-extract.json
@@ -102,13 +102,19 @@
   "sources": [
     {
       "id": "src_0faf9710cf5a",
-      "title": "PubMed PMID 11752510. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Treatment of low back pain with a herbal or synthetic anti-rheumatic: a randomized controlled study. Willow bark extract for low back pain",
       "url": "https://pubmed.ncbi.nlm.nih.gov/11752510/",
       "pmid": "11752510",
       "authors": "PubMed",
       "citation": "PubMed PMID 11752510. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Rheumatology (Oxford)",
+      "year": 2001,
+      "doi": "10.1093/rheumatology/40.12.1388",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "—",

--- a/public/data/compounds-detail/yohimbine.json
+++ b/public/data/compounds-detail/yohimbine.json
@@ -109,13 +109,17 @@
   "sources": [
     {
       "id": "src_0f44264f53df",
-      "title": "PubMed PMID 35118966. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Yohimbine as a treatment for erectile dysfunction: A systematic review and meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/35118966/",
       "pmid": "35118966",
       "authors": "PubMed",
       "citation": "PubMed PMID 35118966. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Turk J Urol",
+      "year": 2021,
+      "doi": "10.5152/tud.2021.21206",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule",

--- a/public/data/compounds-detail/zeaxanthin.json
+++ b/public/data/compounds-detail/zeaxanthin.json
@@ -62,13 +62,19 @@
   "sources": [
     {
       "id": "src_56cc494303b2",
-      "title": "PubMed PMID 23644932. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Lutein + zeaxanthin and omega-3 fatty acids for age-related macular degeneration: the Age-Related Eye Disease Study 2 (AREDS2) randomized clinical trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23644932/",
       "pmid": "23644932",
       "authors": "PubMed",
       "citation": "PubMed PMID 23644932. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "JAMA",
+      "year": 2013,
+      "doi": "10.1001/jama.2013.4997",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "capsule or standardized extract",

--- a/public/data/compounds-detail/zinc.json
+++ b/public/data/compounds-detail/zinc.json
@@ -84,13 +84,19 @@
   "sources": [
     {
       "id": "src_04ef965bd127",
-      "title": "PubMed PMID 15496046. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy of zinc against common cold viruses: an overview",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15496046/",
       "pmid": "15496046",
       "authors": "PubMed",
       "citation": "PubMed PMID 15496046. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Am Pharm Assoc (2003)",
+      "year": 2004,
+      "doi": "10.1331/1544-3191.44.5.594.hulisz",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "dosage": "chelated mineral capsule or powder",

--- a/public/data/herbs-detail/acerola.json
+++ b/public/data/herbs-detail/acerola.json
@@ -32,21 +32,36 @@
       "title": "A Collagen Supplement Improves Skin Hydration, Elasticity, Roughness, and Density: Results of a Randomized, Placebo-Controlled, Blind Study",
       "authors": "Bolke L et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31627309/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31627309/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu11102494",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38396766",
       "title": "Acerola (Malpighia emarginata) Anti-Inflammatory Activity-A Review",
       "authors": "Olędzki R et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38396766/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38396766/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms25042089",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30150795",
       "title": "Acerola, an untapped functional superfruit: a review on latest frontiers",
       "authors": "Prakash A et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30150795/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30150795/",
+      "journal": "J Food Sci Technol",
+      "doi": "10.1007/s13197-018-3309-5",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/agarikon.json
+++ b/public/data/herbs-detail/agarikon.json
@@ -32,21 +32,32 @@
       "title": "Neuroprotective Mushrooms",
       "authors": "Abdelmoaty MM et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40370689/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40370689/",
+      "journal": "NeuroImmune Pharm Ther",
+      "doi": "10.1515/nipt-2024-0004",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34102992",
       "title": "Anti-oxidant and Anticancerous Effect of Fomitopsis officinalis (Vill. ex Fr. Bond. et Sing) Mushroom on Hepatocellular Carcinoma Cells In Vitro through NF-kB Pathway",
       "authors": "Altannavch N et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34102992/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34102992/",
+      "journal": "Anticancer Agents Med Chem",
+      "doi": "10.2174/1871520621666210608101152",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35002589",
       "title": "Old growth forests and large old trees as critical organisms connecting ecosystems and human health. A review",
       "authors": "Gilhen-Baker M et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35002589/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35002589/",
+      "journal": "Environ Chem Lett",
+      "doi": "10.1007/s10311-021-01372-y",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ajwain.json
+++ b/public/data/herbs-detail/ajwain.json
@@ -33,21 +33,30 @@
       "title": "Synthesis and pharmacological evaluation of Andrographolide and Ajwain as promising alternatives to antibiotics for treating Salmonella gallinarum infection in chicken",
       "authors": "Mudasir Ahmad S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39303542/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39303542/",
+      "journal": "Int Immunopharmacol",
+      "doi": "10.1016/j.intimp.2024.113163",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "18940228",
       "title": "Ameliorative effect of ajwain extract on hexachlorocyclohexane-induced lipid peroxidation in rat liver",
       "authors": "Anilakumar KR et al.",
       "year": 2009,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/18940228/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/18940228/",
+      "journal": "Food Chem Toxicol",
+      "doi": "10.1016/j.fct.2008.09.061",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36596101",
       "title": "Effect of ajwain (Trachyspermum ammi) extract and gamma irradiation on the shelf-life extension of rohu (Labeo rohita) and seer (Scomberomorus guttatus) fish steaks during chilled storage",
       "authors": "Mishra PK et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36596101/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36596101/",
+      "journal": "Food Res Int",
+      "doi": "10.1016/j.foodres.2022.112149",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/allium-sativum.json
+++ b/public/data/herbs-detail/allium-sativum.json
@@ -35,21 +35,35 @@
       "title": "Garlic and Hypertension: Efficacy, Mechanism of Action, and Clinical Implications",
       "authors": "Sleiman C et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39275211/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39275211/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu16172895",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28762712",
       "title": "Common Herbal Dietary Supplement-Drug Interactions",
       "authors": "Asher GN et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36650621",
       "title": "Herb-Drug Interactions and Their Impact on Pharmacokinetics: An Update",
       "authors": "Cheng W et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/",
+      "journal": "Curr Drug Metab",
+      "doi": "10.2174/1389200224666230116113240",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/aloe-vera.json
+++ b/public/data/herbs-detail/aloe-vera.json
@@ -43,31 +43,52 @@
       "title": "Pharmacological Update Properties of Aloe Vera and its Major Active Constituents",
       "authors": "Sánchez M et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32183224/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32183224/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules25061324",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37915246",
       "title": "Aloe Barbadensis Miller (Aloe Vera)",
       "authors": "Kaur S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37915246/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37915246/",
+      "journal": "Int J Vitam Nutr Res",
+      "doi": "10.1024/0300-9831/a000797",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38998660",
       "title": "Aloe vera-An Extensive Review Focused on Recent Studies",
       "authors": "Catalano A et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38998660/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38998660/",
+      "journal": "Foods",
+      "doi": "10.3390/foods13132155",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_96fe08d35f48",
-      "title": "PubMed PMID 27347994. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy of Aloe Vera Supplementation on Prediabetes and Early Non-Treated Diabetic Patients: A Systematic Review and Meta-Analysis of Randomized Controlled Trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/27347994/",
       "pmid": "27347994",
       "authors": "PubMed",
       "citation": "PubMed PMID 27347994. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Nutrients",
+      "year": 2016,
+      "doi": "10.3390/nu8070388",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/andrographis-paniculata.json
+++ b/public/data/herbs-detail/andrographis-paniculata.json
@@ -32,21 +32,34 @@
       "title": "Overview of pharmacological activities of Andrographis paniculata and its major compound andrographolide",
       "authors": "Dai Y et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30040451/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30040451/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2018.1501657",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34818697",
       "title": "Andrographolide: A review of its pharmacology, pharmacokinetics, toxicity and clinical trials and pharmaceutical researches",
       "authors": "Zeng B et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34818697/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34818697/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7324",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37821383",
       "title": "Efficacy of Andrographis paniculata spray in acute pharyngitis: A randomized controlled trial",
       "authors": "Okonogi R et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37821383/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37821383/",
+      "journal": "Drug Discov Ther",
+      "doi": "10.5582/ddt.2023.01053",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/anemarrhena-asphodeloides.json
+++ b/public/data/herbs-detail/anemarrhena-asphodeloides.json
@@ -36,21 +36,34 @@
       "title": "Exploring the active components and potential mechanisms of Zhimu-Huangbai herb-pair in the treatment of depression",
       "authors": "Lei X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39904199/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39904199/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2025.156365",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36330891",
       "title": "A review of the botany, ethnopharmacology, phytochemistry, pharmacology, toxicology and quality of Anemarrhena asphodeloides Bunge",
       "authors": "Liu C et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36330891/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36330891/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2022.115857",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39476924",
       "title": "Advances in the study of polysaccharides from Anemarrhena asphodeloides Bge.: A review",
       "authors": "An H et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39476924/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39476924/",
+      "journal": "Int J Biol Macromol",
+      "doi": "10.1016/j.ijbiomac.2024.136999",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/angelica-archangelica.json
+++ b/public/data/herbs-detail/angelica-archangelica.json
@@ -35,21 +35,32 @@
       "title": "Coumarins from Angelica archangelica Linn. and their effects on anxiety-like behavior",
       "authors": "Kumar D et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22960104/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22960104/",
+      "journal": "Prog Neuropsychopharmacol Biol Psychiatry",
+      "doi": "10.1016/j.pnpbp.2012.08.004",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31605258",
       "title": "Awareness and current knowledge of epilepsy",
       "authors": "Khan AU et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31605258/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31605258/",
+      "journal": "Metab Brain Dis",
+      "doi": "10.1007/s11011-019-00494-1",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33047814",
       "title": "Optimization of extraction conditions of Angelica archangelica extract and activity evaluation in experimental fibromyalgia",
       "authors": "Kaur A et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33047814/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33047814/",
+      "journal": "J Food Sci",
+      "doi": "10.1111/1750-3841.15476",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/angelica-dahurica.json
+++ b/public/data/herbs-detail/angelica-dahurica.json
@@ -35,21 +35,34 @@
       "title": "Proteomics and transcriptomics explore the effect of mixture of herbal extract on diabetic wound healing process",
       "authors": "Liu Y et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37267693/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37267693/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2023.154892",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34451622",
       "title": "Oxypeucedanin: Chemotaxonomy, Isolation, and Bioactivities",
       "authors": "Mottaghipisheh J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34451622/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34451622/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants10081577",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35847034",
       "title": "The Angelica dahurica: A Review of Traditional Uses, Phytochemistry and Pharmacology",
       "authors": "Zhao H et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35847034/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35847034/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2022.896637",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/angelica-root.json
+++ b/public/data/herbs-detail/angelica-root.json
@@ -32,21 +32,34 @@
       "title": "Immunomodulatory Mechanisms of Rehmanniae Radix Praeparata-Achyranthes Root-Chinese Angelica Root Combination in Nontraumatic Osteonecrosis of the Femoral Head: A Comprehensive Network Pharmacology and Molecular Docking Study Focusing on Immunological Pathways",
       "authors": "Li X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41498029/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41498029/",
+      "journal": "Mediators Inflamm",
+      "doi": "10.1155/mi/2808908",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "16857355",
       "title": "Pharmaceutical prerequisites for a multi-target therapy",
       "authors": "Kroll U et al.",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/16857355/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/16857355/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2006.03.016",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24365638",
       "title": "Danggui to Angelica sinensis root: are potential benefits to European women lost in translation? A review",
       "authors": "Hook IL et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24365638/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24365638/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2013.12.018",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/angelica-sinensis.json
+++ b/public/data/herbs-detail/angelica-sinensis.json
@@ -40,21 +40,36 @@
       "title": "Extraction, structure, pharmacological activities and drug carrier applications of Angelica sinensis polysaccharide",
       "authors": "Nai J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34090852/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34090852/",
+      "journal": "Int J Biol Macromol",
+      "doi": "10.1016/j.ijbiomac.2021.05.213",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "10675182",
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27677719",
       "title": "Botanicals and Their Bioactive Phytochemicals for Women's Health",
       "authors": "Dietz BM et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/",
+      "journal": "Pharmacol Rev",
+      "doi": "10.1124/pr.115.010843",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/anise-hyssop.json
+++ b/public/data/herbs-detail/anise-hyssop.json
@@ -34,21 +34,30 @@
       "title": "Anise Hyssop Agastache foeniculum Increases Lifespan, Stress Resistance, and Metabolism by Affecting Free Radical Processes in Drosophila",
       "authors": "Strilbytska OM et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33391017/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33391017/",
+      "journal": "Front Physiol",
+      "doi": "10.3389/fphys.2020.596729",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34439010",
       "title": "Biologically Active Extracts from Different Medicinal Plants Tested as Potential Additives against Bee Pathogens",
       "authors": "Pașca C et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34439010/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34439010/",
+      "journal": "Antibiotics (Basel)",
+      "doi": "10.3390/antibiotics10080960",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "22561883",
       "title": "Estragole: a weak direct-acting food-borne genotoxin and potential carcinogen",
       "authors": "Martins C et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22561883/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22561883/",
+      "journal": "Mutat Res",
+      "doi": "10.1016/j.mrgentox.2012.04.009",
+      "metadataSource": "pubmed"
     },
     {
       "title": "Bridging the Chemical Profile and Biological Activities of a New Variety of Agastache foeniculum (Pursh) Kuntze Extracts and Essential Oil",

--- a/public/data/herbs-detail/arjuna.json
+++ b/public/data/herbs-detail/arjuna.json
@@ -41,21 +41,34 @@
       "title": "Plants Used as Antihypertensive",
       "authors": "Verma T et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/",
+      "journal": "Nat Prod Bioprospect",
+      "doi": "10.1007/s13659-020-00281-x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37814683",
       "title": "Antimicrobial and anti-inflammatory activity of Terminalia arjuna",
       "authors": "R V et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37814683/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37814683/",
+      "journal": "Bioinformation",
+      "doi": "10.6026/97320630019184",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24600529",
       "title": "Terminalia arjuna in Chronic Stable Angina: Systematic Review and Meta-Analysis",
       "authors": "Kaur N et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24600529/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24600529/",
+      "journal": "Cardiol Res Pract",
+      "doi": "10.1155/2014/281483",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/artemisia-absinthium.json
+++ b/public/data/herbs-detail/artemisia-absinthium.json
@@ -32,21 +32,34 @@
       "title": "Absinthe--a review",
       "authors": "Lachenmeier DW et al.",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/16891209/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/16891209/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408690590957322",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38616734",
       "title": "Effects of Artemisia absinthium on broiler chicken coccidiosis: a systematic review and meta-analysis",
       "authors": "Hezil N et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38616734/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38616734/",
+      "journal": "Avian Pathol",
+      "doi": "10.1080/03079457.2024.2342882",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36432868",
       "title": "Species-Specific Plant-Derived Nanoparticle Characteristics",
       "authors": "Viršilė A et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36432868/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36432868/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants11223139",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/artemisia-annua.json
+++ b/public/data/herbs-detail/artemisia-annua.json
@@ -38,21 +38,36 @@
       "title": "Artemisinin and Its Derivatives as Potential Anticancer Agents",
       "authors": "Wen L et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39202965/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39202965/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules29163886",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28837410",
       "title": "New insights into artemisinin regulation",
       "authors": "Lv Z et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28837410/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28837410/",
+      "journal": "Plant Signal Behav",
+      "doi": "10.1080/15592324.2017.1366398",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40375936",
       "title": "Unlocking the potential of Artemisia annua for artemisinin production: current insights and emerging strategies",
       "authors": "Vashisth D et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40375936/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40375936/",
+      "journal": "3 Biotech",
+      "doi": "10.1007/s13205-025-04332-3",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/artemisia-capillaris.json
+++ b/public/data/herbs-detail/artemisia-capillaris.json
@@ -35,21 +35,34 @@
       "title": "The Role of Chinese Medicine in the Treatment of Chronic Hepatitis B",
       "authors": "Zheng S et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40708494/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40708494/",
+      "journal": "Am J Chin Med",
+      "doi": "10.1142/S0192415X25500508",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34680529",
       "title": "The Pharmacological Effects and Pharmacokinetics of Active Compounds of Artemisia capillaris",
       "authors": "Hsueh TP et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34680529/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34680529/",
+      "journal": "Biomedicines",
+      "doi": "10.3390/biomedicines9101412",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39186724",
       "title": "Exploration of the potential mechanism of aqueous extract of Artemisia capillaris for the treatment of non-alcoholic fatty liver disease based on network pharmacology and experimental verification",
       "authors": "Liang M et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39186724/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39186724/",
+      "journal": "J Pharm Pharmacol",
+      "doi": "10.1093/jpp/rgae061",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/artemisia-dracunculus.json
+++ b/public/data/herbs-detail/artemisia-dracunculus.json
@@ -29,21 +29,34 @@
       "title": "Artemisia dracunculus (Tarragon): A Review of Its Traditional Uses, Phytochemistry and Pharmacology",
       "authors": "Ekiert H et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33927629/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33927629/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2021.653993",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "21942448",
       "title": "Artemisia dracunculus L. (tarragon): a critical review of its traditional use, chemical composition, pharmacology, and safety",
       "authors": "Obolskiy D et al.",
       "year": 2011,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/21942448/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/21942448/",
+      "journal": "J Agric Food Chem",
+      "doi": "10.1021/jf202277w",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38068651",
       "title": "Unraveling the Potential of Organic Oregano and Tarragon Essential Oils: Profiling Composition, FT-IR and Bioactivities",
       "authors": "Vârban D et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38068651/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38068651/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants12234017",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/artichoke.json
+++ b/public/data/herbs-detail/artichoke.json
@@ -35,21 +35,36 @@
       "title": "Inulin: properties and health benefits",
       "authors": "Qin YQ et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36876591/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36876591/",
+      "journal": "Food Funct",
+      "doi": "10.1039/d2fo01096h",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26310198",
       "title": "Pharmacological Studies of Artichoke Leaf Extract and Their Health Benefits",
       "authors": "Ben Salem M et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26310198/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26310198/",
+      "journal": "Plant Foods Hum Nutr",
+      "doi": "10.1007/s11130-015-0503-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38542782",
       "title": "Functional and Therapeutic Potential of Cynara scolymus in Health Benefits",
       "authors": "Porro C et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38542782/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38542782/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu16060872",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ashitaba.json
+++ b/public/data/herbs-detail/ashitaba.json
@@ -32,21 +32,34 @@
       "title": "Toxicological assessment of Ashitaba Chalcone",
       "authors": "Maronpot RR et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25576957/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25576957/",
+      "journal": "Food Chem Toxicol",
+      "doi": "10.1016/j.fct.2014.12.021",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29880082",
       "title": "Possible antithrombotic effects of Angelica keiskei (Ashitaba)",
       "authors": "Ohkura N et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29880082/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29880082/",
+      "journal": "Pharmazie",
+      "doi": "10.1691/ph.2018.8370",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27399234",
       "title": "A Review of the Medicinal Uses and Pharmacology of Ashitaba",
       "authors": "Caesar LK et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27399234/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27399234/",
+      "journal": "Planta Med",
+      "doi": "10.1055/s-0042-110496",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ashoka.json
+++ b/public/data/herbs-detail/ashoka.json
@@ -34,21 +34,36 @@
       "title": "Social entrepreneurship in obesity prevention: A scoping review",
       "authors": "Chia A et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34841626/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34841626/",
+      "journal": "Obes Rev",
+      "doi": "10.1111/obr.13378",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34954676",
       "title": "The gender responsiveness of social entrepreneurship in health - A review of initiatives by Ashoka fellows",
       "authors": "Khalid S et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34954676/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34954676/",
+      "journal": "Soc Sci Med",
+      "doi": "10.1016/j.socscimed.2021.114665",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37390875",
       "title": "A comprehensive review on Saraca asoca (Fabaceae) - Historical perspective, traditional uses, biological activities, and conservation",
       "authors": "Urumarudappa SKJ et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37390875/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37390875/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.116861",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ashwagandha.json
+++ b/public/data/herbs-detail/ashwagandha.json
@@ -34,21 +34,36 @@
       "title": "Effect of Ashwagandha (Withania somnifera) extract on sleep: A systematic review and meta-analysis",
       "authors": "Cheah KL et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34559859/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34559859/",
+      "journal": "PLoS One",
+      "doi": "10.1371/journal.pone.0257843",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39348746",
       "title": "Effects of Ashwagandha (Withania Somnifera) on stress and anxiety: A systematic review and meta-analysis",
       "authors": "Arumugam V et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39348746/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39348746/",
+      "journal": "Explore (NY)",
+      "doi": "10.1016/j.explore.2024.103062",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31517876",
       "title": "An investigation into the stress-relieving and pharmacological actions of an ashwagandha (Withania somnifera) extract: A randomized, double-blind, placebo-controlled study",
       "authors": "Lopresti AL et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31517876/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31517876/",
+      "journal": "Medicine (Baltimore)",
+      "doi": "10.1097/MD.0000000000017186",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_0abbdfdf8b6d",
@@ -58,7 +73,10 @@
       "pmid": "34559859",
       "year": "2021",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "PLoS One",
+      "authors": "Cheah KL et al.",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_05c07be46c26",

--- a/public/data/herbs-detail/astragalus-membranaceus.json
+++ b/public/data/herbs-detail/astragalus-membranaceus.json
@@ -39,21 +39,36 @@
       "title": "Astragalus polysaccharide: a review of its immunomodulatory effect",
       "authors": "Li CX et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35713852/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35713852/",
+      "journal": "Arch Pharm Res",
+      "doi": "10.1007/s12272-022-01393-3",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26916911",
       "title": "Astragalus membranaceus: A Review of its Protection Against Inflammation and Gastrointestinal Cancers",
       "authors": "Auyeung KK et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26916911/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26916911/",
+      "journal": "Am J Chin Med",
+      "doi": "10.1142/S0192415X16500014",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39215362",
       "title": "Astragali radix (Huangqi): a time-honored nourishing herbal medicine",
       "authors": "Zhang Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39215362/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39215362/",
+      "journal": "Chin Med",
+      "doi": "10.1186/s13020-024-00977-z",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/astragalus.json
+++ b/public/data/herbs-detail/astragalus.json
@@ -37,21 +37,36 @@
       "title": "Astragalus polysaccharide: a review of its immunomodulatory effect",
       "authors": "Li CX et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35713852/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35713852/",
+      "journal": "Arch Pharm Res",
+      "doi": "10.1007/s12272-022-01393-3",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37895122",
       "title": "Plant Extracts as Skin Care and Therapeutic Agents",
       "authors": "Michalak M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37895122/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37895122/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms242015444",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26916911",
       "title": "Astragalus membranaceus: A Review of its Protection Against Inflammation and Gastrointestinal Cancers",
       "authors": "Auyeung KK et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26916911/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26916911/",
+      "journal": "Am J Chin Med",
+      "doi": "10.1142/S0192415X16500014",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/atractylodes-macrocephala.json
+++ b/public/data/herbs-detail/atractylodes-macrocephala.json
@@ -34,21 +34,32 @@
       "title": "Medicine for chronic atrophic gastritis: a systematic review, meta- and network pharmacology analysis",
       "authors": "Weng J et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38170849/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38170849/",
+      "journal": "Ann Med",
+      "doi": "10.1080/07853890.2023.2299352",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40490795",
       "title": "Atractylodes macrocephala-derived extracellular vesicles-like particles enhance the recovery of ulcerative colitis by remodeling intestinal microecological balance",
       "authors": "Tan X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40490795/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40490795/",
+      "journal": "J Nanobiotechnology",
+      "doi": "10.1186/s12951-025-03506-8",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39477683",
       "title": "Atractylenolide I inhibits angiogenesis and reverses sunitinib resistance in clear cell renal cell carcinoma through ATP6V0D2-mediated autophagic degradation of EPAS1/HIF2α",
       "authors": "Li Q et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39477683/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39477683/",
+      "journal": "Autophagy",
+      "doi": "10.1080/15548627.2024.2421699",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/atractylodes.json
+++ b/public/data/herbs-detail/atractylodes.json
@@ -31,21 +31,34 @@
       "title": "Medicine for chronic atrophic gastritis: a systematic review, meta- and network pharmacology analysis",
       "authors": "Weng J et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38170849/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38170849/",
+      "journal": "Ann Med",
+      "doi": "10.1080/07853890.2023.2299352",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39409183",
       "title": "Advances in Gouty Arthritis Management: Integration of Established Therapies, Emerging Treatments, and Lifestyle Interventions",
       "authors": "Yao TK et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39409183/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39409183/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms251910853",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40490795",
       "title": "Atractylodes macrocephala-derived extracellular vesicles-like particles enhance the recovery of ulcerative colitis by remodeling intestinal microecological balance",
       "authors": "Tan X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40490795/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40490795/",
+      "journal": "J Nanobiotechnology",
+      "doi": "10.1186/s12951-025-03506-8",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/bacopa.json
+++ b/public/data/herbs-detail/bacopa.json
@@ -34,31 +34,52 @@
       "title": "Plant-derived nootropics and human cognition: A systematic review",
       "authors": "Lorca C et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34978226/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34978226/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2021.2021137",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36061899",
       "title": "Pharmacological attributes of Bacopa monnieri extract: Current updates and clinical manifestation",
       "authors": "Fatima U et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36061899/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36061899/",
+      "journal": "Front Nutr",
+      "doi": "10.3389/fnut.2022.972379",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36987052",
       "title": "Nootropic Herbs, Shrubs, and Trees as Potential Cognitive Enhancers",
       "authors": "Malík M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36987052/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36987052/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants12061364",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_9e2ace19600b",
-      "title": "PubMed PMID 18611150. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of a standardized Bacopa monnieri extract on cognitive performance, anxiety, and depression in the elderly: a randomized, double-blind, placebo-controlled trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18611150/",
       "pmid": "18611150",
       "authors": "PubMed",
       "citation": "PubMed PMID 18611150. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Altern Complement Med",
+      "year": 2008,
+      "doi": "10.1089/acm.2008.0018",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_fe0411c48dea",

--- a/public/data/herbs-detail/bael.json
+++ b/public/data/herbs-detail/bael.json
@@ -33,21 +33,34 @@
       "title": "Aegle marmelos (L.) Correa (Bael) and its phytochemicals in the treatment and prevention of cancer",
       "authors": "Baliga MS et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23089553/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23089553/",
+      "journal": "Integr Cancer Ther",
+      "doi": "10.1177/1534735412451320",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37026028",
       "title": "Phytochemical and biological review of Aegle marmelos Linn",
       "authors": "Monika S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37026028/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37026028/",
+      "journal": "Future Sci OA",
+      "doi": "10.2144/fsoa-2022-0068",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29615046",
       "title": "Phytochemical composition, antilipidemic and antihypercholestrolemic perspectives of Bael leaf extracts",
       "authors": "Asghar N et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29615046/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29615046/",
+      "journal": "Lipids Health Dis",
+      "doi": "10.1186/s12944-018-0713-9",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/bayberry.json
+++ b/public/data/herbs-detail/bayberry.json
@@ -31,21 +31,34 @@
       "title": "MYB transcription factors encoded by diversified tandem gene clusters cause varied Morella rubra fruit color",
       "authors": "Xue L et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38319742/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38319742/",
+      "journal": "Plant Physiol",
+      "doi": "10.1093/plphys/kiae063",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32114166",
       "title": "Amygdalin - A pharmacological and toxicological review",
       "authors": "He XY et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32114166/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32114166/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2020.112717",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33338751",
       "title": "Myricetin: A review of the most recent research",
       "authors": "Song X et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33338751/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33338751/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2020.111017",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/berberis-vulgaris.json
+++ b/public/data/herbs-detail/berberis-vulgaris.json
@@ -35,21 +35,33 @@
       "title": "Berberine and barberry (Berberis vulgaris): A clinical review",
       "authors": "Imenshahidi M et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30637820/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30637820/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6252",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27671811",
       "title": "Berberine and Its Role in Chronic Disease",
       "authors": "Cicero AF et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/",
+      "journal": "Adv Exp Med Biol",
+      "doi": "10.1007/978-3-319-41334-1_2",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "10767672",
       "title": "Berberine",
       "authors": "PubMed indexed authors",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10767672/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10767672/",
+      "journal": "Altern Med Rev",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/berberis.json
+++ b/public/data/herbs-detail/berberis.json
@@ -45,21 +45,36 @@
       "title": "Biological properties and clinical applications of berberine",
       "authors": "Song D et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32335802/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32335802/",
+      "journal": "Front Med",
+      "doi": "10.1007/s11684-019-0724-6",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30637820",
       "title": "Berberine and barberry (Berberis vulgaris): A clinical review",
       "authors": "Imenshahidi M et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30637820/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30637820/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6252",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27671811",
       "title": "Berberine and Its Role in Chronic Disease",
       "authors": "Cicero AF et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/",
+      "journal": "Adv Exp Med Biol",
+      "doi": "10.1007/978-3-319-41334-1_2",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/black-cohosh.json
+++ b/public/data/herbs-detail/black-cohosh.json
@@ -46,7 +46,12 @@
       "title": "Black cohosh extracts in women with menopausal symptoms",
       "authors": "Meherishi S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37192826/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37192826/",
+      "journal": "Menopause",
+      "doi": "10.1097/GME.0000000000002196",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/black-seed.json
+++ b/public/data/herbs-detail/black-seed.json
@@ -40,31 +40,48 @@
       "title": "Black Cumin (Nigella sativa L.): A Comprehensive Review on Phytochemistry, Health Benefits, Molecular Pharmacology, and Safety",
       "authors": "Hannan MA et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34073784/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34073784/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu13061784",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37184195",
       "title": "Black Cumin Seed",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37184195/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37184195/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000936",
       "title": "Black Seed",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000936/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000936/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_91535100ff5c",
-      "title": "PubMed PMID 26875640. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Nigella sativa (black seed) effects on plasma lipid concentrations in humans: A systematic review and meta-analysis of randomized placebo-controlled trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/26875640/",
       "pmid": "26875640",
       "authors": "PubMed",
       "citation": "PubMed PMID 26875640. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Pharmacol Res",
+      "year": 2016,
+      "doi": "10.1016/j.phrs.2016.02.008",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/black-tea.json
+++ b/public/data/herbs-detail/black-tea.json
@@ -40,21 +40,34 @@
       "title": "Nutraceutical treatment and prevention of benign prostatic hyperplasia and prostate cancer",
       "authors": "Cicero AFG et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31577095/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31577095/",
+      "journal": "Arch Ital Urol Androl",
+      "doi": "10.4081/aiua.2019.3.139",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34029903",
       "title": "Inhibition of α-glucosidases by tea polyphenols in rat intestinal extract and Caco-2 cells grown on Transwell",
       "authors": "Kan L et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34029903/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34029903/",
+      "journal": "Food Chem",
+      "doi": "10.1016/j.foodchem.2021.130047",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24915350",
       "title": "Tea and its consumption: benefits and risks",
       "authors": "Hayat K et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24915350/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24915350/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2012.678949",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/blue-lotus.json
+++ b/public/data/herbs-detail/blue-lotus.json
@@ -37,21 +37,30 @@
       "title": "Integrated breeding strategies for blue lotus based on petal pH, anthocyanin profiling, and gene expression analysis",
       "authors": "Liu Q et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41052496/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41052496/",
+      "journal": "Plant Physiol Biochem",
+      "doi": "10.1016/j.plaphy.2025.110583",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38285776",
       "title": "The Apoptotic Property of Nymphaea Caerulea Flower Extract on Acute Myeloid Leukaemia Cell Line, THP-1",
       "authors": "Chatterjee D et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38285776/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38285776/",
+      "journal": "Asian Pac J Cancer Prev",
+      "doi": "10.31557/APJCP.2024.25.1.123",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34345890",
       "title": "Toxicity From Blue Lotus (Nymphaea caerulea) After Ingestion or Inhalation: A Case Series",
       "authors": "Schimpf M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34345890/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34345890/",
+      "journal": "Mil Med",
+      "doi": "10.1093/milmed/usab328",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/boldo.json
+++ b/public/data/herbs-detail/boldo.json
@@ -33,21 +33,32 @@
       "title": "Tacrolimus and herbs interactions: a review",
       "authors": "Abushammala I et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34620272/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34620272/",
+      "journal": "Pharmazie",
+      "doi": "10.1691/ph.2021.1684",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41353162",
       "title": "Boldo leaves reduce seizures, neuroinflammation, and hemichannel activity in a murine model of chronic epilepsy",
       "authors": "García-Rodríguez C et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41353162/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41353162/",
+      "journal": "Biol Res",
+      "doi": "10.1186/s40659-025-00647-w",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40362563",
       "title": "Peumus boldus Extract Inhibits Lipid Accumulation in 3T3-L1 Adipocytes",
       "authors": "Montaldo L et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40362563/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40362563/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms26094326",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/boswellia-serrata.json
+++ b/public/data/herbs-detail/boswellia-serrata.json
@@ -28,21 +28,36 @@
       "title": "Frankincense--therapeutic properties",
       "authors": "Al-Yasiry AR et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27117114/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27117114/",
+      "journal": "Postepy Hig Med Dosw (Online)",
+      "doi": "10.5604/17322693.1200553",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29018060",
       "title": "Dietary supplements for treating osteoarthritis: a systematic review and meta-analysis",
       "authors": "Liu X et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29018060/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29018060/",
+      "journal": "Br J Sports Med",
+      "doi": "10.1136/bjsports-2016-097333",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32680575",
       "title": "Effectiveness of Boswellia and Boswellia extract for osteoarthritis patients: a systematic review and meta-analysis",
       "authors": "Yu G et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32680575/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32680575/",
+      "journal": "BMC Complement Med Ther",
+      "doi": "10.1186/s12906-020-02985-6",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/brassica-juncea.json
+++ b/public/data/herbs-detail/brassica-juncea.json
@@ -32,21 +32,32 @@
       "title": "Phytotherapy and food applications from Brassica genus",
       "authors": "Salehi B et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33666283/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33666283/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7048",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31504785",
       "title": "Identification and functional characterization of a novel selenocysteine methyltransferase from Brassica juncea L",
       "authors": "Chen M et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31504785/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31504785/",
+      "journal": "J Exp Bot",
+      "doi": "10.1093/jxb/erz390",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33317112",
       "title": "Brassica juncea L. (Mustard) Extract Silver NanoParticles and Knocking off Oxidative Stress, ProInflammatory Cytokine and Reverse DNA Genotoxicity",
       "authors": "Hassan SA et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33317112/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33317112/",
+      "journal": "Biomolecules",
+      "doi": "10.3390/biom10121650",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/brassica-oleracea.json
+++ b/public/data/herbs-detail/brassica-oleracea.json
@@ -31,21 +31,34 @@
       "title": "Brassica oleracea",
       "authors": "Sparrow PA et al.",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/16988364/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/16988364/",
+      "journal": "Methods Mol Biol",
+      "doi": "10.1385/1-59745-130-4:417",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41855365",
       "title": "Broccoli",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41855365/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41855365/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33666283",
       "title": "Phytotherapy and food applications from Brassica genus",
       "authors": "Salehi B et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33666283/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33666283/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7048",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/buckwheat.json
+++ b/public/data/herbs-detail/buckwheat.json
@@ -39,21 +39,34 @@
       "title": "Buckwheat allergy",
       "authors": "Chen F et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41696952/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41696952/",
+      "journal": "Asian Pac J Allergy Immunol",
+      "doi": "10.12932/AP-171025-2165",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39731715",
       "title": "Beverages developed from pseudocereals (quinoa, buckwheat, and amaranth): Nutritional and functional properties",
       "authors": "Li H et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39731715/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39731715/",
+      "journal": "Compr Rev Food Sci Food Saf",
+      "doi": "10.1111/1541-4337.70081",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "16948356",
       "title": "Buckwheat allergy",
       "authors": "Stember RH et al.",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/16948356/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/16948356/",
+      "journal": "Allergy Asthma Proc",
+      "doi": "10.2500/aap.2006.27.2879",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/bupleurum-falcatum.json
+++ b/public/data/herbs-detail/bupleurum-falcatum.json
@@ -33,21 +33,30 @@
       "title": "Ethanol extract of Bupleurum falcatum and saikosaponins inhibit neuroinflammation via inhibition of NF-κB",
       "authors": "Park WH et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26231448/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26231448/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2015.07.039",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "22450800",
       "title": "Bupleurum falcatum prevents depression and anxiety-like behaviors in rats exposed to repeated restraint stress",
       "authors": "Lee B et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22450800/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22450800/",
+      "journal": "J Microbiol Biotechnol",
+      "doi": "10.4014/jmb.1110.10077",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34652253",
       "title": "Suppressing effect of a saikosaponin-enriched extract of Bupleurum falcatum on alcohol and chocolate self-administration in rats",
       "authors": "Maccioni P et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34652253/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34652253/",
+      "journal": "Nat Prod Res",
+      "doi": "10.1080/14786419.2021.1986816",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/burdock.json
+++ b/public/data/herbs-detail/burdock.json
@@ -32,21 +32,33 @@
       "title": "A review of the pharmacological effects of Arctium lappa (burdock)",
       "authors": "Chan YS et al.",
       "year": 2011,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/20981575/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/20981575/",
+      "journal": "Inflammopharmacology",
+      "doi": "10.1007/s10787-010-0062-4",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "11362284",
       "title": "Essiac",
       "authors": "Majchrowicz MA et al.",
       "year": 1995,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/11362284/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/11362284/",
+      "journal": "Notes Undergr",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35873376",
       "title": "Mechanistic insights on burdock (Arctium lappa L.) extract effects on diabetes mellitus",
       "authors": "Mondal SC et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35873376/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35873376/",
+      "journal": "Food Sci Biotechnol",
+      "doi": "10.1007/s10068-022-01091-2",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/calamus.json
+++ b/public/data/herbs-detail/calamus.json
@@ -35,21 +35,36 @@
       "title": "Telovelar surgical approach",
       "authors": "Ghali MGZ et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31807931/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31807931/",
+      "journal": "Neurosurg Rev",
+      "doi": "10.1007/s10143-019-01190-5",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39942962",
       "title": "Aromatherapy and Essential Oils: Holistic Strategies in Complementary and Alternative Medicine for Integral Wellbeing",
       "authors": "Caballero-Gallardo K et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39942962/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39942962/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants14030400",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33494677",
       "title": "Radioprotectors: Nature's Boon",
       "authors": "Lang DK et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33494677/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33494677/",
+      "journal": "Mini Rev Med Chem",
+      "doi": "10.2174/1389557521666210120112814",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/calendula.json
+++ b/public/data/herbs-detail/calendula.json
@@ -34,21 +34,34 @@
       "title": "A systematic review of Calendula officinalis extract for wound healing",
       "authors": "Givol O et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31145533/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31145533/",
+      "journal": "Wound Repair Regen",
+      "doi": "10.1111/wrr.12737",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39500772",
       "title": "Aromatic plants as cosmeceuticals: benefits and applications for skin health",
       "authors": "Olivero-Verbel J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39500772/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39500772/",
+      "journal": "Planta",
+      "doi": "10.1007/s00425-024-04550-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000869",
       "title": "Echinacea",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000869/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000869/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/camellia-sinensis.json
+++ b/public/data/herbs-detail/camellia-sinensis.json
@@ -35,21 +35,35 @@
       "title": "Green Tea (Camellia sinensis): A Review of Its Phytochemistry, Pharmacology, and Toxicology",
       "authors": "Zhao T et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35745040/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35745040/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27123909",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32478963",
       "title": "Warfarin and food, herbal or dietary supplement interactions: A systematic review",
       "authors": "Tan CSS et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32478963/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32478963/",
+      "journal": "Br J Clin Pharmacol",
+      "doi": "10.1111/bcp.14404",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28762712",
       "title": "Common Herbal Dietary Supplement-Drug Interactions",
       "authors": "Asher GN et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/capsicum-annuum.json
+++ b/public/data/herbs-detail/capsicum-annuum.json
@@ -34,21 +34,30 @@
       "title": "Capsicum",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000884/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000884/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29083760",
       "title": "Capsaicin",
       "authors": "Chang A et al.",
       "year": 2026,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29083760/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29083760/",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37493973",
       "title": "Peppers and their constituents against obesity",
       "authors": "Sirotkin AV et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37493973/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37493973/",
+      "journal": "Biol Futur",
+      "doi": "10.1007/s42977-023-00174-3",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_78113367eaf6",

--- a/public/data/herbs-detail/caraway.json
+++ b/public/data/herbs-detail/caraway.json
@@ -33,21 +33,31 @@
       "title": "Black Seed",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000936/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000936/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000850",
       "title": "Caraway",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000850/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000850/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "17427617",
       "title": "Peppermint oil",
       "authors": "Kligler B et al.",
       "year": 2007,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17427617/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17427617/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/carob.json
+++ b/public/data/herbs-detail/carob.json
@@ -30,21 +30,36 @@
       "title": "A clinical trial about effects of prebiotic and probiotic supplementation on weight loss, psychological profile and metabolic parameters in obese subjects",
       "authors": "Ben Othman R et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36606510/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36606510/",
+      "journal": "Endocrinol Diabetes Metab",
+      "doi": "10.1002/edm2.402",
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37457186",
       "title": "Nutritional, biochemical, and clinical applications of carob: A review",
       "authors": "Ikram A et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37457186/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37457186/",
+      "journal": "Food Sci Nutr",
+      "doi": "10.1002/fsn3.3367",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31583011",
       "title": "Functional polysaccharides of carob fruit: a review",
       "authors": "Zhu BJ et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31583011/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31583011/",
+      "journal": "Chin Med",
+      "doi": "10.1186/s13020-019-0261-x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cat-s-claw.json
+++ b/public/data/herbs-detail/cat-s-claw.json
@@ -33,21 +33,34 @@
       "title": "Neuroprotective Herbs for the Management of Alzheimer's Disease",
       "authors": "Gregory J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33917843/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33917843/",
+      "journal": "Biomolecules",
+      "doi": "10.3390/biom11040543",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31643645",
       "title": "Cat's Claw",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31643645/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31643645/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "17210508",
       "title": "Cat's claw: an Amazonian vine decreases inflammation in osteoarthritis",
       "authors": "Hardin SR et al.",
       "year": 2007,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17210508/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17210508/",
+      "journal": "Complement Ther Clin Pract",
+      "doi": "10.1016/j.ctcp.2006.10.003",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/celastrus-paniculatus.json
+++ b/public/data/herbs-detail/celastrus-paniculatus.json
@@ -36,21 +36,36 @@
       "title": "Phytochemistry and pharmacology of Celastrus paniculatus Wild.: a nootropic drug",
       "authors": "Aleem M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34529902/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34529902/",
+      "journal": "J Complement Integr Med",
+      "doi": "10.1515/jcim-2021-0251",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35005853",
       "title": "Neuroprotective potential of Celastrus paniculatus seeds against common neurological ailments: a narrative review",
       "authors": "Sankaramourthy D et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35005853/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35005853/",
+      "journal": "J Complement Integr Med",
+      "doi": "10.1515/jcim-2021-0448",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35199395",
       "title": "An extensive review on phytochemistry and pharmacological activities of Indian medicinal plant Celastrus paniculatus Willd",
       "authors": "Nagpal K et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35199395/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35199395/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7424",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/chaga.json
+++ b/public/data/herbs-detail/chaga.json
@@ -35,21 +35,36 @@
       "title": "Chaga mushroom: a super-fungus with countless facets and untapped potential",
       "authors": "Fordjour E et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38116085/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38116085/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2023.1273786",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37513265",
       "title": "Medicinal Mushrooms: Their Bioactive Components, Nutritional Value and Application in Functional Food Production-A Review",
       "authors": "Łysakowska P et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37513265/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37513265/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules28145393",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38813471",
       "title": "Therapeutic properties of Inonotus obliquus (Chaga mushroom): A review",
       "authors": "Ern PTY et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38813471/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38813471/",
+      "journal": "Mycology",
+      "doi": "10.1080/21501203.2023.2260408",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/chinese-skullcap.json
+++ b/public/data/herbs-detail/chinese-skullcap.json
@@ -37,21 +37,34 @@
       "title": "The Use of Chinese Skullcap (Scutellaria baicalensis) and Its Extracts for Sustainable Animal Production",
       "authors": "Yin B et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33917159/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33917159/",
+      "journal": "Animals (Basel)",
+      "doi": "10.3390/ani11041039",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35530094",
       "title": "Polyphenols of Chinese skullcap roots: from chemical profiles to anticancer effects",
       "authors": "Wang L et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35530094/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35530094/",
+      "journal": "RSC Adv",
+      "doi": "10.1039/c9ra03229k",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30708034",
       "title": "Chinese Skullcap (Scutellaria baicalensis Georgi) inhibits inflammation and proliferation on benign prostatic hyperplasia in rats",
       "authors": "Jin BR et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30708034/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30708034/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2019.01.039",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/chuanxiong.json
+++ b/public/data/herbs-detail/chuanxiong.json
@@ -37,21 +37,36 @@
       "title": "Ligusticum chuanxiong: a chemical, pharmacological and clinical review",
       "authors": "Wang Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40235541/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40235541/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2025.1523176",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39180449",
       "title": "Ligusticum chuanxiong Hort.: a review of its phytochemistry, pharmacology, and toxicology",
       "authors": "Kong Q et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39180449/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39180449/",
+      "journal": "J Pharm Pharmacol",
+      "doi": "10.1093/jpp/rgae105",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35483189",
       "title": "Tetramethylpyrazine: A review on its mechanisms and functions",
       "authors": "Lin J et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35483189/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35483189/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2022.113005",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cichorium-intybus.json
+++ b/public/data/herbs-detail/cichorium-intybus.json
@@ -35,21 +35,34 @@
       "title": "Esculin inhibits hepatic stellate cell activation and CCl(4)-induced liver fibrosis by activating the Nrf2/GPX4 signaling pathway",
       "authors": "Xu S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38471319/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38471319/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.155465",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31578592",
       "title": "Cytotoxicity of Cichorium intybus L. metabolites (Review)",
       "authors": "Imam KMSU et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31578592/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31578592/",
+      "journal": "Oncol Rep",
+      "doi": "10.3892/or.2019.7336",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32768902",
       "title": "Chicory (Cichorium intybus L.) as a food ingredient - Nutritional composition, bioactivity, safety, and health claims: A review",
       "authors": "Perović J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32768902/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32768902/",
+      "journal": "Food Chem",
+      "doi": "10.1016/j.foodchem.2020.127676",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cinnamomum-verum.json
+++ b/public/data/herbs-detail/cinnamomum-verum.json
@@ -29,21 +29,36 @@
       "title": "Antibacterial mechanisms of cinnamon and its constituents: A review",
       "authors": "Vasconcelos NG et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29702210/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29702210/",
+      "journal": "Microb Pathog",
+      "doi": "10.1016/j.micpath.2018.04.036",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35807953",
       "title": "Cinnamon as a Complementary Therapeutic Approach for Dysglycemia and Dyslipidemia Control in Type 2 Diabetes Mellitus and Its Molecular Mechanism of Action: A Review",
       "authors": "Silva ML et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35807953/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35807953/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu14132773",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37818728",
       "title": "The effect of cinnamon supplementation on glycemic control in patients with type 2 diabetes mellitus: An updated systematic review and dose-response meta-analysis of randomized controlled trials",
       "authors": "Moridpour AH et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37818728/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37818728/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.8026",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cissus.json
+++ b/public/data/herbs-detail/cissus.json
@@ -32,21 +32,36 @@
       "title": "Seed Geometry in the Vitaceae",
       "authors": "Cervantes E et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34451740/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34451740/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants10081695",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "22976133",
       "title": "A review and evaluation of the efficacy and safety of Cissus quadrangularis extracts",
       "authors": "Stohs SJ et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22976133/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22976133/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.4846",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34503406",
       "title": "Review of the Phytochemistry and Biological Activity of Cissus incisa Leaves",
       "authors": "Nocedo-Mena D et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34503406/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34503406/",
+      "journal": "Curr Top Med Chem",
+      "doi": "10.2174/1568026621666210909163612",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cistanche-deserticola.json
+++ b/public/data/herbs-detail/cistanche-deserticola.json
@@ -33,21 +33,34 @@
       "title": "Cistanche deserticola extract and its active components, echinacoside, ameliorate sarcopenia by activating the IGF-1/PI3K-AKT pathway to modulate ferroptosis",
       "authors": "Wang X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41106096/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41106096/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2025.157378",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35930138",
       "title": "Cistanche Deserticola for Regulation of Bone Metabolism: Therapeutic Potential and Molecular Mechanisms on Postmenopausal Osteoporosis",
       "authors": "Wang C et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35930138/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35930138/",
+      "journal": "Chin J Integr Med",
+      "doi": "10.1007/s11655-022-3518-z",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38876007",
       "title": "Chemical composition, pharmacological effects, and parasitic mechanisms of Cistanche deserticola: An update",
       "authors": "Zhang S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38876007/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38876007/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.155808",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cistanche.json
+++ b/public/data/herbs-detail/cistanche.json
@@ -30,21 +30,34 @@
       "title": "Herba Cistanches: Anti-aging",
       "authors": "Wang N et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29344414/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29344414/",
+      "journal": "Aging Dis",
+      "doi": "10.14336/AD.2017.0720",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27659301",
       "title": "Anti-ageing active ingredients from herbs and nutraceuticals used in traditional Chinese medicine: pharmacological mechanisms and implications for drug discovery",
       "authors": "Shen CY et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27659301/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27659301/",
+      "journal": "Br J Pharmacol",
+      "doi": "10.1111/bph.13631",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41106096",
       "title": "Cistanche deserticola extract and its active components, echinacoside, ameliorate sarcopenia by activating the IGF-1/PI3K-AKT pathway to modulate ferroptosis",
       "authors": "Wang X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41106096/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41106096/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2025.157378",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_b5b0b0a73b41",

--- a/public/data/herbs-detail/citicoline.json
+++ b/public/data/herbs-detail/citicoline.json
@@ -115,13 +115,19 @@
   "sources": [
     {
       "id": "src_ad8ff3b198d3",
-      "title": "PubMed PMID 33978188. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Citicoline and Memory Function in Healthy Older Adults: A Randomized, Double-Blind, Placebo-Controlled Clinical Trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/33978188/",
       "pmid": "33978188",
       "authors": "PubMed",
       "citation": "PubMed PMID 33978188. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Nutr",
+      "year": 2021,
+      "doi": "10.1093/jn/nxab119",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/citrus-bergamia.json
+++ b/public/data/herbs-detail/citrus-bergamia.json
@@ -38,21 +38,36 @@
       "title": "Biological Activities and Safety of Citrus spp. Essential Oils",
       "authors": "Dosoky NS et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29976894/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29976894/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms19071966",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27747942",
       "title": "Clinical Pharmacology of Citrus bergamia: A Systematic Review",
       "authors": "Mannucci C et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27747942/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27747942/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.5734",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25784877",
       "title": "Citrus bergamia essential oil: from basic research to clinical application",
       "authors": "Navarra M et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25784877/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25784877/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2015.00036",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/citrus-sinensis.json
+++ b/public/data/herbs-detail/citrus-sinensis.json
@@ -35,21 +35,36 @@
       "title": "Biological Activities and Safety of Citrus spp. Essential Oils",
       "authors": "Dosoky NS et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29976894/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29976894/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms19071966",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39500772",
       "title": "Aromatic plants as cosmeceuticals: benefits and applications for skin health",
       "authors": "Olivero-Verbel J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39500772/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39500772/",
+      "journal": "Planta",
+      "doi": "10.1007/s00425-024-04550-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25588369",
       "title": "Clinical evaluation of Moro (Citrus sinensis (L.) Osbeck) orange juice supplementation for the weight management",
       "authors": "Cardile V et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25588369/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25588369/",
+      "journal": "Nat Prod Res",
+      "doi": "10.1080/14786419.2014.1000897",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/clove.json
+++ b/public/data/herbs-detail/clove.json
@@ -33,21 +33,36 @@
       "title": "Antibacterial and Antifungal Activities of Spices",
       "authors": "Liu Q et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28621716/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28621716/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms18061283",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34770801",
       "title": "Clove Essential Oil (Syzygium aromaticum L. Myrtaceae): Extraction, Chemical Composition, Food Applications, and Essential Bioactivity for Human Health",
       "authors": "Haro-González JN et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34770801/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34770801/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26216387",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33916044",
       "title": "Biological Properties and Prospects for the Application of Eugenol-A Review",
       "authors": "Ulanowska M et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33916044/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33916044/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms22073671",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cnidium-monnieri.json
+++ b/public/data/herbs-detail/cnidium-monnieri.json
@@ -33,21 +33,34 @@
       "title": "Cnidium monnieri: A Review of Traditional Uses, Phytochemical and Ethnopharmacological Properties",
       "authors": "Li YM et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26243582/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26243582/",
+      "journal": "Am J Chin Med",
+      "doi": "10.1142/S0192415X15500500",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32028721",
       "title": "Phytochemistry, Ethnopharmacology, Pharmacokinetics and Toxicology of Cnidium monnieri (L.) Cusson",
       "authors": "Sun Y et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32028721/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32028721/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms21031006",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40256714",
       "title": "Osthole ameliorates chronic pruritus in 2,4-dichloronitrobenzene-induced atopic dermatitis by inhibiting IL-31 production",
       "authors": "He S et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40256714/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40256714/",
+      "journal": "Chin Herb Med",
+      "doi": "10.1016/j.chmed.2024.01.003",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/coffea-arabica.json
+++ b/public/data/herbs-detail/coffea-arabica.json
@@ -32,21 +32,36 @@
       "title": "The anti-obesity and health-promoting effects of tea and coffee",
       "authors": "Sirotkin AV et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33992045/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33992045/",
+      "journal": "Physiol Res",
+      "doi": "10.33549/physiolres.934674",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33374338",
       "title": "Neuroprotective Effects of Coffee Bioactive Compounds: A Review",
       "authors": "Socała K et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33374338/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33374338/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms22010107",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36769029",
       "title": "Health Benefits of Coffee Consumption for Cancer and Other Diseases and Mechanisms of Action",
       "authors": "Safe S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36769029/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36769029/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms24032706",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/coffee-cherry.json
+++ b/public/data/herbs-detail/coffee-cherry.json
@@ -39,21 +39,32 @@
       "title": "A Randomized, Double-Blind, Placebo-Controlled, Parallel Study Investigating the Efficacy of a Whole Coffee Cherry Extract and Phosphatidylserine Formulation on Cognitive Performance of Healthy Adults with Self-Perceived Memory Problems",
       "authors": "Doma KM et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36929344/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36929344/",
+      "journal": "Neurol Ther",
+      "doi": "10.1007/s40120-023-00454-z",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32825719",
       "title": "Applications of Compounds from Coffee Processing By-Products",
       "authors": "Iriondo-DeHond A et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32825719/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32825719/",
+      "journal": "Biomolecules",
+      "doi": "10.3390/biom10091219",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38572469",
       "title": "Geographic-Scale Coffee Cherry Counting with Smartphones and Deep Learning",
       "authors": "Palacio JCR et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38572469/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38572469/",
+      "journal": "Plant Phenomics",
+      "doi": "10.34133/plantphenomics.0165",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/commiphora-mukul.json
+++ b/public/data/herbs-detail/commiphora-mukul.json
@@ -38,21 +38,36 @@
       "title": "A Systematic Review and Meta-Analysis of Ayurvedic Herbal Preparations for Hypercholesterolemia",
       "authors": "Gyawali D et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34071454/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34071454/",
+      "journal": "Medicina (Kaunas)",
+      "doi": "10.3390/medicina57060546",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37301302",
       "title": "Commiphora mukul (Hook. ex Stocks) Engl.: Historical records, application rules, phytochemistry, pharmacology, clinical research, and adverse reaction",
       "authors": "Garang Z et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37301302/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37301302/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.116717",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38148708",
       "title": "Current stage of preclinical and clinical development of guggulsterone in cancers: Challenges and promises",
       "authors": "Ijaz S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38148708/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38148708/",
+      "journal": "Cell Biol Int",
+      "doi": "10.1002/cbin.12112",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/coptis-chinensis.json
+++ b/public/data/herbs-detail/coptis-chinensis.json
@@ -35,21 +35,36 @@
       "title": "Biological properties and clinical applications of berberine",
       "authors": "Song D et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32335802/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32335802/",
+      "journal": "Front Med",
+      "doi": "10.1007/s11684-019-0724-6",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33174095",
       "title": "Plants Used as Antihypertensive",
       "authors": "Verma T et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/",
+      "journal": "Nat Prod Bioprospect",
+      "doi": "10.1007/s13659-020-00281-x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36650621",
       "title": "Herb-Drug Interactions and Their Impact on Pharmacokinetics: An Update",
       "authors": "Cheng W et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/",
+      "journal": "Curr Drug Metab",
+      "doi": "10.2174/1389200224666230116113240",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/coptis.json
+++ b/public/data/herbs-detail/coptis.json
@@ -36,21 +36,34 @@
       "title": "Biological properties and clinical applications of berberine",
       "authors": "Song D et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32335802/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32335802/",
+      "journal": "Front Med",
+      "doi": "10.1007/s11684-019-0724-6",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36650621",
       "title": "Herb-Drug Interactions and Their Impact on Pharmacokinetics: An Update",
       "authors": "Cheng W et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/",
+      "journal": "Curr Drug Metab",
+      "doi": "10.2174/1389200224666230116113240",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39068762",
       "title": "Berberine alleviates ulcerative colitis by inhibiting inflammation through targeting IRGM1",
       "authors": "Meng G et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39068762/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39068762/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.155909",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cordyceps-sinensis.json
+++ b/public/data/herbs-detail/cordyceps-sinensis.json
@@ -32,21 +32,36 @@
       "title": "Herbal medicine for sports: a review",
       "authors": "Sellami M et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29568244/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29568244/",
+      "journal": "J Int Soc Sports Nutr",
+      "doi": "10.1186/s12970-018-0218-y",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37373268",
       "title": "Anti-Cancer Potential of Edible/Medicinal Mushrooms in Breast Cancer",
       "authors": "Gariboldi MB et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37373268/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37373268/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms241210120",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31030757",
       "title": "The structures and biological functions of polysaccharides from traditional Chinese herbs",
       "authors": "Zeng P et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31030757/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31030757/",
+      "journal": "Prog Mol Biol Transl Sci",
+      "doi": "10.1016/bs.pmbts.2019.03.003",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/coriandrum-sativum.json
+++ b/public/data/herbs-detail/coriandrum-sativum.json
@@ -36,21 +36,34 @@
       "title": "Plants Used as Antihypertensive",
       "authors": "Verma T et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/",
+      "journal": "Nat Prod Bioprospect",
+      "doi": "10.1007/s13659-020-00281-x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000851",
       "title": "Coriander",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000851/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000851/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37513187",
       "title": "Coriandrum sativum and Its Utility in Psychiatric Disorders",
       "authors": "Santibáñez A et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37513187/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37513187/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules28145314",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cornus-officinalis.json
+++ b/public/data/herbs-detail/cornus-officinalis.json
@@ -35,21 +35,34 @@
       "title": "Cornus officinalis: a potential herb for treatment of osteoporosis",
       "authors": "Tang X et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38111697/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38111697/",
+      "journal": "Front Med (Lausanne)",
+      "doi": "10.3389/fmed.2023.1289144",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37579922",
       "title": "Rehmannia glutinosa Libosch and Cornus officinalis Sieb herb couple ameliorates renal interstitial fibrosis in CKD rats by inhibiting the TGF-β1/MAPK signaling pathway",
       "authors": "Zhu JH et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37579922/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37579922/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.117039",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29155174",
       "title": "Ethnopharmacology, phytochemistry, and pharmacology of Cornus officinalis Sieb. et Zucc",
       "authors": "Huang J et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29155174/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29155174/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2017.11.010",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/corydalis.json
+++ b/public/data/herbs-detail/corydalis.json
@@ -37,21 +37,34 @@
       "title": "The Analgesic Properties of Corydalis yanhusuo",
       "authors": "Alhassen L et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34946576/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34946576/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26247498",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35003289",
       "title": "Processing and Compatibility of Corydalis yanhusuo: Phytochemistry, Pharmacology, Pharmacokinetics, and Safety",
       "authors": "Wu L et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35003289/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35003289/",
+      "journal": "Evid Based Complement Alternat Med",
+      "doi": "10.1155/2021/1271953",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38551844",
       "title": "Corynoline Suppresses Osteoclastogenesis and Attenuates ROS Activities by Regulating NF-κB/MAPKs and Nrf2 Signaling Pathways",
       "authors": "Jin C et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38551844/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38551844/",
+      "journal": "J Agric Food Chem",
+      "doi": "10.1021/acs.jafc.3c07088",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cranberry.json
+++ b/public/data/herbs-detail/cranberry.json
@@ -30,31 +30,49 @@
       "title": "Cranberry Polyphenols and Prevention against Urinary Tract Infections: Relevant Considerations",
       "authors": "González de Llano D et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32752183/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32752183/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules25153523",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000897",
       "title": "Cranberry",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000897/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000897/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "18204103",
       "title": "Safety and efficacy of cranberry (vaccinium macrocarpon) during pregnancy and lactation",
       "authors": "Dugoua JJ et al.",
       "year": 2008,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/18204103/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/18204103/",
+      "journal": "Can J Clin Pharmacol",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_c9055177bf1f",
-      "title": "PubMed PMID 37068952. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Cranberries for preventing urinary tract infections",
       "url": "https://pubmed.ncbi.nlm.nih.gov/37068952/",
       "pmid": "37068952",
       "authors": "PubMed",
       "citation": "PubMed PMID 37068952. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Cochrane Database Syst Rev",
+      "year": 2023,
+      "doi": "10.1002/14651858.CD001321.pub6",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/crataegus-monogyna.json
+++ b/public/data/herbs-detail/crataegus-monogyna.json
@@ -29,21 +29,32 @@
       "title": "Hawthorn",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36753600/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36753600/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000891",
       "title": "Hawthorn",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000891/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000891/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "12597258",
       "title": "Hawthorn",
       "authors": "Fong HH et al.",
       "year": 2002,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/12597258/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/12597258/",
+      "journal": "J Cardiovasc Nurs",
+      "doi": "10.1097/00005082-200207000-00002",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/crocus-sativus.json
+++ b/public/data/herbs-detail/crocus-sativus.json
@@ -35,21 +35,36 @@
       "title": "The Effects of Crocus sativus (Saffron) on ADHD: A Systematic Review",
       "authors": "Seyedi-Sahebari S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37864351/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37864351/",
+      "journal": "J Atten Disord",
+      "doi": "10.1177/10870547231203176",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30036891",
       "title": "The Efficacy of Saffron in the Treatment of Mild to Moderate Depression: A Meta-analysis",
       "authors": "Tóth B et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30036891/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30036891/",
+      "journal": "Planta Med",
+      "doi": "10.1055/a-0660-9565",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35276955",
       "title": "Saffron (Crocus sativus L.): A Source of Nutrients for Health and for the Treatment of Neuropsychiatric and Age-Related Diseases",
       "authors": "El Midaoui A et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35276955/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35276955/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu14030597",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_dc98fa665a32",

--- a/public/data/herbs-detail/curcuma-wenyujin.json
+++ b/public/data/herbs-detail/curcuma-wenyujin.json
@@ -34,21 +34,30 @@
       "title": "Curcuma wenyujin extract alleviates cognitive deficits and restrains pyroptosis through PINK1/Parkin mediated autophagy in Alzheimer's disease",
       "authors": "Qi Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39954619/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39954619/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2025.156482",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38604260",
       "title": "Curcuma wenyujin rhizomes extract ameliorates lipid accumulation",
       "authors": "Wang H et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38604260/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38604260/",
+      "journal": "Fitoterapia",
+      "doi": "10.1016/j.fitote.2024.105957",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37610136",
       "title": "Two new guaiane-type sesquiterpenes from Curcuma wenyujin",
       "authors": "Jiang XJ et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37610136/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37610136/",
+      "journal": "J Asian Nat Prod Res",
+      "doi": "10.1080/10286020.2023.2249833",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/curcuma-zedoaria.json
+++ b/public/data/herbs-detail/curcuma-zedoaria.json
@@ -32,21 +32,34 @@
       "title": "Curcuma zedoaria Rosc. (white turmeric): a review of its chemical, pharmacological and ethnomedicinal properties",
       "authors": "Lobo R et al.",
       "year": 2009,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/19126292/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/19126292/",
+      "journal": "J Pharm Pharmacol",
+      "doi": "10.1211/jpp/61.01.0003",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38338400",
       "title": "The Extraction, Determination, and Bioactivity of Curcumenol: A Comprehensive Review",
       "authors": "Li J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38338400/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38338400/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules29030656",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30884305",
       "title": "Sesquiterpenes from Curcuma zedoaria rhizomes and their cytotoxicity against human gastric cancer AGS cells",
       "authors": "Lee TK et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30884305/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30884305/",
+      "journal": "Bioorg Chem",
+      "doi": "10.1016/j.bioorg.2019.03.015",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/curcumin.json
+++ b/public/data/herbs-detail/curcumin.json
@@ -31,61 +31,96 @@
       "title": "Efficacy and Safety of Curcumin and Curcuma longa Extract in the Treatment of Arthritis: A Systematic Review and Meta-Analysis of Randomized Controlled Trial",
       "authors": "Zeng L et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35935936/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35935936/",
+      "journal": "Front Immunol",
+      "doi": "10.3389/fimmu.2022.891822",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27837604",
       "title": "Curcumin (Turmeric) and cancer",
       "authors": "Unlu A et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27837604/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27837604/",
+      "journal": "J BUON",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26528921",
       "title": "Curcumin, an active component of turmeric (Curcuma longa), and its effects on health",
       "authors": "Kocaadam B et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26528921/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26528921/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2015.1077195",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_690ac9bb5f89",
-      "title": "PubMed PMID 27403209. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Impact of the 'Artful Moments' Intervention on Persons with Dementia and Their Care Partners: a Pilot Study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/27403209/",
       "pmid": "27403209",
       "authors": "PubMed",
       "citation": "PubMed PMID 27403209. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Can Geriatr J",
+      "year": 2016,
+      "doi": "10.5770/cgj.19.220",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_7dce165a398a",
-      "title": "PubMed PMID 23832433. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy and safety of curcumin in major depressive disorder: a randomized controlled trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23832433/",
       "pmid": "23832433",
       "authors": "PubMed",
       "citation": "PubMed PMID 23832433. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytother Res",
+      "year": 2014,
+      "doi": "10.1002/ptr.5025",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_c3f7857d2f8d",
-      "title": "PubMed PMID 19594223. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Anti-inflammatory properties of curcumin, a major constituent of Curcuma longa: a review of preclinical and clinical research",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19594223/",
       "pmid": "19594223",
       "authors": "PubMed",
       "citation": "PubMed PMID 19594223. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Altern Med Rev",
+      "year": 2009,
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_fc1b62a1b742",
-      "title": "PubMed PMID 27533649. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy of Turmeric Extracts and Curcumin for Alleviating the Symptoms of Joint Arthritis: A Systematic Review and Meta-Analysis of Randomized Clinical Trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/27533649/",
       "pmid": "27533649",
       "authors": "PubMed",
       "citation": "PubMed PMID 27533649. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Med Food",
+      "year": 2016,
+      "doi": "10.1089/jmf.2016.3705",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/curry-leaf.json
+++ b/public/data/herbs-detail/curry-leaf.json
@@ -32,21 +32,34 @@
       "title": "Murraya koenigii (L.) Spreng. as a Natural Intervention for Diabesity: A Review",
       "authors": "Jachak SM et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39253925/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39253925/",
+      "journal": "Curr Pharm Des",
+      "doi": "10.2174/0113816128304471240801183021",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37701635",
       "title": "A comprehensive review on genomic resources in medicinally and industrially important major spices for future breeding programs: Status, utility and challenges",
       "authors": "Das P et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37701635/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37701635/",
+      "journal": "Curr Res Food Sci",
+      "doi": "10.1016/j.crfs.2023.100579",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41150909",
       "title": "Trunk injection of a curry leaf extract to promote citrus tree health in Huanglongbing-endemic regions",
       "authors": "Aglave T et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41150909/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41150909/",
+      "journal": "Plant Dis",
+      "doi": "10.1094/PDIS-10-25-2132-SC",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cyclea-peltata.json
+++ b/public/data/herbs-detail/cyclea-peltata.json
@@ -32,21 +32,30 @@
       "title": "Protective effect of Cyclea peltata Lam on cisplatin-induced nephrotoxicity and oxidative damage",
       "authors": "Vijayan FP et al.",
       "year": 2007,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17715566/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17715566/",
+      "journal": "J Basic Clin Physiol Pharmacol",
+      "doi": "10.1515/jbcpp.2007.18.2.101",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "19397987",
       "title": "Gastric antisecretory and antiulcer activities of Cyclea peltata (Lam.) Hook. f. & Thoms. in rats",
       "authors": "Shine VJ et al.",
       "year": 2009,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/19397987/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/19397987/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2009.04.039",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35349772",
       "title": "Development of EPS-rich herbal shampoo base fermented using Cyclea peltata leaf powder and Lactobacillus plantarum",
       "authors": "Cheni Cheri D et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35349772/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35349772/",
+      "journal": "J Cosmet Dermatol",
+      "doi": "10.1111/jocd.14949",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/cymbopogon-citratus.json
+++ b/public/data/herbs-detail/cymbopogon-citratus.json
@@ -33,21 +33,34 @@
       "title": "Aromatic plants as cosmeceuticals: benefits and applications for skin health",
       "authors": "Olivero-Verbel J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39500772/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39500772/",
+      "journal": "Planta",
+      "doi": "10.1007/s00425-024-04550-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37383807",
       "title": "Bangladeshi medicinal plant dataset",
       "authors": "Borkatulla B et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37383807/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37383807/",
+      "journal": "Data Brief",
+      "doi": "10.1016/j.dib.2023.109211",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39072200",
       "title": "Ethnopharmacology, chemical composition and functions of Cymbopogon citratus",
       "authors": "Du X et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39072200/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39072200/",
+      "journal": "Chin Herb Med",
+      "doi": "10.1016/j.chmed.2023.07.002",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/damiana.json
+++ b/public/data/herbs-detail/damiana.json
@@ -34,21 +34,30 @@
       "title": "Antiphotoaging Effects of Damiana (Turnera diffusa) Leaves Extract via Regulation AP-1 and Nrf2/ARE Signaling Pathways",
       "authors": "Kim M et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35684259/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35684259/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants11111486",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40125913",
       "title": "Damiana (Turnera diffusa) Reduces Adipocyte Cell Differentiation and Ameliorates Myocyte Glucose Uptake",
       "authors": "Chae HS et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40125913/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40125913/",
+      "journal": "J Diet Suppl",
+      "doi": "10.1080/19390211.2025.2480582",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30823394",
       "title": "Cytotoxic Properties of Damiana (Turnera diffusa) Extracts and Constituents and A Validated Quantitative UHPLC-DAD Assay",
       "authors": "Willer J et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30823394/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30823394/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules24050855",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/dandelion.json
+++ b/public/data/herbs-detail/dandelion.json
@@ -37,21 +37,34 @@
       "title": "Scalp Seborrheic Dermatitis: What We Know So Far",
       "authors": "Leroy AK et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37325288/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37325288/",
+      "journal": "Skin Appendage Disord",
+      "doi": "10.1159/000529854",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37446683",
       "title": "Dandelion (Taraxacum Genus): A Review of Chemical Constituents and Pharmacological Effects",
       "authors": "Fan M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37446683/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37446683/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules28135022",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36091818",
       "title": "Anti-Inflammatory Effects and Mechanisms of Dandelion in RAW264.7 Macrophages and Zebrafish Larvae",
       "authors": "Li W et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36091818/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36091818/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2022.906927",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/danshen.json
+++ b/public/data/herbs-detail/danshen.json
@@ -34,21 +34,34 @@
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29698387",
       "title": "Salvia miltiorrhizaBurge (Danshen): a golden herbal medicine in cardiovascular therapeutics",
       "authors": "Li ZM et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29698387/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29698387/",
+      "journal": "Acta Pharmacol Sin",
+      "doi": "10.1038/aps.2017.193",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39296670",
       "title": "Huangqi-Danshen Decoction Against Renal Fibrosis in UUO Mice via TGF-β1 Induced Downstream Signaling Pathway",
       "authors": "Huang X et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39296670/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39296670/",
+      "journal": "Drug Des Devel Ther",
+      "doi": "10.2147/DDDT.S457100",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/daphne-odora.json
+++ b/public/data/herbs-detail/daphne-odora.json
@@ -31,21 +31,30 @@
       "title": "Daphne odora Exerts Depigmenting Effects via Inhibiting CREB/MITF and Activating AKT/ERK-Signaling Pathways",
       "authors": "Eom YS et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35892714/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35892714/",
+      "journal": "Curr Issues Mol Biol",
+      "doi": "10.3390/cimb44080228",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40941781",
       "title": "Identification of Daphnane Diterpenoids from Flower Buds and Blooming Flowers of Daphne odora Using UHPLC-Q-Exactive-Orbitrap MS",
       "authors": "Otsuki K et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40941781/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40941781/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants14172616",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37062005",
       "title": "Complete genome sequence of daphne virus 1, a novel cytorhabdovirus infecting Daphne odora",
       "authors": "Belete MT et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37062005/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37062005/",
+      "journal": "Arch Virol",
+      "doi": "10.1007/s00705-023-05734-5",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/dendrobium.json
+++ b/public/data/herbs-detail/dendrobium.json
@@ -32,21 +32,36 @@
       "title": "Dendrobium micropropagation: a review",
       "authors": "da Silva JA et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26046143/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26046143/",
+      "journal": "Plant Cell Rep",
+      "doi": "10.1007/s00299-015-1754-4",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30066218",
       "title": "Genome-wide researches and applications on Dendrobium",
       "authors": "Zheng SG et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30066218/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30066218/",
+      "journal": "Planta",
+      "doi": "10.1007/s00425-018-2960-4",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35576743",
       "title": "Alkaloids from Dendrobium and their biosynthetic pathway, biological activity and total synthesis",
       "authors": "Duan H et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35576743/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35576743/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2022.154132",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/dong-quai.json
+++ b/public/data/herbs-detail/dong-quai.json
@@ -40,21 +40,34 @@
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27677719",
       "title": "Botanicals and Their Bioactive Phytochemicals for Women's Health",
       "authors": "Dietz BM et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/",
+      "journal": "Pharmacol Rev",
+      "doi": "10.1124/pr.115.010843",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000896",
       "title": "Dong Quai",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000896/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000896/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/elderberry.json
+++ b/public/data/herbs-detail/elderberry.json
@@ -34,31 +34,52 @@
       "title": "Elderberry for prevention and treatment of viral respiratory illnesses: a systematic review",
       "authors": "Wieland LS et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33827515/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33827515/",
+      "journal": "BMC Complement Med Ther",
+      "doi": "10.1186/s12906-021-03283-5",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35348337",
       "title": "Elderberry (Sambucus nigra L.): Bioactive Compounds, Health Functions, and Applications",
       "authors": "Liu D et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35348337/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35348337/",
+      "journal": "J Agric Food Chem",
+      "doi": "10.1021/acs.jafc.2c00010",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30670267",
       "title": "Black elderberry (Sambucus nigra) supplementation effectively treats upper respiratory symptoms: A meta-analysis of randomized, controlled clinical trials",
       "authors": "Hawkins J et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30670267/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30670267/",
+      "journal": "Complement Ther Med",
+      "doi": "10.1016/j.ctim.2018.12.004",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_28c26c941797",
-      "title": "PubMed PMID 30670267. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Black elderberry (Sambucus nigra) supplementation effectively treats upper respiratory symptoms: A meta-analysis of randomized, controlled clinical trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/30670267/",
       "pmid": "30670267",
       "authors": "PubMed",
       "citation": "PubMed PMID 30670267. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Complement Ther Med",
+      "year": 2019,
+      "doi": "10.1016/j.ctim.2018.12.004",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/elecampane.json
+++ b/public/data/herbs-detail/elecampane.json
@@ -34,21 +34,33 @@
       "title": "Systemic allergic dermatitis caused by sesquiterpene lactones",
       "authors": "Paulsen E et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27568784/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27568784/",
+      "journal": "Contact Dermatitis",
+      "doi": "10.1111/cod.12671",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "17919303",
       "title": "Contact allergy and medicinal herbs",
       "authors": "Aberer W et al.",
       "year": 2008,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17919303/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17919303/",
+      "journal": "J Dtsch Dermatol Ges",
+      "doi": "10.1111/j.1610-0387.2007.06425.x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30428203",
       "title": "Ultrasound and Microwave-Assisted Extraction of Elecampane (Inula helenium) Roots",
       "authors": "Petkova N et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30428203/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30428203/",
+      "journal": "Nat Prod Commun",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/elettaria-cardamomum.json
+++ b/public/data/herbs-detail/elettaria-cardamomum.json
@@ -31,21 +31,36 @@
       "title": "Ayurvedic Herbal Medicines: A Literature Review of Their Applications in Female Reproductive Health",
       "authors": "Patibandla S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38558676/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38558676/",
+      "journal": "Cureus",
+      "doi": "10.7759/cureus.55240",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34283916",
       "title": "Effectiveness of Inhaled Aromatherapy on Chemotherapy-Induced Nausea and Vomiting: A Systematic Review",
       "authors": "Toniolo J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34283916/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34283916/",
+      "journal": "J Altern Complement Med",
+      "doi": "10.1089/acm.2021.0067",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33506690",
       "title": "Functional foods modulating inflammation and metabolism in chronic diseases: a systematic review",
       "authors": "Luvián-Morales J et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33506690/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33506690/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2021.1875189",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/eleuthero.json
+++ b/public/data/herbs-detail/eleuthero.json
@@ -33,21 +33,32 @@
       "title": "Eleuthero",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000865/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000865/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25005060",
       "title": "Biotechnological production of eleutherosides: current state and perspectives",
       "authors": "Murthy HN et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25005060/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25005060/",
+      "journal": "Appl Microbiol Biotechnol",
+      "doi": "10.1007/s00253-014-5899-9",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32061978",
       "title": "Selective in vivo molecular and cellular biocompatibility of black peppercorns by piperine-protein intrinsic atomic interaction with elicited oxidative stress and apoptosis in zebrafish eleuthero embryos",
       "authors": "Patel P et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32061978/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32061978/",
+      "journal": "Ecotoxicol Environ Saf",
+      "doi": "10.1016/j.ecoenv.2020.110321",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/embelia-ribes.json
+++ b/public/data/herbs-detail/embelia-ribes.json
@@ -31,21 +31,36 @@
       "title": "Antidiabetic activity of Embelia ribes, embelin and its derivatives: A systematic review and meta-analysis",
       "authors": "Durg S et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27984799/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27984799/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2016.12.001",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35883850",
       "title": "Reviewing the Traditional/Modern Uses, Phytochemistry, Essential Oils/Extracts and Pharmacology of Embelia ribes Burm",
       "authors": "Sharma V et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35883850/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35883850/",
+      "journal": "Antioxidants (Basel)",
+      "doi": "10.3390/antiox11071359",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28289385",
       "title": "Plant Derived Phytocompound, Embelin in CNS Disorders: A Systematic Review",
       "authors": "Kundap UP et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28289385/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28289385/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2017.00076",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/epimedium-brevicornum.json
+++ b/public/data/herbs-detail/epimedium-brevicornum.json
@@ -36,21 +36,30 @@
       "title": "Epimedium brevicornum Maxim. Extract exhibits pigmentation by melanin biosynthesis and melanosome biogenesis/transfer",
       "authors": "Hong C et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36249817/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36249817/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2022.963160",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40089686",
       "title": "Epimedium brevicornum Maxim alleviates diabetes osteoporosis by regulating AGE-RAGE signaling pathway",
       "authors": "Lei SS et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40089686/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40089686/",
+      "journal": "Mol Med",
+      "doi": "10.1186/s10020-025-01152-2",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28798396",
       "title": "Flavonoid glycosides isolated from Epimedium brevicornum and their estrogen biosynthesis-promoting effects",
       "authors": "Li F et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28798396/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28798396/",
+      "journal": "Sci Rep",
+      "doi": "10.1038/s41598-017-08203-7",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/epimedium.json
+++ b/public/data/herbs-detail/epimedium.json
@@ -35,21 +35,34 @@
       "title": "Botanicals and Their Bioactive Phytochemicals for Women's Health",
       "authors": "Dietz BM et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/",
+      "journal": "Pharmacol Rev",
+      "doi": "10.1124/pr.115.010843",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35676785",
       "title": "Anti-inflammatory and immunoregulatory effects of icariin and icaritin",
       "authors": "Bi Z et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35676785/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35676785/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2022.113180",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39026367",
       "title": "Adipose-derived stem cell exosomes loaded with icariin alleviates rheumatoid arthritis by modulating macrophage polarization in rats",
       "authors": "Yan Q et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39026367/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39026367/",
+      "journal": "J Nanobiotechnology",
+      "doi": "10.1186/s12951-024-02711-1",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/eschscholzia-californica.json
+++ b/public/data/herbs-detail/eschscholzia-californica.json
@@ -30,21 +30,32 @@
       "title": "California poppy (Eschscholzia californica), the Papaveraceae golden girl model organism for evodevo and specialized metabolism",
       "authors": "Becker A et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36938015/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36938015/",
+      "journal": "Front Plant Sci",
+      "doi": "10.3389/fpls.2023.1084358",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37673017",
       "title": "Alkaloids in commercial preparations of California poppy - Quantification, intestinal permeability and microbiota interactions",
       "authors": "Chauveau A et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37673017/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37673017/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2023.115420",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37172085",
       "title": "Electromagnetic fields disrupt the pollination service by honeybees",
       "authors": "Molina-Montenegro MA et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37172085/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37172085/",
+      "journal": "Sci Adv",
+      "doi": "10.1126/sciadv.adh1455",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/eucalyptus.json
+++ b/public/data/herbs-detail/eucalyptus.json
@@ -33,21 +33,34 @@
       "title": "Oil of Lemon Eucalyptus",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29999893/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29999893/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39458790",
       "title": "Regeneration and Genetic Transformation in Eucalyptus Species, Current Research and Future Perspectives",
       "authors": "Wang Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39458790/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39458790/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants13202843",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27914909",
       "title": "Benefits, pitfalls and risks of phytotherapy in clinical practice in otorhinolaryngology",
       "authors": "Laccourreye O et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27914909/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27914909/",
+      "journal": "Eur Ann Otorhinolaryngol Head Neck Dis",
+      "doi": "10.1016/j.anorl.2016.11.001",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/eucommia.json
+++ b/public/data/herbs-detail/eucommia.json
@@ -31,21 +31,30 @@
       "title": "Somatostatin and Mannooligosaccharide Modified Selenium Nanoparticles with Dual-Targeting for Ulcerative Colitis Treatment",
       "authors": "Ye R et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40214514/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40214514/",
+      "journal": "ACS Nano",
+      "doi": "10.1021/acsnano.5c00355",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38518640",
       "title": "Aqueous extract of fermented Eucommia ulmoides leaves alleviates hyperlipidemia by maintaining gut homeostasis and modulating metabolism in high-fat diet fed rats",
       "authors": "Duan Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38518640/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38518640/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2023.155291",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41288788",
       "title": "Eucommia ulmoides Oliver (Duzhong) extract ameliorates cerebral ischemic stroke in mice by remodeling intestinal microbiota and metabolites",
       "authors": "Qi X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41288788/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41288788/",
+      "journal": "Metab Brain Dis",
+      "doi": "10.1007/s11011-025-01750-3",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/evening-primrose.json
+++ b/public/data/herbs-detail/evening-primrose.json
@@ -29,21 +29,34 @@
       "title": "Herbal Products Used in Menopause and for Gynecological Disorders",
       "authors": "Kenda M et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26247421",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000954",
       "title": "Evening Primrose",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000954/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000954/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29403626",
       "title": "A review of effective herbal medicines in controlling menopausal symptoms",
       "authors": "Kargozar R et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29403626/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29403626/",
+      "journal": "Electron Physician",
+      "doi": "10.19082/5826",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/fennel.json
+++ b/public/data/herbs-detail/fennel.json
@@ -32,21 +32,36 @@
       "title": "Dietary supplements for dysmenorrhoea",
       "authors": "Pattanittum P et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27000311/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27000311/",
+      "journal": "Cochrane Database Syst Rev",
+      "doi": "10.1002/14651858.CD002124.pub2",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40317096",
       "title": "Nutritional and herbal interventions for polycystic ovary syndrome (PCOS): a comprehensive review of dietary approaches, macronutrient impact, and herbal medicine in management",
       "authors": "Muhammed Saeed AA et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40317096/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40317096/",
+      "journal": "J Health Popul Nutr",
+      "doi": "10.1186/s41043-025-00899-y",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29403626",
       "title": "A review of effective herbal medicines in controlling menopausal symptoms",
       "authors": "Kargozar R et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29403626/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29403626/",
+      "journal": "Electron Physician",
+      "doi": "10.19082/5826",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/feverfew.json
+++ b/public/data/herbs-detail/feverfew.json
@@ -35,21 +35,32 @@
       "title": "Migraine Headache Prophylaxis",
       "authors": "Ha H et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30600979/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30600979/",
+      "journal": "Am Fam Physician",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40378325",
       "title": "Migraine Headache Prophylaxis",
       "authors": "Moreland P et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40378325/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40378325/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39853578",
       "title": "Nutraceuticals and Headache 2024: Riboflavin, Coenzyme Q10, Feverfew, Magnesium, Melatonin, and Butterbur",
       "authors": "Tepper SJ et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39853578/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39853578/",
+      "journal": "Curr Pain Headache Rep",
+      "doi": "10.1007/s11916-025-01358-3",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ficus-carica.json
+++ b/public/data/herbs-detail/ficus-carica.json
@@ -35,21 +35,34 @@
       "title": "Fig-derived exosome-like nanoparticles attenuating bone metastasis of breast cancer through establishing an anti-tumor microenvironment",
       "authors": "Wang DD et al.",
       "year": 2026,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41500295/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41500295/",
+      "journal": "Pharmacol Res",
+      "doi": "10.1016/j.phrs.2026.108088",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41515938",
       "title": "Effects of Common Fig (Ficus carica L.) and Its Extracts on Certain Cancer Types: Focusing on the Mechanism of Action",
       "authors": "Gökçen EN et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41515938/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41515938/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms27010056",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38831870",
       "title": "Physicochemistry, Nutritional, and Therapeutic Potential of Ficus carica - A Promising Nutraceutical",
       "authors": "Fazel MF et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38831870/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38831870/",
+      "journal": "Drug Des Devel Ther",
+      "doi": "10.2147/DDDT.S436446",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/fingerroot.json
+++ b/public/data/herbs-detail/fingerroot.json
@@ -35,28 +35,42 @@
       "title": "Fingerroot, Boesenbergia rotunda and its Aphrodisiac Activity",
       "authors": "Ongwisespaiboon O et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28503050/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28503050/",
+      "journal": "Pharmacogn Rev",
+      "doi": "10.4103/phrev.phrev_50_16",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36699694",
       "title": "Pharmacological Activities of Fingerroot Extract and Its Phytoconstituents Against SARS-CoV-2 Infection in Golden Syrian Hamsters",
       "authors": "Kongratanapasert T et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36699694/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36699694/",
+      "journal": "J Exp Pharmacol",
+      "doi": "10.2147/JEP.S382895",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38328737",
       "title": "Oral sub-chronic toxicity of fingerroot (Boesenbergia rotunda) rhizome extract formulation in Wistar rats",
       "authors": "Techapichetvanich P et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38328737/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38328737/",
+      "journal": "Toxicol Rep",
+      "doi": "10.1016/j.toxrep.2024.01.013",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35721953",
       "title": "Assessment of the CYP1A2 Inhibition-Mediated Drug Interaction Potential for Pinocembrin Using In Silico, In Vitro, and In Vivo Approaches",
       "authors": "Bhatt S et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35721953/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35721953/",
+      "journal": "ACS Omega",
+      "doi": "10.1021/acsomega.2c02315",
+      "metadataSource": "pubmed"
     },
     {
       "title": "Inhibitory Effect of Boesenbergia rotunda and Its Major Flavonoids, Pinostrobin and Pinocembrin on Carbohydrate Digestive Enzymes and Intestinal Glucose Transport in Caco-2 Cells",
@@ -70,7 +84,12 @@
       "title": "Traditional usages, chemical metabolites, pharmacological activities, and pharmacokinetics of Boesenbergia rotunda (L.) Mansf.: a comprehensive review",
       "authors": "Wang Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40176912/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40176912/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2025.1527210",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/fraxinus-rhynchophylla.json
+++ b/public/data/herbs-detail/fraxinus-rhynchophylla.json
@@ -36,21 +36,32 @@
       "title": "Esculin inhibits hepatic stellate cell activation and CCl(4)-induced liver fibrosis by activating the Nrf2/GPX4 signaling pathway",
       "authors": "Xu S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38471319/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38471319/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.155465",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34808701",
       "title": "Esculetin: A review of its pharmacology and pharmacokinetics",
       "authors": "Zhang L et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34808701/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34808701/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7311",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38561058",
       "title": "Esculin induces endoplasmic reticulum stress and drives apoptosis and ferroptosis in colorectal cancer via PERK regulating eIF2α/CHOP and Nrf2/HO-1 cascades",
       "authors": "Ji X et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38561058/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38561058/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2024.118139",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/galangal.json
+++ b/public/data/herbs-detail/galangal.json
@@ -32,21 +32,34 @@
       "title": "Insights into the anticancer effects of galangal and galangin: A comprehensive review",
       "authors": "Wu Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39353308/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39353308/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.156085",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40527613",
       "title": "Galangin alleviates vitiligo by targeting ANXA2 degradation in macrophages",
       "authors": "Wei W et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40527613/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40527613/",
+      "journal": "Br J Pharmacol",
+      "doi": "10.1111/bph.70103",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39408345",
       "title": "Potential Neuroprotective Effects of Alpinia officinarum Hance (Galangal): A Review",
       "authors": "Abd Rahman IZ et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39408345/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39408345/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu16193378",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ganoderma-lucidum.json
+++ b/public/data/herbs-detail/ganoderma-lucidum.json
@@ -32,21 +32,36 @@
       "title": "A Review of Ganoderma Triterpenoids and Their Bioactivities",
       "authors": "Galappaththi MCA et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36671409/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36671409/",
+      "journal": "Biomolecules",
+      "doi": "10.3390/biom13010024",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29141563",
       "title": "Ganoderma lucidum Polysaccharides as An Anti-cancer Agent",
       "authors": "Sohretoglu D et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29141563/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29141563/",
+      "journal": "Anticancer Agents Med Chem",
+      "doi": "10.2174/1871520617666171113121246",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34411377",
       "title": "Ganoderma lucidum (Reishi) an edible mushroom; a comprehensive and critical review of its nutritional, cosmeceutical, mycochemical, pharmacological, clinical, and toxicological properties",
       "authors": "Ahmad R et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34411377/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34411377/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7215",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/garcinia-indica.json
+++ b/public/data/herbs-detail/garcinia-indica.json
@@ -34,21 +34,34 @@
       "title": "(1S,5R,7R,30S)-14-De-oxy-isogarcinol",
       "authors": "Kaur R et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22719626/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22719626/",
+      "journal": "Acta Crystallogr Sect E Struct Rep Online",
+      "doi": "10.1107/S1600536812020788",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34959738",
       "title": "Pharmacological Activity of Garcinia indica (Kokum): An Updated Review",
       "authors": "Lim SH et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34959738/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34959738/",
+      "journal": "Pharmaceuticals (Basel)",
+      "doi": "10.3390/ph14121338",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35933691",
       "title": "Bioactive compounds, bio-functional properties, and food applications of Garcinia indica: A review",
       "authors": "Desai S et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35933691/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35933691/",
+      "journal": "J Food Biochem",
+      "doi": "10.1111/jfbc.14344",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/garcinia-mangostana.json
+++ b/public/data/herbs-detail/garcinia-mangostana.json
@@ -33,21 +33,34 @@
       "title": "Mechanistic Insights into the Anti-Glioma Effects of Exosome-Like Nanoparticles Derived from Garcinia Mangostana L.: A Metabolomics, Network Pharmacology, and Experimental Study",
       "authors": "Luo X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40321800/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40321800/",
+      "journal": "Int J Nanomedicine",
+      "doi": "10.2147/IJN.S514930",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36937066",
       "title": "The origin of cultivated mangosteen (Garcinia mangostana L. var. mangostana): Critical assessments and an evolutionary-ecological perspective",
       "authors": "Yao TL et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36937066/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36937066/",
+      "journal": "Ecol Evol",
+      "doi": "10.1002/ece3.9792",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32280205",
       "title": "Nanoparticle Drug Delivery Systems for α-Mangostin",
       "authors": "Wathoni N et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32280205/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32280205/",
+      "journal": "Nanotechnol Sci Appl",
+      "doi": "10.2147/NSA.S243017",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/garlic.json
+++ b/public/data/herbs-detail/garlic.json
@@ -36,41 +36,65 @@
       "title": "Chemical Constituents and Pharmacological Activities of Garlic (Allium sativum L.): A Review",
       "authors": "El-Saber Batiha G et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32213941/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32213941/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu12030872",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25153873",
       "title": "Allicin: chemistry and biological properties",
       "authors": "Borlinghaus J et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25153873/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25153873/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules190812591",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "10675182",
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_580ec4d8897a",
-      "title": "PubMed PMID 22492349. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Prevalence and pattern of congenital heart disease in Uttarakhand, India",
       "url": "https://pubmed.ncbi.nlm.nih.gov/22492349/",
       "pmid": "22492349",
       "authors": "PubMed",
       "citation": "PubMed PMID 22492349. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Indian J Pediatr",
+      "year": 2013,
+      "doi": "10.1007/s12098-012-0738-4",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_b2edf411006a",
-      "title": "PubMed PMID 24035939. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Effects of Allium sativum (garlic) on systolic and diastolic blood pressure in patients with essential hypertension",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24035939/",
       "pmid": "24035939",
       "authors": "PubMed",
       "citation": "PubMed PMID 24035939. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Pak J Pharm Sci",
+      "year": 2013,
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/gastrodia.json
+++ b/public/data/herbs-detail/gastrodia.json
@@ -31,21 +31,34 @@
       "title": "Review on pharmacological effects of gastrodin",
       "authors": "Xiao G et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37749449/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37749449/",
+      "journal": "Arch Pharm Res",
+      "doi": "10.1007/s12272-023-01463-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38552431",
       "title": "Gastrodin regulates the TLR4/TRAF6/NF-κB pathway to reduce neuroinflammation and microglial activation in an AD model",
       "authors": "Wang W et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38552431/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38552431/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.155518",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38165423",
       "title": "Gastrodin: a comprehensive pharmacological review",
       "authors": "Wang Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38165423/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38165423/",
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "doi": "10.1007/s00210-023-02920-9",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ginger.json
+++ b/public/data/herbs-detail/ginger.json
@@ -33,41 +33,66 @@
       "title": "A critical review of Ginger's (Zingiber officinale) antioxidant, anti-inflammatory, and immunomodulatory activities",
       "authors": "Ayustaningwarno F et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38903613/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38903613/",
+      "journal": "Front Nutr",
+      "doi": "10.3389/fnut.2024.1364836",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36364048",
       "title": "Effect of Ginger on Inflammatory Diseases",
       "authors": "Ballester P et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36364048/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36364048/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27217223",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31151279",
       "title": "Bioactive Compounds and Bioactivities of Ginger (Zingiber officinale Roscoe)",
       "authors": "Mao QQ et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31151279/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31151279/",
+      "journal": "Foods",
+      "doi": "10.3390/foods8060185",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_608a1375392c",
-      "title": "PubMed PMID 12542115. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Evolution of the mortality rate in the age class of 75-84 years worldwide",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12542115/",
       "pmid": "12542115",
       "authors": "PubMed",
       "citation": "PubMed PMID 12542115. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Acta Cardiol",
+      "year": 2002,
+      "doi": "10.2143/AC.57.6.2005461",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_69af43e333e7",
-      "title": "PubMed PMID 11275030. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Ginger for nausea and vomiting in pregnancy: randomized, double-masked, placebo-controlled trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/11275030/",
       "pmid": "11275030",
       "authors": "PubMed",
       "citation": "PubMed PMID 11275030. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Obstet Gynecol",
+      "year": 2001,
+      "doi": "10.1016/s0029-7844(00)01228-x",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ginkgo-biloba.json
+++ b/public/data/herbs-detail/ginkgo-biloba.json
@@ -33,21 +33,36 @@
       "title": "Warfarin and food, herbal or dietary supplement interactions: A systematic review",
       "authors": "Tan CSS et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32478963/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32478963/",
+      "journal": "Br J Clin Pharmacol",
+      "doi": "10.1111/bcp.14404",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34978226",
       "title": "Plant-derived nootropics and human cognition: A systematic review",
       "authors": "Lorca C et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34978226/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34978226/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2021.2021137",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31376068",
       "title": "Neuroprotective and Antioxidant Effect of Ginkgo biloba Extract Against AD and Other Neurological Disorders",
       "authors": "Singh SK et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31376068/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31376068/",
+      "journal": "Neurotherapeutics",
+      "doi": "10.1007/s13311-019-00767-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/glycyrrhiza-glabra.json
+++ b/public/data/herbs-detail/glycyrrhiza-glabra.json
@@ -38,21 +38,36 @@
       "title": "Toxicological Effects of Glycyrrhiza glabra (Licorice): A Review",
       "authors": "Nazari S et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28833680/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28833680/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.5893",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30117204",
       "title": "Liquorice (Glycyrrhiza glabra): A phytochemical and pharmacological review",
       "authors": "Pastorino G et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30117204/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30117204/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6178",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "10675182",
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/goldenseal.json
+++ b/public/data/herbs-detail/goldenseal.json
@@ -38,21 +38,33 @@
       "title": "Common Herbal Dietary Supplement-Drug Interactions",
       "authors": "Asher GN et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27671811",
       "title": "Berberine and Its Role in Chronic Disease",
       "authors": "Cicero AF et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/",
+      "journal": "Adv Exp Med Biol",
+      "doi": "10.1007/978-3-319-41334-1_2",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33242239",
       "title": "Berberine",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33242239/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33242239/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/green-tea-extract.json
+++ b/public/data/herbs-detail/green-tea-extract.json
@@ -31,31 +31,47 @@
       "title": "Common Herbal Dietary Supplement-Drug Interactions",
       "authors": "Asher GN et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31643260",
       "title": "Green Tea",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31643260/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31643260/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26093535",
       "title": "Therapeutic effect of high-dose green tea extract on weight reduction: A randomized, double-blind, placebo-controlled clinical trial",
       "authors": "Chen IJ et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26093535/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26093535/",
+      "journal": "Clin Nutr",
+      "doi": "10.1016/j.clnu.2015.05.003",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_280a9a995334",
-      "title": "PubMed PMID 15598647. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Phosphorylation by Pho85 cyclin-dependent kinase acts as a signal for the down-regulation of the yeast sphingoid long-chain base kinase Lcb4 during the stationary phase",
       "url": "https://pubmed.ncbi.nlm.nih.gov/15598647/",
       "pmid": "15598647",
       "authors": "PubMed",
       "citation": "PubMed PMID 15598647. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Biol Chem",
+      "year": 2005,
+      "doi": "10.1074/jbc.M410908200",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/guarana.json
+++ b/public/data/herbs-detail/guarana.json
@@ -40,21 +40,36 @@
       "title": "Effects of the consumption of guarana on human health: A narrative review",
       "authors": "Torres EAFS et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34755935/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34755935/",
+      "journal": "Compr Rev Food Sci Food Saf",
+      "doi": "10.1111/1541-4337.12862",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33802176",
       "title": "The Use and Impact of Cognitive Enhancers among University Students: A Systematic Review",
       "authors": "Sharif S et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33802176/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33802176/",
+      "journal": "Brain Sci",
+      "doi": "10.3390/brainsci11030355",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36862943",
       "title": "International society of sports nutrition position stand: energy drinks and energy shots",
       "authors": "Jagim AR et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36862943/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36862943/",
+      "journal": "J Int Soc Sports Nutr",
+      "doi": "10.1080/15502783.2023.2171314",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/guayusa.json
+++ b/public/data/herbs-detail/guayusa.json
@@ -36,21 +36,34 @@
       "title": "Acute Effects of Naturally Occurring Guayusa Tea and Nordic Lion's Mane Extracts on Cognitive Performance",
       "authors": "La Monica MB et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38140277/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38140277/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu15245018",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31366209",
       "title": "A critical review of the composition and history of safe use of guayusa: a stimulant and antioxidant novel food",
       "authors": "Wise G et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31366209/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31366209/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2019.1643286",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38920890",
       "title": "Evaluation of Ilex guayusa and Piper marginatum Extract Cytotoxicity on Human Dental Pulp Mesenchymal Stem Cells",
       "authors": "Sequeda-Castañeda LG et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38920890/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38920890/",
+      "journal": "Dent J (Basel)",
+      "doi": "10.3390/dj12060189",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/gudmar.json
+++ b/public/data/herbs-detail/gudmar.json
@@ -32,7 +32,10 @@
       "title": "Variation in gymnemic acid content and non-destructive harvesting of Gymnema sylvestre (Gudmar)",
       "authors": "Pandey AK et al.",
       "year": 2010,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/21589758/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/21589758/",
+      "journal": "Pharmacognosy Res",
+      "doi": "10.4103/0974-8490.72330",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/gymnema-sylvestre.json
+++ b/public/data/herbs-detail/gymnema-sylvestre.json
@@ -29,31 +29,48 @@
       "title": "Gymnema",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39666848/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39666848/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "23472485",
       "title": "Adverse effects of herbal medicines: an overview of systematic reviews",
       "authors": "Posadzki P et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23472485/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23472485/",
+      "journal": "Clin Med (Lond)",
+      "doi": "10.7861/clinmedicine.13-1-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34467577",
       "title": "The effect of Gymnema sylvestre supplementation on glycemic control in type 2 diabetes patients: A systematic review and meta-analysis",
       "authors": "Devangan S et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34467577/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34467577/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7265",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_5f132d994c7e",
-      "title": "PubMed PMID 22592140. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Police custody following drink-driving: a prospective study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/22592140/",
       "pmid": "22592140",
       "authors": "PubMed",
       "citation": "PubMed PMID 22592140. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Drug Alcohol Depend",
+      "year": 2012,
+      "doi": "10.1016/j.drugalcdep.2012.04.013",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/harpagophytum-procumbens.json
+++ b/public/data/herbs-detail/harpagophytum-procumbens.json
@@ -32,21 +32,36 @@
       "title": "Phytomedicine in Joint Disorders",
       "authors": "Dragos D et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28275210/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28275210/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu9010070",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "23472485",
       "title": "Adverse effects of herbal medicines: an overview of systematic reviews",
       "authors": "Posadzki P et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23472485/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23472485/",
+      "journal": "Clin Med (Lond)",
+      "doi": "10.7861/clinmedicine.13-1-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "17128436",
       "title": "A review of the biological and potential therapeutic actions of Harpagophytum procumbens",
       "authors": "Grant L et al.",
       "year": 2007,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17128436/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17128436/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.2029",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/hericium-erinaceus.json
+++ b/public/data/herbs-detail/hericium-erinaceus.json
@@ -28,21 +28,34 @@
       "title": "Neurotrophic and Neuroprotective Effects of Hericium erinaceus",
       "authors": "Szućko-Kociuba I et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37958943/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37958943/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms242115960",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40284172",
       "title": "Lion's Mane Mushroom (Hericium erinaceus): A Neuroprotective Fungus with Antioxidant, Anti-Inflammatory, and Antimicrobial Potential-A Narrative Review",
       "authors": "Contato AG et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40284172/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40284172/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu17081307",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38289992",
       "title": "Lion’s Mane",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38289992/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38289992/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_3eb0f5163a0f",

--- a/public/data/herbs-detail/holy-basil.json
+++ b/public/data/herbs-detail/holy-basil.json
@@ -38,13 +38,19 @@
   "sources": [
     {
       "id": "src_c9c95a2ed78b",
-      "title": "PubMed PMID 28400848. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The Clinical Efficacy and Safety of Tulsi in Humans: A Systematic Review of the Literature",
       "url": "https://pubmed.ncbi.nlm.nih.gov/28400848/",
       "pmid": "28400848",
       "authors": "PubMed",
       "citation": "PubMed PMID 28400848. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Evid Based Complement Alternat Med",
+      "year": 2017,
+      "doi": "10.1155/2017/9217567",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/honeysuckle.json
+++ b/public/data/herbs-detail/honeysuckle.json
@@ -32,21 +32,30 @@
       "title": "Alleviation of colitis by honeysuckle MIR2911 via direct regulation of gut microbiota",
       "authors": "Li W et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39378978/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39378978/",
+      "journal": "J Control Release",
+      "doi": "10.1016/j.jconrel.2024.09.050",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38490155",
       "title": "Cynaroside improved depressive-like behavior in CUMS mice by suppressing microglial inflammation and ferroptosis",
       "authors": "Zhou Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38490155/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38490155/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2024.116425",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37226859",
       "title": "High-resolution genome mapping and functional dissection of chlorogenic acid production in Lonicera maackii",
       "authors": "Li R et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37226859/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37226859/",
+      "journal": "Plant Physiol",
+      "doi": "10.1093/plphys/kiad295",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/hops.json
+++ b/public/data/herbs-detail/hops.json
@@ -34,21 +34,36 @@
       "title": "Herbal Products Used in Menopause and for Gynecological Disorders",
       "authors": "Kenda M et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26247421",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36144755",
       "title": "Medicinal Plants Used for Anxiety, Depression, or Stress Treatment: An Update",
       "authors": "Kenda M et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36144755/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36144755/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27186021",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27677719",
       "title": "Botanicals and Their Bioactive Phytochemicals for Women's Health",
       "authors": "Dietz BM et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/",
+      "journal": "Pharmacol Rev",
+      "doi": "10.1124/pr.115.010843",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_911a7102c58d",

--- a/public/data/herbs-detail/horse-chestnut.json
+++ b/public/data/herbs-detail/horse-chestnut.json
@@ -34,21 +34,31 @@
       "title": "Peripheral Edema: Evaluation and Management in Primary Care",
       "authors": "Patel H et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36379502/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36379502/",
+      "journal": "Am Fam Physician",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31643542",
       "title": "Horse Chestnut",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31643542/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31643542/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40348378",
       "title": "The role of venoactive compounds in the treatment of chronic venous disease",
       "authors": "Gloviczki ML et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40348378/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40348378/",
+      "journal": "J Vasc Surg Venous Lymphat Disord",
+      "doi": "10.1016/j.jvsv.2025.102258",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/houttuynia.json
+++ b/public/data/herbs-detail/houttuynia.json
@@ -32,21 +32,32 @@
       "title": "Antiviral treatment for viral pneumonia: current drugs and natural compounds",
       "authors": "Zhang H et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40050867/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40050867/",
+      "journal": "Virol J",
+      "doi": "10.1186/s12985-025-02666-1",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39742094",
       "title": "Houttuynia cordata-Derived Exosome-Like Nanoparticles Mitigate Colitis in Mice via Inhibition of the NLRP3 Signaling Pathway and Modulation of the Gut Microbiota",
       "authors": "Li JH et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39742094/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39742094/",
+      "journal": "Int J Nanomedicine",
+      "doi": "10.2147/IJN.S493434",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37901360",
       "title": "Identifying the Potential of miRNAs in Houttuynia cordata-Derived Exosome-Like Nanoparticles Against Respiratory RNA Viruses",
       "authors": "Zhu H et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37901360/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37901360/",
+      "journal": "Int J Nanomedicine",
+      "doi": "10.2147/IJN.S425173",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/huperzia-serrata.json
+++ b/public/data/herbs-detail/huperzia-serrata.json
@@ -31,21 +31,36 @@
       "title": "Huperzine A and Its Neuroprotective Molecular Signaling in Alzheimer's Disease",
       "authors": "Friedli MJ et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34770940/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34770940/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26216531",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "14725492",
       "title": "Huperzine A",
       "authors": "PubMed indexed authors",
       "year": 2004,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/14725492/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/14725492/",
+      "journal": "Drugs R D",
+      "doi": "10.2165/00126839-200405010-00009",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31778363",
       "title": "The use of Huperzia species for the treatment of Alzheimer's disease",
       "authors": "Kim Thu D et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31778363/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31778363/",
+      "journal": "J Basic Clin Physiol Pharmacol",
+      "doi": "10.1515/jbcpp-2019-0159",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/hypericum-perforatum.json
+++ b/public/data/herbs-detail/hypericum-perforatum.json
@@ -32,21 +32,36 @@
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36246064",
       "title": "Hypericum perforatum: Traditional uses, clinical trials, and drug interactions",
       "authors": "Nobakht SZ et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36246064/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36246064/",
+      "journal": "Iran J Basic Med Sci",
+      "doi": "10.22038/IJBMS.2022.65112.14338",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35294606",
       "title": "St. John's wort (Hypericum perforatum) and depression: what happens to the neurotransmitter systems?",
       "authors": "Kholghi G et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35294606/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35294606/",
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "doi": "10.1007/s00210-022-02229-z",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/isatis.json
+++ b/public/data/herbs-detail/isatis.json
@@ -31,21 +31,36 @@
       "title": "Latin American Plants against Microorganisms",
       "authors": "Cuevas-Cianca SI et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38068631/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38068631/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants12233997",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33779758",
       "title": "Isatis indigotica: a review of phytochemistry, pharmacological activities and clinical applications",
       "authors": "Chen Q et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33779758/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33779758/",
+      "journal": "J Pharm Pharmacol",
+      "doi": "10.1093/jpp/rgab014",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38301993",
       "title": "The double-edged sword effect of indigo naturalis",
       "authors": "Xu Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38301993/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38301993/",
+      "journal": "Food Chem Toxicol",
+      "doi": "10.1016/j.fct.2024.114476",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/japanese-knotweed.json
+++ b/public/data/herbs-detail/japanese-knotweed.json
@@ -37,21 +37,32 @@
       "title": "Control and Disposal of Invasive Japanese Knotweed Reynoutria japonica Houtt. Using Microwave Treatment",
       "authors": "Słowiński K et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39620580/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39620580/",
+      "journal": "J Vis Exp",
+      "doi": "10.3791/67660",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35009007",
       "title": "Allelopathy of Knotweeds as Invasive Plants",
       "authors": "Kato-Noguchi H et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35009007/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35009007/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants11010003",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36134975",
       "title": "Japanese Knotweed Rhizome Bark Extract Inhibits Live SARS-CoV-2 In Vitro",
       "authors": "Jug U et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36134975/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36134975/",
+      "journal": "Bioengineering (Basel)",
+      "doi": "10.3390/bioengineering9090429",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/jatamansi.json
+++ b/public/data/herbs-detail/jatamansi.json
@@ -32,21 +32,36 @@
       "title": "Valeriana jatamansi: Bioactive Compounds and their Medicinal Uses",
       "authors": "Maurya AK et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38318825/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38318825/",
+      "journal": "Curr Top Med Chem",
+      "doi": "10.2174/0115680266273617240129042653",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38042505",
       "title": "Nardostachys jatamansi: Phytochemistry, ethnomedicinal uses, and pharmacological activities: A comprehensive review",
       "authors": "Pathak S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38042505/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38042505/",
+      "journal": "Fitoterapia",
+      "doi": "10.1016/j.fitote.2023.105764",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39447789",
       "title": "Endoperoxidases in biosynthesis of endoperoxide bonds",
       "authors": "Zhang S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39447789/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39447789/",
+      "journal": "Int J Biol Macromol",
+      "doi": "10.1016/j.ijbiomac.2024.136806",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/jujube.json
+++ b/public/data/herbs-detail/jujube.json
@@ -32,21 +32,36 @@
       "title": "Potential of natural products and gut microbiome in tumor immunotherapy",
       "authors": "Cao L et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39567970/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39567970/",
+      "journal": "Chin Med",
+      "doi": "10.1186/s13020-024-01032-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38254493",
       "title": "A Literature Review of the Pharmacological Effects of Jujube",
       "authors": "Zhu D et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38254493/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38254493/",
+      "journal": "Foods",
+      "doi": "10.3390/foods13020193",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34472292",
       "title": "[Fruit cracking: a review]",
       "authors": "Li H et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34472292/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34472292/",
+      "journal": "Sheng Wu Gong Cheng Xue Bao",
+      "doi": "10.13345/j.cjb.200553",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/juniper.json
+++ b/public/data/herbs-detail/juniper.json
@@ -34,21 +34,34 @@
       "title": "World Endometriosis Society consensus on the classification of endometriosis",
       "authors": "Johnson NP et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27920089/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27920089/",
+      "journal": "Hum Reprod",
+      "doi": "10.1093/humrep/dew293",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36445447",
       "title": "[Phytotherapy in uro-oncology]",
       "authors": "Bauer-Büntzel C et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36445447/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36445447/",
+      "journal": "Urologie",
+      "doi": "10.1007/s00120-022-01979-1",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33874310",
       "title": "Reviews",
       "authors": "PubMed indexed authors",
       "year": 1991,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33874310/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33874310/",
+      "journal": "New Phytol",
+      "doi": "10.1111/j.1469-8137.1991.tb00015.x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/kanna.json
+++ b/public/data/herbs-detail/kanna.json
@@ -40,21 +40,34 @@
       "title": "A Chewable Cure \"Kanna\": Biological and Pharmaceutical Properties of Sceletium tortuosum",
       "authors": "Manganyi MC et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33924742/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33924742/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26092557",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27939420",
       "title": "Mesembrine alkaloids: Review of their occurrence, chemistry, and pharmacology",
       "authors": "Krstenansky JL et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27939420/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27939420/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2016.12.004",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25240931",
       "title": "GC-MS, LC-MS(n), LC-high resolution-MS(n), and NMR studies on the metabolism and toxicological detection of mesembrine and mesembrenone, the main alkaloids of the legal high \"Kanna\" isolated from Sceletium tortuosum",
       "authors": "Meyer GM et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25240931/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25240931/",
+      "journal": "Anal Bioanal Chem",
+      "doi": "10.1007/s00216-014-8109-9",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/kudzu.json
+++ b/public/data/herbs-detail/kudzu.json
@@ -37,21 +37,36 @@
       "title": "Botanicals and Their Bioactive Phytochemicals for Women's Health",
       "authors": "Dietz BM et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27677719/",
+      "journal": "Pharmacol Rev",
+      "doi": "10.1124/pr.115.010843",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "21315814",
       "title": "Kudzu root: traditional uses and potential medicinal benefits in diabetes and cardiovascular diseases",
       "authors": "Wong KH et al.",
       "year": 2011,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/21315814/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/21315814/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2011.02.001",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36358493",
       "title": "Pharmacological Activity, Pharmacokinetics, and Clinical Research Progress of Puerarin",
       "authors": "Wang D et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36358493/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36358493/",
+      "journal": "Antioxidants (Basel)",
+      "doi": "10.3390/antiox11112121",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/lagerstroemia-speciosa.json
+++ b/public/data/herbs-detail/lagerstroemia-speciosa.json
@@ -30,21 +30,34 @@
       "title": "A review of the efficacy and safety of banaba (Lagerstroemia speciosa L.) and corosolic acid",
       "authors": "Stohs SJ et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22095937/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22095937/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.3664",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40613623",
       "title": "Exploring nutraceutical solutions for prediabetes: a narrative review on the effects of banaba and chromium picolinate",
       "authors": "Derosa G et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40613623/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40613623/",
+      "journal": "Eur Rev Med Pharmacol Sci",
+      "doi": "10.26355/eurrev_202506_37275",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "15671695",
       "title": "Effects of malted barley extract and banaba extract on blood glucose levels in genetically diabetic mice",
       "authors": "Hong H et al.",
       "year": 2004,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/15671695/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/15671695/",
+      "journal": "J Med Food",
+      "doi": "10.1089/jmf.2004.7.487",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/lavandula-angustifolia.json
+++ b/public/data/herbs-detail/lavandula-angustifolia.json
@@ -31,21 +31,36 @@
       "title": "Biological activities of lavender essential oil",
       "authors": "Cavanagh HM et al.",
       "year": 2002,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/12112282/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/12112282/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.1103",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31655395",
       "title": "Effects of lavender on anxiety: A systematic review and meta-analysis",
       "authors": "Donelli D et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31655395/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31655395/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2019.153099",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29464801",
       "title": "Herbal medicine for depression and anxiety: A systematic review with assessment of potential psycho-oncologic relevance",
       "authors": "Yeung KS et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29464801/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29464801/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6033",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_525198d2adf3",

--- a/public/data/herbs-detail/lawsonia-inermis.json
+++ b/public/data/herbs-detail/lawsonia-inermis.json
@@ -31,21 +31,36 @@
       "title": "Herbal Extracts with Antifungal Activity against Candida albicans: A Systematic Review",
       "authors": "Hsu H et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32600229/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32600229/",
+      "journal": "Mini Rev Med Chem",
+      "doi": "10.2174/1389557520666200628032116",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38010396",
       "title": "Therapeutic potential of Lawsonia inermis Linn: a comprehensive overview",
       "authors": "Batiha GE et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38010396/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38010396/",
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "doi": "10.1007/s00210-023-02735-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24886774",
       "title": "Lawsonia inermis L. (henna): ethnobotanical, phytochemical and pharmacological aspects",
       "authors": "Badoni Semwal R et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24886774/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24886774/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2014.05.042",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/lemon-verbena.json
+++ b/public/data/herbs-detail/lemon-verbena.json
@@ -32,21 +32,36 @@
       "title": "Aloysia citrodora Paláu (Lemon verbena): A review of phytochemistry and pharmacology",
       "authors": "Bahramsoltani R et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29698776/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29698776/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2018.04.021",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35620220",
       "title": "Anaesthesia of decapod crustaceans",
       "authors": "de Souza Valente C et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35620220/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35620220/",
+      "journal": "Vet Anim Sci",
+      "doi": "10.1016/j.vas.2022.100252",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39286661",
       "title": "Effectiveness of Lemon Verbena (Cymbopogon citratus) in Oral Candidiasis: A Systematic Review",
       "authors": "Cuenca-León K et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39286661/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39286661/",
+      "journal": "Clin Cosmet Investig Dent",
+      "doi": "10.2147/CCIDE.S478181",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/licorice.json
+++ b/public/data/herbs-detail/licorice.json
@@ -39,21 +39,36 @@
       "title": "Herb-Drug Interactions and Their Impact on Pharmacokinetics: An Update",
       "authors": "Cheng W et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/",
+      "journal": "Curr Drug Metab",
+      "doi": "10.2174/1389200224666230116113240",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28833680",
       "title": "Toxicological Effects of Glycyrrhiza glabra (Licorice): A Review",
       "authors": "Nazari S et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28833680/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28833680/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.5893",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "18446848",
       "title": "Review of pharmacological effects of Glycyrrhiza sp. and its bioactive compounds",
       "authors": "Asl MN et al.",
       "year": 2008,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/18446848/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/18446848/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.2362",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ligusticum-chuanxiong.json
+++ b/public/data/herbs-detail/ligusticum-chuanxiong.json
@@ -37,21 +37,34 @@
       "title": "Ligusticum chuanxiong: a chemical, pharmacological and clinical review",
       "authors": "Wang Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40235541/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40235541/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2025.1523176",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39004032",
       "title": "Elucidating the mechanisms of Buyang Huanwu Decoction in treating chronic cerebral ischemia: A combined approach using network pharmacology, molecular docking, and in vivo validation",
       "authors": "Cao Y et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39004032/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39004032/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.155820",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39180449",
       "title": "Ligusticum chuanxiong Hort.: a review of its phytochemistry, pharmacology, and toxicology",
       "authors": "Kong Q et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39180449/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39180449/",
+      "journal": "J Pharm Pharmacol",
+      "doi": "10.1093/jpp/rgae105",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/lions-mane.json
+++ b/public/data/herbs-detail/lions-mane.json
@@ -33,31 +33,52 @@
       "title": "Neurotrophic and Neuroprotective Effects of Hericium erinaceus",
       "authors": "Szućko-Kociuba I et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37958943/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37958943/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms242115960",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40284172",
       "title": "Lion's Mane Mushroom (Hericium erinaceus): A Neuroprotective Fungus with Antioxidant, Anti-Inflammatory, and Antimicrobial Potential-A Narrative Review",
       "authors": "Contato AG et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40284172/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40284172/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu17081307",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33917843",
       "title": "Neuroprotective Herbs for the Management of Alzheimer's Disease",
       "authors": "Gregory J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33917843/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33917843/",
+      "journal": "Biomolecules",
+      "doi": "10.3390/biom11040543",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_79eae7626c5c",
-      "title": "PubMed PMID 18844328. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Improving effects of the mushroom Yamabushitake (Hericium erinaceus) on mild cognitive impairment: a double-blind placebo-controlled clinical trial",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18844328/",
       "pmid": "18844328",
       "authors": "PubMed",
       "citation": "PubMed PMID 18844328. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytother Res",
+      "year": 2009,
+      "doi": "10.1002/ptr.2634",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/lithospermum-erythrorhizon.json
+++ b/public/data/herbs-detail/lithospermum-erythrorhizon.json
@@ -32,21 +32,36 @@
       "title": "Anti-Aging Potential of Phytoextract Loaded-Pharmaceutical Creams for Human Skin Cell Longetivity",
       "authors": "Jadoon S et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26448818/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26448818/",
+      "journal": "Oxid Med Cell Longev",
+      "doi": "10.1155/2015/709628",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31275019",
       "title": "Lithospermum erythrorhizon cell cultures: Present and future aspects",
       "authors": "Yazaki K et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31275019/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31275019/",
+      "journal": "Plant Biotechnol (Tokyo)",
+      "doi": "10.5511/plantbiotechnology.17.0823a",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35620294",
       "title": "Evidence and Potential Mechanism of Action of Lithospermum erythrorhizon and Its Active Components for Psoriasis",
       "authors": "Wang J et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35620294/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35620294/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2022.781850",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/longan.json
+++ b/public/data/herbs-detail/longan.json
@@ -32,21 +32,34 @@
       "title": "Recent chemical synthesis of plant polysaccharides",
       "authors": "Wang X et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37716049/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37716049/",
+      "journal": "Curr Opin Chem Biol",
+      "doi": "10.1016/j.cbpa.2023.102387",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37313777",
       "title": "Genome-wide high-throughput chromosome conformation capture analysis reveals hierarchical chromatin interactions during early somatic embryogenesis",
       "authors": "Chen Y et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37313777/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37313777/",
+      "journal": "Plant Physiol",
+      "doi": "10.1093/plphys/kiad348",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31090276",
       "title": "Pericarp and seed of litchi and longan fruits: constituent, extraction, bioactive activity, and potential utilization",
       "authors": "Zhu XR et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31090276/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31090276/",
+      "journal": "J Zhejiang Univ Sci B",
+      "doi": "10.1631/jzus.B1900161",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/luo-han-guo.json
+++ b/public/data/herbs-detail/luo-han-guo.json
@@ -33,21 +33,30 @@
       "title": "Research progress of pharmacological effects of Siraitia grosvenorii extract",
       "authors": "Li H et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34718674/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34718674/",
+      "journal": "J Pharm Pharmacol",
+      "doi": "10.1093/jpp/rgab150",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41272020",
       "title": "Exploring the potential mechanisms of anti-pulmonary fibrosis effects of Luo Han Guo via network pharmacology, molecular docking, and experimental validation",
       "authors": "Cui Q et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41272020/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41272020/",
+      "journal": "Sci Rep",
+      "doi": "10.1038/s41598-025-25270-3",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41841386",
       "title": "Divergent Synthesis of Mogrosides",
       "authors": "Petrović G et al.",
       "year": 2026,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41841386/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41841386/",
+      "journal": "J Org Chem",
+      "doi": "10.1021/acs.joc.6c00056",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/maca.json
+++ b/public/data/herbs-detail/maca.json
@@ -31,31 +31,50 @@
       "title": "Medicinal effects of Peruvian maca (Lepidium meyenii): a review",
       "authors": "da Silva Leitão Peres N  et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31951246/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31951246/",
+      "journal": "Food Funct",
+      "doi": "10.1039/c9fo02732g",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38440178",
       "title": "Exploring the chemical and pharmacological variability of Lepidium meyenii: a comprehensive review of the effects of maca",
       "authors": "Ulloa Del Carpio N et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38440178/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38440178/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2024.1360422",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38398854",
       "title": "Not All Maca Is Created Equal: A Review of Colors, Nutrition, Phytochemicals, and Clinical Uses",
       "authors": "Minich DM et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38398854/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38398854/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu16040530",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_3910aa71f4eb",
-      "title": "PubMed PMID 18072817. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Spotlight on rasagiline in Parkinson's disease",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18072817/",
       "pmid": "18072817",
       "authors": "PubMed",
       "citation": "PubMed PMID 18072817. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "CNS Drugs",
+      "year": 2008,
+      "doi": "10.2165/00023210-200822010-00007",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_1f49196ffdbf",

--- a/public/data/herbs-detail/magnolia-officinalis.json
+++ b/public/data/herbs-detail/magnolia-officinalis.json
@@ -33,21 +33,34 @@
       "title": "Safety and efficacy of zanubrutinib in relapsed/refractory marginal zone lymphoma: final analysis of the MAGNOLIA study",
       "authors": "Opat S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37682792/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37682792/",
+      "journal": "Blood Adv",
+      "doi": "10.1182/bloodadvances.2023010668",
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29925102",
       "title": "Safety and Toxicology of Magnolol and Honokiol",
       "authors": "Sarrica A et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29925102/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29925102/",
+      "journal": "Planta Med",
+      "doi": "10.1055/a-0642-1966",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40751788",
       "title": "Metabolism of coclaurine into the WADA-banned substance higenamine: a doping-relevant analytical evaluation of Kampo extracts",
       "authors": "Sakamoto S et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40751788/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40751788/",
+      "journal": "J Nat Med",
+      "doi": "10.1007/s11418-025-01940-4",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/maitake-d-fraction.json
+++ b/public/data/herbs-detail/maitake-d-fraction.json
@@ -32,21 +32,32 @@
       "title": "Antitumoral and antimetastatic activity of Maitake D-Fraction in triple-negative breast cancer cells",
       "authors": "Alonso EN et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29805742/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29805742/",
+      "journal": "Oncotarget",
+      "doi": "10.18632/oncotarget.25174",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "21480800",
       "title": "Maitake (D fraction) mushroom extract induces apoptosis in breast cancer cells by BAK-1 gene activation",
       "authors": "Soares R et al.",
       "year": 2011,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/21480800/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/21480800/",
+      "journal": "J Med Food",
+      "doi": "10.1089/jmf.2010.0095",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36070433",
       "title": "Effect of Maitake D-fraction in advanced laryngeal and pharyngeal cancers during concurrent chemoradiotherapy: A randomized clinical trial",
       "authors": "Hu Q et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36070433/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36070433/",
+      "journal": "Acta Biochim Pol",
+      "doi": "10.18388/abp.2020_5996",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/mangifera-indica.json
+++ b/public/data/herbs-detail/mangifera-indica.json
@@ -36,21 +36,32 @@
       "title": "Mangifera indica (mango)",
       "authors": "Shah KA et al.",
       "year": 2010,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22228940/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22228940/",
+      "journal": "Pharmacogn Rev",
+      "doi": "10.4103/0973-7847.65325",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41155688",
       "title": "A Review on Phytochemistry, Ethnopharmacology, and Antiparasitic Potential of Mangifera indica L",
       "authors": "Mendonça D et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41155688/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41155688/",
+      "journal": "Pharmaceuticals (Basel)",
+      "doi": "10.3390/ph18101576",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35662629",
       "title": "Anti-inflammatory and immunomodulatory activity of Mangifera indica L. reveals the modulation of COX-2/mPGES-1 axis and Th17/Treg ratio",
       "authors": "Saviano A et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35662629/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35662629/",
+      "journal": "Pharmacol Res",
+      "doi": "10.1016/j.phrs.2022.106283",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/mangosteen.json
+++ b/public/data/herbs-detail/mangosteen.json
@@ -32,21 +32,32 @@
       "title": "A Canadian Consensus on Androgenetic Alopecia: Approach and Management",
       "authors": "Landells I et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40986632/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40986632/",
+      "journal": "J Cutan Med Surg",
+      "doi": "10.1177/12034754251368849",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39312451",
       "title": "Discovery of Natural Products for Cancer Prevention",
       "authors": "Blanco Carcache PJ et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39312451/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39312451/",
+      "journal": "Cancer J",
+      "doi": "10.1097/PPO.0000000000000745",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39170416",
       "title": "Mangosteen extract reduces the bacterial load of eggshell and improves egg quality",
       "authors": "Zhu J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39170416/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39170416/",
+      "journal": "Heliyon",
+      "doi": "10.1016/j.heliyon.2024.e35857",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/maral-root.json
+++ b/public/data/herbs-detail/maral-root.json
@@ -33,21 +33,32 @@
       "title": "Chromatographic separation, determination and identification of ecdysteroids: Focus on Maral root (Rhaponticum carthamoides, Leuzea carthamoides)",
       "authors": "Głazowska J et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30303602/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30303602/",
+      "journal": "J Sep Sci",
+      "doi": "10.1002/jssc.201800506",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40332350",
       "title": "Maral Root Extract and Its Main Constituent 20-Hydroxyecdysone Enhance Stress Resilience in Caenorhabditis elegans",
       "authors": "Todorova V et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40332350/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40332350/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms26083739",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36364156",
       "title": "Chemical Profiling and Biological Activity of Extracts from Nine Norwegian Medicinal and Aromatic Plants",
       "authors": "Slimestad R et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36364156/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36364156/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27217335",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/matricaria-chamomilla.json
+++ b/public/data/herbs-detail/matricaria-chamomilla.json
@@ -29,21 +29,36 @@
       "title": "Warfarin and food, herbal or dietary supplement interactions: A systematic review",
       "authors": "Tan CSS et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32478963/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32478963/",
+      "journal": "Br J Clin Pharmacol",
+      "doi": "10.1111/bcp.14404",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29280987",
       "title": "Anti-Inflammatory and Skin Barrier Repair Effects of Topical Application of Some Plant Oils",
       "authors": "Lin TK et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29280987/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29280987/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms19010070",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36615326",
       "title": "Chamomile: A Review of Its Traditional Uses, Chemical Constituents, Pharmacological Activities and Quality Control Studies",
       "authors": "Dai YL et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36615326/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36615326/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules28010133",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_260b165ed8d2",

--- a/public/data/herbs-detail/melissa-officinalis.json
+++ b/public/data/herbs-detail/melissa-officinalis.json
@@ -37,31 +37,52 @@
       "title": "Depression and Its Phytopharmacotherapy-A Narrative Review",
       "authors": "Dobrek L et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36902200/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36902200/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms24054772",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36144755",
       "title": "Medicinal Plants Used for Anxiety, Depression, or Stress Treatment: An Update",
       "authors": "Kenda M et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36144755/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36144755/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27186021",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37376614",
       "title": "A Narrative Review of Alternative Symptomatic Treatments for Herpes Simplex Virus",
       "authors": "Chang JY et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37376614/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37376614/",
+      "journal": "Viruses",
+      "doi": "10.3390/v15061314",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_826d7cae36e1",
-      "title": "PubMed PMID 34449930. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effects of lemon balm (Melissa officinalis L.) on depression and anxiety in clinical trials: A systematic review and meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/34449930/",
       "pmid": "34449930",
       "authors": "PubMed",
       "citation": "PubMed PMID 34449930. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytother Res",
+      "year": 2021,
+      "doi": "10.1002/ptr.7252",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_a05ea67138e7",

--- a/public/data/herbs-detail/milk-thistle.json
+++ b/public/data/herbs-detail/milk-thistle.json
@@ -33,31 +33,50 @@
       "title": "Milk thistle (Silybum marianum): A concise overview on its chemistry, pharmacological, and nutraceutical uses in liver diseases",
       "authors": "Abenavoli L et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30080294/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30080294/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6171",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31069872",
       "title": "Safety and toxicity of silymarin, the major constituent of milk thistle extract: An updated review",
       "authors": "Soleimani V et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31069872/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31069872/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6361",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000830",
       "title": "Milk Thistle",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000830/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000830/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_e4d69d9267bd",
-      "title": "PubMed PMID 28419855. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A Randomized Trial of Silymarin for the Treatment of Nonalcoholic Steatohepatitis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/28419855/",
       "pmid": "28419855",
       "authors": "PubMed",
       "citation": "PubMed PMID 28419855. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Clin Gastroenterol Hepatol",
+      "year": 2017,
+      "doi": "10.1016/j.cgh.2017.04.016",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/momordica-charantia.json
+++ b/public/data/herbs-detail/momordica-charantia.json
@@ -32,21 +32,34 @@
       "title": "Bitter Melon",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37043592/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37043592/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35911428",
       "title": "Complementary and alternative medicine for glycemic control of diabetes mellitus: A systematic review",
       "authors": "Setiyorini E et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35911428/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35911428/",
+      "journal": "J Public Health Res",
+      "doi": "10.1177/22799036221106582",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32951763",
       "title": "Hypoglycemic efficacy and safety of Momordica charantia (bitter melon) in patients with type 2 diabetes mellitus",
       "authors": "Kim SK et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32951763/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32951763/",
+      "journal": "Complement Ther Med",
+      "doi": "10.1016/j.ctim.2020.102524",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/morinda-citrifolia.json
+++ b/public/data/herbs-detail/morinda-citrifolia.json
@@ -39,21 +39,36 @@
       "title": "D-mannose for preventing and treating urinary tract infections",
       "authors": "Cooper TE et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36041061/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36041061/",
+      "journal": "Cochrane Database Syst Rev",
+      "doi": "10.1002/14651858.CD013608.pub2",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "23472485",
       "title": "Adverse effects of herbal medicines: an overview of systematic reviews",
       "authors": "Posadzki P et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23472485/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23472485/",
+      "journal": "Clin Med (Lond)",
+      "doi": "10.7861/clinmedicine.13-1-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31840355",
       "title": "Indian Morinda species: A review",
       "authors": "Singh B et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31840355/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31840355/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6579",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/moringa.json
+++ b/public/data/herbs-detail/moringa.json
@@ -37,21 +37,36 @@
       "title": "Moringa oleifera: An Updated Comprehensive Review of Its Pharmacological Activities, Ethnomedicinal, Phytopharmaceutical Formulation, Clinical, Phytochemical, and Toxicological Aspects",
       "authors": "Pareek A et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36768420/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36768420/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms24032098",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25374169",
       "title": "Health benefits of Moringa oleifera",
       "authors": "Abdull Razis AF et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25374169/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25374169/",
+      "journal": "Asian Pac J Cancer Prev",
+      "doi": "10.7314/apjcp.2014.15.20.8571",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "17089328",
       "title": "Moringa oleifera: a food plant with multiple medicinal uses",
       "authors": "Anwar F et al.",
       "year": 2007,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17089328/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17089328/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.2023",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/morus-alba.json
+++ b/public/data/herbs-detail/morus-alba.json
@@ -33,21 +33,34 @@
       "title": "Morus alba: a comprehensive phytochemical and pharmacological review",
       "authors": "Batiha GE et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36877269/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36877269/",
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "doi": "10.1007/s00210-023-02434-4",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37120060",
       "title": "Mulberry extract ameliorates T2DM-related symptoms via AMPK pathway in STZ-HFD-induced C57BL/6J mice",
       "authors": "Zhang L et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37120060/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37120060/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.116475",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39544693",
       "title": "Morus alba: natural and valuable effects in weight loss management",
       "authors": "Ntalouka F et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39544693/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39544693/",
+      "journal": "Front Clin Diabetes Healthc",
+      "doi": "10.3389/fcdhc.2024.1395688",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/mucuna.json
+++ b/public/data/herbs-detail/mucuna.json
@@ -38,21 +38,36 @@
       "title": "Microneurography of pruritus",
       "authors": "Handwerker HO et al.",
       "year": 2010,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/19576959/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/19576959/",
+      "journal": "Neurosci Lett",
+      "doi": "10.1016/j.neulet.2009.06.092",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40808332",
       "title": "Levodopa and Plant-Derived Bioactive Compounds in Parkinson's Disease: Mechanisms, Efficacy, and Future Perspectives",
       "authors": "Aktaş E et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40808332/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40808332/",
+      "journal": "CNS Neurosci Ther",
+      "doi": "10.1111/cns.70540",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24598311",
       "title": "The role of L-DOPA in plants",
       "authors": "Soares AR et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24598311/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24598311/",
+      "journal": "Plant Signal Behav",
+      "doi": "10.4161/psb.28275",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/mugwort.json
+++ b/public/data/herbs-detail/mugwort.json
@@ -34,21 +34,32 @@
       "title": "The skin prick test - European standards",
       "authors": "Heinzerling L et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23369181/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23369181/",
+      "journal": "Clin Transl Allergy",
+      "doi": "10.1186/2045-7022-3-3",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "21875536",
       "title": "Spice allergy",
       "authors": "Chen JL et al.",
       "year": 2011,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/21875536/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/21875536/",
+      "journal": "Ann Allergy Asthma Immunol",
+      "doi": "10.1016/j.anai.2011.06.020",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27222528",
       "title": "Sunflower seed allergy",
       "authors": "Ukleja-Sokołowska N et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27222528/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27222528/",
+      "journal": "Int J Immunopathol Pharmacol",
+      "doi": "10.1177/0394632016651648",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/muira-puama.json
+++ b/public/data/herbs-detail/muira-puama.json
@@ -30,21 +30,32 @@
       "title": "Selected herbals and human exercise performance",
       "authors": "Bucci LR et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10919969/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10919969/",
+      "journal": "Am J Clin Nutr",
+      "doi": "10.1093/ajcn/72.2.624S",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29551532",
       "title": "Effect of ginger, Paullinia cupana, muira puama and l- citrulline, singly or in combination, on modulation of the inducible nitric oxide- NO-cGMP pathway in rat penile smooth muscle cells",
       "authors": "Ferrini MG et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29551532/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29551532/",
+      "journal": "Nitric Oxide",
+      "doi": "10.1016/j.niox.2018.03.010",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39845379",
       "title": "Nutraceutical and low energy shockwave treatments improved sexual function recovery in a rat pelvic neurovascular injury model",
       "authors": "Crisostomo-Wynne TC et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39845379/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39845379/",
+      "journal": "Sex Med",
+      "doi": "10.1093/sexmed/qfaf001",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/mulberry-leaf.json
+++ b/public/data/herbs-detail/mulberry-leaf.json
@@ -33,21 +33,32 @@
       "title": "Mulberry leaves ameliorate diabetes via regulating metabolic profiling and AGEs/RAGE and p38 MAPK/NF-κB pathway",
       "authors": "Li JS et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34626776/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34626776/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2021.114713",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40527063",
       "title": "Mulberry leaf improves type 2 diabetes in mice via gut microbiota-SCFAs-GPRs axis and AMPK signaling pathway",
       "authors": "Zhang Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40527063/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40527063/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2025.156970",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38892603",
       "title": "Understanding the Impact of Different Doses of Reducose(®) Mulberry Leaf Extract on Blood Glucose and Insulin Responses after Eating a Complex Meal: Results from a Double-Blind, Randomised, Crossover Trial",
       "authors": "Thondre PS et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38892603/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38892603/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu16111670",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/myristica-fragrans.json
+++ b/public/data/herbs-detail/myristica-fragrans.json
@@ -32,21 +32,34 @@
       "title": "Nutmeg (Myristica fragrans Houtt.) essential oil: A review on its composition, biological, and pharmacological activities",
       "authors": "Ashokkumar K et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35567294/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35567294/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7491",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000898",
       "title": "Nutmeg",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000898/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000898/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33206347",
       "title": "Phytochemical and pharmacological properties of Myristica fragrans Houtt.: an updated review",
       "authors": "Ha MT et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33206347/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33206347/",
+      "journal": "Arch Pharm Res",
+      "doi": "10.1007/s12272-020-01285-4",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/myrtle.json
+++ b/public/data/herbs-detail/myrtle.json
@@ -34,21 +34,34 @@
       "title": "Myrtle: a versatile medicinal plant",
       "authors": "Gorjian H et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38625264/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38625264/",
+      "journal": "Nutrire",
+      "doi": "10.1186/s41110-023-00194-y",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34410296",
       "title": "Lemon myrtle extract inhibits lactate production by Streptococcus mutans",
       "authors": "Yabuta Y et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34410296/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34410296/",
+      "journal": "Biosci Biotechnol Biochem",
+      "doi": "10.1093/bbb/zbab147",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29975606",
       "title": "Lessons from the Incursion of Myrtle Rust in Australia",
       "authors": "Carnegie AJ et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29975606/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29975606/",
+      "journal": "Annu Rev Phytopathol",
+      "doi": "10.1146/annurev-phyto-080516-035256",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/neem.json
+++ b/public/data/herbs-detail/neem.json
@@ -37,21 +37,34 @@
       "title": "Rosemary and neem: an insight into their combined anti-dandruff and anti-hair loss efficacy",
       "authors": "Hashem MM et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38565924/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38565924/",
+      "journal": "Sci Rep",
+      "doi": "10.1038/s41598-024-57838-w",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38358164",
       "title": "Alternative first-line malaria treatment",
       "authors": "Maafoh C et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38358164/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38358164/",
+      "journal": "Ann Afr Med",
+      "doi": "10.4103/aam.aam_35_23",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38290997",
       "title": "Phytotherapy in periodontics as an effective and sustainable supplemental treatment: a narrative review",
       "authors": "Gawish AS et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38290997/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38290997/",
+      "journal": "J Periodontal Implant Sci",
+      "doi": "10.5051/jpis.2301420071",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/nelumbo-nucifera.json
+++ b/public/data/herbs-detail/nelumbo-nucifera.json
@@ -34,21 +34,32 @@
       "title": "Anti-Aging Potential of Phytoextract Loaded-Pharmaceutical Creams for Human Skin Cell Longetivity",
       "authors": "Jadoon S et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26448818/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26448818/",
+      "journal": "Oxid Med Cell Longev",
+      "doi": "10.1155/2015/709628",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39445611",
       "title": "Nuciferine Alleviates High-Fat Diet- and ApoE(-/-)-Induced Hepatic Steatosis and Ferroptosis in NAFLD Mice via the PPARα Signaling Pathway",
       "authors": "Qiu J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39445611/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39445611/",
+      "journal": "J Agric Food Chem",
+      "doi": "10.1021/acs.jafc.4c04929",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34361003",
       "title": "Effect of Neferine on DNCB-Induced Atopic Dermatitis in HaCaT Cells and BALB/c Mice",
       "authors": "Yang CC et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34361003/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34361003/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms22158237",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/nettle-root.json
+++ b/public/data/herbs-detail/nettle-root.json
@@ -33,21 +33,36 @@
       "title": "Treatment of Benign Prostatic Hyperplasia by Natural Drugs",
       "authors": "Csikós E et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34885733/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34885733/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26237141",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31163183",
       "title": "Screening of pharmacological uses of Urtica dioica and others benefits",
       "authors": "Dhouibi R et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31163183/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31163183/",
+      "journal": "Prog Biophys Mol Biol",
+      "doi": "10.1016/j.pbiomolbio.2019.05.008",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "17509841",
       "title": "A comprehensive review on the stinging nettle effect and efficacy profiles. Part II: urticae radix",
       "authors": "Chrubasik JE et al.",
       "year": 2007,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17509841/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17509841/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2007.03.014",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/nigella-sativa.json
+++ b/public/data/herbs-detail/nigella-sativa.json
@@ -38,21 +38,36 @@
       "title": "A review on therapeutic potential of Nigella sativa: A miracle herb",
       "authors": "Ahmad A et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23646296/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23646296/",
+      "journal": "Asian Pac J Trop Biomed",
+      "doi": "10.1016/S2221-1691(13)60075-1",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34073784",
       "title": "Black Cumin (Nigella sativa L.): A Comprehensive Review on Phytochemistry, Health Benefits, Molecular Pharmacology, and Safety",
       "authors": "Hannan MA et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34073784/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34073784/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu13061784",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39769174",
       "title": "Nigella sativa: A Comprehensive Review of Its Therapeutic Potential, Pharmacological Properties, and Clinical Applications",
       "authors": "Alberts A et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39769174/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39769174/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms252413410",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/noni.json
+++ b/public/data/herbs-detail/noni.json
@@ -35,21 +35,32 @@
       "title": "Noni",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31643695/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31643695/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37313239",
       "title": "Resmetirom: An Orally Administered, Smallmolecule, Liver-directed, β-selective THR Agonist for the Treatment of Non-alcoholic Fatty Liver Disease and Non-alcoholic Steatohepatitis",
       "authors": "Karim G et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37313239/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37313239/",
+      "journal": "touchREV Endocrinol",
+      "doi": "10.17925/EE.2023.19.1.60",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41875856",
       "title": "Noni Franklin-Tong",
       "authors": "Franklin-Tong N et al.",
       "year": 2026,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41875856/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41875856/",
+      "journal": "Curr Biol",
+      "doi": "10.1016/j.cub.2026.01.057",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/notoginseng.json
+++ b/public/data/herbs-detail/notoginseng.json
@@ -37,21 +37,32 @@
       "title": "Panax notoginseng: derived exosome-like nanoparticles attenuate ischemia reperfusion injury via altering microglia polarization",
       "authors": "Li S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37946257/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37946257/",
+      "journal": "J Nanobiotechnology",
+      "doi": "10.1186/s12951-023-02161-1",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33127555",
       "title": "Chemical constituents of Panax ginseng and Panax notoginseng explain why they differ in therapeutic efficacy",
       "authors": "Liu H et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33127555/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33127555/",
+      "journal": "Pharmacol Res",
+      "doi": "10.1016/j.phrs.2020.105263",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35372585",
       "title": "Using Network Pharmacology to Explore the Mechanism of Panax notoginseng in the Treatment of Myocardial Fibrosis",
       "authors": "Han J et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35372585/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35372585/",
+      "journal": "J Diabetes Res",
+      "doi": "10.1155/2022/8895950",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ocimum-basilicum.json
+++ b/public/data/herbs-detail/ocimum-basilicum.json
@@ -41,21 +41,32 @@
       "title": "Basil",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000886/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000886/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38257301",
       "title": "Antimicrobial and Other Pharmacological Properties of Ocimum basilicum, Lamiaceae",
       "authors": "Zhakipbekov K et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38257301/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38257301/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules29020388",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38433659",
       "title": "Sweet basil (Ocimum basilicum) leaf and seed extracts alleviate neuronal dysfunction in aluminum chloride-induced neurotoxicity in Drosophila melanogaster Meigen model",
       "authors": "Oyeniran OH et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38433659/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38433659/",
+      "journal": "Drug Chem Toxicol",
+      "doi": "10.1080/01480545.2024.2317828",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ocotea-odorifera.json
+++ b/public/data/herbs-detail/ocotea-odorifera.json
@@ -32,28 +32,42 @@
       "title": "Confirmation of ethnopharmacological anti-inflammatory properties of Ocotea odorifera and determination of its main active compounds",
       "authors": "de Alcântara BGV et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32918995/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32918995/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2020.113378",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28407959",
       "title": "Identification of phenolic compounds and biologically related activities from Ocotea odorifera aqueous extract leaves",
       "authors": "Gontijo DC et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28407959/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28407959/",
+      "journal": "Food Chem",
+      "doi": "10.1016/j.foodchem.2017.03.087",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36432799",
       "title": "Exploring Contact Toxicity of Essential Oils against Sitophilus zeamais through a Meta-Analysis Approach",
       "authors": "Achimón F et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36432799/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36432799/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants11223070",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "22024337",
       "title": "Comprehensive toxicity study of safrole using a medium-term animal model with gpt delta rats",
       "authors": "Jin M et al.",
       "year": 2011,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22024337/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22024337/",
+      "journal": "Toxicology",
+      "doi": "10.1016/j.tox.2011.09.088",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/olea-europaea.json
+++ b/public/data/herbs-detail/olea-europaea.json
@@ -35,21 +35,34 @@
       "title": "Nutritional Supplements for Skin Health-A Review of What Should Be Chosen and Why",
       "authors": "Januszewski J et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38256329/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38256329/",
+      "journal": "Medicina (Kaunas)",
+      "doi": "10.3390/medicina60010068",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36513474",
       "title": "What is the efficacy of dietary, nutraceutical, and probiotic interventions for the management of gastroesophageal reflux disease symptoms? A systematic literature review and meta-analysis",
       "authors": "Martin Z et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36513474/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36513474/",
+      "journal": "Clin Nutr ESPEN",
+      "doi": "10.1016/j.clnesp.2022.09.015",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39719741",
       "title": "Olive leaf extract (OLE) reduces mast cell-mediated allergic inflammation",
       "authors": "Somma F et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39719741/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39719741/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2024.117784",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/ophiopogon.json
+++ b/public/data/herbs-detail/ophiopogon.json
@@ -34,21 +34,34 @@
       "title": "The structures and biological functions of polysaccharides from traditional Chinese herbs",
       "authors": "Zeng P et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31030757/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31030757/",
+      "journal": "Prog Mol Biol Transl Sci",
+      "doi": "10.1016/bs.pmbts.2019.03.003",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39101149",
       "title": "Ophiopogonin D: review of pharmacological activity",
       "authors": "Chen KQ et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39101149/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39101149/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2024.1401627",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41800803",
       "title": "Methylophiopogonanone a attenuates pulmonary fibrosis by inhibiting SPP1-mediated macrophage polarization via the PI3K/Akt pathway",
       "authors": "Yang F et al.",
       "year": 2026,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41800803/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41800803/",
+      "journal": "Animal Model Exp Med",
+      "doi": "10.1002/ame2.70157",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/orange-peel.json
+++ b/public/data/herbs-detail/orange-peel.json
@@ -34,21 +34,34 @@
       "title": "Eosinophilic Fasciitis: Current and Remaining Challenges",
       "authors": "Mazilu D et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36768300/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36768300/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms24031982",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000952",
       "title": "Bitter Orange",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000952/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000952/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38435393",
       "title": "Essential oils: a systematic review on revolutionizing health, nutrition, and omics for optimal well-being",
       "authors": "Pezantes-Orellana C et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38435393/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38435393/",
+      "journal": "Front Med (Lausanne)",
+      "doi": "10.3389/fmed.2024.1337785",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/oregano.json
+++ b/public/data/herbs-detail/oregano.json
@@ -32,21 +32,32 @@
       "title": "Antimicrobial Activity of Basil, Oregano, and Thyme Essential Oils",
       "authors": "Sakkas H et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27994215/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27994215/",
+      "journal": "J Microbiol Biotechnol",
+      "doi": "10.4014/jmb.1608.08024",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37184199",
       "title": "Oregano",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37184199/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37184199/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000904",
       "title": "Oregano",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000904/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000904/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/paeonia-lactiflora.json
+++ b/public/data/herbs-detail/paeonia-lactiflora.json
@@ -35,21 +35,34 @@
       "title": "Medicine for chronic atrophic gastritis: a systematic review, meta- and network pharmacology analysis",
       "authors": "Weng J et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38170849/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38170849/",
+      "journal": "Ann Med",
+      "doi": "10.1080/07853890.2023.2299352",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31836457",
       "title": "Anti-inflammatory and immunoregulatory effects of paeoniflorin and total glucosides of paeony",
       "authors": "Zhang L et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31836457/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31836457/",
+      "journal": "Pharmacol Ther",
+      "doi": "10.1016/j.pharmthera.2019.107452",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000962",
       "title": "Peony",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000962/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000962/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/paeonia-suffruticosa.json
+++ b/public/data/herbs-detail/paeonia-suffruticosa.json
@@ -37,21 +37,32 @@
       "title": "Peony",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000962/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000962/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40115263",
       "title": "Paeonia suffruticosa Andrews root extract ameliorates photoaging via regulating IRS1/PI3K/FOXO pathway",
       "authors": "Liu J et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40115263/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40115263/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2025.1520392",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31030097",
       "title": "Paeonol: pharmacological effects and mechanisms of action",
       "authors": "Zhang L et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31030097/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31030097/",
+      "journal": "Int Immunopharmacol",
+      "doi": "10.1016/j.intimp.2019.04.033",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/panax-quinquefolius.json
+++ b/public/data/herbs-detail/panax-quinquefolius.json
@@ -29,21 +29,35 @@
       "title": "Management of Fatigue in Adult Survivors of Cancer: ASCO-Society for Integrative Oncology Guideline Update",
       "authors": "Bower JE et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38754041/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38754041/",
+      "journal": "J Clin Oncol",
+      "doi": "10.1200/JCO.24.00541",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28762712",
       "title": "Common Herbal Dietary Supplement-Drug Interactions",
       "authors": "Asher GN et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37385964",
       "title": "Pharmacological Effects of Ginseng: Multiple Constituents and Multiple Actions on Humans",
       "authors": "Zhou G et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37385964/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37385964/",
+      "journal": "Am J Chin Med",
+      "doi": "10.1142/S0192415X23500507",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/papaya-leaf.json
+++ b/public/data/herbs-detail/papaya-leaf.json
@@ -35,21 +35,36 @@
       "title": "Therapeutic application of Carica papaya leaf extract in the management of human diseases",
       "authors": "Singh SP et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32367410/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32367410/",
+      "journal": "Daru",
+      "doi": "10.1007/s40199-020-00348-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37234180",
       "title": "A Comparative Analysis of Effectiveness of Recombinant Interleukin-11 Versus Papaya Leaf Extract for Treatment of Thrombocytopenia: A Review",
       "authors": "Mishra KP et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37234180/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37234180/",
+      "journal": "Indian J Clin Biochem",
+      "doi": "10.1007/s12291-022-01097-x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35458146",
       "title": "Carica papaya Leaf Juice for Dengue: A Scoping Review",
       "authors": "Teh BP et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35458146/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35458146/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu14081584",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/parsley.json
+++ b/public/data/herbs-detail/parsley.json
@@ -36,21 +36,34 @@
       "title": "Parsley",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000940/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000940/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38435393",
       "title": "Essential oils: a systematic review on revolutionizing health, nutrition, and omics for optimal well-being",
       "authors": "Pezantes-Orellana C et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38435393/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38435393/",
+      "journal": "Front Med (Lausanne)",
+      "doi": "10.3389/fmed.2024.1337785",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38068725",
       "title": "A Scoping Review of the Clinical Evidence for the Health Benefits of Culinary Doses of Herbs and Spices for the Prevention and Treatment of Metabolic Syndrome",
       "authors": "Mackonochie M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38068725/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38068725/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu15234867",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/passiflora-incarnata.json
+++ b/public/data/herbs-detail/passiflora-incarnata.json
@@ -32,31 +32,52 @@
       "title": "Passiflora incarnata in Neuropsychiatric Disorders-A Systematic Review",
       "authors": "Janda K et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33352740/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33352740/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu12123894",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29464801",
       "title": "Herbal medicine for depression and anxiety: A systematic review with assessment of potential psycho-oncologic relevance",
       "authors": "Yeung KS et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29464801/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29464801/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6033",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35378276",
       "title": "Medicinal herbs for the treatment of anxiety: A systematic review and network meta-analysis",
       "authors": "Zhang W et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35378276/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35378276/",
+      "journal": "Pharmacol Res",
+      "doi": "10.1016/j.phrs.2022.106204",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_3213bd269e3f",
-      "title": "PubMed PMID 18499602. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Preoperative oral Passiflora incarnata reduces anxiety in ambulatory surgery patients: a double-blind, placebo-controlled study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/18499602/",
       "pmid": "18499602",
       "authors": "PubMed",
       "citation": "PubMed PMID 18499602. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Anesth Analg",
+      "year": 2008,
+      "doi": "10.1213/ane.0b013e318172c3f9",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_cde5874cd342",

--- a/public/data/herbs-detail/pastinaca-sativa.json
+++ b/public/data/herbs-detail/pastinaca-sativa.json
@@ -32,21 +32,34 @@
       "title": "Review of Pharmacological Properties and Chemical Constituents of Pastinaca sativa",
       "authors": "Kenari HM et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33833896/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33833896/",
+      "journal": "J Pharmacopuncture",
+      "doi": "10.3831/KPI.2021.24.1.14",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31173794",
       "title": "Wild parsnip (Pastinaca sativa)-induced photosensitization",
       "authors": "Stegelmeier BL et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31173794/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31173794/",
+      "journal": "Toxicon",
+      "doi": "10.1016/j.toxicon.2019.06.007",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39202761",
       "title": "New Insights Concerning Phytophotodermatitis Induced by Phototoxic Plants",
       "authors": "Grosu Dumitrescu C et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39202761/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39202761/",
+      "journal": "Life (Basel)",
+      "doi": "10.3390/life14081019",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/pau-d-arco.json
+++ b/public/data/herbs-detail/pau-d-arco.json
@@ -34,21 +34,34 @@
       "title": "Pau d'arco activates Nrf2-dependent gene expression via the MEK/ERK-pathway",
       "authors": "Richter M et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24646717/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24646717/",
+      "journal": "J Toxicol Sci",
+      "doi": "10.2131/jts.39.353",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "18992801",
       "title": "Red Lapacho (Tabebuia impetiginosa)--a global ethnopharmacological commodity?",
       "authors": "Gómez Castellanos JR et al.",
       "year": 2009,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/18992801/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/18992801/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2008.10.004",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "22632862",
       "title": "The use of herbal medicine in cancer-related anorexia/ cachexia treatment around the world",
       "authors": "Cheng KC et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22632862/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22632862/",
+      "journal": "Curr Pharm Des",
+      "doi": "10.2174/138161212803216979",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/peppermint.json
+++ b/public/data/herbs-detail/peppermint.json
@@ -33,21 +33,33 @@
       "title": "A review of the bioactivity and potential health benefits of peppermint tea (Mentha piperita L.)",
       "authors": "McKay DL et al.",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/16767798/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/16767798/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.1936",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32173933",
       "title": "Ethnomedicinal, phytochemical and pharmacological updates on Peppermint (Mentha × piperita L.)-A review",
       "authors": "Mahendran G et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32173933/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32173933/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6664",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "21144345",
       "title": "Mentha piperita (peppermint)",
       "authors": "Herro E et al.",
       "year": 2010,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/21144345/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/21144345/",
+      "journal": "Dermatitis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/perilla.json
+++ b/public/data/herbs-detail/perilla.json
@@ -30,21 +30,34 @@
       "title": "Perilla frutescens Leaf-Derived Extracellular Vesicle-Like Particles Carry Pab-miR-396a-5p to Alleviate Psoriasis by Modulating IL-17 Signaling",
       "authors": "Liu Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40248109/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40248109/",
+      "journal": "Research (Wash D C)",
+      "doi": "10.34133/research.0675",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "20505356",
       "title": "Stress-induced flowering",
       "authors": "Wada KC et al.",
       "year": 2010,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/20505356/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/20505356/",
+      "journal": "Plant Signal Behav",
+      "doi": "10.4161/psb.5.8.11826",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37570851",
       "title": "The Role and Mechanism of Perilla frutescens in Cancer Treatment",
       "authors": "Huang S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37570851/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37570851/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules28155883",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/phellodendron-amurense.json
+++ b/public/data/herbs-detail/phellodendron-amurense.json
@@ -37,21 +37,34 @@
       "title": "Berberine and Its Role in Chronic Disease",
       "authors": "Cicero AF et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/",
+      "journal": "Adv Exp Med Biol",
+      "doi": "10.1007/978-3-319-41334-1_2",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39612339",
       "title": "Convergent evolution of berberine biosynthesis",
       "authors": "Xu Z et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39612339/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39612339/",
+      "journal": "Sci Adv",
+      "doi": "10.1126/sciadv.ads3596",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38465436",
       "title": "Safety Issues of Herb-Warfarin Interactions",
       "authors": "Hazra S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38465436/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38465436/",
+      "journal": "Curr Drug Metab",
+      "doi": "10.2174/0113892002290846240228061506",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/phellodendron.json
+++ b/public/data/herbs-detail/phellodendron.json
@@ -35,21 +35,34 @@
       "title": "Berberine and Its Role in Chronic Disease",
       "authors": "Cicero AF et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27671811/",
+      "journal": "Adv Exp Med Biol",
+      "doi": "10.1007/978-3-319-41334-1_2",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25498346",
       "title": "Meta-analysis of the effect and safety of berberine in the treatment of type 2 diabetes mellitus, hyperlipemia and hypertension",
       "authors": "Lan J et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25498346/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25498346/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2014.09.049",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39612339",
       "title": "Convergent evolution of berberine biosynthesis",
       "authors": "Xu Z et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39612339/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39612339/",
+      "journal": "Sci Adv",
+      "doi": "10.1126/sciadv.ads3596",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/phosphatidylserine.json
+++ b/public/data/herbs-detail/phosphatidylserine.json
@@ -31,31 +31,47 @@
       "title": "Phosphatidylserine and the human brain",
       "authors": "Glade MJ et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25933483/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25933483/",
+      "journal": "Nutrition",
+      "doi": "10.1016/j.nut.2014.10.014",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31051106",
       "title": "Deficient Endoplasmic Reticulum-Mitochondrial Phosphatidylserine Transfer Causes Liver Disease",
       "authors": "Hernández-Alvarez MI et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31051106/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31051106/",
+      "journal": "Cell",
+      "doi": "10.1016/j.cell.2019.04.010",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26811286",
       "title": "Phosphatidylethanolamine Metabolism in Health and Disease",
       "authors": "Calzada E et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26811286/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26811286/",
+      "journal": "Int Rev Cell Mol Biol",
+      "doi": "10.1016/bs.ircmb.2015.10.001",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_48f7980a9212",
-      "title": "PubMed PMID 12140984. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "[Identification of fragmented bodies of the killed from group burials]",
       "url": "https://pubmed.ncbi.nlm.nih.gov/12140984/",
       "pmid": "12140984",
       "authors": "PubMed",
       "citation": "PubMed PMID 12140984. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Voen Med Zh",
+      "year": 2002,
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/piper-longum.json
+++ b/public/data/herbs-detail/piper-longum.json
@@ -36,21 +36,32 @@
       "title": "Piperine promotes PI3K/AKT/mTOR-mediated gut-brain autophagy to degrade α-Synuclein in Parkinson's disease rats",
       "authors": "Yu L et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38158101/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38158101/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.117628",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35349239",
       "title": "Black Pepper",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35349239/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35349239/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36256521",
       "title": "Piper longum L.: A comprehensive review on traditional uses, phytochemistry, pharmacology, and health-promoting activities",
       "authors": "Biswas P et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36256521/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36256521/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.7649",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/piper-methysticum.json
+++ b/public/data/herbs-detail/piper-methysticum.json
@@ -33,21 +33,35 @@
       "title": "Clinician guidelines for the treatment of psychiatric disorders with nutraceuticals and phytoceuticals: The World Federation of Societies of Biological Psychiatry (WFSBP) and Canadian Network for Mood and Anxiety Treatments (CANMAT) Taskforce",
       "authors": "Sarris J et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35311615/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35311615/",
+      "journal": "World J Biol Psychiatry",
+      "doi": "10.1080/15622975.2021.2013041",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33424664",
       "title": "Pharmacotherapy of Anxiety Disorders: Current and Emerging Treatment Options",
       "authors": "Garakani A et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33424664/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33424664/",
+      "journal": "Front Psychiatry",
+      "doi": "10.3389/fpsyt.2020.595584",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28762712",
       "title": "Common Herbal Dietary Supplement-Drug Interactions",
       "authors": "Asher GN et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/piper-nigrum.json
+++ b/public/data/herbs-detail/piper-nigrum.json
@@ -28,21 +28,36 @@
       "title": "Curcumin: A Review of Its Effects on Human Health",
       "authors": "Hewlings SJ et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29065496/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29065496/",
+      "journal": "Foods",
+      "doi": "10.3390/foods6100092",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32929825",
       "title": "Piperine: A review of its biological effects",
       "authors": "Haq IU et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32929825/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32929825/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6855",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30651162",
       "title": "Health Benefits of Culinary Herbs and Spices",
       "authors": "Jiang TA et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30651162/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30651162/",
+      "journal": "J AOAC Int",
+      "doi": "10.5740/jaoacint.18-0418",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/plantago-lanceolata.json
+++ b/public/data/herbs-detail/plantago-lanceolata.json
@@ -31,21 +31,32 @@
       "title": "Plantago major and Plantago lanceolata Exhibit Antioxidant and Borrelia burgdorferi Inhibiting Activities",
       "authors": "Laanet PR et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39000214/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39000214/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms25137112",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40512457",
       "title": "Natural antitussive products for children and adolescents: darkness and shadow",
       "authors": "Ciprandi G et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40512457/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40512457/",
+      "journal": "Minerva Pediatr (Torino)",
+      "doi": "10.23736/S2724-5276.25.07848-6",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38002180",
       "title": "Polyphenols in Agricultural Grassland Crops and Their Health-Promoting Activities-A Review",
       "authors": "Verhulst EP et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38002180/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38002180/",
+      "journal": "Foods",
+      "doi": "10.3390/foods12224122",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/plantago-major.json
+++ b/public/data/herbs-detail/plantago-major.json
@@ -31,21 +31,36 @@
       "title": "Update on the treatment of chemotherapy and radiotherapy-induced buccal mucositis: a systematic review",
       "authors": "Wen S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37314054/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37314054/",
+      "journal": "Acta Odontol Latinoam",
+      "doi": "10.54589/aol.36/1/3",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29028587",
       "title": "Chemical constituents and medical benefits of Plantago major",
       "authors": "Adom MB et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29028587/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29028587/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2017.09.152",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37631007",
       "title": "Antimicrobial and Other Biomedical Properties of Extracts from Plantago major, Plantaginaceae",
       "authors": "Zhakipbekov K et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37631007/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37631007/",
+      "journal": "Pharmaceuticals (Basel)",
+      "doi": "10.3390/ph16081092",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/plumbago-zeylanica.json
+++ b/public/data/herbs-detail/plumbago-zeylanica.json
@@ -31,21 +31,30 @@
       "title": "Plumbagin ameliorates LPS-induced acute lung injury by regulating PI3K/AKT/mTOR and Keap1-Nrf2/HO-1 signalling pathways",
       "authors": "Liu Z et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38990057/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38990057/",
+      "journal": "J Cell Mol Med",
+      "doi": "10.1111/jcmm.18386",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38232876",
       "title": "Purification and structural characterization of two polysaccharides with anti-inflammatory activities from Plumbago zeylanica L",
       "authors": "Zhang X et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38232876/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38232876/",
+      "journal": "Int J Biol Macromol",
+      "doi": "10.1016/j.ijbiomac.2024.129455",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39616734",
       "title": "Plumbagin alleviates muscle atrophy in female mice through inhibiting the DANCR/NF-κB axis",
       "authors": "Liu Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39616734/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39616734/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.156282",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/polygala.json
+++ b/public/data/herbs-detail/polygala.json
@@ -31,21 +31,34 @@
       "title": "Polygala tenuifolia willd. Extract alleviates LPS-induced acute lung injury in rats via TLR4/NF-κB pathway and NLRP3 inflammasome suppression",
       "authors": "Guo S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38972239/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38972239/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.155859",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "22414105",
       "title": "Nature against depression",
       "authors": "El-Alfy AT et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22414105/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22414105/",
+      "journal": "Curr Med Chem",
+      "doi": "10.2174/092986712800229096",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31765761",
       "title": "A review on the phytopharmacological studies of the genus Polygala",
       "authors": "Lacaille-Dubois MA et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31765761/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31765761/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2019.112417",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/pomegranate.json
+++ b/public/data/herbs-detail/pomegranate.json
@@ -33,21 +33,34 @@
       "title": "Pomegranate (Punica granatum L.) Extract Effects on Inflammaging",
       "authors": "Cordiano R et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39275022/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39275022/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules29174174",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37748009",
       "title": "Pomegranate",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37748009/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37748009/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36076615",
       "title": "Medicinal uses, pharmacological activities, phytochemistry, and the molecular mechanisms of Punica granatum L. (pomegranate) plant extracts: A review",
       "authors": "Maphetu N et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36076615/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36076615/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2022.113256",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/poria.json
+++ b/public/data/herbs-detail/poria.json
@@ -35,21 +35,32 @@
       "title": "Poria cocos: traditional uses, triterpenoid components and their renoprotective pharmacology",
       "authors": "Guo ZY et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39482471/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39482471/",
+      "journal": "Acta Pharmacol Sin",
+      "doi": "10.1038/s41401-024-01404-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37788785",
       "title": "Fuling-Zexie formula attenuates hyperuricemia-induced nephropathy and inhibits JAK2/STAT3 signaling and NLRP3 inflammasome activation in mice",
       "authors": "Lu M et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37788785/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37788785/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.117262",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39520951",
       "title": "Kaixinsan regulates neuronal mitochondrial homeostasis to improve the cognitive function of Alzheimer's disease by activating CaMKKβ-AMPK-PGC-1α signaling axis",
       "authors": "Ren J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39520951/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39520951/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.156170",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/psoralea-corylifolia.json
+++ b/public/data/herbs-detail/psoralea-corylifolia.json
@@ -39,21 +39,34 @@
       "title": "Applications of bakuchiol in dermatology: Systematic review of the literature",
       "authors": "Puyana C et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36176207/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36176207/",
+      "journal": "J Cosmet Dermatol",
+      "doi": "10.1111/jocd.15420",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24471735",
       "title": "Bakuchiol: a retinol-like functional compound revealed by gene expression profiling and clinically proven to have anti-aging effects",
       "authors": "Chaudhuri RK et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24471735/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24471735/",
+      "journal": "Int J Cosmet Sci",
+      "doi": "10.1111/ics.12117",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "22772918",
       "title": "Isobavachalcone: an overview",
       "authors": "Kuete V et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22772918/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22772918/",
+      "journal": "Chin J Integr Med",
+      "doi": "10.1007/s11655-012-1142-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/psyllium.json
+++ b/public/data/herbs-detail/psyllium.json
@@ -34,21 +34,36 @@
       "title": "Effects of dietary fibers or probiotics on functional constipation symptoms and roles of gut microbiota: a double-blinded randomized placebo trial",
       "authors": "Lai H et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37078654/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37078654/",
+      "journal": "Gut Microbes",
+      "doi": "10.1080/19490976.2023.2197837",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33762150",
       "title": "The effects of foods on LDL cholesterol levels: A systematic review of the accumulated evidence from systematic reviews and meta-analyses of randomized controlled trials",
       "authors": "Schoeneck M et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33762150/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33762150/",
+      "journal": "Nutr Metab Cardiovasc Dis",
+      "doi": "10.1016/j.numecd.2020.12.032",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "23609775",
       "title": "Fiber and prebiotics: mechanisms and health benefits",
       "authors": "Slavin J et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23609775/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23609775/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu5041417",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/pueraria-lobata.json
+++ b/public/data/herbs-detail/pueraria-lobata.json
@@ -36,21 +36,32 @@
       "title": "Network Pharmacology and Bioinformatics Study of Six Medicinal Food Homologous Plants Against Colorectal Cancer",
       "authors": "Zhao X et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39940699/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39940699/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms26030930",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24339367",
       "title": "Puerarin: a review of pharmacological effects",
       "authors": "Zhou YX et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24339367/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24339367/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.5083",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39326132",
       "title": "Puerarin ameliorates colitis by direct suppression of macrophage M1 polarization in DSS mice",
       "authors": "Tao Q et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39326132/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39326132/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2024.156048",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/pueraria-mirifica.json
+++ b/public/data/herbs-detail/pueraria-mirifica.json
@@ -31,21 +31,32 @@
       "title": "Medical applications of phytoestrogens from the Thai herb Pueraria mirifica",
       "authors": "Malaivijitnond S et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22460444/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22460444/",
+      "journal": "Front Med",
+      "doi": "10.1007/s11684-012-0184-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38539824",
       "title": "Dietary Puerarin Supplementation Improves Immune Response and Antioxidant Capacity of Sows",
       "authors": "Cao S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38539824/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38539824/",
+      "journal": "Antioxidants (Basel)",
+      "doi": "10.3390/antiox13030290",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36232220",
       "title": "Inhibition of LPS-Induced Microglial Activation by the Ethyl Acetate Extract of Pueraria mirifica",
       "authors": "Jantaratnotai N et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36232220/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36232220/",
+      "journal": "Int J Environ Res Public Health",
+      "doi": "10.3390/ijerph191912920",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/punarnava.json
+++ b/public/data/herbs-detail/punarnava.json
@@ -32,21 +32,30 @@
       "title": "Clinical efficacy of Punarnava Mandura and Dhatri Lauha in the management of Garbhini Pandu (anemia in pregnancy)",
       "authors": "Khandelwal DA et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27833367/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27833367/",
+      "journal": "Ayu",
+      "doi": "10.4103/0974-8520.190700",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "23723672",
       "title": "Clinical efficacy of Gokshura-Punarnava Basti in the management of microalbuminuria in diabetes mellitus",
       "authors": "Ramteke RS et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/23723672/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/23723672/",
+      "journal": "Ayu",
+      "doi": "10.4103/0974-8520.110535",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26664234",
       "title": "A clinical study of Punarnava Mandura in the management of Pandu Roga in old age (geriatric anemia)",
       "authors": "Pandya MG et al.",
       "year": 2014,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26664234/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26664234/",
+      "journal": "Ayu",
+      "doi": "10.4103/0974-8520.153735",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/quercetin.json
+++ b/public/data/herbs-detail/quercetin.json
@@ -34,41 +34,64 @@
       "title": "Health Benefits of Quercetin in Age-Related Diseases",
       "authors": "Deepika et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35458696/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35458696/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27082498",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34087741",
       "title": "The role of quercetin in plants",
       "authors": "Singh P et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34087741/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34087741/",
+      "journal": "Plant Physiol Biochem",
+      "doi": "10.1016/j.plaphy.2021.05.023",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27187333",
       "title": "Quercetin and Its Anti-Allergic Immune Response",
       "authors": "Mlcek J et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27187333/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27187333/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules21050623",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_0ee85759f520",
-      "title": "PubMed PMID 26907242. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Multicomponent Synthesis and Evaluation of New 1,2,3-Triazole Derivatives of Dihydropyrimidinones as Acidic Corrosion Inhibitors for Steel",
       "url": "https://pubmed.ncbi.nlm.nih.gov/26907242/",
       "pmid": "26907242",
       "authors": "PubMed",
       "citation": "PubMed PMID 26907242. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Molecules",
+      "year": 2016,
+      "doi": "10.3390/molecules21020250",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_8fa47d3b8cbe",
-      "title": "PubMed PMID 19589961. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Ingestion of whey hydrolysate, casein, or soy protein isolate: effects on mixed muscle protein synthesis at rest and following resistance exercise in young men",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19589961/",
       "pmid": "19589961",
       "authors": "PubMed",
       "citation": "PubMed PMID 19589961. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Appl Physiol (1985)",
+      "year": 2009,
+      "doi": "10.1152/japplphysiol.00076.2009",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/raspberry-leaf.json
+++ b/public/data/herbs-detail/raspberry-leaf.json
@@ -33,21 +33,34 @@
       "title": "Raspberry",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000844/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000844/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31975502",
       "title": "Anti-aging and brightening effects of a topical treatment containing vitamin C, vitamin E, and raspberry leaf cell culture extract: A split-face, randomized controlled trial",
       "authors": "Rattanawiwatpong P et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31975502/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31975502/",
+      "journal": "J Cosmet Dermatol",
+      "doi": "10.1111/jocd.13305",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35336978",
       "title": "Known and Potential Invertebrate Vectors of Raspberry Viruses",
       "authors": "Tan JL et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35336978/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35336978/",
+      "journal": "Viruses",
+      "doi": "10.3390/v14030571",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/red-clover.json
+++ b/public/data/herbs-detail/red-clover.json
@@ -34,21 +34,36 @@
       "title": "Herbal Products Used in Menopause and for Gynecological Disorders",
       "authors": "Kenda M et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26247421",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39477563",
       "title": "Complementary and Alternative Medicine for Menopause",
       "authors": "Smith-Francis MJ et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39477563/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39477563/",
+      "journal": "Nurs Clin North Am",
+      "doi": "10.1016/j.cnur.2024.08.001",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33383165",
       "title": "Neither soy nor isoflavone intake affects male reproductive hormones: An expanded and updated meta-analysis of clinical studies",
       "authors": "Reed KE et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33383165/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33383165/",
+      "journal": "Reprod Toxicol",
+      "doi": "10.1016/j.reprotox.2020.12.019",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/rehmannia-glutinosa.json
+++ b/public/data/herbs-detail/rehmannia-glutinosa.json
@@ -34,21 +34,34 @@
       "title": "Progress of research into the pharmacological effect and clinical application of the traditional Chinese medicine Rehmanniae Radix",
       "authors": "Jia J et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37907043/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37907043/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2023.115809",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37579922",
       "title": "Rehmannia glutinosa Libosch and Cornus officinalis Sieb herb couple ameliorates renal interstitial fibrosis in CKD rats by inhibiting the TGF-β1/MAPK signaling pathway",
       "authors": "Zhu JH et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37579922/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37579922/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.117039",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36634722",
       "title": "Extraction, structure and bioactivities of polysaccharides from Rehmannia glutinosa: A review",
       "authors": "Bian Z et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36634722/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36634722/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2022.116132",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/resveratrol.json
+++ b/public/data/herbs-detail/resveratrol.json
@@ -34,41 +34,64 @@
       "title": "Resveratrol and Its Effects on the Vascular System",
       "authors": "Breuss JM et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30934670/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30934670/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms20071523",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31756276",
       "title": "Resveratrol: a review of plant sources, synthesis, stability, modification and food application",
       "authors": "Tian B et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31756276/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31756276/",
+      "journal": "J Sci Food Agric",
+      "doi": "10.1002/jsfa.10152",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36079777",
       "title": "Effects of Resveratrol, Curcumin and Quercetin Supplementation on Bone Metabolism-A Systematic Review",
       "authors": "Inchingolo AD et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36079777/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36079777/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu14173519",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_341679e94c68",
-      "title": "PubMed PMID 23347199. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "High prevalence of rheumatic heart disease in schoolchildren detected by echocardiography screening in New Caledonia",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23347199/",
       "pmid": "23347199",
       "authors": "PubMed",
       "citation": "PubMed PMID 23347199. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Paediatr Child Health",
+      "year": 2013,
+      "doi": "10.1111/jpc.12087",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_b60492c555a2",
-      "title": "PubMed PMID 22271614. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Synthesis of hyperbranched polyethylene amphiphiles by chain walking polymerization in tandem with RAFT polymerization and supramolecular self-assembly vesicles",
       "url": "https://pubmed.ncbi.nlm.nih.gov/22271614/",
       "pmid": "22271614",
       "authors": "PubMed",
       "citation": "PubMed PMID 22271614. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Macromol Rapid Commun",
+      "year": 2012,
+      "doi": "10.1002/marc.201100825",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/rheum-palmatum.json
+++ b/public/data/herbs-detail/rheum-palmatum.json
@@ -30,21 +30,34 @@
       "title": "Emodin: A Review of its Pharmacology, Toxicity and Pharmacokinetics",
       "authors": "Dong X et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27188216/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27188216/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.5631",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31680350",
       "title": "Aloe-emodin: A review of its pharmacology, toxicity, and pharmacokinetics",
       "authors": "Dong X et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31680350/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31680350/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6532",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000922",
       "title": "Rhubarb",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000922/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000922/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/rhodiola.json
+++ b/public/data/herbs-detail/rhodiola.json
@@ -30,41 +30,68 @@
       "title": "Plant Adaptogens-History and Future Perspectives",
       "authors": "Todorova V et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34445021/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34445021/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu13082861",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35745023",
       "title": "The Effectiveness of Rhodiola rosea L. Preparations in Alleviating Various Aspects of Life-Stress Symptoms and Stress-Induced Conditions-Encouraging Clinical Evidence",
       "authors": "Ivanova Stojcheva E et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35745023/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35745023/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27123902",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29568244",
       "title": "Herbal medicine for sports: a review",
       "authors": "Sellami M et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29568244/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29568244/",
+      "journal": "J Int Soc Sports Nutr",
+      "doi": "10.1186/s12970-018-0218-y",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_2ee233da1a3a",
-      "title": "PubMed PMID 19016404. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "A randomised, double-blind, placebo-controlled, parallel-group study of the standardised extract shr-5 of the roots of Rhodiola rosea in the treatment of subjects with stress-related fatigue",
       "url": "https://pubmed.ncbi.nlm.nih.gov/19016404/",
       "pmid": "19016404",
       "authors": "PubMed",
       "citation": "PubMed PMID 19016404. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Planta Med",
+      "year": 2009,
+      "doi": "10.1055/s-0028-1088346",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_74fdaae54d8a",
-      "title": "PubMed PMID 20378318. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Rosenroot (Rhodiola rosea): traditional use, chemical composition, pharmacology and clinical efficacy",
       "url": "https://pubmed.ncbi.nlm.nih.gov/20378318/",
       "pmid": "20378318",
       "authors": "PubMed",
       "citation": "PubMed PMID 20378318. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytomedicine",
+      "year": 2010,
+      "doi": "10.1016/j.phymed.2010.02.002",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_212be327d082",

--- a/public/data/herbs-detail/rice-bran.json
+++ b/public/data/herbs-detail/rice-bran.json
@@ -37,21 +37,33 @@
       "title": "Dermatological uses of rice products: Trend or true?",
       "authors": "Zamil DH et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35587098/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35587098/",
+      "journal": "J Cosmet Dermatol",
+      "doi": "10.1111/jocd.15099",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33138751",
       "title": "Biological and Pharmacological Effects of Gamma-oryzanol: An Updated Review of the Molecular Mechanisms",
       "authors": "Ramazani E et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33138751/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33138751/",
+      "journal": "Curr Pharm Des",
+      "doi": "10.2174/1381612826666201102101428",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34239993",
       "title": "The effects of twenty-four nutrients and phytonutrients on immune system function and inflammation: A narrative review",
       "authors": "Poles J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34239993/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34239993/",
+      "journal": "J Clin Transl Res",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/rooibos.json
+++ b/public/data/herbs-detail/rooibos.json
@@ -32,21 +32,34 @@
       "title": "Tacrolimus and herbs interactions: a review",
       "authors": "Abushammala I et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34620272/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34620272/",
+      "journal": "Pharmazie",
+      "doi": "10.1691/ph.2021.1684",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32364226",
       "title": "Experimental assembly reveals ecological drift as a major driver of root nodule bacterial diversity in a woody legume crop",
       "authors": "Ramoneda J et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32364226/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32364226/",
+      "journal": "FEMS Microbiol Ecol",
+      "doi": "10.1093/femsec/fiaa083",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34402103",
       "title": "Rooibos (Aspalathus linearis) influence on health and ovarian functions",
       "authors": "Sirotkin AV et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34402103/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34402103/",
+      "journal": "J Anim Physiol Anim Nutr (Berl)",
+      "doi": "10.1111/jpn.13624",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/rose-hips.json
+++ b/public/data/herbs-detail/rose-hips.json
@@ -34,21 +34,36 @@
       "title": "Phytochemistry, Traditional Uses and Pharmacological Profile of Rose Hip: A Review",
       "authors": "Ayati Z et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30317989/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30317989/",
+      "journal": "Curr Pharm Des",
+      "doi": "10.2174/1381612824666181010151849",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28587101",
       "title": "Therapeutic Applications of Rose Hips from Different Rosa Species",
       "authors": "Mármol I et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28587101/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28587101/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms18061137",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37937578",
       "title": "A Comprehensive Review on Phytochemistry and Pharmacology of Rosa Species (Rosaceae)",
       "authors": "Fayaz F et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37937578/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37937578/",
+      "journal": "Curr Top Med Chem",
+      "doi": "10.2174/0115680266274385231023075011",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/roselle-seed.json
+++ b/public/data/herbs-detail/roselle-seed.json
@@ -32,21 +32,31 @@
       "title": "The Potential of Roselle (Hibiscus sabdariffa) Plant in Industrial Applications: A Promising Source of Functional Compounds",
       "authors": "Chew LY et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38432993/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38432993/",
+      "journal": "J Oleo Sci",
+      "doi": "10.5650/jos.ess23111",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "17995816",
       "title": "Roselle (Hibiscus sabdariffa) seed oil is a rich source of gamma-tocopherol",
       "authors": "Mohamed R et al.",
       "year": 2007,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/17995816/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/17995816/",
+      "journal": "J Food Sci",
+      "doi": "10.1111/j.1750-3841.2007.00285.x",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "24575672",
       "title": "In vitro antioxidant activities of extract and oil from roselle (Hibiscus sabdariffa L.) seed against sunflower oil autoxidation",
       "authors": "Nyam KL et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/24575672/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/24575672/",
+      "journal": "Malays J Nutr",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/rosemary.json
+++ b/public/data/herbs-detail/rosemary.json
@@ -36,21 +36,34 @@
       "title": "Rosmarinus officinalis L. (rosemary) as therapeutic and prophylactic agent",
       "authors": "de Oliveira JR et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30621719/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30621719/",
+      "journal": "J Biomed Sci",
+      "doi": "10.1186/s12929-019-0499-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38174012",
       "title": "Complementary and alternative supplements: a review of dermatologic effectiveness for androgenetic alopecia",
       "authors": "Ufomadu P et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38174012/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38174012/",
+      "journal": "Proc (Bayl Univ Med Cent)",
+      "doi": "10.1080/08998280.2023.2263829",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38565924",
       "title": "Rosemary and neem: an insight into their combined anti-dandruff and anti-hair loss efficacy",
       "authors": "Hashem MM et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38565924/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38565924/",
+      "journal": "Sci Rep",
+      "doi": "10.1038/s41598-024-57838-w",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/saffron.json
+++ b/public/data/herbs-detail/saffron.json
@@ -32,21 +32,36 @@
       "title": "The Effects of Crocus sativus (Saffron) on ADHD: A Systematic Review",
       "authors": "Seyedi-Sahebari S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37864351/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37864351/",
+      "journal": "J Atten Disord",
+      "doi": "10.1177/10870547231203176",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29464801",
       "title": "Herbal medicine for depression and anxiety: A systematic review with assessment of potential psycho-oncologic relevance",
       "authors": "Yeung KS et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29464801/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29464801/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6033",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36235697",
       "title": "Effectivity of Saffron Extract (Saffr'Activ) on Treatment for Children and Adolescents with Attention Deficit/Hyperactivity Disorder (ADHD): A Clinical Effectivity Study",
       "authors": "Blasco-Fontecilla H et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36235697/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36235697/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu14194046",
+      "studyType": "Uncontrolled trial",
+      "studyClass": "uncontrolled-trial",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/sage.json
+++ b/public/data/herbs-detail/sage.json
@@ -39,21 +39,34 @@
       "title": "Huntington's disease clinical trials update: March 2025",
       "authors": "Farag M et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40302443/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40302443/",
+      "journal": "J Huntingtons Dis",
+      "doi": "10.1177/18796397251337000",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29403626",
       "title": "A review of effective herbal medicines in controlling menopausal symptoms",
       "authors": "Kargozar R et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29403626/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29403626/",
+      "journal": "Electron Physician",
+      "doi": "10.19082/5826",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29034191",
       "title": "Pharmacological properties of Salvia officinalis and its components",
       "authors": "Ghorbani A et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29034191/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29034191/",
+      "journal": "J Tradit Complement Med",
+      "doi": "10.1016/j.jtcme.2016.12.014",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/salacia-reticulata.json
+++ b/public/data/herbs-detail/salacia-reticulata.json
@@ -29,21 +29,36 @@
       "title": "Salacia spp.: recent insights on biotechnological interventions and future perspectives",
       "authors": "Chavan J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38326604/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38326604/",
+      "journal": "Appl Microbiol Biotechnol",
+      "doi": "10.1007/s00253-023-12998-z",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26031882",
       "title": "Anti-diabetic and Anti-hyperlipidemic Effects and Safety of Salacia reticulata and Related Species",
       "authors": "Stohs SJ et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26031882/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26031882/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.5382",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "25889885",
       "title": "Salacia reticulata (Kothala himbutu) revisited; a missed opportunity to treat diabetes and obesity?",
       "authors": "Medagama AB et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/25889885/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/25889885/",
+      "journal": "Nutr J",
+      "doi": "10.1186/s12937-015-0013-4",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/salvia-miltiorrhiza.json
+++ b/public/data/herbs-detail/salvia-miltiorrhiza.json
@@ -31,21 +31,36 @@
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36650621",
       "title": "Herb-Drug Interactions and Their Impact on Pharmacokinetics: An Update",
       "authors": "Cheng W et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36650621/",
+      "journal": "Curr Drug Metab",
+      "doi": "10.2174/1389200224666230116113240",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29698387",
       "title": "Salvia miltiorrhizaBurge (Danshen): a golden herbal medicine in cardiovascular therapeutics",
       "authors": "Li ZM et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29698387/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29698387/",
+      "journal": "Acta Pharmacol Sin",
+      "doi": "10.1038/aps.2017.193",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/saw-palmetto.json
+++ b/public/data/herbs-detail/saw-palmetto.json
@@ -32,21 +32,36 @@
       "title": "An overview of herbal alternatives in androgenetic alopecia",
       "authors": "Dhariwala MY et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30980598/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30980598/",
+      "journal": "J Cosmet Dermatol",
+      "doi": "10.1111/jocd.12930",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "19719333",
       "title": "Interactions between herbal medicines and prescribed drugs: an updated systematic review",
       "authors": "Izzo AA et al.",
       "year": 2009,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/19719333/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/19719333/",
+      "journal": "Drugs",
+      "doi": "10.2165/11317010-000000000-00000",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31807332",
       "title": "Use of saw palmetto (Serenoa repens) extract for benign prostatic hyperplasia",
       "authors": "Kwon Y et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31807332/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31807332/",
+      "journal": "Food Sci Biotechnol",
+      "doi": "10.1007/s10068-019-00605-9",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_e220f13ccd17",

--- a/public/data/herbs-detail/schisandra-berry.json
+++ b/public/data/herbs-detail/schisandra-berry.json
@@ -34,14 +34,22 @@
       "title": "A narrative review on the role of traditional Chinese medicine (TCM) in treating coronary artery disease",
       "authors": "Zhang A et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40143483/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40143483/",
+      "journal": "J Pak Med Assoc",
+      "doi": "10.47391/JPMA.11610",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "16552829",
       "title": "Biochemical basis of the \"Qi-invigorating\" action of Schisandra berry (wu-wei-zi) in Chinese medicine",
       "authors": "Ko KM et al.",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/16552829/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/16552829/",
+      "journal": "Am J Chin Med",
+      "doi": "10.1142/S0192415X06003734",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/schisandra-chinensis.json
+++ b/public/data/herbs-detail/schisandra-chinensis.json
@@ -35,21 +35,36 @@
       "title": "Plant Adaptogens-History and Future Perspectives",
       "authors": "Todorova V et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34445021/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34445021/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu13082861",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37895122",
       "title": "Plant Extracts as Skin Care and Therapeutic Agents",
       "authors": "Michalak M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37895122/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37895122/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms242015444",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36987052",
       "title": "Nootropic Herbs, Shrubs, and Trees as Potential Cognitive Enhancers",
       "authors": "Malík M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36987052/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36987052/",
+      "journal": "Plants (Basel)",
+      "doi": "10.3390/plants12061364",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/schisandra.json
+++ b/public/data/herbs-detail/schisandra.json
@@ -30,21 +30,31 @@
       "title": "Schisandra chinensis and its phytotherapeutical applications",
       "authors": "Rybnikář M et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31431019/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31431019/",
+      "journal": "Ceska Slov Farm",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30731931",
       "title": "First Report of Botrytis Leaf Blight and Fruit Rot on Schisandra chinensis Caused by Botrytis cinerea in China",
       "authors": "Yu RH et al.",
       "year": 2011,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30731931/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30731931/",
+      "journal": "Plant Dis",
+      "doi": "10.1094/PDIS-02-11-0086",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30722342",
       "title": "First Report of Fruit Rot on Schisandra chinensis Caused by Penicillium glabrum and P. adametzii in China",
       "authors": "Chen CQ et al.",
       "year": 2013,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30722342/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30722342/",
+      "journal": "Plant Dis",
+      "doi": "10.1094/PDIS-08-12-0799-PDN",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_660c3852670e",

--- a/public/data/herbs-detail/scutellaria-baicalensis.json
+++ b/public/data/herbs-detail/scutellaria-baicalensis.json
@@ -39,21 +39,34 @@
       "title": "Scutellaria baicalensis Extracts Restrict Intestinal Epithelial Cell Ferroptosis by Regulating Lipid Peroxidation and GPX4/ACSL4 in Colitis",
       "authors": "Zhang J et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40220415/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40220415/",
+      "journal": "Phytomedicine",
+      "doi": "10.1016/j.phymed.2025.156708",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31070530",
       "title": "A comprehensive review on phytochemistry, pharmacology, and flavonoid biosynthesis of Scutellaria baicalensis",
       "authors": "Wang ZL et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31070530/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31070530/",
+      "journal": "Pharm Biol",
+      "doi": "10.1080/13880209.2018.1492620",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31236960",
       "title": "Scutellaria baicalensis Georgi. (Lamiaceae): a review of its traditional uses, botany, phytochemistry, pharmacology and toxicology",
       "authors": "Zhao T et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31236960/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31236960/",
+      "journal": "J Pharm Pharmacol",
+      "doi": "10.1111/jphp.13129",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/scutellaria-lateriflora.json
+++ b/public/data/herbs-detail/scutellaria-lateriflora.json
@@ -32,21 +32,30 @@
       "title": "Herb-induced liver injury: Systematic review and meta-analysis",
       "authors": "Ballotin VR et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34307603/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34307603/",
+      "journal": "World J Clin Cases",
+      "doi": "10.12998/wjcc.v9.i20.5490",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "40205009",
       "title": "Wogonin attenuates septic cardiomyopathy by suppressing ALOX15-mediated ferroptosis",
       "authors": "Ye H et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40205009/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40205009/",
+      "journal": "Acta Pharmacol Sin",
+      "doi": "10.1038/s41401-025-01547-1",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38495279",
       "title": "Insights into skullcap herb-induced liver injury",
       "authors": "Soldera J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38495279/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38495279/",
+      "journal": "World J Hepatol",
+      "doi": "10.4254/wjh.v16.i2.120",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/selaginella-tamariscina.json
+++ b/public/data/herbs-detail/selaginella-tamariscina.json
@@ -33,21 +33,32 @@
       "title": "Selaginella tamariscina Ethanol Extract Attenuates Influenza A Virus Infection by Inhibiting Hemagglutinin and Neuraminidase",
       "authors": "Cho WK et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39064820/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39064820/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu16142377",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39258186",
       "title": "Amentoflavone from Selaginella tamariscina inhibits SARS-CoV-2 RNA-dependent RNA polymerase",
       "authors": "Youn KW et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39258186/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39258186/",
+      "journal": "Heliyon",
+      "doi": "10.1016/j.heliyon.2024.e36568",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34302944",
       "title": "The traditional and modern uses of Selaginella tamariscina (P.Beauv.) Spring, in medicine and cosmetic: Applications and bioactive ingredients",
       "authors": "Bailly C et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34302944/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34302944/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2021.114444",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "title": "Inhibitory Effect of Selaginellins from Selaginella tamariscina (Beauv.) Spring against Cytochrome P450 and Uridine 5'-Diphosphoglucuronosyltransferase Isoforms on Human Liver Microsomes",

--- a/public/data/herbs-detail/serenoa-repens.json
+++ b/public/data/herbs-detail/serenoa-repens.json
@@ -34,21 +34,36 @@
       "title": "Natural Compounds Used for Treating Hair Loss",
       "authors": "Gasmi A et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37151166/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37151166/",
+      "journal": "Curr Pharm Des",
+      "doi": "10.2174/1381612829666230505100147",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30980598",
       "title": "An overview of herbal alternatives in androgenetic alopecia",
       "authors": "Dhariwala MY et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30980598/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30980598/",
+      "journal": "J Cosmet Dermatol",
+      "doi": "10.1111/jocd.12930",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32066284",
       "title": "A review of the treatment of male pattern hair loss",
       "authors": "York K et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32066284/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32066284/",
+      "journal": "Expert Opin Pharmacother",
+      "doi": "10.1080/14656566.2020.1721463",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/shankhpushpi.json
+++ b/public/data/herbs-detail/shankhpushpi.json
@@ -31,21 +31,36 @@
       "title": "Neuroprotective Herbs for the Management of Alzheimer's Disease",
       "authors": "Gregory J et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33917843/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33917843/",
+      "journal": "Biomolecules",
+      "doi": "10.3390/biom11040543",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35878793",
       "title": "Role of Shankhpushpi (Convolvulus pluricaulis) in neurological disorders: An umbrella review covering evidence from ethnopharmacology to clinical studies",
       "authors": "Sharma R et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35878793/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35878793/",
+      "journal": "Neurosci Biobehav Rev",
+      "doi": "10.1016/j.neubiorev.2022.104795",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "19912732",
       "title": "An update on Shankhpushpi, a cognition-boosting Ayurvedic medicine",
       "authors": "Sethiya NK et al.",
       "year": 2009,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/19912732/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/19912732/",
+      "journal": "Zhong Xi Yi Jie He Xue Bao",
+      "doi": "10.3736/jcim20091101",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/silybum-marianum.json
+++ b/public/data/herbs-detail/silybum-marianum.json
@@ -33,21 +33,35 @@
       "title": "Common Herbal Dietary Supplement-Drug Interactions",
       "authors": "Asher GN et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28762712/",
+      "journal": "Am Fam Physician",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30080294",
       "title": "Milk thistle (Silybum marianum): A concise overview on its chemistry, pharmacological, and nutraceutical uses in liver diseases",
       "authors": "Abenavoli L et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30080294/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30080294/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6171",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32065376",
       "title": "Silymarin as Supportive Treatment in Liver Diseases: A Narrative Review",
       "authors": "Gillessen A et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32065376/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32065376/",
+      "journal": "Adv Ther",
+      "doi": "10.1007/s12325-020-01251-y",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/sophora-alopecuroides.json
+++ b/public/data/herbs-detail/sophora-alopecuroides.json
@@ -30,21 +30,36 @@
       "title": "Sophora alopecuroides L.: An ethnopharmacological, phytochemical, and pharmacological review",
       "authors": "Wang R et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31442619/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31442619/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2019.112172",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35433636",
       "title": "Research Advances on Matrine",
       "authors": "Sun XY et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35433636/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35433636/",
+      "journal": "Front Chem",
+      "doi": "10.3389/fchem.2022.867318",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38746009",
       "title": "A review on the pharmacology, pharmacokinetics and toxicity of sophocarpine",
       "authors": "Wei S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38746009/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38746009/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2024.1353234",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/sophora-flavescens.json
+++ b/public/data/herbs-detail/sophora-flavescens.json
@@ -36,21 +36,30 @@
       "title": "Oral administration of Sophora Flavescens-derived exosomes-like nanovesicles carrying CX5461 ameliorates DSS-induced colitis in mice",
       "authors": "Zhang M et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39379937/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39379937/",
+      "journal": "J Nanobiotechnology",
+      "doi": "10.1186/s12951-024-02856-z",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38797379",
       "title": "Beneficial effects of oxymatrine from Sophora flavescens on alleviating Ulcerative colitis by improving inflammation and ferroptosis",
       "authors": "Gao BB et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38797379/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38797379/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2024.118385",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34368883",
       "title": "Oxymatrine attenuates oxidized low‑density lipoprotein‑induced HUVEC injury by inhibiting NLRP3 inflammasome‑mediated pyroptosis via the activation of the SIRT1/Nrf2 signaling pathway",
       "authors": "Jin X et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34368883/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34368883/",
+      "journal": "Int J Mol Med",
+      "doi": "10.3892/ijmm.2021.5020",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/soursop.json
+++ b/public/data/herbs-detail/soursop.json
@@ -33,21 +33,34 @@
       "title": "Pharmacological Activities of Soursop (Annona muricata Lin.)",
       "authors": "Mutakin M et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35208993/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35208993/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27041201",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37048268",
       "title": "Soursop (Annona muricata) Properties and Perspectives for Integral Valorization",
       "authors": "Santos IL et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37048268/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37048268/",
+      "journal": "Foods",
+      "doi": "10.3390/foods12071448",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39171117",
       "title": "Soursop leaf extract and fractions protects against L-NAME-induced hypertension and hyperlipidemia",
       "authors": "Nsor OO et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39171117/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39171117/",
+      "journal": "Front Nutr",
+      "doi": "10.3389/fnut.2024.1437101",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/soybean.json
+++ b/public/data/herbs-detail/soybean.json
@@ -38,21 +38,36 @@
       "title": "Toward a \"Green Revolution\" for Soybean",
       "authors": "Liu S et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32171732/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32171732/",
+      "journal": "Mol Plant",
+      "doi": "10.1016/j.molp.2020.03.002",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31649123",
       "title": "Celebrating 20 Years of Genetic Discoveries in Legume Nodulation and Symbiotic Nitrogen Fixation",
       "authors": "Roy S et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31649123/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31649123/",
+      "journal": "Plant Cell",
+      "doi": "10.1105/tpc.19.00279",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33090664",
       "title": "Molecular mechanisms for the photoperiodic regulation of flowering in soybean",
       "authors": "Lin X et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33090664/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33090664/",
+      "journal": "J Integr Plant Biol",
+      "doi": "10.1111/jipb.13021",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/st-johns-wort.json
+++ b/public/data/herbs-detail/st-johns-wort.json
@@ -32,21 +32,34 @@
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "35294606",
       "title": "St. John's wort (Hypericum perforatum) and depression: what happens to the neurotransmitter systems?",
       "authors": "Kholghi G et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/35294606/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/35294606/",
+      "journal": "Naunyn Schmiedebergs Arch Pharmacol",
+      "doi": "10.1007/s00210-022-02229-z",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000829",
       "title": "St. John's Wort",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000829/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000829/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/stellera-chamaejasme.json
+++ b/public/data/herbs-detail/stellera-chamaejasme.json
@@ -30,21 +30,34 @@
       "title": "Chemical Constituents and Pharmacological Activities of Stellera chamaejasme",
       "authors": "Li XQ et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30179119/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30179119/",
+      "journal": "Curr Pharm Des",
+      "doi": "10.2174/1381612824666180903110802",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32360044",
       "title": "Ethnopharmacology, phytochemistry, pharmacology, clinical applications and toxicology of the genus Stellera Linn.: A review",
       "authors": "Zhang N et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32360044/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32360044/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2020.112915",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39597571",
       "title": "Ingesting Stellera chamaejasme Significantly Impacts the Gastrointestinal Tract Bacterial Community and Diversity in Plateau Zokors (Eospalax baileyi)",
       "authors": "Guo J et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39597571/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39597571/",
+      "journal": "Microorganisms",
+      "doi": "10.3390/microorganisms12112182",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/stephania-cepharantha.json
+++ b/public/data/herbs-detail/stephania-cepharantha.json
@@ -30,21 +30,32 @@
       "title": "Pharmacological Effects and Clinical Prospects of Cepharanthine",
       "authors": "Liang D et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36558061/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36558061/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules27248933",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "41655513",
       "title": "Transcriptome analysis of Stephania cepharantha and characterization of two CYP80B genes involved in the benzylisoquinoline alkaloid biosynthesis",
       "authors": "Feng Y et al.",
       "year": 2026,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41655513/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41655513/",
+      "journal": "Plant Physiol Biochem",
+      "doi": "10.1016/j.plaphy.2026.111088",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30678239",
       "title": "High Performance Liquid Chromatography Determination and Optimization of the Extraction Process for the Total Alkaloids from Traditional Herb Stephania cepharantha Hayata",
       "authors": "Xiao J et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30678239/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30678239/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules24030388",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/stephania-japonica.json
+++ b/public/data/herbs-detail/stephania-japonica.json
@@ -31,21 +31,32 @@
       "title": "Antiviral activity of Stephania japonica extract against porcine epidemic diarrhea virus infection",
       "authors": "Zhao Y et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/40706130/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/40706130/",
+      "journal": "Vet Microbiol",
+      "doi": "10.1016/j.vetmic.2025.110647",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38381605",
       "title": "The genome of Stephania japonica provides insights into the biosynthesis of cepharanthine",
       "authors": "Liu Z et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38381605/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38381605/",
+      "journal": "Cell Rep",
+      "doi": "10.1016/j.celrep.2024.113832",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33057963",
       "title": "Traditional Herbal Medicines Against CNS Disorders from Bangladesh",
       "authors": "Uddin MJ et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33057963/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33057963/",
+      "journal": "Nat Prod Bioprospect",
+      "doi": "10.1007/s13659-020-00269-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/stephania-tetrandra.json
+++ b/public/data/herbs-detail/stephania-tetrandra.json
@@ -31,21 +31,34 @@
       "title": "Stephania tetrandra S. Moore: a promising candidate drug for treating diabetic kidney disease",
       "authors": "Wang W et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/41031161/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/41031161/",
+      "journal": "Front Pharmacol",
+      "doi": "10.3389/fphar.2025.1651023",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "26899361",
       "title": "Tetrandrine--A molecule of wide bioactivity",
       "authors": "Bhagya N et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26899361/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26899361/",
+      "journal": "Phytochemistry",
+      "doi": "10.1016/j.phytochem.2016.02.005",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37043739",
       "title": "Modulation of in Vitro SARS-CoV-2 Infection by Stephania tetrandra and Its Alkaloid Constituents",
       "authors": "Khadilkar A et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37043739/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37043739/",
+      "journal": "J Nat Prod",
+      "doi": "10.1021/acs.jnatprod.3c00159",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/suma.json
+++ b/public/data/herbs-detail/suma.json
@@ -33,21 +33,34 @@
       "title": "SUMA",
       "authors": "Saad ZS et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/21945692/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/21945692/",
+      "journal": "Neuroimage",
+      "doi": "10.1016/j.neuroimage.2011.09.016",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37337697",
       "title": "Antiproliferative assay of suma or Brazilian ginseng (Hebanthe eriantha) methanolic extract on HCT116 and 4T1 cancer cell lines, in vitro toxicity on Artemia salina larvae, and antibacterial activity",
       "authors": "Rahamouz-Haghighi S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37337697/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37337697/",
+      "journal": "Nat Prod Res",
+      "doi": "10.1080/14786419.2023.2225688",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "10919969",
       "title": "Selected herbals and human exercise performance",
       "authors": "Bucci LR et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10919969/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10919969/",
+      "journal": "Am J Clin Nutr",
+      "doi": "10.1093/ajcn/72.2.624S",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/syzygium-aromaticum.json
+++ b/public/data/herbs-detail/syzygium-aromaticum.json
@@ -34,21 +34,36 @@
       "title": "Clove Essential Oil (Syzygium aromaticum L. Myrtaceae): Extraction, Chemical Composition, Food Applications, and Essential Bioactivity for Human Health",
       "authors": "Haro-González JN et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34770801/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34770801/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26216387",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32019140",
       "title": "Syzygium aromaticum L. (Myrtaceae): Traditional Uses, Bioactive Chemical Constituents, Pharmacological and Toxicological Activities",
       "authors": "Batiha GE et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32019140/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32019140/",
+      "journal": "Biomolecules",
+      "doi": "10.3390/biom10020202",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28346030",
       "title": "Antimicrobial activity of eugenol and essential oils containing eugenol: A mechanistic viewpoint",
       "authors": "Marchese A et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28346030/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28346030/",
+      "journal": "Crit Rev Microbiol",
+      "doi": "10.1080/1040841X.2017.1295225",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/tamarind.json
+++ b/public/data/herbs-detail/tamarind.json
@@ -32,21 +32,34 @@
       "title": "Oxidative stress, hormones, and effects of natural antioxidants on intestinal inflammation in inflammatory bowel disease",
       "authors": "Sahoo DK et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37701897/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37701897/",
+      "journal": "Front Endocrinol (Lausanne)",
+      "doi": "10.3389/fendo.2023.1217165",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33840996",
       "title": "Tamarind (Tamarindus indica L.) Seed a Candidate Protein Source with Potential for Combating SARS-CoV-2 Infection in Obesity",
       "authors": "Morais AHA et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33840996/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33840996/",
+      "journal": "Drug Target Insights",
+      "doi": "10.33393/dti.2021.2192",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31643417",
       "title": "Garcinia Cambogia",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31643417/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31643417/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/terminalia-arjuna.json
+++ b/public/data/herbs-detail/terminalia-arjuna.json
@@ -29,21 +29,34 @@
       "title": "Plants Used as Antihypertensive",
       "authors": "Verma T et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33174095/",
+      "journal": "Nat Prod Bioprospect",
+      "doi": "10.1007/s13659-020-00281-x",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36933876",
       "title": "Therapeutic potential and industrial applications of Terminalia arjuna bark",
       "authors": "Kumar V et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36933876/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36933876/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2023.116352",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "37814683",
       "title": "Antimicrobial and anti-inflammatory activity of Terminalia arjuna",
       "authors": "R V et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37814683/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37814683/",
+      "journal": "Bioinformation",
+      "doi": "10.6026/97320630019184",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/theobroma-cacao.json
+++ b/public/data/herbs-detail/theobroma-cacao.json
@@ -29,21 +29,34 @@
       "title": "Mediterranean diet: The role of long-chain ω-3 fatty acids in fish; polyphenols in fruits, vegetables, cereals, coffee, tea, cacao and wine; probiotics and vitamins in prevention of stroke, age-related cognitive decline, and Alzheimer disease",
       "authors": "Román GC et al.",
       "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31521398/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31521398/",
+      "journal": "Rev Neurol (Paris)",
+      "doi": "10.1016/j.neurol.2019.08.005",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29119920",
       "title": "Polyphenols: Inflammation",
       "authors": "Natsume M et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29119920/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29119920/",
+      "journal": "Curr Pharm Des",
+      "doi": "10.2174/1381612823666171109104141",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30372004",
       "title": "Chocolate",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30372004/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30372004/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/thunder-god-vine.json
+++ b/public/data/herbs-detail/thunder-god-vine.json
@@ -41,21 +41,32 @@
       "title": "Treatment of obesity with celastrol",
       "authors": "Liu J et al.",
       "year": 2015,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26000480/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26000480/",
+      "journal": "Cell",
+      "doi": "10.1016/j.cell.2015.05.011",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36732502",
       "title": "Celastrol suppresses colorectal cancer via covalent targeting peroxiredoxin 1",
       "authors": "Xu H et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36732502/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36732502/",
+      "journal": "Signal Transduct Target Ther",
+      "doi": "10.1038/s41392-022-01231-4",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32323812",
       "title": "Therapeutic targets of thunder god vine (Tripterygium wilfordii hook) in rheumatoid arthritis (Review)",
       "authors": "Song X et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32323812/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32323812/",
+      "journal": "Mol Med Rep",
+      "doi": "10.3892/mmr.2020.11052",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/thyme.json
+++ b/public/data/herbs-detail/thyme.json
@@ -34,21 +34,36 @@
       "title": "Antimicrobial Activity of Basil, Oregano, and Thyme Essential Oils",
       "authors": "Sakkas H et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27994215/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27994215/",
+      "journal": "J Microbiol Biotechnol",
+      "doi": "10.4014/jmb.1608.08024",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29785774",
       "title": "Thymol, thyme, and other plant sources: Health and potential uses",
       "authors": "Salehi B et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29785774/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29785774/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6109",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32917001",
       "title": "Thymol and Thyme Essential Oil-New Insights into Selected Therapeutic Applications",
       "authors": "Kowalczyk A et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32917001/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32917001/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules25184125",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/tongkat-ali.json
+++ b/public/data/herbs-detail/tongkat-ali.json
@@ -34,31 +34,48 @@
       "title": "Tongkat Ali",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39527684/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39527684/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36013514",
       "title": "Eurycoma longifolia (Jack) Improves Serum Total Testosterone in Men: A Systematic Review and Meta-Analysis of Clinical Trials",
       "authors": "Leisegang K et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36013514/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36013514/",
+      "journal": "Medicina (Kaunas)",
+      "doi": "10.3390/medicina58081047",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33541567",
       "title": "A 6-month, double-blind, placebo-controlled, randomized trial to evaluate the effect of Eurycoma longifolia (Tongkat Ali) and concurrent training on erectile function and testosterone levels in androgen deficiency of aging males (ADAM)",
       "authors": "Leitão AE et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33541567/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33541567/",
+      "journal": "Maturitas",
+      "doi": "10.1016/j.maturitas.2020.12.002",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_a2c634d38f77",
-      "title": "PubMed PMID 23754792. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Tongkat Ali as a potential herbal supplement for physically active male and female seniors--a pilot study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/23754792/",
       "pmid": "23754792",
       "authors": "PubMed",
       "citation": "PubMed PMID 23754792. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Phytother Res",
+      "year": 2014,
+      "doi": "10.1002/ptr.5017",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/tribulus-terrestris.json
+++ b/public/data/herbs-detail/tribulus-terrestris.json
@@ -25,13 +25,19 @@
   "sources": [
     {
       "id": "src_fc06f95d7d33",
-      "title": "PubMed PMID 17530942. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "The effect of five weeks of Tribulus terrestris supplementation on muscle strength and body composition during preseason training in elite rugby league players",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17530942/",
       "pmid": "17530942",
       "authors": "PubMed",
       "citation": "PubMed PMID 17530942. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "J Strength Cond Res",
+      "year": 2007,
+      "doi": "10.1519/R-18395.1",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/trigonella-foenum-graecum.json
+++ b/public/data/herbs-detail/trigonella-foenum-graecum.json
@@ -32,21 +32,34 @@
       "title": "Integration of molecular docking, molecular dynamics and network pharmacology to explore the multi-target pharmacology of fenugreek against diabetes",
       "authors": "Luo W et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37257051/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37257051/",
+      "journal": "J Cell Mol Med",
+      "doi": "10.1111/jcmm.17787",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32048383",
       "title": "Effect of fenugreek extract supplement on testosterone levels in male: A meta-analysis of clinical trials",
       "authors": "Mansoori A et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32048383/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32048383/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.6627",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33150931",
       "title": "Examining the Effects of Herbs on Testosterone Concentrations in Men: A Systematic Review",
       "authors": "Smith SJ et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33150931/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33150931/",
+      "journal": "Adv Nutr",
+      "doi": "10.1093/advances/nmaa134",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/tripterygium-wilfordii.json
+++ b/public/data/herbs-detail/tripterygium-wilfordii.json
@@ -41,21 +41,34 @@
       "title": "A comprehensive review on celastrol, triptolide and triptonide: Insights on their pharmacological activity, toxicity, combination therapy, new dosage form and novel drug delivery routes",
       "authors": "Song J et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37062220/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37062220/",
+      "journal": "Biomed Pharmacother",
+      "doi": "10.1016/j.biopha.2023.114705",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "39368758",
       "title": "Exploring the liver toxicity mechanism of Tripterygium wilfordii extract based on metabolomics, network pharmacological analysis and experimental validation",
       "authors": "Zhou GL et al.",
       "year": 2025,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39368758/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39368758/",
+      "journal": "J Ethnopharmacol",
+      "doi": "10.1016/j.jep.2024.118888",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38149060",
       "title": "Mechanistic engineering of celastrol liposomes induces ferroptosis and apoptosis by directly targeting VDAC2 in hepatocellular carcinoma",
       "authors": "Luo P et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38149060/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38149060/",
+      "journal": "Asian J Pharm Sci",
+      "doi": "10.1016/j.ajps.2023.100874",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/turkey-tail.json
+++ b/public/data/herbs-detail/turkey-tail.json
@@ -32,21 +32,34 @@
       "title": "Medicinal Mushrooms: Their Bioactive Components, Nutritional Value and Application in Functional Food Production-A Review",
       "authors": "Łysakowska P et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37513265/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37513265/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules28145393",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "36995535",
       "title": "Medicinal Mushroom Supplements in Cancer: A Systematic Review of Clinical Studies",
       "authors": "Narayanan S et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/36995535/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36995535/",
+      "journal": "Curr Oncol Rep",
+      "doi": "10.1007/s11912-023-01408-2",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "28267306",
       "title": "Medicinal Mushrooms (PDQ®): Patient Version",
       "authors": "PDQ Integrative, Alternative, and Complementary Therapies Editorial Board et al.",
       "year": 2002,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/28267306/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/28267306/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/turmeric.json
+++ b/public/data/herbs-detail/turmeric.json
@@ -37,31 +37,52 @@
       "title": "Curcumin, an active component of turmeric (Curcuma longa), and its effects on health",
       "authors": "Kocaadam B et al.",
       "year": 2017,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/26528921/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/26528921/",
+      "journal": "Crit Rev Food Sci Nutr",
+      "doi": "10.1080/10408398.2015.1077195",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "27213821",
       "title": "Effects of Turmeric (Curcuma longa) on Skin Health: A Systematic Review of the Clinical Evidence",
       "authors": "Vaughn AR et al.",
       "year": 2016,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/27213821/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/27213821/",
+      "journal": "Phytother Res",
+      "doi": "10.1002/ptr.5640",
+      "studyType": "Systematic review",
+      "studyClass": "systematic-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "38558676",
       "title": "Ayurvedic Herbal Medicines: A Literature Review of Their Applications in Female Reproductive Health",
       "authors": "Patibandla S et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38558676/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38558676/",
+      "journal": "Cureus",
+      "doi": "10.7759/cureus.55240",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_90b27b328f33",
-      "title": "PubMed PMID 24672232. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Efficacy and safety of Curcuma domestica extracts compared with ibuprofen in patients with knee osteoarthritis: a multicenter study",
       "url": "https://pubmed.ncbi.nlm.nih.gov/24672232/",
       "pmid": "24672232",
       "authors": "PubMed",
       "citation": "PubMed PMID 24672232. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Clin Interv Aging",
+      "year": 2014,
+      "doi": "10.2147/CIA.S58535",
+      "studyType": "Randomized controlled trial",
+      "studyClass": "rct",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/tyrosine.json
+++ b/public/data/herbs-detail/tyrosine.json
@@ -32,31 +32,48 @@
       "title": "The shikimate pathway and aromatic amino Acid biosynthesis in plants",
       "authors": "Maeda H et al.",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/22554242/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/22554242/",
+      "journal": "Annu Rev Plant Biol",
+      "doi": "10.1146/annurev-arplant-042811-105439",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000526",
       "title": "Interferon Alfacon-1",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000526/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000526/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "12482446",
       "title": "Rosmarinic acid",
       "authors": "Petersen M et al.",
       "year": 2003,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/12482446/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/12482446/",
+      "journal": "Phytochemistry",
+      "doi": "10.1016/s0031-9422(02)00513-7",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_a3adb67a41f3",
-      "title": "PubMed PMID 8629725. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Tracking community sentinel events: breast cancer mortality and neighborhood risk for advanced-stage tumors in Denver",
       "url": "https://pubmed.ncbi.nlm.nih.gov/8629725/",
       "pmid": "8629725",
       "authors": "PubMed",
       "citation": "PubMed PMID 8629725. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Public Health",
+      "year": 1996,
+      "doi": "10.2105/ajph.86.5.717",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/valerian.json
+++ b/public/data/herbs-detail/valerian.json
@@ -32,31 +32,52 @@
       "title": "Valerian Root in Treating Sleep Problems and Associated Disorders-A Systematic Review and Meta-Analysis",
       "authors": "Shinjyo N et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33086877/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33086877/",
+      "journal": "J Evid Based Integr Med",
+      "doi": "10.1177/2515690X20967323",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34946512",
       "title": "Herbal Products Used in Menopause and for Gynecological Disorders",
       "authors": "Kenda M et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26247421",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33480339",
       "title": "Anti-anxiety Properties of Selected Medicinal Plants",
       "authors": "Khan A et al.",
       "year": 2022,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33480339/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33480339/",
+      "journal": "Curr Pharm Biotechnol",
+      "doi": "10.2174/1389201022666210122125131",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_63fe90f947a8",
-      "title": "PubMed PMID 17145239. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
+      "title": "Valerian for sleep: a systematic review and meta-analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/17145239/",
       "pmid": "17145239",
       "authors": "PubMed",
       "citation": "PubMed PMID 17145239. Minimal citation row added from existing workbook PMID; title/year/journal still require PubMed metadata extraction.",
       "note": "evidence citation lookup; PMID source present in Evidence_Register",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "journal": "Am J Med",
+      "year": 2006,
+      "doi": "10.1016/j.amjmed.2006.02.026",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_911a7102c58d",

--- a/public/data/herbs-detail/valeriana-officinalis.json
+++ b/public/data/herbs-detail/valeriana-officinalis.json
@@ -34,21 +34,36 @@
       "title": "Valerian Root in Treating Sleep Problems and Associated Disorders-A Systematic Review and Meta-Analysis",
       "authors": "Shinjyo N et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33086877/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33086877/",
+      "journal": "J Evid Based Integr Med",
+      "doi": "10.1177/2515690X20967323",
+      "studyType": "Meta-analysis",
+      "studyClass": "meta-analysis",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30058034",
       "title": "Insomnia in Elderly Patients: Recommendations for Pharmacological Management",
       "authors": "Abad VC et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30058034/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30058034/",
+      "journal": "Drugs Aging",
+      "doi": "10.1007/s40266-018-0569-8",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "34946512",
       "title": "Herbal Products Used in Menopause and for Gynecological Disorders",
       "authors": "Kenda M et al.",
       "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34946512/",
+      "journal": "Molecules",
+      "doi": "10.3390/molecules26247421",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "id": "src_1bcdfb0b0168",

--- a/public/data/herbs-detail/verbena-officinalis.json
+++ b/public/data/herbs-detail/verbena-officinalis.json
@@ -32,21 +32,34 @@
       "title": "Plant Extracts as Skin Care and Therapeutic Agents",
       "authors": "Michalak M et al.",
       "year": 2023,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/37895122/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37895122/",
+      "journal": "Int J Mol Sci",
+      "doi": "10.3390/ijms242015444",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30000912",
       "title": "Vervain",
       "authors": "PubMed indexed authors",
       "year": 2006,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30000912/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30000912/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "32937665",
       "title": "Verbena officinalis (Common Vervain) - A Review on the Investigations of This Medicinally Important Plant Species",
       "authors": "Kubica P et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/32937665/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32937665/",
+      "journal": "Planta Med",
+      "doi": "10.1055/a-1232-5758",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/vitis-vinifera.json
+++ b/public/data/herbs-detail/vitis-vinifera.json
@@ -32,21 +32,36 @@
       "title": "Phytotherapy in periodontics as an effective and sustainable supplemental treatment: a narrative review",
       "authors": "Gawish AS et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/38290997/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38290997/",
+      "journal": "J Periodontal Implant Sci",
+      "doi": "10.5051/jpis.2301420071",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "29232282",
       "title": "Selected Food/Herb-Drug Interactions: Mechanisms and Clinical Relevance",
       "authors": "Amadi CN et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29232282/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29232282/",
+      "journal": "Am J Ther",
+      "doi": "10.1097/MJT.0000000000000705",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "33171832",
       "title": "Grape Pomace Valorization: A Systematic Review and Meta-Analysis",
       "authors": "Antonić B et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/33171832/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/33171832/",
+      "journal": "Foods",
+      "doi": "10.3390/foods9111627",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/white-peony.json
+++ b/public/data/herbs-detail/white-peony.json
@@ -32,21 +32,32 @@
       "title": "Composite microneedles loaded with Astragalus membranaceus polysaccharide nanoparticles promote wound healing by curbing the ROS/NF-κB pathway to regulate macrophage polarization",
       "authors": "Liu X et al.",
       "year": 2024,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/39227108/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39227108/",
+      "journal": "Carbohydr Polym",
+      "doi": "10.1016/j.carbpol.2024.122574",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "30144752",
       "title": "Advancement in the chemical analysis of Paeoniae Radix (Shaoyao)",
       "authors": "Yan B et al.",
       "year": 2018,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30144752/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/30144752/",
+      "journal": "J Pharm Biomed Anal",
+      "doi": "10.1016/j.jpba.2018.08.009",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "42196951",
       "title": "Characterization of Isoorientin and Paeoniflorin as Botanical Glucocorticoid Receptor Modulators from White Peony and Chasteberry",
       "authors": "Bashatwah RM et al.",
       "year": 2026,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/42196951/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/42196951/",
+      "journal": "Nutrients",
+      "doi": "10.3390/nu18101491",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/yohimbe.json
+++ b/public/data/herbs-detail/yohimbe.json
@@ -42,21 +42,34 @@
       "title": "Herb-drug interactions",
       "authors": "Fugh-Berman A et al.",
       "year": 2000,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/10675182/",
+      "journal": "Lancet",
+      "doi": "10.1016/S0140-6736(99)06457-0",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31644013",
       "title": "Yohimbine",
       "authors": "PubMed indexed authors",
       "year": 2012,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31644013/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31644013/",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     },
     {
       "pubmedId": "31447414",
       "title": "Sexual Performance Anxiety",
       "authors": "Pyke RE et al.",
       "year": 2020,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/31447414/"
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31447414/",
+      "journal": "Sex Med Rev",
+      "doi": "10.1016/j.sxmr.2019.07.001",
+      "studyType": "Narrative review",
+      "studyClass": "narrative-review",
+      "metadataSource": "pubmed"
     }
   ],
   "governance": {

--- a/scripts/data/apply-pubmed-metadata.ts
+++ b/scripts/data/apply-pubmed-metadata.ts
@@ -1,0 +1,151 @@
+/**
+ * Write fetched PubMed metadata into the cited sources.
+ *
+ * Everything applied here comes from the esummary response for that exact
+ * PMID, cached by `fetch-pubmed-metadata.mjs`. Nothing is inferred: a field is
+ * filled only when PubMed supplied a value, and each touched source records
+ * `metadataSource: 'pubmed'` so the provenance of every value stays visible.
+ *
+ * Existing curated values win. The only case where an existing value is
+ * replaced is a placeholder title — "PubMed PMID 37818728. Minimal citation row
+ * added from existing evidence." is a note about missing metadata, not a study
+ * title, and PubMed has the real one.
+ *
+ * PubMed's own publication types are the authoritative study design, so they
+ * also populate `studyType` through the canonical study-class taxonomy. That
+ * replaces design strings that were previously guessed from the title.
+ *
+ * Usage: tsx scripts/data/apply-pubmed-metadata.ts [--dry-run]
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { isPlaceholderCitationTitle, normalizeDoi } from '../../lib/citation-identifiers.mjs'
+import { STUDY_CLASS_INFO, normalizeStudyClass, strongestStudyClass, type StudyClass } from '../../lib/study-class'
+
+const ROOT = process.cwd()
+const DATA_DIR = path.join(ROOT, 'public', 'data')
+const CACHE_PATH = path.join(ROOT, 'ops', 'cache', 'pubmed-metadata.json')
+const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'pubmed-metadata-applied.json')
+const DRY_RUN = process.argv.includes('--dry-run')
+
+type PubmedRecord = {
+  pmid: string
+  title: string
+  authors: string
+  journal: string
+  year: number | null
+  doi: string
+  publicationTypes: string[]
+}
+
+const text = (value: unknown) => String(value ?? '').trim()
+
+/**
+ * PubMed tags nearly every record "Journal Article", which says nothing about
+ * design. The specific tags alongside it are what carry the information, so the
+ * strongest recognised class across all tags wins.
+ */
+function studyClassFromPublicationTypes(types: readonly string[]): StudyClass {
+  const classes = types
+    .filter((type) => !/^journal article$/i.test(type))
+    .map((type) => normalizeStudyClass(type))
+    .filter((studyClass) => studyClass !== 'unclassified')
+  return strongestStudyClass(classes)
+}
+
+function main() {
+  if (!existsSync(CACHE_PATH)) {
+    console.error('[pubmed-apply] No cache. Run: node scripts/data/fetch-pubmed-metadata.mjs')
+    process.exit(1)
+  }
+
+  const cache = JSON.parse(readFileSync(CACHE_PATH, 'utf8'))
+  const records: Record<string, PubmedRecord> = cache.records ?? {}
+
+  const filled: Record<string, number> = {}
+  const touchedFiles: string[] = []
+  const unresolved: { slug: string; pmid: string; title: string }[] = []
+  let sourcesTouched = 0
+
+  for (const dir of ['herbs-detail', 'compounds-detail']) {
+    const full = path.join(DATA_DIR, dir)
+    if (!existsSync(full)) continue
+
+    for (const file of readdirSync(full)) {
+      if (!file.endsWith('.json')) continue
+      const filePath = path.join(full, file)
+      const record = JSON.parse(readFileSync(filePath, 'utf8'))
+      const sources = Array.isArray(record.sources) ? record.sources : []
+      if (!sources.length) continue
+
+      let touched = false
+      const next = sources.map((source: Record<string, unknown>) => {
+        const pmid = text(source.pmid ?? source.pubmedId)
+        if (!pmid) return source
+
+        const meta = records[pmid]
+        if (!meta) {
+          unresolved.push({ slug: String(record.slug ?? file), pmid, title: text(source.title).slice(0, 80) })
+          return source
+        }
+
+        const updated = { ...source }
+        const fill = (key: string, value: string | number) => {
+          updated[key] = value
+          filled[key] = (filled[key] ?? 0) + 1
+          touched = true
+        }
+
+        if (meta.journal && !text(source.journal)) fill('journal', meta.journal)
+        if (meta.year && !text(source.year)) fill('year', meta.year)
+        if (meta.authors && !text(source.authors ?? source.author_or_label)) fill('authors', meta.authors)
+        if (meta.doi && !normalizeDoi(source.doi)) fill('doi', meta.doi)
+        // A placeholder title is a note about absent metadata, so PubMed's
+        // title is strictly better. A curated title is left alone.
+        if (meta.title && isPlaceholderCitationTitle(source.title)) fill('title', meta.title)
+
+        const studyClass = studyClassFromPublicationTypes(meta.publicationTypes)
+        if (studyClass !== 'unclassified' && text(source.studyType) !== STUDY_CLASS_INFO[studyClass].label) {
+          fill('studyType', STUDY_CLASS_INFO[studyClass].label)
+          updated.studyClass = studyClass
+        }
+
+        if (touched && updated !== source) updated.metadataSource = 'pubmed'
+        return updated
+      })
+
+      if (!touched) continue
+      sourcesTouched += next.filter((s: Record<string, unknown>) => s.metadataSource === 'pubmed').length
+      touchedFiles.push(`${dir}/${file}`)
+      if (!DRY_RUN) {
+        record.sources = next
+        writeFileSync(filePath, `${JSON.stringify(record, null, 2)}\n`)
+      }
+    }
+  }
+
+  if (!DRY_RUN) {
+    writeFileSync(
+      REPORT_PATH,
+      `${JSON.stringify({ generatedAt: new Date().toISOString(), filled, filesTouched: touchedFiles.length, sourcesTouched, unresolved }, null, 2)}\n`,
+    )
+  }
+
+  console.log(`\nPubMed metadata applied${DRY_RUN ? ' (dry run)' : ''}`)
+  console.log('='.repeat(66))
+  console.log(`Files touched     ${touchedFiles.length}`)
+  console.log(`Sources enriched  ${sourcesTouched}`)
+  for (const [field, count] of Object.entries(filled).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(count).padStart(5)}  ${field}`)
+  }
+  if (unresolved.length) {
+    console.log(`\nCitations whose PMID PubMed does not recognise: ${unresolved.length}`)
+    for (const item of unresolved.slice(0, 10)) {
+      console.log(`  ${item.slug} · PMID ${item.pmid} · ${item.title}`)
+    }
+  }
+}
+
+main()

--- a/scripts/data/fetch-pubmed-metadata.mjs
+++ b/scripts/data/fetch-pubmed-metadata.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Fetch real bibliographic metadata for every cited PMID from PubMed.
+ *
+ * 987 of 1070 citations carry no journal, 194 no year, 93 no authors, and 157
+ * have a placeholder where the study title should be. All of that is public
+ * record — it just was never retrieved. This asks NCBI E-utilities for it.
+ *
+ * Nothing here is invented: every field written comes from the esummary
+ * response for that exact PMID, and a PMID that PubMed does not recognise is
+ * recorded as a failure rather than filled in with a guess.
+ *
+ * Results are cached in `ops/cache/pubmed-metadata.json`, so reruns are free
+ * and the merge step can be re-applied without hitting the network.
+ *
+ * Usage:
+ *   node scripts/data/fetch-pubmed-metadata.mjs [--limit=N] [--refresh]
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const DATA_DIR = path.join(ROOT, 'public', 'data')
+const CACHE_PATH = path.join(ROOT, 'ops', 'cache', 'pubmed-metadata.json')
+
+const ENDPOINT = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi'
+/** NCBI allows 3 requests/second without an API key; stay well inside that. */
+const REQUEST_SPACING_MS = 400
+const BATCH_SIZE = 150
+
+const args = process.argv.slice(2)
+const limitArg = args.find((a) => a.startsWith('--limit='))
+const LIMIT = limitArg ? Number(limitArg.split('=')[1]) : Infinity
+const REFRESH = args.includes('--refresh')
+
+const PMID_PATTERN = /^[1-9]\d{0,8}$/
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function collectPmids() {
+  const ids = new Set()
+  for (const dir of ['herbs-detail', 'compounds-detail']) {
+    const full = path.join(DATA_DIR, dir)
+    if (!fs.existsSync(full)) continue
+    for (const file of fs.readdirSync(full)) {
+      if (!file.endsWith('.json')) continue
+      const record = JSON.parse(fs.readFileSync(path.join(full, file), 'utf8'))
+      for (const source of Array.isArray(record.sources) ? record.sources : []) {
+        const pmid = String(source.pmid ?? source.pubmedId ?? '').trim()
+        if (PMID_PATTERN.test(pmid)) ids.add(pmid)
+      }
+    }
+  }
+  return [...ids].sort()
+}
+
+function readCache() {
+  if (REFRESH || !fs.existsSync(CACHE_PATH)) return {}
+  try {
+    const parsed = JSON.parse(fs.readFileSync(CACHE_PATH, 'utf8'))
+    return parsed && typeof parsed === 'object' ? parsed.records ?? {} : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Year of publication, from the most specific date PubMed supplies. */
+function extractYear(entry) {
+  const raw = String(entry.sortpubdate || entry.pubdate || entry.epubdate || '')
+  const match = raw.match(/\b(1[89]\d{2}|20\d{2})\b/)
+  return match ? Number(match[1]) : null
+}
+
+function extractDoi(entry) {
+  const ids = Array.isArray(entry.articleids) ? entry.articleids : []
+  const doi = ids.find((id) => id.idtype === 'doi')
+  return doi ? String(doi.value).trim() : ''
+}
+
+/** "Cheah KL et al." — the form already used elsewhere in the dataset. */
+function formatAuthors(entry) {
+  const authors = Array.isArray(entry.authors)
+    ? entry.authors.filter((a) => a.authtype === 'Author').map((a) => String(a.name).trim()).filter(Boolean)
+    : []
+  if (!authors.length) return ''
+  if (authors.length === 1) return authors[0]
+  if (authors.length === 2) return `${authors[0]} and ${authors[1]}`
+  return `${authors[0]} et al.`
+}
+
+function normalizeEntry(pmid, entry) {
+  return {
+    pmid,
+    title: String(entry.title ?? '').replace(/\s+/g, ' ').replace(/\.$/, '').trim(),
+    authors: formatAuthors(entry),
+    authorCount: Array.isArray(entry.authors) ? entry.authors.filter((a) => a.authtype === 'Author').length : 0,
+    journal: String(entry.source ?? '').trim(),
+    year: extractYear(entry),
+    volume: String(entry.volume ?? '').trim(),
+    pages: String(entry.pages ?? '').trim(),
+    doi: extractDoi(entry),
+    /** PubMed's own publication types — the authoritative study design. */
+    publicationTypes: Array.isArray(entry.pubtype) ? entry.pubtype.map(String) : [],
+    fetchedFrom: 'pubmed-esummary',
+  }
+}
+
+async function fetchBatch(pmids) {
+  const url = `${ENDPOINT}?db=pubmed&retmode=json&id=${pmids.join(',')}`
+  const response = await fetch(url, { headers: { 'User-Agent': 'thehippiescientist.net citation verification' } })
+  if (!response.ok) throw new Error(`PubMed responded ${response.status}`)
+  const payload = await response.json()
+  const result = payload?.result
+  if (!result) throw new Error('PubMed returned no result block')
+
+  const out = {}
+  const failures = []
+  for (const pmid of pmids) {
+    const entry = result[pmid]
+    // PubMed reports an unknown id with an `error` key rather than omitting it.
+    if (!entry || entry.error) {
+      failures.push({ pmid, reason: entry?.error ? String(entry.error) : 'not-returned' })
+      continue
+    }
+    out[pmid] = normalizeEntry(pmid, entry)
+  }
+  return { out, failures }
+}
+
+async function main() {
+  const allPmids = collectPmids()
+  const cache = readCache()
+  const pending = allPmids.filter((pmid) => !cache[pmid]).slice(0, LIMIT)
+
+  console.log(`\nPubMed metadata fetch`)
+  console.log('='.repeat(66))
+  console.log(`Cited PMIDs      ${allPmids.length}`)
+  console.log(`Already cached   ${allPmids.length - allPmids.filter((p) => !cache[p]).length}`)
+  console.log(`To fetch         ${pending.length}`)
+
+  const failures = []
+  for (let index = 0; index < pending.length; index += BATCH_SIZE) {
+    const batch = pending.slice(index, index + BATCH_SIZE)
+    process.stdout.write(`  batch ${Math.floor(index / BATCH_SIZE) + 1}: ${batch.length} ids … `)
+    try {
+      const { out, failures: batchFailures } = await fetchBatch(batch)
+      Object.assign(cache, out)
+      failures.push(...batchFailures)
+      console.log(`${Object.keys(out).length} resolved, ${batchFailures.length} unresolved`)
+    } catch (error) {
+      console.log(`FAILED (${error.message})`)
+      failures.push(...batch.map((pmid) => ({ pmid, reason: error.message })))
+    }
+    if (index + BATCH_SIZE < pending.length) await sleep(REQUEST_SPACING_MS)
+  }
+
+  fs.mkdirSync(path.dirname(CACHE_PATH), { recursive: true })
+  fs.writeFileSync(
+    CACHE_PATH,
+    `${JSON.stringify({ fetchedAt: new Date().toISOString(), count: Object.keys(cache).length, failures, records: cache }, null, 2)}\n`,
+  )
+
+  const resolved = allPmids.filter((pmid) => cache[pmid])
+  console.log(`\nResolved         ${resolved.length} / ${allPmids.length}`)
+  console.log(`Unresolved       ${allPmids.length - resolved.length}`)
+  console.log(`  with journal   ${resolved.filter((p) => cache[p].journal).length}`)
+  console.log(`  with year      ${resolved.filter((p) => cache[p].year).length}`)
+  console.log(`  with authors   ${resolved.filter((p) => cache[p].authors).length}`)
+  console.log(`  with DOI       ${resolved.filter((p) => cache[p].doi).length}`)
+  console.log(`\nCache: ${path.relative(ROOT, CACHE_PATH)}`)
+}
+
+main().catch((error) => {
+  console.error(`[pubmed-metadata] ${error.message}`)
+  process.exit(1)
+})


### PR DESCRIPTION
## What was missing

**987 of 1070 citations had no journal, 194 no year, 93 no authors**, and 157 carried a placeholder where the study title belongs:

> `"PubMed PMID 37818728. Minimal citation row added from existing evidence."`

All of it is public record that was simply never retrieved.

## What this does

`fetch-pubmed-metadata.mjs` asks NCBI E-utilities for all **837 cited PMIDs** and caches the result. `apply-pubmed-metadata.ts` writes it into the sources. **836 of 837 resolved.**

**943 citations across 375 profiles now carry real bibliographic data:**

| | before | after |
|---|---:|---:|
| missing journal | 987 | **122** |
| missing year | 194 | **41** |
| missing authors | 93 | **70** |
| placeholder title | 157 | **1** |

## Nothing is inferred

- A field is filled **only** where PubMed supplied a value
- Existing curated values win
- Every touched source records `metadataSource: 'pubmed'` so provenance stays visible
- The one case where an existing value is replaced is a **placeholder title** — a note about absent metadata, not a title

PubMed's own publication types now drive `studyType` through the canonical study-class taxonomy from #3180, replacing **681 design labels that were previously guessed from the title**. `"Journal Article"` is ignored because PubMed tags nearly everything with it; the specific tags alongside it carry the information.

## A real finding

**PMID 17127598, cited by `/compounds/policosanol`, does not resolve** — `"cannot get document summary"` from both esummary and efetch. That citation points at a study PubMed does not have, and its title already admitted the metadata was never retrieved. Left in place and reported rather than deleted, since removing a citation changes what a claim rests on.

## Verification

Checked applied values against the live PubMed record field for field:

```
cinnamon-extract PMID 37818728
  applied: "The effect of cinnamon supplementation on glycemic control in patients with
            type 2 diabetes mellitus: An updated systematic review and dose-response
            meta-analysis of randomized controlled trials"
           Phytother Res | 2024 | Meta-analysis
  PubMed:  same title | Phytother Res | 2024 Jan | Systematic Review, Meta-Analysis
```

- `tsc --noEmit` — 45 errors, same as main
- Full suite — 38 failing files vs 39 baseline; only delta reproduces on main
- `eslint` clean
- `validate:citation-identifiers` — 1070 scanned, **0 blocking**

Cache is committed so the merge can be re-applied without re-hitting the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q6dk9xa1jngoNqWPmXNsR