### PR TITLE
fix(ci): restore fast lint and TypeScript quality gate

### DIFF
--- a/app/evidence/evidence-digest/2026-08-evidence-literacy/page.tsx
+++ b/app/evidence/evidence-digest/2026-08-evidence-literacy/page.tsx
@@ -5,10 +5,11 @@ import { buildPageMetadata, SITE_URL } from '@/src/lib/seo'
 import { SafetyDisclaimerBox } from '@/components/monetization/SafetyDisclaimerBox'
 
 const SLUG = '2026-08-evidence-literacy'
-const edition = getEvidenceDigestEdition(SLUG)
+const resolvedEdition = getEvidenceDigestEdition(SLUG)
 
-if (!edition) throw new Error(`Missing evidence digest edition: ${SLUG}`)
+if (!resolvedEdition) throw new Error(`Missing evidence digest edition: ${SLUG}`)
 
+const edition = resolvedEdition
 const PATH = `/evidence/evidence-digest/${SLUG}/`
 const SHARE_SUBJECT = encodeURIComponent(edition.title)
 const SHARE_BODY = encodeURIComponent(`Worth reading: ${edition.title}\n\n${SITE_URL}${PATH}`)

--- a/components/safety/__tests__/AdditiveRiskPanel.test.tsx
+++ b/components/safety/__tests__/AdditiveRiskPanel.test.tsx
@@ -8,7 +8,9 @@ function risk(overrides: Partial<MechanismRisk> = {}): MechanismRisk {
     mechanism: 'serotonergic',
     label: 'Serotonergic activity',
     severity: 'severe',
+    certainties: ['theoretical'],
     partnerCount: 2,
+    provenanceCoverage: { withProvenance: 0, total: 2 },
     topPartners: [
       { slug: 'herb-b', name: 'Herb B' },
       { slug: 'herb-c', name: 'Herb C' },
@@ -33,7 +35,7 @@ describe('AdditiveRiskPanel', () => {
 
   it('uses singular "supplement" wording when only one partner shares the flag', () => {
     const { container } = render(
-      <AdditiveRiskPanel risks={[risk({ partnerCount: 1, topPartners: [{ slug: 'herb-b', name: 'Herb B' }] })]} displayName="Herb A" />,
+      <AdditiveRiskPanel risks={[risk({ partnerCount: 1, provenanceCoverage: { withProvenance: 0, total: 1 }, topPartners: [{ slug: 'herb-b', name: 'Herb B' }] })]} displayName="Herb A" />,
     )
     expect(container.querySelector('.text-xs.text-muted')?.textContent).toMatch(/1\s*other supplement\s*share this flag/)
   })
@@ -49,6 +51,7 @@ describe('AdditiveRiskPanel', () => {
         risks={[
           risk({
             partnerCount: 5,
+            provenanceCoverage: { withProvenance: 0, total: 5 },
             topPartners: [
               { slug: 'a', name: 'Herb A' },
               { slug: 'b', name: 'Herb B' },

--- a/lib/__tests__/runtime-link-candidates.test.ts
+++ b/lib/__tests__/runtime-link-candidates.test.ts
@@ -37,10 +37,12 @@ describe('renderable runtime link candidate index', () => {
   })
 
   it('ignores records without a usable slug', () => {
+    const missingSlug = { indexability_status: 'PUBLISH' } as unknown as RuntimeRecord
+
     expect(
       buildRenderableRuntimeRecordIndex([
         { slug: '', indexability_status: 'PUBLISH' },
-        { indexability_status: 'PUBLISH' },
+        missingSlug,
       ]),
     ).toEqual(new Map())
   })

--- a/lib/citation-identifiers.mjs
+++ b/lib/citation-identifiers.mjs
@@ -25,6 +25,9 @@ export const DOI_PATTERN = /^10\.\d{4,9}\/\S+$/
 /** Separators seen between identifiers packed into one cell. */
 const IDENTIFIER_SEPARATOR = /[;,]|\s+and\s+|\s{2,}/i
 
+/** Separators seen between full URLs packed into one workbook cell. */
+const URL_SEPARATOR = /\s*\|\s*|\r?\n+/
+
 /**
  * @param {unknown} value
  * @returns {string}
@@ -91,15 +94,39 @@ export function normalizePmidList(value) {
 }
 
 /**
- * The identifier a citation should link to, preferring DOI.
+ * Every usable full URL in a value, in order, de-duplicated.
+ *
+ * Some legacy workbook cells contain multiple complete links separated by a
+ * pipe. A browser cannot navigate to the packed string, so keep the first
+ * valid link as the canonical href while leaving identifier fields available
+ * for additional study counting.
+ *
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+export function normalizeCitationUrlList(value) {
+  const raw = text(value)
+  if (!raw) return []
+
+  const seen = new Set()
+  for (const part of raw.split(URL_SEPARATOR)) {
+    const candidate = part.trim()
+    if (!/^https?:\/\/\S+$/i.test(candidate)) continue
+    if (!seen.has(candidate)) seen.add(candidate)
+  }
+  return [...seen]
+}
+
+/**
+ * The identifier a citation should link to, preferring a direct URL when one
+ * is usable, then DOI, then PMID.
  *
  * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown, url?: unknown }} source
  * @returns {string}
  */
 export function citationUrl(source) {
-  const direct = text(source?.url)
-  // A packed multi-identifier URL is not usable; rebuild it from the id fields.
-  if (/^https?:\/\//i.test(direct) && !IDENTIFIER_SEPARATOR.test(direct)) return direct
+  const [direct] = normalizeCitationUrlList(source?.url)
+  if (direct) return direct
 
   const doi = normalizeDoi(source?.doi)
   if (isValidDoi(doi)) return `https://doi.org/${doi}`

--- a/scripts/media/build-research-graphics.mjs
+++ b/scripts/media/build-research-graphics.mjs
@@ -92,7 +92,7 @@ async function writeGraphic(baseName, svg, metadata, sharp) {
     svg: path.relative(root, svgPath).split(path.sep).join('/'),
     png: pngGenerated ? path.relative(root, pngPath).split(path.sep).join('/') : null,
     approvedForPublicUse: false,
-    embedHtml: `<a href="${metadata.sourceUrl}"><img src="${metadata.publicSvgUrl}" alt="${esc(metadata.alt)}"><\/a><p>Source: <a href="${metadata.sourceUrl}">The Hippie Scientist</a></p>`,
+    embedHtml: `<a href="${metadata.sourceUrl}"><img src="${metadata.publicSvgUrl}" alt="${esc(metadata.alt)}"></a><p>Source: <a href="${metadata.sourceUrl}">The Hippie Scientist</a></p>`,
   }
 }
 

--- a/scripts/ops/regression-baseline.mjs
+++ b/scripts/ops/regression-baseline.mjs
@@ -49,7 +49,7 @@ function parseJsonLd(html) {
 
 function parseEvidenceGrades(html) {
   const visible = text(html);
-  const found = matches(visible, /(?:evidence\s+grade|grade)\s*[:\-]?\s*(Avoid\/Insufficient|[ABCD])\b/gi);
+  const found = matches(visible, /(?:evidence\s+grade|grade)\s*[:-]?\s*(Avoid\/Insufficient|[ABCD])\b/gi);
   return uniq(found.map((grade) => grade.length === 1 ? grade.toUpperCase() : 'Avoid/Insufficient'));
 }
 

--- a/src/components/editorial/LastUpdatedBadge.tsx
+++ b/src/components/editorial/LastUpdatedBadge.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 type LastUpdatedBadgeProps = {
   date?: string | null
   label?: string
@@ -48,12 +50,12 @@ export default function LastUpdatedBadge({
       {showCorrectionLink ? (
         <>
           <span aria-hidden="true" className="text-muted/30">•</span>
-          <a
+          <Link
             href="/info/corrections/"
             className="text-brand-700 underline-offset-2 hover:underline dark:text-brand-100"
           >
             Report a correction
-          </a>
+          </Link>
         </>
       ) : null}
     </span>

--- a/src/components/goals/GoalHubSections.tsx
+++ b/src/components/goals/GoalHubSections.tsx
@@ -23,16 +23,16 @@ export default async function GoalHubSections({
 }: GoalHubSectionsProps) {
   const entityTypeMap = await getSlugEntityTypeMap()
   const ingredients = getGoalIngredientCandidates(goalSlug)
-    .map((candidate) => {
+    .map((candidate): GoalHubLink | null => {
       const entityType = entityTypeMap[candidate.slug]
       if (!entityType) return null
       return {
         label: candidate.label,
         href: `/${entityType === 'herb' ? 'herbs' : 'compounds'}/${candidate.slug}/`,
         note: candidate.note,
-      } satisfies GoalHubLink
+      }
     })
-    .filter((link): link is GoalHubLink => Boolean(link))
+    .filter((link): link is GoalHubLink => link !== null)
 
   const hasLinks = stack || ingredients.length > 0 || compares.length > 0 || seoEntry
   if (!hasLinks) return null

--- a/src/components/safety/__tests__/SafetyCheckerClient.mao-distinct.test.tsx
+++ b/src/components/safety/__tests__/SafetyCheckerClient.mao-distinct.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import SafetyCheckerClient from '../SafetyCheckerClient'
+import type { SafetyToolItem } from '@/lib/safety-checker-engine'
 
 vi.mock('next/link', () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => (
@@ -8,19 +9,21 @@ vi.mock('next/link', () => ({
   ),
 }))
 
-const herbs = [
+const herbs: SafetyToolItem[] = [
   {
     slug: 'rhodiola-rosea',
     name: 'Rhodiola Rosea',
+    type: 'herb',
     safety: 'Caution: Mild MAOI-like activity. Avoid with strong stimulants or SSRIs.',
     mechanism: 'Inhibits monoamine oxidase (MAOI) enzymes.',
   },
 ]
 
-const compounds = [
+const compounds: SafetyToolItem[] = [
   {
     slug: 'kanna-extract',
     name: 'Kanna Extract',
+    type: 'compound',
     safety: 'Caution: Serotonergic modulation. Avoid with SSRIs or MAOIs.',
     mechanism: 'Serotonin reuptake inhibitor. 5-HT signaling increase.',
   },

--- a/src/components/safety/__tests__/SafetyCheckerClient.test.tsx
+++ b/src/components/safety/__tests__/SafetyCheckerClient.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import SafetyCheckerClient from '../SafetyCheckerClient'
+import type { SafetyToolItem } from '@/lib/safety-checker-engine'
 
 vi.mock('next/link', () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) => (
@@ -8,37 +9,42 @@ vi.mock('next/link', () => ({
   ),
 }))
 
-const mockHerbs = [
+const mockHerbs: SafetyToolItem[] = [
   {
     slug: 'kava',
     name: 'Kava',
+    type: 'herb',
     safety: 'Caution: Sedative properties. Avoid combining with alcohol or other CNS depressants.',
     mechanism: 'GABA-A positive allosteric modulator.',
   },
   {
     slug: 'valerian-root',
     name: 'Valerian Root',
+    type: 'herb',
     safety: 'Caution: May cause drowsiness. High CNS depressant loading in combination.',
     mechanism: 'Enhances GABAergic transmission.',
   },
   {
     slug: 'rhodiola-rosea',
     name: 'Rhodiola Rosea',
+    type: 'herb',
     safety: 'Caution: Mild MAOI-like activity. Avoid with strong stimulants or SSRIs.',
     mechanism: 'Inhibits monoamine oxidase (MAOI) enzymes.',
   }
 ]
 
-const mockCompounds = [
+const mockCompounds: SafetyToolItem[] = [
   {
     slug: 'caffeine',
     name: 'Caffeine',
+    type: 'compound',
     safety: 'Caution: Stimulant. Can cause heart rate increases.',
     mechanism: 'Adenosine receptor antagonist. Stimulant activity.',
   },
   {
     slug: 'kanna-extract',
     name: 'Kanna Extract',
+    type: 'compound',
     safety: 'Caution: Serotonergic modulation. Avoid with SSRIs or MAOIs.',
     mechanism: 'Serotonin reuptake inhibitor. 5-HT signaling increase.',
   }

--- a/src/lib/article-citation-metadata.ts
+++ b/src/lib/article-citation-metadata.ts
@@ -121,7 +121,7 @@ export function buildCitationReadySummary({
     ...keyTakeaways.map(cleanSentence),
   ])
 
-  let selected = preserveAuthoredCaveat(authoredSentences.slice(0, 4), authoredSentences)
+  const selected = preserveAuthoredCaveat(authoredSentences.slice(0, 4), authoredSentences)
 
   if (selected.length < 2) {
     if (sourceCount > 0 && evidenceGrade) {

--- a/src/lib/growth.ts
+++ b/src/lib/growth.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { canTrackAnalytics } from '@/lib/consent'
-import { readStorage, writeStorage } from '@/utils/storageState'
+import { getLS as readStorage, setLS as writeStorage } from '@/src/lib/storage'
 import { useLocation } from './router-compat'
 
 export type SavedEntityType = 'herb' | 'compound' | 'article' | 'blend'

--- a/tests/form-guide-publication-gate.test.ts
+++ b/tests/form-guide-publication-gate.test.ts
@@ -73,9 +73,11 @@ describe('form guide publication gate', () => {
 
   it('preserves object and delimiter-separated form representations', () => {
     const objectRecord: RuntimeRecord = {
+      slug: 'object-forms',
       forms: { extract: 'standardized', powder: 'whole root' },
     }
     const stringRecord: RuntimeRecord = {
+      slug: 'string-forms',
       available_forms: 'capsule | liquid',
     }
 

--- a/tests/interaction-route-map-visibility.test.ts
+++ b/tests/interaction-route-map-visibility.test.ts
@@ -33,10 +33,12 @@ describe('interaction partner route map visibility', () => {
   })
 
   it('does not create route entries for records without a valid slug', () => {
+    const missingSlug = { indexability_status: 'PUBLISH' } as unknown as RuntimeRecord
+
     expect(
       buildRenderableSlugEntityTypeMap(
         [{ slug: '', indexability_status: 'PUBLISH' }],
-        [{ indexability_status: 'PUBLISH' }],
+        [missingSlug],
       ),
     ).toEqual({})
   })

--- a/tests/runtime-comparison-publication-gate.test.ts
+++ b/tests/runtime-comparison-publication-gate.test.ts
@@ -75,12 +75,13 @@ describe('runtime comparison publication gate', () => {
   })
 
   it('preserves structured comparison field rendering after consolidation', () => {
-    const record: RuntimeRecord = {
+    const record = {
+      slug: 'structured-safety',
       safety: {
         common: ['GI upset', 'headache'],
         note: 'Dose dependent',
       },
-    }
+    } as unknown as RuntimeRecord
 
     expect(comparisonValueToText(record.safety)).toBe(
       'common: GI upset; headache; note: Dose dependent',

--- a/tests/runtime-metadata-cache-visibility.test.ts
+++ b/tests/runtime-metadata-cache-visibility.test.ts
@@ -45,11 +45,16 @@ describe('runtime metadata cache visibility', () => {
   })
 
   it('ignores records without a usable slug', () => {
+    const missingSlug = {
+      name: 'Missing',
+      indexability_status: 'PUBLISH',
+    } as unknown as RuntimeRecord
+
     expect(
       buildRenderableMetadataMap(
         [
           { slug: '', name: 'Empty', indexability_status: 'PUBLISH' },
-          { name: 'Missing', indexability_status: 'PUBLISH' },
+          missingSlug,
         ],
         'herb',
       ),


### PR DESCRIPTION
Closes #3279

## Relevant URLs
- `src/lib/growth.ts`
- `src/lib/storage.ts`
- `app/evidence/evidence-digest/2026-08-evidence-literacy/page.tsx`
- `src/components/goals/GoalHubSections.tsx`
- `src/components/editorial/LastUpdatedBadge.tsx`
- `src/lib/article-citation-metadata.ts`
- `lib/citation-identifiers.mjs`
- safety/runtime publication-gate test fixtures

## Acceptance criteria
- `npm run lint` has no errors from the reported baseline failures.
- `npm run typecheck` has no errors from the reported baseline failures.
- `npm run check:fast` progresses through citation validation into UI-specific checks.
- Packed legacy citation URL cells export one usable canonical href instead of a malformed multi-URL href.
- Runtime, safety, indexability, and evidence contracts are not weakened to make tests compile.

## Validation commands
- `npm run lint`
- `npm run typecheck`
- `npm run check:fast`
- `npm run validate:citation-identifiers`
- GitHub Actions: CI, Fast UI Check, Atomic upgrade gate, Site Health Check

## Before → after metrics
- Before: 4 blocking ESLint errors; 30+ TypeScript diagnostics in the first Fast UI typecheck pass; missing `@/utils/storageState` module; multiple fixtures drifted from required runtime/safety contracts; 4 malformed pipe-packed citation URLs blocked `check:fast` after lint/typecheck were repaired.
- After: reported lint/type diagnostics are fixed at their narrowest source; growth storage uses the existing canonical helper; intentionally malformed test inputs are explicit at the test boundary; packed full citation URLs normalize to one valid canonical href.

## Generator/source-of-truth decision
- `src/lib/storage.ts`, existing runtime/safety types, and `lib/citation-identifiers.mjs` remain authoritative. Citation repair is implemented in the canonical identifier helper used by the runtime citation exporter rather than patching generated `public/data` output.

## Regression contract
- Do not weaken TypeScript, ESLint, RuntimeRecord slug requirements, SafetyToolItem type requirements, citation validation, or release-quality gates.
- Do not change scientific claims, evidence grades, publication/indexability decisions, or safety screening semantics.
- Keep intentionally malformed records confined to explicit negative-test fixtures.
- Do not publish packed multi-URL citation strings as browser hrefs.