### PR TITLE
refactor(nav): remove unused navigation compatibility layer

### DIFF
--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -1,7 +1,3 @@
-import { primaryNavigation, type PrimaryNavigationItem } from './primary-navigation'
-
-export type NavigationItem = PrimaryNavigationItem
-
 export interface BreadcrumbItem {
   label: string
   href: string
@@ -16,9 +12,6 @@ export interface RouteMetadata {
 }
 
 export const SITE_URL = 'https://thehippiescientist.net'
-
-// One navigation source of truth for the header, schema, helper utilities, and tests.
-export const mainNavigation: NavigationItem[] = primaryNavigation
 
 export const routeLabels: Record<string, RouteMetadata> = {
   '/': {
@@ -326,20 +319,4 @@ export function getRouteMetadata(pathname: string): RouteMetadata | null {
 
   const patternKey = findDynamicRoutePattern(normalizedPath)
   return patternKey ? routeLabels[patternKey] : null
-}
-
-export function flattenNavigation(
-  items: NavigationItem[] = mainNavigation
-): Array<{ item: NavigationItem; level: number; path: string }> {
-  const result: Array<{ item: NavigationItem; level: number; path: string }> = []
-
-  function traverse(currentItems: NavigationItem[], level: number) {
-    for (const item of currentItems) {
-      result.push({ item, level, path: item.href })
-      if (item.children) traverse(item.children, level + 1)
-    }
-  }
-
-  traverse(items, 0)
-  return result
 }


### PR DESCRIPTION
## Summary
- Removes the unused `NavigationItem` alias.
- Removes the unused `mainNavigation` re-export alias.
- Removes the unused `flattenNavigation()` helper.
- Removes the now-unneeded import of `primaryNavigation` from `navigation-config.ts`.

## Why
The live navigation already consumes `primaryNavigation` directly. These helpers had no external consumers and kept an obsolete second API surface alive for no benefit.

## Regression contract
- `routeLabels`, breadcrumb generation, route validation, and route metadata lookup are unchanged.
- No header, footer, route, or content behavior changes.
- This is dead compatibility-layer removal only.