### PR TITLE
refactor(data): centralize citation identity aliases

### DIFF
--- a/lib/__tests__/citation-identifiers.test.ts
+++ b/lib/__tests__/citation-identifiers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   citationCompleteness,
+  citationIdentifiers,
   citationUrl,
   isPlaceholderCitationTitle,
   isValidDoi,
@@ -18,8 +19,6 @@ import {
 
 describe('normalizePmidList', () => {
   it('splits a cell holding two studies into two identifiers', () => {
-    // Verbatim from 11-keto-beta-boswellic-acid, which shipped both PMIDs in
-    // one field and rendered a single unresolvable link.
     expect(normalizePmidList('15070181; 22167571')).toEqual(['15070181', '22167571'])
     expect(normalizePmidList('33799504; 33034447')).toEqual(['33799504', '33034447'])
   })
@@ -31,7 +30,6 @@ describe('normalizePmidList', () => {
   })
 
   it('drops malformed identifiers rather than passing them through', () => {
-    // A leading zero or a non-numeric value would render as a dead link.
     expect(normalizePmidList('0123456')).toEqual([])
     expect(normalizePmidList('not-a-pmid')).toEqual([])
     expect(normalizePmidList('')).toEqual([])
@@ -60,18 +58,28 @@ describe('normalizeDoi / isValidDoi', () => {
   })
 
   it('validates the registrant prefix', () => {
-    expect(isValidDoi('10.1016/j.jep.2021.114'
-      )).toBe(true)
+    expect(isValidDoi('10.1016/j.jep.2021.114')).toBe(true)
     expect(isValidDoi('11.1000/xyz')).toBe(false)
     expect(isValidDoi('10.1000')).toBe(false)
     expect(isValidDoi('')).toBe(false)
   })
 })
 
+describe('citationIdentifiers', () => {
+  it('returns DOI and PMID aliases for the same study', () => {
+    expect(citationIdentifiers({ doi: 'HTTPS://DOI.ORG/10.1000/XYZ123', pmid: '34559859' })).toEqual([
+      'doi:10.1000/xyz123',
+      'pmid:34559859',
+    ])
+  })
+
+  it('keeps every valid PMID alias from a packed source cell', () => {
+    expect(citationIdentifiers({ pmid: '15070181; 22167571' })).toEqual(['pmid:15070181', 'pmid:22167571'])
+  })
+})
+
 describe('citationUrl', () => {
   it('rebuilds the link when the stored URL packs two identifiers', () => {
-    // The stored value was ".../15070181/; https://.../22167571/" — one href
-    // that resolves nowhere. The first identifier wins.
     expect(
       citationUrl({
         url: 'https://pubmed.ncbi.nlm.nih.gov/15070181/; https://pubmed.ncbi.nlm.nih.gov/22167571/',
@@ -98,7 +106,6 @@ describe('citationUrl', () => {
 
 describe('isPlaceholderCitationTitle', () => {
   it('recognises a metadata note published as a study title', () => {
-    // Real value attached to PMID 37818728.
     expect(isPlaceholderCitationTitle('PubMed PMID 37818728. Minimal citation row added from existing evidence.')).toBe(true)
     expect(isPlaceholderCitationTitle('Systematic review metadata; abstract unavailable in fetch')).toBe(true)
     expect(isPlaceholderCitationTitle('')).toBe(true)
@@ -124,6 +131,12 @@ describe('citationCompleteness', () => {
     expect(result.complete).toBe(false)
     expect(result.missing).toEqual(['journal'])
     expect(result.identifier).toBe('pmid:34559859')
+  })
+
+  it('uses the DOI as the preferred identifier while preserving PMID as an alias', () => {
+    const source = { doi: '10.1000/XYZ123', pmid: '34559859' }
+    expect(citationCompleteness(source).identifier).toBe('doi:10.1000/xyz123')
+    expect(citationIdentifiers(source)).toContain('pmid:34559859')
   })
 
   it('counts a placeholder title as a missing title', () => {

--- a/lib/citation-identifiers.mjs
+++ b/lib/citation-identifiers.mjs
@@ -81,7 +81,6 @@ export function normalizePmidList(value) {
 
   const seen = new Set()
   for (const part of raw.split(IDENTIFIER_SEPARATOR)) {
-    // Tolerate `PMID: 12345` and bare pubmed URLs inside a packed cell.
     const candidate = part
       .trim()
       .replace(/^pmid:?\s*/i, '')
@@ -91,6 +90,24 @@ export function normalizePmidList(value) {
     if (isValidPmid(candidate)) seen.add(candidate)
   }
   return [...seen]
+}
+
+/**
+ * Return every stable identifier that names a citation, in canonical form.
+ * DOI is listed first because it is the preferred resolver; PMIDs remain
+ * aliases for identity/deduplication even when a DOI is present.
+ *
+ * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }} source
+ * @returns {string[]}
+ */
+export function citationIdentifiers(source) {
+  const identifiers = []
+  const doi = normalizeDoi(source?.doi)
+  if (isValidDoi(doi)) identifiers.push(`doi:${doi.toLowerCase()}`)
+  for (const pmid of normalizePmidList(source?.pmid ?? source?.pubmedId)) {
+    identifiers.push(`pmid:${pmid}`)
+  }
+  return identifiers
 }
 
 /**
@@ -139,10 +156,6 @@ export function citationUrl(source) {
 
 /**
  * Titles that record the absence of metadata rather than naming a study.
- *
- * `"PubMed PMID 37818728. Minimal citation row added from existing evidence."`
- * is a note to whoever fills the row in, and it currently renders as the study
- * title on a live page.
  */
 const PLACEHOLDER_TITLE_PATTERNS = [
   /minimal citation row/i,
@@ -172,9 +185,7 @@ export function isPlaceholderCitationTitle(value) {
  */
 export function citationCompleteness(source) {
   const missing = []
-  const doi = normalizeDoi(source?.doi)
-  const pmids = normalizePmidList(source?.pmid ?? source?.pubmedId)
-  const identifier = isValidDoi(doi) ? `doi:${doi}` : pmids[0] ? `pmid:${pmids[0]}` : ''
+  const [identifier = ''] = citationIdentifiers(source)
 
   if (!identifier) missing.push('identifier')
   if (isPlaceholderCitationTitle(source?.title)) missing.push('title')

--- a/scripts/ci/validate-citation-identifiers.mjs
+++ b/scripts/ci/validate-citation-identifiers.mjs
@@ -27,6 +27,7 @@ import path from 'node:path'
 
 import {
   citationCompleteness,
+  citationIdentifiers,
   isPlaceholderCitationTitle,
   isValidDoi,
   isValidPmid,
@@ -94,6 +95,7 @@ function main() {
 
       const rawPmid = text(source.pmid ?? source.pubmedId)
       const rawDoi = normalizeDoi(source.doi)
+      const canonicalDoi = rawDoi.toLowerCase()
       const rawUrl = text(source.url)
 
       if (rawPmid && !isValidPmid(rawPmid)) {
@@ -107,8 +109,8 @@ function main() {
       }
 
       if (isValidPmid(rawPmid) && isValidDoi(rawDoi)) {
-        addMapping(pmidToDois, rawPmid, rawDoi)
-        addMapping(doiToPmids, rawDoi, rawPmid)
+        addMapping(pmidToDois, rawPmid, canonicalDoi)
+        addMapping(doiToPmids, canonicalDoi, rawPmid)
       }
 
       const completeness = citationCompleteness(source)
@@ -119,22 +121,22 @@ function main() {
         advisory.push({ url, missing: ['placeholder-title'], value: text(source.title).slice(0, 90) })
       }
 
-      if (completeness.identifier) {
-        if (profileIdentifiers.has(completeness.identifier)) {
-          duplicateProfileSources.push({
-            url,
-            identifier: completeness.identifier,
-            title: text(source.title).slice(0, 80),
-          })
-        } else {
-          profileIdentifiers.add(completeness.identifier)
-        }
+      const aliases = citationIdentifiers(source)
+      const duplicateAliases = aliases.filter((identifier) => profileIdentifiers.has(identifier))
+      if (duplicateAliases.length) {
+        duplicateProfileSources.push({
+          url,
+          identifiers: duplicateAliases,
+          title: text(source.title).slice(0, 80),
+        })
+      }
+      for (const identifier of aliases) profileIdentifiers.add(identifier)
 
-        // Same identifier, different titles — one study recorded inconsistently.
-        const titles = seenByIdentifier.get(completeness.identifier) ?? new Set()
-        const normalized = text(source.title).toLowerCase()
-        if (normalized) titles.add(normalized)
-        seenByIdentifier.set(completeness.identifier, titles)
+      const normalizedTitle = text(source.title).toLowerCase()
+      for (const identifier of aliases) {
+        const titles = seenByIdentifier.get(identifier) ?? new Set()
+        if (normalizedTitle) titles.add(normalizedTitle)
+        seenByIdentifier.set(identifier, titles)
       }
     }
   }
@@ -182,7 +184,7 @@ function main() {
   if (duplicateProfileSources.length) {
     console.error(`\n[citation-identifiers] FAILED — ${duplicateProfileSources.length} duplicate source reference(s) within profiles.`)
     for (const duplicate of duplicateProfileSources.slice(0, 20)) {
-      console.error(`  ${duplicate.url} · ${duplicate.identifier} · ${duplicate.title}`)
+      console.error(`  ${duplicate.url} · ${duplicate.identifiers.join(', ')} · ${duplicate.title}`)
     }
     process.exit(1)
   }


### PR DESCRIPTION
Introduces a canonical citationIdentifiers helper that preserves DOI and PMID aliases for the same study, normalizes DOI identity casing, and updates profile deduplication/title-conflict checks to reason over every alias instead of only a preferred identifier. Includes focused tests for alias behavior.