### PR TITLE
refactor(nav): remove unused parallel footer config

### DIFF
--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -234,23 +234,6 @@ export const routeLabels: Record<string, RouteMetadata> = {
   },
 }
 
-export const footerLinks = {
-  legal: [
-    { label: 'Privacy Policy', href: '/info/privacy' },
-    { label: 'Disclaimer', href: '/info/disclaimer' },
-    { label: 'Affiliate Disclosure', href: '/info/affiliate-disclosure' },
-  ],
-  social: [],
-  meta: [
-    { label: 'Explore Everything', href: '/library' },
-    { label: 'Articles', href: '/articles' },
-    { label: 'Evidence Report', href: '/evidence/evidence-report' },
-    { label: 'Evidence Lookup', href: '/evidence/evidence-checker' },
-    { label: 'Sitemap', href: '/sitemap.xml' },
-    { label: 'RSS', href: '/rss.xml' },
-  ],
-}
-
 const SEGMENT_LABEL_OVERRIDES: Record<string, string> = {
   'lions-mane': "Lion's Mane",
   'l-theanine': 'L-Theanine',


### PR DESCRIPTION
## Summary
- Removes the unused `footerLinks` export from `lib/navigation-config.ts`.
- Leaves the active footer implementation in `src/components/Footer.tsx` unchanged.

## Why
Repository search shows `footerLinks` is only defined, never consumed. Keeping a dead second footer navigation map creates a false source of truth that can drift away from the actual footer.

## Regression contract
- No live navigation or route changes.
- `primaryNavigation`, breadcrumb metadata, route validation, and footer rendering remain unchanged.
- This is a pure dead-configuration removal.