### PR TITLE
fix(ci): preserve merge base during release classification

### DIFF
--- a/.github/workflows/atomic-upgrade-gate.yml
+++ b/.github/workflows/atomic-upgrade-gate.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF"
           changed="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
           printf '%s\n' "$changed"
           printf '%s\n' "$changed" | node scripts/ci/classify-release-impact.mjs --github-output="$GITHUB_OUTPUT"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF"
           changed="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
           printf '%s\n' "$changed"
           printf '%s\n' "$changed" | node scripts/ci/classify-release-impact.mjs --github-output="$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #3276

## Relevant URLs
- `.github/workflows/check.yml`
- `.github/workflows/atomic-upgrade-gate.yml`
- Failed Site Health run: PR #3275

## Acceptance criteria
- Site Health release-impact classification retains a valid merge base when `main` advances during a PR run.
- Atomic release-impact classification retains a valid merge base under the same condition.
- Existing release-sensitive path classification remains unchanged.
- No application/runtime behavior changes.

## Validation commands
- `git fetch origin "$BASE_REF"`
- `git diff --name-only "origin/$BASE_REF"...HEAD`
- Existing `node scripts/ci/classify-release-impact.mjs --github-output="$GITHUB_OUTPUT"`
- GitHub Actions: Site Health Check and Atomic upgrade gate

## Before → after metrics
- Before: 2 workflow locations re-shallowed the base ref with `--depth=1`; observed `fatal: origin/main...HEAD: no merge base` in Site Health.
- After: 0 release-impact workflow locations re-shallow the base ref; both preserve the full-history checkout ancestry.

## Generator/source-of-truth decision
- No generator or generated artifact changes. The GitHub workflow YAML files are the source of truth for CI classification behavior.

## Regression contract
- Do not weaken or bypass release-impact classification.
- Do not change which paths are considered release-sensitive.
- Do not alter application, content, schema, or runtime behavior.
- The existing three-dot diff against `origin/$BASE_REF` must remain authoritative.