### PR TITLE
refactor(home): collapse homepage to one decision flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from 'next'
 import HomepageV2 from '@/components/homepage-v2'
-import HomepageDecisionShortcuts from '@/components/HomepageDecisionShortcuts'
-import NewsletterSignup from '@/components/NewsletterSignup'
 import { buildPageMetadata } from '../src/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -25,13 +23,5 @@ export const metadata: Metadata = buildPageMetadata({
 })
 
 export default function Page() {
-  return (
-    <>
-      <HomepageV2 />
-      <div className='mx-auto max-w-6xl px-5 py-10 sm:px-8 sm:py-16 lg:px-10'>
-        <NewsletterSignup location='homepage-editorial' variant='editorial' />
-      </div>
-      <HomepageDecisionShortcuts />
-    </>
-  )
+  return <HomepageV2 />
 }


### PR DESCRIPTION
## Summary
- Removes the second homepage newsletter signup that duplicated the earlier safety-checklist conversion path.
- Removes the appended `HomepageDecisionShortcuts` block whose goal cards repeated the primary goal-navigation already rendered by `HomepageV2`.
- Makes `HomepageV2` the single authoritative homepage composition.

## Why
The live homepage currently repeats the same decisions and conversion prompts multiple times, increasing scroll length and weakening hierarchy. This reduces duplicate UI without removing the primary goal, profile, comparison, safety, article, or methodology paths.

## Regression contract
- Homepage metadata is unchanged.
- Primary homepage navigation and all `HomepageV2` content remain unchanged.
- This PR only removes redundant appended sections.