### PR TITLE
refactor(nav): give Ingredients one clear job

### DIFF
--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -31,9 +31,6 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     children: [
       { label: 'Herb database', href: '/herbs', description: 'Canonical herb profiles with evidence, dosing context, and safety summaries' },
       { label: 'Compound database', href: '/compounds', description: 'Nutrients, isolated compounds, standardized extracts, and active constituents' },
-      { label: 'Evidence database', href: '/evidence/evidence-checker', description: 'Search ingredients by the strength of their human evidence' },
-      { label: 'Herb guides', href: '/guides/herbs', description: 'Long-form practical guides for important botanicals' },
-      { label: 'Dosing guide', href: '/info/dosing', description: 'Studied doses, forms, timing, bioavailability, and dose realism basics' },
       { label: 'Search everything', href: '/search', description: 'Search common names, scientific names, compounds, guides, and research resources' },
     ],
   },


### PR DESCRIPTION
## Summary
- Reduces the Ingredients dropdown from six destinations to three.
- Keeps it focused on lookup/discovery: Herb database, Compound database, and Search everything.
- Removes Evidence database, Herb guides, and Dosing guide from this dropdown because they already belong to other site areas.

## Why
The same destinations were being surfaced under multiple top-level intents, making the header feel broader than it actually is. Ingredients should answer “what is this ingredient?” while Research and guide surfaces own evidence and editorial education.

## Regression contract
- No routes are removed.
- Evidence Database remains under Research.
- Herb guides and Dosing remain directly accessible elsewhere in the site.
- Top-level navigation order is unchanged.