### PR TITLE
refactor(nav): reduce Compare to two core actions

### DIFF
--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -41,9 +41,6 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     activePrefixes: ['/guides/compare'],
     children: [
       { label: 'Comparison center', href: '/guides/compare', description: 'Browse published side-by-side evidence and safety comparisons' },
-      { label: 'Melatonin vs Magnesium', href: '/guides/compare/melatonin-vs-magnesium', description: 'Compare two common sleep-oriented options by evidence, timing, and tradeoffs' },
-      { label: 'Rhodiola vs Ashwagandha', href: '/guides/compare/rhodiola-vs-ashwagandha', description: 'Compare two adaptogens with different stimulation and stress profiles' },
-      { label: 'Ashwagandha vs Magnesium', href: '/guides/compare/ashwagandha-vs-magnesium', description: 'Compare stress, sleep, evidence, and safety differences' },
       { label: 'Build your own', href: '/guides/compare/dynamic', description: 'Choose two ingredients and inspect the structured research matrix' },
     ],
   },


### PR DESCRIPTION
## Summary
- Removes three hand-picked comparison pages from the global Compare dropdown.
- Keeps only `Comparison center` and `Build your own`.

## Why
Global navigation should expose durable actions, not a rotating sample of content. The comparison hub already owns discovery of specific comparisons, while the dynamic builder owns custom comparison intent.

## Regression contract
- No comparison routes are removed.
- `/guides/compare/` remains the canonical browse surface for published comparisons.
- `/guides/compare/dynamic` remains directly accessible from global navigation.
- Active-prefix behavior is unchanged.