### PR TITLE
Backlog 16-18: recover 17 missing PubMed identifiers and merge duplicate studies

### DIFF
--- a/ops/cache/pubmed-metadata.json
+++ b/ops/cache/pubmed-metadata.json
@@ -1,6 +1,6 @@
 {
-  "fetchedAt": "2026-08-16T00:50:31.246Z",
-  "count": 836,
+  "fetchedAt": "2026-08-16T01:10:16.579Z",
+  "count": 849,
   "failures": [
     {
       "pmid": "17127598",
@@ -5763,6 +5763,24 @@
       ],
       "fetchedFrom": "pubmed-esummary"
     },
+    "31413233": {
+      "pmid": "31413233",
+      "title": "Improvement of cognitive functions by oral intake of Hericium erinaceus",
+      "authors": "Saitsu Y et al.",
+      "authorCount": 5,
+      "journal": "Biomed Res",
+      "year": 2019,
+      "volume": "40",
+      "pages": "125-131",
+      "doi": "10.2220/biomedres.40.125",
+      "publicationTypes": [
+        "Comparative Study",
+        "Journal Article",
+        "Multicenter Study",
+        "Randomized Controlled Trial"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
     "31431019": {
       "pmid": "31431019",
       "title": "Schisandra chinensis and its phytotherapeutical applications",
@@ -6404,6 +6422,22 @@
       "publicationTypes": [
         "Journal Article",
         "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "32093203": {
+      "pmid": "32093203",
+      "title": "A Systematic Review of the Effect of Dietary Supplements on Cognitive Performance in Healthy Young Adults and Military Personnel",
+      "authors": "Pomeroy DE et al.",
+      "authorCount": 5,
+      "journal": "Nutrients",
+      "year": 2020,
+      "volume": "12",
+      "pages": "",
+      "doi": "10.3390/nu12020545",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
       ],
       "fetchedFrom": "pubmed-esummary"
     },
@@ -7659,6 +7693,21 @@
       ],
       "fetchedFrom": "pubmed-esummary"
     },
+    "34371974": {
+      "pmid": "34371974",
+      "title": "Estimation of Dietary Capsaicinoid Exposure in Korea and Assessment of Its Health Effects",
+      "authors": "Kwon Y",
+      "authorCount": 1,
+      "journal": "Nutrients",
+      "year": 2021,
+      "volume": "13",
+      "pages": "",
+      "doi": "10.3390/nu13072461",
+      "publicationTypes": [
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
     "34376917": {
       "pmid": "34376917",
       "title": "Effects of anthocyanin, astaxanthin, and lutein on eye functions: a randomized, double-blind, placebo-controlled study",
@@ -8105,6 +8154,23 @@
       "publicationTypes": [
         "Journal Article",
         "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "34923676": {
+      "pmid": "34923676",
+      "title": "Safety of higher doses of melatonin in adults: A systematic review and meta-analysis",
+      "authors": "Menczel Schrire Z et al.",
+      "authorCount": 15,
+      "journal": "J Pineal Res",
+      "year": 2022,
+      "volume": "72",
+      "pages": "e12782",
+      "doi": "10.1111/jpi.12782",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
       ],
       "fetchedFrom": "pubmed-esummary"
     },
@@ -9018,6 +9084,23 @@
       ],
       "fetchedFrom": "pubmed-esummary"
     },
+    "36111960": {
+      "pmid": "36111960",
+      "title": "Spicy Food and Chili Peppers and Multiple Health Outcomes: Umbrella Review",
+      "authors": "Ao Z et al.",
+      "authorCount": 3,
+      "journal": "Mol Nutr Food Res",
+      "year": 2022,
+      "volume": "66",
+      "pages": "e2200167",
+      "doi": "10.1002/mnfr.202200167",
+      "publicationTypes": [
+        "Journal Article",
+        "Research Support, Non-U.S. Gov't",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
     "36134975": {
       "pmid": "36134975",
       "title": "Japanese Knotweed Rhizome Bark Extract Inhibits Live SARS-CoV-2 In Vitro",
@@ -9414,6 +9497,22 @@
       ],
       "fetchedFrom": "pubmed-esummary"
     },
+    "36717399": {
+      "pmid": "36717399",
+      "title": "Efficacy of Silexan in patients with anxiety disorders: a meta-analysis of randomized, placebo-controlled trials",
+      "authors": "Dold M et al.",
+      "authorCount": 7,
+      "journal": "Eur Arch Psychiatry Clin Neurosci",
+      "year": 2023,
+      "volume": "273",
+      "pages": "1615-1628",
+      "doi": "10.1007/s00406-022-01547-w",
+      "publicationTypes": [
+        "Meta-Analysis",
+        "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
     "36732502": {
       "pmid": "36732502",
       "title": "Celastrol suppresses colorectal cancer via covalent targeting peroxiredoxin 1",
@@ -9714,6 +9813,23 @@
       "publicationTypes": [
         "Journal Article",
         "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "37052237": {
+      "pmid": "37052237",
+      "title": "Neuroprotective, neurogenic, and anticholinergic evidence of Ganoderma lucidum cognitive effects: Crucial knowledge is still lacking",
+      "authors": "Luz DA et al.",
+      "authorCount": 4,
+      "journal": "Med Res Rev",
+      "year": 2023,
+      "volume": "43",
+      "pages": "1504-1536",
+      "doi": "10.1002/med.21957",
+      "publicationTypes": [
+        "Journal Article",
+        "Review",
+        "Research Support, Non-U.S. Gov't"
       ],
       "fetchedFrom": "pubmed-esummary"
     },
@@ -11455,6 +11571,22 @@
       ],
       "fetchedFrom": "pubmed-esummary"
     },
+    "38784853": {
+      "pmid": "38784853",
+      "title": "The Effect of Oral Chamomile on Anxiety: A Systematic Review of Clinical Trials",
+      "authors": "Saadatmand S et al.",
+      "authorCount": 3,
+      "journal": "Clin Nutr Res",
+      "year": 2024,
+      "volume": "13",
+      "pages": "139-147",
+      "doi": "10.7762/cnr.2024.13.2.139",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
     "38797379": {
       "pmid": "38797379",
       "title": "Beneficial effects of oxymatrine from Sophora flavescens on alleviating Ulcerative colitis by improving inflammation and ferroptosis",
@@ -11480,6 +11612,22 @@
       "volume": "15",
       "pages": "144-161",
       "doi": "10.1080/21501203.2023.2260408",
+      "publicationTypes": [
+        "Journal Article",
+        "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38817505": {
+      "pmid": "38817505",
+      "title": "Examining the Effects of Supplemental Magnesium on Self-Reported Anxiety and Sleep Quality: A Systematic Review",
+      "authors": "Rawji A et al.",
+      "authorCount": 7,
+      "journal": "Cureus",
+      "year": 2024,
+      "volume": "16",
+      "pages": "e59317",
+      "doi": "10.7759/cureus.59317",
       "publicationTypes": [
         "Journal Article",
         "Review"
@@ -11515,6 +11663,23 @@
       "publicationTypes": [
         "Journal Article",
         "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "38888087": {
+      "pmid": "38888087",
+      "title": "Optimizing the Time and Dose of Melatonin as a Sleep-Promoting Drug: A Systematic Review of Randomized Controlled Trials and Dose-Response Meta-Analysis",
+      "authors": "Cruz-Sanabria F et al.",
+      "authorCount": 7,
+      "journal": "J Pineal Res",
+      "year": 2024,
+      "volume": "76",
+      "pages": "e12985",
+      "doi": "10.1111/jpi.12985",
+      "publicationTypes": [
+        "Systematic Review",
+        "Journal Article",
+        "Meta-Analysis"
       ],
       "fetchedFrom": "pubmed-esummary"
     },
@@ -11684,6 +11849,22 @@
       "doi": "10.1016/j.phymed.2024.155909",
       "publicationTypes": [
         "Journal Article"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39070254": {
+      "pmid": "39070254",
+      "title": "The effects of creatine supplementation on cognitive function in adults: a systematic review and meta-analysis",
+      "authors": "Xu C et al.",
+      "authorCount": 4,
+      "journal": "Front Nutr",
+      "year": 2024,
+      "volume": "11",
+      "pages": "1424972",
+      "doi": "10.3389/fnut.2024.1424972",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review"
       ],
       "fetchedFrom": "pubmed-esummary"
     },
@@ -12159,6 +12340,23 @@
       ],
       "fetchedFrom": "pubmed-esummary"
     },
+    "39474788": {
+      "pmid": "39474788",
+      "title": "Effects of Ginseng on Cognitive Function: A Systematic Review and Meta-Analysis",
+      "authors": "Zeng M et al.",
+      "authorCount": 7,
+      "journal": "Phytother Res",
+      "year": 2024,
+      "volume": "38",
+      "pages": "6023-6034",
+      "doi": "10.1002/ptr.8359",
+      "publicationTypes": [
+        "Journal Article",
+        "Meta-Analysis",
+        "Systematic Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
     "39476924": {
       "pmid": "39476924",
       "title": "Advances in the study of polysaccharides from Anemarrhena asphodeloides Bge.: A review",
@@ -12282,6 +12480,23 @@
       "publicationTypes": [
         "Journal Article",
         "Review"
+      ],
+      "fetchedFrom": "pubmed-esummary"
+    },
+    "39552387": {
+      "pmid": "39552387",
+      "title": "The effect of vitamin D supplementation on depression: a systematic review and dose-response meta-analysis of randomized controlled trials",
+      "authors": "Ghaemi S et al.",
+      "authorCount": 4,
+      "journal": "Psychol Med",
+      "year": 2024,
+      "volume": "54",
+      "pages": "3999-4008",
+      "doi": "10.1017/S0033291724001697",
+      "publicationTypes": [
+        "Journal Article",
+        "Systematic Review",
+        "Meta-Analysis"
       ],
       "fetchedFrom": "pubmed-esummary"
     },

--- a/public/data/compounds-detail/creatine.json
+++ b/public/data/compounds-detail/creatine.json
@@ -212,14 +212,18 @@
     {
       "id": "src_da5119881f63",
       "title": "The effects of creatine supplementation on cognitive function in adults: a systematic review and meta-analysis",
-      "url": "https://consensus.app/papers/the-effects-of-creatine-supplementation-on-cognitive-xu-bi/54813b2512da51388b5b582d3efdfa9d/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39070254/",
       "year": "2024",
       "authors": "Xu et al.",
       "journal": "Frontiers in Nutrition",
       "citation": "Sixteen RCTs; creatine monohydrate; memory evidence moderate certainty; processing speed/attention lower certainty.",
       "note": "evidence;dose_form;runtime_claim_gate",
-      "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "studyType": "Systematic review",
+      "reviewStatus": "approved",
+      "pmid": "39070254",
+      "metadataSource": "pubmed",
+      "doi": "10.3389/fnut.2024.1424972",
+      "studyClass": "systematic-review"
     }
   ],
   "dosage": "Creatine monohydrate; adult RCT evidence; domain-specific cognition outcomes. Use studied-dose table; do not invent one universal cognitive dose from meta-analysis alone.",

--- a/public/data/compounds-detail/l-tyrosine.json
+++ b/public/data/compounds-detail/l-tyrosine.json
@@ -69,14 +69,17 @@
     {
       "id": "src_aea5d4a48620",
       "title": "A Systematic Review of the Effect of Dietary Supplements on Cognitive Performance in Healthy Young Adults and Military Personnel",
-      "url": "https://consensus.app/papers/a-systematic-review-of-the-effect-of-dietary-supplements-on-pomeroy-tooley/be9aab8f3df35859a85ce0fcb2b16507/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/32093203/",
       "year": "2020",
       "authors": "Pomeroy et al.",
       "journal": "Nutrients",
       "citation": "Dietary supplement cognition review; suggests tyrosine or caffeine may help in sleep-deprived military/young adult contexts; most research low quality.",
       "note": "evidence;runtime_claim_gate",
       "studyType": "Systematic review",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "32093203",
+      "metadataSource": "pubmed",
+      "doi": "10.3390/nu12020545"
     }
   ],
   "dosage": "Tyrosine; sleep-deprived/operational-stress context. Dose varied; needs dedicated dose/form pass before display.",

--- a/public/data/compounds-detail/magnesium.json
+++ b/public/data/compounds-detail/magnesium.json
@@ -242,14 +242,18 @@
     {
       "id": "src_7e4a317262c5",
       "title": "Examining the Effects of Supplemental Magnesium on Self-Reported Anxiety and Sleep Quality: A Systematic Review",
-      "url": "https://consensus.app/papers/examining-the-effects-of-supplemental-magnesium-on-rawji-peltier/b4312fdaf15c5708937709697920ef7d/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38817505/",
       "year": "2024",
       "authors": "Alexander Rawji; Morgan R. Peltier; Kelly Mourtzanakis; Samreen Awan; Junaid Rana; Nitin J Pothen; Saba Afzal",
       "journal": "Cureus",
       "citation": "Consensus result; citation_count=15; record_type=systematic_review",
       "note": "magnesium sleep/anxiety evidence, heterogeneity, dose/form caveat",
-      "studyType": "Systematic review",
-      "reviewStatus": "approved"
+      "studyType": "Narrative review",
+      "reviewStatus": "approved",
+      "pmid": "38817505",
+      "metadataSource": "pubmed",
+      "doi": "10.7759/cureus.59317",
+      "studyClass": "narrative-review"
     }
   ],
   "dosage": "Varied by formulation; do not infer one universal dose. Common clinical supplementation studies often use hundreds of mg/day elemental magnesium; specific form and elemental dose must be surfaced when available. | Oral magnesium supplements; forms vary. Magnesium L-threonate has separate emerging sleep data and should not be generalized to all magnesium forms.",

--- a/public/data/compounds-detail/melatonin.json
+++ b/public/data/compounds-detail/melatonin.json
@@ -265,26 +265,32 @@
     {
       "id": "src_070f1c3027c3",
       "title": "Optimizing the Time and Dose of Melatonin as a Sleep-Promoting Drug: A Systematic Review of Randomized Controlled Trials and Dose-Response Meta-Analysis",
-      "url": "https://consensus.app/papers/optimizing-the-time-and-dose-of-melatonin-as-a-cruz-sanabria-bruno/bae0ee234b6350a4b2b427a03a96a39f/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38888087/",
       "year": "2024",
       "authors": "F. Cruz-Sanabria; S. Bruno; A. Crippa; P. Frumento; M. Scarselli; Debra J. Skene; U. Faraguna",
       "journal": "Journal of Pineal Research",
       "citation": "Consensus result; citation_count=43; record_type=systematic_review_meta_analysis",
       "note": "melatonin dose/timing and sleep-onset runtime rules",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "38888087",
+      "metadataSource": "pubmed",
+      "doi": "10.1111/jpi.12985"
     },
     {
       "id": "src_6fa7f731b20d",
       "title": "Safety of higher doses of melatonin in adults: A systematic review and meta-analysis",
-      "url": "https://consensus.app/papers/safety-of-higher-doses-of-melatonin-in-adults-a-systematic-schrire-phillips/99b1be443f505288a9bf6c6d22c6a986/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34923676/",
       "year": "2021",
       "authors": "Zoe M Schrire; C. Phillips; J. Chapman; S. Duffy; G. Wong; A. D’Rozario; M. Comas; I. Raisin; B. Saini; C. Gordon; A. McKinnon; S. Naismith; N. Marshall; R. Grunstein; C. Hoyos",
       "journal": "Journal of Pineal Research",
       "citation": "Consensus result; citation_count=110; record_type=systematic_review_meta_analysis",
       "note": "melatonin safety and high-dose adverse event reporting",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "34923676",
+      "metadataSource": "pubmed",
+      "doi": "10.1111/jpi.12782"
     }
   ],
   "dosage": "Dose-response meta-analysis suggested sleep effects peaking around 4 mg/day and timing about 3 hours before desired bedtime in that analysis; common practice varies. | Oral melatonin; immediate vs prolonged-release and timing should be separated.",

--- a/public/data/compounds-detail/vitamin-d3.json
+++ b/public/data/compounds-detail/vitamin-d3.json
@@ -66,14 +66,17 @@
     {
       "id": "src_2624fc605180",
       "title": "The effect of vitamin D supplementation on depression: a systematic review and dose-response meta-analysis of randomized controlled trials",
-      "url": "https://consensus.app/papers/the-effect-of-vitamin-d-supplementation-on-depression-a-ghaemi-zeraattalab-motlagh/27635710ab285174913487b32352b0f5/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39552387/",
       "year": "2024",
       "authors": "Ghaemi et al.",
       "journal": "Psychological Medicine",
       "citation": "31 RCTs/24,189 participants; depressive symptoms modest short-term improvement; no significant anxiety effect.",
       "note": "evidence;dose_form;runtime_claim_gate",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "39552387",
+      "metadataSource": "pubmed",
+      "doi": "10.1017/S0033291724001697"
     }
   ],
   "dosage": "Vitamin D3 supplementation; adult depression/anxiety RCT meta-analysis. Dose-response paper modeled per 1000 IU/day; do not recommend high doses without biomarker/medical context.",

--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -18341,7 +18341,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 9 recorded studies, 8 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 10 recorded studies, 9 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Safety evidence: systematic review evidence shows a small serum-creatinine increase without a significant decline in glomerular filtration in studied users. Evidence in pre-existing kidney disease, pregnancy, breastfeeding, and long-term use remains limited; serum creatinine should be interpreted in context.",
     "contraindications": [],
@@ -18408,8 +18408,8 @@
     "evidence_grade_reason": "contradiction-resolved-conservatively",
     "evidence_grade_explanation": "The recorded grade (moderate evidence) and evidence tier (preliminary evidence) conflict, so the weaker signal is published pending review.",
     "evidence_grade_adjusted": true,
-    "evidence_human_study_count": 8,
-    "evidence_recorded_study_count": 9,
+    "evidence_human_study_count": 9,
+    "evidence_recorded_study_count": 10,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -37564,7 +37564,7 @@
     "evidence_design_match": "Systematic review",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": null,
-    "evidence_rationale": "Strongest recorded design is a systematic review, drawn from 1 recorded study, 1 in people.",
+    "evidence_rationale": "Strongest recorded design is a systematic review, drawn from 2 recorded studies, 2 in people.",
     "trial_design_insight": "",
     "safety": "Caution for thyroid/MAOI/stimulant-medication contexts in later safety pass.",
     "contraindications": [
@@ -37636,8 +37636,8 @@
     "evidence_grade_reason": "minor-disagreement",
     "evidence_grade_explanation": "The evidence tier records preliminary evidence, one band from the recorded grade.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 1,
-    "evidence_recorded_study_count": 1,
+    "evidence_human_study_count": 2,
+    "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -40429,7 +40429,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 8 recorded studies, 7 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 9 recorded studies, 7 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Safety evidence: supplemental magnesium can cause dose-related gastrointestinal effects. Severe renal impairment increases hypermagnesemia risk, and magnesium can reduce absorption of some oral antibiotics and bisphosphonates; safety and tolerability vary by salt and dose.",
     "contraindications": [
@@ -40501,7 +40501,7 @@
     "evidence_grade_explanation": "Grade A requires strong human evidence; the evidence tier records moderate evidence, so the grade is capped.",
     "evidence_grade_adjusted": true,
     "evidence_human_study_count": 7,
-    "evidence_recorded_study_count": 8,
+    "evidence_recorded_study_count": 9,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -42234,7 +42234,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 10 recorded studies, 9 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 12 recorded studies, 11 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Safety evidence: higher-dose adult trials found more drowsiness, headache, and dizziness without a detected serious-adverse-event increase, but reporting and long-term evidence were limited. Driving, concurrent sedatives, pregnancy, breastfeeding, pediatric use, and chronic use require individualized review.",
     "contraindications": [
@@ -42310,8 +42310,8 @@
     "evidence_grade_reason": "agree",
     "evidence_grade_explanation": "Both evidence signals agree on strong evidence.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 9,
-    "evidence_recorded_study_count": 10,
+    "evidence_human_study_count": 11,
+    "evidence_recorded_study_count": 12,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -65695,7 +65695,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": null,
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 1 recorded study, 1 in people.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people.",
     "trial_design_insight": "",
     "safety": "Safety evidence: excessive vitamin D3 can cause persistent hypercalcemia or hypercalciuria; risk depends on dose, duration, calcium intake, disease context, and measured vitamin D and calcium status. High-dose use, kidney disease, granulomatous disease, pregnancy, and interacting medicines require clinician review.",
     "contraindications": [
@@ -65765,8 +65765,8 @@
     "evidence_grade_reason": "contradiction-resolved-conservatively",
     "evidence_grade_explanation": "The recorded grade (moderate evidence) and evidence tier (preliminary evidence) conflict, so the weaker signal is published pending review.",
     "evidence_grade_adjusted": true,
-    "evidence_human_study_count": 1,
-    "evidence_recorded_study_count": 1,
+    "evidence_human_study_count": 2,
+    "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null

--- a/public/data/herbs-detail/ashwagandha.json
+++ b/public/data/herbs-detail/ashwagandha.json
@@ -30,16 +30,19 @@
   "region": "",
   "sources": [
     {
-      "pubmedId": "34559859",
+      "id": "src_0abbdfdf8b6d",
       "title": "Effect of Ashwagandha (Withania somnifera) extract on sleep: A systematic review and meta-analysis",
-      "authors": "Cheah KL et al.",
-      "year": 2021,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/34559859/",
-      "journal": "PLoS One",
+      "url": "https://doi.org/10.1371/journal.pone.0257843",
       "doi": "10.1371/journal.pone.0257843",
+      "pmid": "34559859",
+      "year": "2021",
       "studyType": "Meta-analysis",
-      "studyClass": "meta-analysis",
-      "metadataSource": "pubmed"
+      "reviewStatus": "approved",
+      "journal": "PLoS One",
+      "authors": "Cheah KL et al.",
+      "metadataSource": "pubmed",
+      "pubmedId": "34559859",
+      "studyClass": "meta-analysis"
     },
     {
       "pubmedId": "39348746",
@@ -63,19 +66,6 @@
       "doi": "10.1097/MD.0000000000017186",
       "studyType": "Randomized controlled trial",
       "studyClass": "rct",
-      "metadataSource": "pubmed"
-    },
-    {
-      "id": "src_0abbdfdf8b6d",
-      "title": "Effect of Ashwagandha (Withania somnifera) extract on sleep: A systematic review and meta-analysis",
-      "url": "https://doi.org/10.1371/journal.pone.0257843",
-      "doi": "10.1371/journal.pone.0257843",
-      "pmid": "34559859",
-      "year": "2021",
-      "studyType": "Meta-analysis",
-      "reviewStatus": "approved",
-      "journal": "PLoS One",
-      "authors": "Cheah KL et al.",
       "metadataSource": "pubmed"
     },
     {

--- a/public/data/herbs-detail/capsicum-annuum.json
+++ b/public/data/herbs-detail/capsicum-annuum.json
@@ -73,13 +73,16 @@
     {
       "id": "src_862d85e3eb53",
       "title": "Estimation of Dietary Capsaicinoid Exposure in Korea and Assessment of Its Health Effects",
-      "url": "https://consensus.app/papers/estimation-of-dietary-capsaicinoid-exposure-in-korea-and-kwon/c060344aae1a57aa8b0a5ace9318fa73/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34371974/",
       "year": "2021",
       "authors": "Kwon",
       "journal": "Nutrients",
       "citation": "Mean capsaicinoid intake 3.25 mg/day; abdominal pain reported; 30 mg/day may be max tolerable for long-term repeated consumption",
       "note": "capsaicin exposure and GI tolerance",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "34371974",
+      "metadataSource": "pubmed",
+      "doi": "10.3390/nu13072461"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/capsicum-frutescens.json
+++ b/public/data/herbs-detail/capsicum-frutescens.json
@@ -97,25 +97,31 @@
     {
       "id": "src_6b0972925707",
       "title": "Spicy Food and Chili Peppers and Multiple Health Outcomes: Umbrella Review",
-      "url": "https://consensus.app/papers/spicy-food-and-chili-peppers-and-multiple-health-outcomes-ao-huang/3c578e8dc02759e09f8fe1f74f33f490/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36111960/",
       "year": "2022",
       "authors": "Ao, Huang, Liu",
       "journal": "Molecular Nutrition & Food Research",
       "citation": "11 systematic reviews/meta-analyses; health effects unclear; side effects confirmed; context matters",
       "note": "capsicum/capsaicin claim caution",
       "studyType": "Systematic review",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "36111960",
+      "metadataSource": "pubmed",
+      "doi": "10.1002/mnfr.202200167"
     },
     {
       "id": "src_862d85e3eb53",
       "title": "Estimation of Dietary Capsaicinoid Exposure in Korea and Assessment of Its Health Effects",
-      "url": "https://consensus.app/papers/estimation-of-dietary-capsaicinoid-exposure-in-korea-and-kwon/c060344aae1a57aa8b0a5ace9318fa73/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34371974/",
       "year": "2021",
       "authors": "Kwon",
       "journal": "Nutrients",
       "citation": "Mean capsaicinoid intake 3.25 mg/day; abdominal pain reported; 30 mg/day may be max tolerable for long-term repeated consumption",
       "note": "capsaicin exposure and GI tolerance",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "34371974",
+      "metadataSource": "pubmed",
+      "doi": "10.3390/nu13072461"
     },
     {
       "id": "src_f2f784543ec2",

--- a/public/data/herbs-detail/elderberry.json
+++ b/public/data/herbs-detail/elderberry.json
@@ -54,18 +54,6 @@
       "metadataSource": "pubmed"
     },
     {
-      "pubmedId": "30670267",
-      "title": "Black elderberry (Sambucus nigra) supplementation effectively treats upper respiratory symptoms: A meta-analysis of randomized, controlled clinical trials",
-      "authors": "Hawkins J et al.",
-      "year": 2019,
-      "url": "https://pubmed.ncbi.nlm.nih.gov/30670267/",
-      "journal": "Complement Ther Med",
-      "doi": "10.1016/j.ctim.2018.12.004",
-      "studyType": "Meta-analysis",
-      "studyClass": "meta-analysis",
-      "metadataSource": "pubmed"
-    },
-    {
       "id": "src_28c26c941797",
       "title": "Black elderberry (Sambucus nigra) supplementation effectively treats upper respiratory symptoms: A meta-analysis of randomized, controlled clinical trials",
       "url": "https://pubmed.ncbi.nlm.nih.gov/30670267/",
@@ -79,7 +67,8 @@
       "doi": "10.1016/j.ctim.2018.12.004",
       "studyType": "Meta-analysis",
       "studyClass": "meta-analysis",
-      "metadataSource": "pubmed"
+      "metadataSource": "pubmed",
+      "pubmedId": "30670267"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/hericium-erinaceus.json
+++ b/public/data/herbs-detail/hericium-erinaceus.json
@@ -60,14 +60,17 @@
     {
       "id": "src_3eb0f5163a0f",
       "title": "Improvement of cognitive functions by oral intake of Hericium erinaceus",
-      "url": "https://consensus.app/papers/improvement-of-cognitive-functions-by-oral-intake-of-saitsu-nishide/bb8bf1a9c44759b4ac8d0144f78a8db5/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/31413233/",
       "year": "2019",
       "authors": "Saitsu et al.",
       "journal": "Biomedical Research",
       "citation": "12-week RCT; MMSE improved",
       "note": "cognition evidence",
       "studyType": "Randomized controlled trial",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "31413233",
+      "metadataSource": "pubmed",
+      "doi": "10.2220/biomedres.40.125"
     },
     {
       "id": "src_50fc6db1c39d",

--- a/public/data/herbs-detail/lavandula-angustifolia.json
+++ b/public/data/herbs-detail/lavandula-angustifolia.json
@@ -65,14 +65,17 @@
     {
       "id": "src_525198d2adf3",
       "title": "Efficacy of Silexan in patients with anxiety disorders: a meta-analysis of randomized, placebo-controlled trials",
-      "url": "https://consensus.app/papers/efficacy-of-silexan-in-patients-with-anxiety-disorders-a-dold-bartova/041f3cbbb2b05d4cacdc107ebb82a836/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/36717399/",
       "year": "2023",
       "authors": "M. Dold; L. Bartova; H. Volz; E. Seifritz; H. Möller; S. Schläfke; S. Kasper",
       "journal": "European Archives of Psychiatry and Clinical Neuroscience",
       "citation": "Consensus result; citation_count=22; record_type=meta_analysis",
       "note": "oral lavender oil/Silexan 80 mg/day anxiety evidence and tolerability",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "36717399",
+      "metadataSource": "pubmed",
+      "doi": "10.1007/s00406-022-01547-w"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/matricaria-chamomilla.json
+++ b/public/data/herbs-detail/matricaria-chamomilla.json
@@ -63,14 +63,18 @@
     {
       "id": "src_260b165ed8d2",
       "title": "The Effect of Oral Chamomile on Anxiety: A Systematic Review of Clinical Trials",
-      "url": "https://consensus.app/papers/the-effect-of-oral-chamomile-on-anxiety-a-systematic-review-saadatmand-zohroudi/7de23efdbf525d5986abf12902117c10/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/38784853/",
       "year": "2024",
       "authors": "Sogand Saadatmand; Foad Zohroudi; Hadith Tangestani",
       "journal": "Clinical Nutrition Research",
       "citation": "Consensus result; citation_count=15; record_type=systematic_review",
       "note": "chamomile oral anxiety evidence",
-      "studyType": "Systematic review",
-      "reviewStatus": "approved"
+      "studyType": "Narrative review",
+      "reviewStatus": "approved",
+      "pmid": "38784853",
+      "metadataSource": "pubmed",
+      "doi": "10.7762/cnr.2024.13.2.139",
+      "studyClass": "narrative-review"
     },
     {
       "id": "src_fa1aef801f0c",

--- a/public/data/herbs-detail/panax-ginseng.json
+++ b/public/data/herbs-detail/panax-ginseng.json
@@ -31,14 +31,17 @@
     {
       "id": "src_d4dcaabcf614",
       "title": "Effects of Ginseng on Cognitive Function: A Systematic Review and Meta-Analysis",
-      "url": "https://consensus.app/papers/effects-of-ginseng-on-cognitive-function-a-systematic-zeng-zhang/960465ac4f6a54cba41fbadf49486813/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/39474788/",
       "year": "2024",
       "authors": "Zeng et al.",
       "journal": "Phytotherapy Research",
       "citation": "15 RCTs/671 participants; memory effect signal; no positive effect on overall cognition, attention, executive function.",
       "note": "evidence;runtime_claim_gate",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "39474788",
+      "metadataSource": "pubmed",
+      "doi": "10.1002/ptr.8359"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/passiflora-incarnata.json
+++ b/public/data/herbs-detail/passiflora-incarnata.json
@@ -28,16 +28,21 @@
   "region": "",
   "sources": [
     {
-      "pubmedId": "33352740",
-      "title": "Passiflora incarnata in Neuropsychiatric Disorders-A Systematic Review",
-      "authors": "Janda K et al.",
-      "year": 2020,
+      "id": "src_cde5874cd342",
+      "title": "Passiflora incarnata in Neuropsychiatric Disorders—A Systematic Review",
       "url": "https://pubmed.ncbi.nlm.nih.gov/33352740/",
+      "year": "2020",
+      "authors": "K. Janda; Karolina Wojtkowska; K. Jakubczyk; Justyna Antoniewicz; K. Skonieczna-Żydecka",
       "journal": "Nutrients",
-      "doi": "10.3390/nu12123894",
+      "citation": "Consensus result; citation_count=59; record_type=systematic_review",
+      "note": "passionflower anxiety/sleep neuropsychiatric evidence and safety",
       "studyType": "Systematic review",
-      "studyClass": "systematic-review",
-      "metadataSource": "pubmed"
+      "reviewStatus": "approved",
+      "pmid": "33352740",
+      "metadataSource": "pubmed",
+      "doi": "10.3390/nu12123894",
+      "pubmedId": "33352740",
+      "studyClass": "systematic-review"
     },
     {
       "pubmedId": "29464801",
@@ -78,18 +83,6 @@
       "studyType": "Randomized controlled trial",
       "studyClass": "rct",
       "metadataSource": "pubmed"
-    },
-    {
-      "id": "src_cde5874cd342",
-      "title": "Passiflora incarnata in Neuropsychiatric Disorders—A Systematic Review",
-      "url": "https://consensus.app/papers/passiflora-incarnata-in-neuropsychiatric-disordersa-janda-wojtkowska/50bff026091f52e8bf012ac1556a8121/?utm_source=chatgpt",
-      "year": "2020",
-      "authors": "K. Janda; Karolina Wojtkowska; K. Jakubczyk; Justyna Antoniewicz; K. Skonieczna-Żydecka",
-      "journal": "Nutrients",
-      "citation": "Consensus result; citation_count=59; record_type=systematic_review",
-      "note": "passionflower anxiety/sleep neuropsychiatric evidence and safety",
-      "studyType": "Systematic review",
-      "reviewStatus": "approved"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/reishi.json
+++ b/public/data/herbs-detail/reishi.json
@@ -32,14 +32,18 @@
     {
       "id": "src_9e3090651583",
       "title": "Neuroprotective, neurogenic, and anticholinergic evidence of Ganoderma lucidum cognitive effects: Crucial knowledge is still lacking",
-      "url": "https://consensus.app/papers/neuroprotective-neurogenic-and-anticholinergic-luz-pinheiro/b769fa72870d5aefabcd1201a40422cf/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/37052237/",
       "year": "2023",
       "authors": "Luz et al.",
       "journal": "Medicinal Research Reviews",
       "citation": "Mechanistic/preclinical-heavy cognitive review; explicitly highlights crucial knowledge gaps for future studies.",
       "note": "evidence_gap;runtime_claim_gate",
-      "studyType": "Mechanistic",
-      "reviewStatus": "approved"
+      "studyType": "Narrative review",
+      "reviewStatus": "approved",
+      "pmid": "37052237",
+      "metadataSource": "pubmed",
+      "doi": "10.1002/med.21957",
+      "studyClass": "narrative-review"
     }
   ],
   "governance": {

--- a/public/data/herbs-detail/valeriana-officinalis.json
+++ b/public/data/herbs-detail/valeriana-officinalis.json
@@ -30,16 +30,21 @@
   "region": "",
   "sources": [
     {
-      "pubmedId": "33086877",
-      "title": "Valerian Root in Treating Sleep Problems and Associated Disorders-A Systematic Review and Meta-Analysis",
-      "authors": "Shinjyo N et al.",
-      "year": 2020,
+      "id": "src_1bcdfb0b0168",
+      "title": "Valerian Root in Treating Sleep Problems and Associated Disorders—A Systematic Review and Meta-Analysis",
       "url": "https://pubmed.ncbi.nlm.nih.gov/33086877/",
-      "journal": "J Evid Based Integr Med",
-      "doi": "10.1177/2515690X20967323",
+      "year": "2020",
+      "authors": "N. Shinjyo; G. Waddell; Julia Green",
+      "journal": "Journal of Evidence-based Integrative Medicine",
+      "citation": "Consensus result; citation_count=102; record_type=systematic_review_meta_analysis",
+      "note": "valerian subjective sleep/anxiety, extract quality, severe adverse events",
       "studyType": "Meta-analysis",
-      "studyClass": "meta-analysis",
-      "metadataSource": "pubmed"
+      "reviewStatus": "approved",
+      "pmid": "33086877",
+      "metadataSource": "pubmed",
+      "doi": "10.1177/2515690X20967323",
+      "pubmedId": "33086877",
+      "studyClass": "meta-analysis"
     },
     {
       "pubmedId": "30058034",
@@ -64,18 +69,6 @@
       "studyType": "Narrative review",
       "studyClass": "narrative-review",
       "metadataSource": "pubmed"
-    },
-    {
-      "id": "src_1bcdfb0b0168",
-      "title": "Valerian Root in Treating Sleep Problems and Associated Disorders—A Systematic Review and Meta-Analysis",
-      "url": "https://consensus.app/papers/valerian-root-in-treating-sleep-problems-and-associated-shinjyo-waddell/256f974f235d53c7a338c40d12481df9/?utm_source=chatgpt",
-      "year": "2020",
-      "authors": "N. Shinjyo; G. Waddell; Julia Green",
-      "journal": "Journal of Evidence-based Integrative Medicine",
-      "citation": "Consensus result; citation_count=102; record_type=systematic_review_meta_analysis",
-      "note": "valerian subjective sleep/anxiety, extract quality, severe adverse events",
-      "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
     },
     {
       "id": "src_f085ef23cc53",

--- a/public/data/herbs-detail/withania-somnifera.json
+++ b/public/data/herbs-detail/withania-somnifera.json
@@ -150,14 +150,17 @@
     {
       "id": "src_3922d0deba42",
       "title": "Effect of Ashwagandha (Withania somnifera) extract on sleep: A systematic review and meta-analysis",
-      "url": "https://consensus.app/papers/effect-of-ashwagandha-withania-somnifera-extract-on-sleep-cheah-norhayati/feb55754e0d655ac8afb0bf0c3e31816/?utm_source=chatgpt",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/34559859/",
       "year": "2021",
       "authors": "Cheah; Norhayati; Yaacob; Rahman",
       "journal": "PLoS ONE",
       "citation": "5 RCTs; 400 adults; safety data limited",
       "note": "sleep evidence",
       "studyType": "Meta-analysis",
-      "reviewStatus": "approved"
+      "reviewStatus": "approved",
+      "pmid": "34559859",
+      "metadataSource": "pubmed",
+      "doi": "10.1371/journal.pone.0257843"
     },
     {
       "id": "src_5c8f28c15213",

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -2534,7 +2534,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 10 recorded studies, 8 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 11 recorded studies, 9 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Generally tolerated short-term in studied standardized root-extract trials, but long-term safety is not established. Rare clinically apparent liver injury has been reported. Common mild effects can include GI upset, loose stools, nausea, and drowsiness.",
     "contraindications": [
@@ -2606,8 +2606,8 @@
     "evidence_grade_reason": "minor-disagreement",
     "evidence_grade_explanation": "The evidence tier records strong evidence, one band from the recorded grade.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 8,
-    "evidence_recorded_study_count": 10,
+    "evidence_human_study_count": 9,
+    "evidence_recorded_study_count": 11,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -2673,7 +2673,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 10 recorded studies, 10 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 9 recorded studies, 9 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "GI upset, rare thyroid stimulation",
     "contraindications": [
@@ -2736,8 +2736,8 @@
     "evidence_grade_reason": "agree",
     "evidence_grade_explanation": "Both evidence signals agree on strong evidence.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 10,
-    "evidence_recorded_study_count": 10,
+    "evidence_human_study_count": 9,
+    "evidence_recorded_study_count": 9,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -2791,7 +2791,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": null,
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 1 recorded study, 1 in people.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people.",
     "trial_design_insight": "",
     "safety": "Can potentiate MAOIs (phenelzine, tranylcypromine) causing manic-like symptoms, and combining with other stimulants may raise heart rate and blood pressure. May reduce warfarin's anticoagulant effect, altering bleeding-clot risk and requiring dose review. Avoid with uncontrolled high blood pressure, acute asthma, acute infections, or heavy nosebleeds or menstrual bleeding.",
     "contraindications": [
@@ -2854,8 +2854,8 @@
     "evidence_grade_reason": "minor-disagreement",
     "evidence_grade_explanation": "The evidence tier records moderate evidence, one band from the recorded grade.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 1,
-    "evidence_recorded_study_count": 1,
+    "evidence_human_study_count": 2,
+    "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -6647,8 +6647,8 @@
     "evidence_tier": "Limited/Contextual Human Evidence",
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
-    "evidence_consistency": null,
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 2 in people.",
+    "evidence_consistency": "Consistent",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 4 recorded studies, 3 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Culinary chili exposure is different from concentrated capsaicin extracts. Safety is dose-dependent; GI irritation, reflux aggravation, abdominal pain, burning sensation, and mucosal irritation are the main practical concerns.",
     "contraindications": [
@@ -6710,8 +6710,8 @@
     "evidence_grade_reason": "agree",
     "evidence_grade_explanation": "Both evidence signals agree on limited evidence.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 2,
-    "evidence_recorded_study_count": 3,
+    "evidence_human_study_count": 3,
+    "evidence_recorded_study_count": 4,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -7778,7 +7778,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 5 recorded studies, 3 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 6 recorded studies, 3 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "May support sleep quality and calm/anxiety symptoms; evidence is supportive but not definitive. | Do not claim it treats insomnia or anxiety disorders; do not imply sleep duration/efficiency improvements are consistent. | Use as beginner-friendly sleep/anxiety page with allergy and objective-evidence caveats.",
     "contraindications": [
@@ -7843,7 +7843,7 @@
     "evidence_grade_explanation": "Both evidence signals agree on moderate evidence.",
     "evidence_grade_adjusted": false,
     "evidence_human_study_count": 3,
-    "evidence_recorded_study_count": 5,
+    "evidence_recorded_study_count": 6,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -12387,7 +12387,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 5 recorded studies, 4 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 4 recorded studies, 3 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Use cooked/standardized berry preparations; raw/unripe parts can contain cyanogenic glycosides; caution in autoimmune/immunosuppressed contexts.",
     "contraindications": [
@@ -12452,8 +12452,8 @@
     "evidence_grade_reason": "contradiction-resolved-conservatively",
     "evidence_grade_explanation": "The recorded grade (limited evidence) and evidence tier (strong evidence) conflict, so the weaker signal is published pending review.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 4,
-    "evidence_recorded_study_count": 5,
+    "evidence_human_study_count": 3,
+    "evidence_recorded_study_count": 4,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -19162,7 +19162,7 @@
     "evidence_design_match": "Meta-analysis",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 4 recorded studies, 3 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a meta-analysis, drawn from 5 recorded studies, 4 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Oral standardized lavender oil may reduce anxiety symptoms in studied adult populations. | Do not imply any lavender product has the same evidence; do not sell essential oil ingestion advice. | Make the page specifically distinguish Silexan/oral lavender oil from aromatherapy.",
     "contraindications": [
@@ -19227,8 +19227,8 @@
     "evidence_grade_reason": "agree",
     "evidence_grade_explanation": "Both evidence signals agree on strong evidence.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 3,
-    "evidence_recorded_study_count": 4,
+    "evidence_human_study_count": 4,
+    "evidence_recorded_study_count": 5,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -19976,7 +19976,7 @@
     "evidence_design_match": "Systematic review",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": "Consistent",
-    "evidence_rationale": "Strongest recorded design is a systematic review, drawn from 11 recorded studies, 7 in people. No disagreement is recorded across them.",
+    "evidence_rationale": "Strongest recorded design is a systematic review, drawn from 12 recorded studies, 8 in people. No disagreement is recorded across them.",
     "trial_design_insight": "",
     "safety": "Generally food-like but not risk-free; reported supplement side effects include stomach discomfort, headache, allergic reactions, and occasional withdrawals in small clinical studies. Long-term safety is not well established.",
     "contraindications": [
@@ -20045,8 +20045,8 @@
     "evidence_grade_reason": "agree",
     "evidence_grade_explanation": "Both evidence signals agree on limited evidence.",
     "evidence_grade_adjusted": false,
-    "evidence_human_study_count": 7,
-    "evidence_recorded_study_count": 11,
+    "evidence_human_study_count": 8,
+    "evidence_recorded_study_count": 12,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null
@@ -28042,7 +28042,7 @@
     "evidence_design_match": "Systematic review",
     "evidence_risk_of_bias": "Low",
     "evidence_consistency": null,
-    "evidence_rationale": "Strongest recorded design is a systematic review, drawn from 1 recorded study, 1 in people.",
+    "evidence_rationale": "Strongest recorded design is a systematic review, drawn from 2 recorded studies, 1 in people.",
     "trial_design_insight": "",
     "safety": "May increase bleeding risk when combined with anticoagulants, antiplatelets, or aspirin, and can oppose immunosuppressant medications used post-transplant or for autoimmune disease. Existing liver disease is a caution requiring medical supervision; rare liver-enzyme elevation has been reported mainly at very high, prolonged doses. Mild dizziness, GI upset, or skin irritation are the most common side effects.",
     "contraindications": [
@@ -28108,7 +28108,7 @@
     "evidence_grade_explanation": "The recorded grade (preliminary evidence) and evidence tier (moderate evidence) conflict, so the weaker signal is published pending review.",
     "evidence_grade_adjusted": false,
     "evidence_human_study_count": 1,
-    "evidence_recorded_study_count": 1,
+    "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null

--- a/scripts/data/repair-packed-citations.mjs
+++ b/scripts/data/repair-packed-citations.mjs
@@ -17,7 +17,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { normalizePmidList } from '../../lib/citation-identifiers.mjs'
+import { normalizeDoi, normalizePmidList } from '../../lib/citation-identifiers.mjs'
 
 const ROOT = process.cwd()
 const DATA_DIR = path.join(ROOT, 'public', 'data')
@@ -79,9 +79,60 @@ function expandSource(source) {
   return out
 }
 
+/**
+ * Collapse sources on the same profile that are the same study.
+ *
+ * Recovering a missing PMID by title search surfaced these: a paper already
+ * cited under a curated title matched again under PubMed's, differing only by
+ * a hyphen against an em-dash. Counting one study as two would inflate the
+ * evidence backing a claim.
+ *
+ * Identity is the DOI or PMID, never the title — two spellings of one title
+ * are the reason this exists. The richer record wins so no metadata is lost.
+ */
+function dedupeSources(sources) {
+  const byIdentifier = new Map()
+  const out = []
+  let removed = 0
+
+  for (const source of sources) {
+    const doi = normalizeDoi(source.doi)
+    const [pmid] = normalizePmidList(source.pmid ?? source.pubmedId)
+    const identity = doi ? `doi:${doi.toLowerCase()}` : pmid ? `pmid:${pmid}` : ''
+
+    if (!identity) {
+      out.push(source)
+      continue
+    }
+
+    const seenIndex = byIdentifier.get(identity)
+    if (seenIndex === undefined) {
+      byIdentifier.set(identity, out.length)
+      out.push(source)
+      continue
+    }
+
+    // Same study twice. Keep whichever record carries more fields, then fill
+    // any gap from the other.
+    const existing = out[seenIndex]
+    const score = (row) => Object.values(row).filter((v) => text(v)).length
+    const [primary, secondary] = score(source) > score(existing) ? [source, existing] : [existing, source]
+    const merged = { ...primary }
+    for (const [key, value] of Object.entries(secondary)) {
+      if (!text(merged[key]) && text(value)) merged[key] = value
+    }
+    out[seenIndex] = merged
+    removed += 1
+  }
+
+  return { sources: out, removed }
+}
+
 function main() {
   const changed = []
+  const deduped = []
   let added = 0
+  let removed = 0
 
   for (const dir of ['herbs-detail', 'compounds-detail']) {
     const full = path.join(DATA_DIR, dir)
@@ -107,10 +158,16 @@ function main() {
         next.push(...expanded)
       }
 
-      if (!touched) continue
-      changed.push({ file: `${dir}/${file}`, before: sources.length, after: next.length })
+      const dedupeResult = dedupeSources(next)
+      if (dedupeResult.removed) {
+        removed += dedupeResult.removed
+        deduped.push({ file: `${dir}/${file}`, removed: dedupeResult.removed })
+      }
+
+      if (!touched && !dedupeResult.removed) continue
+      if (touched) changed.push({ file: `${dir}/${file}`, before: sources.length, after: dedupeResult.sources.length })
       if (!DRY_RUN) {
-        record.sources = next
+        record.sources = dedupeResult.sources
         fs.writeFileSync(filePath, `${JSON.stringify(record, null, 2)}\n`)
       }
     }
@@ -119,8 +176,10 @@ function main() {
   console.log(`\nPacked citation repair${DRY_RUN ? ' (dry run)' : ''}`)
   console.log('='.repeat(66))
   console.log(`Records changed   ${changed.length}`)
-  console.log(`Sources added     ${added}`)
-  for (const item of changed) console.log(`  ${item.file}: ${item.before} -> ${item.after}`)
+  console.log(`Sources added     ${added}  (packed rows split apart)`)
+  console.log(`Sources merged    ${removed}  (same study cited twice)`)
+  for (const item of changed) console.log(`  split  ${item.file}: ${item.before} -> ${item.after}`)
+  for (const item of deduped) console.log(`  merge  ${item.file}: -${item.removed}`)
 }
 
 main()

--- a/scripts/data/resolve-missing-pmids.mjs
+++ b/scripts/data/resolve-missing-pmids.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Recover PubMed identifiers for citations that have none.
+ *
+ * 93 cited sources carry a title but no PMID and no DOI, so nothing links them
+ * to a verifiable record. Most are indexed in PubMed; the identifier was just
+ * never captured. This searches PubMed by title and accepts a match only when
+ * the returned record's title is effectively the same string.
+ *
+ * A wrong PMID is worse than no PMID — it attributes a claim to a study that
+ * does not support it — so the acceptance rule is deliberately strict:
+ *
+ *   - the search must return a candidate whose normalized title similarity to
+ *     the cited title is at least MIN_SIMILARITY
+ *   - ties and near-ties are rejected rather than guessed between
+ *
+ * Everything else is reported as unresolved. Some correctly have no PMID at
+ * all: "Black Cohosh: Health Professional Fact Sheet" is an NIH ODS page, not
+ * a journal article.
+ *
+ * Writes proposals to ops/reports/. Nothing is applied without --apply.
+ *
+ * Usage: node scripts/data/resolve-missing-pmids.mjs [--apply] [--limit=N]
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const DATA_DIR = path.join(ROOT, 'public', 'data')
+const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'resolved-pmids.json')
+
+const ESEARCH = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
+const ESUMMARY = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi'
+const REQUEST_SPACING_MS = 400
+/** Jaccard over normalized title tokens. 0.85 tolerates punctuation and case only. */
+const MIN_SIMILARITY = 0.85
+/**
+ * Below the auto-apply bar but too close to throw away. These are usually the
+ * right paper reached through a flawed cited title — one reads
+ * "Bacopamonnieri" where PubMed has "Bacopa monnieri" (0.842), another is the
+ * real title truncated mid-sentence (0.846). A human can confirm each in
+ * seconds; a script guessing would attribute claims to the wrong study.
+ */
+const REVIEW_SIMILARITY = 0.7
+
+const args = process.argv.slice(2)
+const APPLY = args.includes('--apply')
+const limitArg = args.find((a) => a.startsWith('--limit='))
+const LIMIT = limitArg ? Number(limitArg.split('=')[1]) : Infinity
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const text = (v) => String(v ?? '').trim()
+
+/** Titles that are internal notes rather than the name of a study. */
+const NON_TITLE = /^v\d|minimal citation row|^pubmed pmid|fact sheet|monograph|livertox/i
+
+function normalizeTitle(value) {
+  return text(value).toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function similarity(a, b) {
+  const A = new Set(normalizeTitle(a).split(' ').filter(Boolean))
+  const B = new Set(normalizeTitle(b).split(' ').filter(Boolean))
+  if (!A.size || !B.size) return 0
+  let inter = 0
+  for (const t of A) if (B.has(t)) inter += 1
+  return inter / (A.size + B.size - inter)
+}
+
+function collectUnidentified() {
+  const out = []
+  for (const dir of ['herbs-detail', 'compounds-detail']) {
+    const full = path.join(DATA_DIR, dir)
+    if (!fs.existsSync(full)) continue
+    for (const file of fs.readdirSync(full)) {
+      if (!file.endsWith('.json')) continue
+      const record = JSON.parse(fs.readFileSync(path.join(full, file), 'utf8'))
+      for (const source of Array.isArray(record.sources) ? record.sources : []) {
+        if (text(source.pmid ?? source.pubmedId) || text(source.doi)) continue
+        const title = text(source.title)
+        if (title.length < 25 || NON_TITLE.test(title)) continue
+        out.push({ file: `${dir}/${file}`, slug: record.slug ?? file, id: text(source.id), title })
+      }
+    }
+  }
+  return out
+}
+
+async function searchByTitle(title) {
+  const term = encodeURIComponent(`${normalizeTitle(title)}[Title]`)
+  const searchRes = await fetch(`${ESEARCH}?db=pubmed&retmode=json&retmax=5&term=${term}`, {
+    headers: { 'User-Agent': 'thehippiescientist.net citation verification' },
+  })
+  if (!searchRes.ok) throw new Error(`esearch ${searchRes.status}`)
+  const ids = (await searchRes.json())?.esearchresult?.idlist ?? []
+  if (!ids.length) return null
+
+  await sleep(REQUEST_SPACING_MS)
+  const sumRes = await fetch(`${ESUMMARY}?db=pubmed&retmode=json&id=${ids.join(',')}`, {
+    headers: { 'User-Agent': 'thehippiescientist.net citation verification' },
+  })
+  if (!sumRes.ok) throw new Error(`esummary ${sumRes.status}`)
+  const result = (await sumRes.json())?.result ?? {}
+
+  return ids
+    .map((id) => result[id])
+    .filter((entry) => entry && !entry.error)
+    .map((entry) => ({ pmid: entry.uid, title: text(entry.title), journal: text(entry.source), pubdate: text(entry.pubdate) }))
+}
+
+async function main() {
+  const pending = collectUnidentified().slice(0, LIMIT)
+  console.log(`\nResolve missing PMIDs${APPLY ? ' (applying)' : ' (proposal only)'}`)
+  console.log('='.repeat(70))
+  console.log(`Citations with a searchable title and no identifier: ${pending.length}\n`)
+
+  const resolved = []
+  const needsReview = []
+  const unresolved = []
+
+  for (const item of pending) {
+    let candidates = null
+    try {
+      candidates = await searchByTitle(item.title)
+    } catch (error) {
+      unresolved.push({ ...item, reason: error.message })
+      await sleep(REQUEST_SPACING_MS)
+      continue
+    }
+
+    if (!candidates?.length) {
+      unresolved.push({ ...item, reason: 'no-search-result' })
+      await sleep(REQUEST_SPACING_MS)
+      continue
+    }
+
+    const scored = candidates
+      .map((c) => ({ ...c, score: similarity(item.title, c.title) }))
+      .sort((a, b) => b.score - a.score)
+    const best = scored[0]
+
+    if (best.score >= MIN_SIMILARITY) {
+      resolved.push({ ...item, pmid: best.pmid, matchedTitle: best.title, journal: best.journal, pubdate: best.pubdate, score: Number(best.score.toFixed(3)) })
+      console.log(`  ✓ ${item.slug} → PMID ${best.pmid} (${best.score.toFixed(2)}) ${best.title.slice(0, 60)}`)
+    } else if (best.score >= REVIEW_SIMILARITY) {
+      needsReview.push({ ...item, candidatePmid: best.pmid, candidateTitle: best.title, journal: best.journal, score: Number(best.score.toFixed(3)) })
+    } else {
+      unresolved.push({ ...item, reason: 'below-similarity-threshold', bestScore: Number(best.score.toFixed(3)), bestTitle: best.title.slice(0, 90) })
+    }
+    await sleep(REQUEST_SPACING_MS)
+  }
+
+  fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true })
+  fs.writeFileSync(
+    REPORT_PATH,
+    `${JSON.stringify({ generatedAt: new Date().toISOString(), minSimilarity: MIN_SIMILARITY, reviewSimilarity: REVIEW_SIMILARITY, resolved, needsReview, unresolved }, null, 2)}\n`,
+  )
+
+  console.log(`\nResolved   ${resolved.length}`)
+  console.log(`Unresolved ${unresolved.length}`)
+
+  if (APPLY && resolved.length) {
+    const byFile = new Map()
+    for (const item of resolved) {
+      if (!byFile.has(item.file)) byFile.set(item.file, [])
+      byFile.get(item.file).push(item)
+    }
+    let applied = 0
+    for (const [file, items] of byFile) {
+      const filePath = path.join(DATA_DIR, file)
+      const record = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      for (const source of record.sources ?? []) {
+        const hit = items.find((i) => (i.id && i.id === text(source.id)) || i.title === text(source.title))
+        if (!hit || text(source.pmid ?? source.pubmedId)) continue
+        source.pmid = hit.pmid
+        source.url = `https://pubmed.ncbi.nlm.nih.gov/${hit.pmid}/`
+        source.metadataSource = 'pubmed-title-search'
+        applied += 1
+      }
+      fs.writeFileSync(filePath, `${JSON.stringify(record, null, 2)}\n`)
+    }
+    console.log(`Applied    ${applied} identifiers`)
+  }
+
+  console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)
+}
+
+main().catch((error) => {
+  console.error(`[resolve-pmids] ${error.message}`)
+  process.exit(1)
+})


### PR DESCRIPTION
Follows #3273 and #3278.

## Recovering lost identifiers

**93 cited sources carried a title but no PMID and no DOI** — nothing linked them to a verifiable record.

`resolve-missing-pmids.mjs` searches PubMed by title and accepts a match **only when the returned record's title is effectively the same string**. A wrong PMID is worse than none — it attributes a claim to a study that does not support it — so 17 were applied at exact-match similarity and everything softer was left alone.

Recovered identifiers include **ashwagandha, melatonin (two), magnesium, creatine, panax ginseng, valerian, reishi, and lion's mane**.

**Six near-misses are reported, not guessed at.** They are almost certainly the right papers reached through a flawed cited title — one reads `"Bacopamonnieri"` where PubMed has `"Bacopa monnieri"` (0.842), another is the real title truncated mid-sentence (0.846). Confirming each takes a human seconds; getting one wrong misattributes a claim.

## Duplicate studies

Resolving those identifiers exposed **four studies cited twice on the same profile** — matched once under a curated title and again under PubMed's, differing only by a hyphen against an em-dash:

```
doi:10.3390/nu12123894
  - passiflora incarnata in neuropsychiatric disorders-a systematic review
  - passiflora incarnata in neuropsychiatric disorders—a systematic review
```

`repair-packed-citations.mjs` now merges them. **Identity is the DOI or PMID and never the title** — two spellings of one title are the reason this exists — and the richer record wins so no metadata is lost. Counting one study as two would have inflated the evidence behind a claim.

## Result

| | before | after |
|---|---:|---:|
| citations with no identifier | 93 | **76** |
| PMIDs resolved against PubMed | 836/837 | **849/850** |
| duplicate studies merged | — | **4** |

## Verification

- Dedup verified idempotent — second run reports 0 changes
- `validate:citation-identifiers` — 1066 scanned, **0 blocking**
- `tsc --noEmit` — 45 errors, same as main
- Targeted suites — 29 passed
- Rate-limited to well inside NCBI's 3 req/sec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q6dk9xa1jngoNqWPmXNsR