### PR TITLE
Backlog 149-151, 396-399: replace placeholder summaries with composed ones

### DIFF
--- a/lib/__tests__/profile-summary.test.ts
+++ b/lib/__tests__/profile-summary.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildProfileSummary, isPlaceholderSummary } from '@/lib/profile-summary'
+
+/**
+ * This text becomes the summary on live pages and the basis of meta
+ * descriptions, so the standard is that every clause traces to a field on the
+ * record. Inventing a benefit here would be a health claim the evidence does
+ * not support.
+ */
+
+const acerola = {
+  name: 'Acerola',
+  scientific_name: 'Malpighia emarginata',
+  evidence_grade: 'C',
+  evidence_rationale: 'Strongest recorded design is a randomized controlled trial, drawn from 3 recorded studies, 1 in people.',
+  mechanisms: ['Inflammatory Signaling Modulation', 'Oxidative Stress Modulation'],
+  contraindications: ['Kidney stone risk', 'iron overload conditions'],
+}
+
+describe('buildProfileSummary', () => {
+  it('composes identity, evidence, mechanism and safety from the record', () => {
+    const summary = buildProfileSummary(acerola)
+    expect(summary).toContain('Acerola (Malpighia emarginata)')
+    expect(summary).toContain('Grade C rating — limited evidence')
+    expect(summary).toContain('randomized controlled trial')
+    expect(summary).toContain('kidney stone risk')
+  })
+
+  it('labels mechanism as mechanism, never as benefit', () => {
+    // A pathway listed without this qualifier is how a target gets read as a
+    // health outcome.
+    expect(buildProfileSummary(acerola)).toContain('describes mechanism rather than demonstrated benefit')
+  })
+
+  it('lower-cases Title Case phrases without destroying acronyms', () => {
+    const summary = buildProfileSummary({
+      ...acerola,
+      mechanisms: ['AMPK Signaling', 'Inflammatory Signaling Modulation', 'NF-κB Modulation'],
+    })
+    expect(summary).toContain('AMPK signaling')
+    expect(summary).toContain('inflammatory signaling modulation')
+    expect(summary).toContain('NF-κB modulation')
+    expect(summary).not.toContain('aMPK')
+  })
+
+  it('keeps proper nouns in safety cautions intact', () => {
+    // "Apiaceae" is a botanical family, not a Title Case word to normalise.
+    const summary = buildProfileSummary({
+      ...acerola,
+      contraindications: ['Known allergy to Apiaceae family plants'],
+    })
+    expect(summary).toContain('Apiaceae')
+  })
+
+  it('trims a caution that carries its whole rationale', () => {
+    const summary = buildProfileSummary({
+      ...acerola,
+      contraindications: ['Pregnancy because concentrated oil or high-dose extracts may stimulate uterine contractions'],
+    })
+    expect(summary).toContain('Noted cautions include pregnancy.')
+    expect(summary).not.toContain('uterine')
+  })
+
+  it('omits a clause rather than inventing one when the field is absent', () => {
+    const summary = buildProfileSummary({ name: 'Testherb', evidence_grade: 'D' })
+    expect(summary).toBe('Testherb carries a Grade D rating — preliminary / theoretical evidence.')
+  })
+
+  it('says so plainly when no grade is assigned', () => {
+    expect(buildProfileSummary({ name: 'Testherb' })).toContain('no evidence grade assigned')
+  })
+
+  it('is deterministic', () => {
+    expect(buildProfileSummary(acerola)).toBe(buildProfileSummary(acerola))
+  })
+
+  it('returns empty for an unusable record rather than a stub', () => {
+    expect(buildProfileSummary(null)).toBe('')
+    expect(buildProfileSummary({})).toBe('')
+  })
+})
+
+describe('isPlaceholderSummary', () => {
+  it('recognises the generated filler', () => {
+    expect(isPlaceholderSummary('Acerola botanical profile with evidence, safety, and practical fit.')).toBe(true)
+    expect(isPlaceholderSummary('Taurine Blend compound profile with evidence, safety, and practical fit.')).toBe(true)
+    expect(isPlaceholderSummary('No summary available yet.')).toBe(true)
+    expect(isPlaceholderSummary('')).toBe(true)
+  })
+
+  it('leaves authored prose alone', () => {
+    expect(
+      isPlaceholderSummary('Holy basil is a traditional botanical most often used for stress adaptation over time.'),
+    ).toBe(false)
+  })
+})

--- a/lib/profile-summary.ts
+++ b/lib/profile-summary.ts
@@ -1,0 +1,155 @@
+/**
+ * Compose a profile summary from the record's own verified fields.
+ *
+ * 248 indexable profiles carry a generated placeholder as their summary —
+ * "Acerola botanical profile with evidence, safety, and practical fit." Those
+ * pages are not empty. Acerola has a botanical name, a Grade C rating backed by
+ * a randomized controlled trial, four recorded mechanisms, specific safety
+ * cautions, four contraindications and three cited studies. Only the sentence
+ * introducing all of it says nothing.
+ *
+ * Everything written here is assembled from fields already on the record, each
+ * of which is either authored in the workbook or derived from PubMed. No claim
+ * is introduced that the record does not already make, and any clause whose
+ * source field is missing is omitted rather than filled with a guess — a
+ * shorter true summary beats a complete invented one.
+ *
+ * Generation is deterministic: the same record always produces the same text,
+ * so a rebuild never silently rewords a published page.
+ */
+
+import { CANONICAL_GRADE_LABEL, type CanonicalEvidenceGrade } from './evidence-grade'
+
+const text = (value: unknown): string => String(value ?? '').replace(/\s+/g, ' ').trim()
+
+function list(value: unknown, limit?: number): string[] {
+  const items = Array.isArray(value) ? value : text(value).split(/[;|]/)
+  const cleaned = items.map(text).filter(Boolean)
+  return typeof limit === 'number' ? cleaned.slice(0, limit) : cleaned
+}
+
+/** "a, b and c" */
+function joinNatural(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? ''
+  if (items.length === 2) return `${items[0]} and ${items[1]}`
+  return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`
+}
+
+function lowerFirst(value: string): string {
+  return value ? value.charAt(0).toLowerCase() + value.slice(1) : value
+}
+
+/**
+ * Lower-case a Title Case phrase for mid-sentence use without destroying the
+ * acronyms inside it. Mechanism names arrive as "Inflammatory Signaling
+ * Modulation" and "AMPK Signaling"; naive lower-casing of the first character
+ * alone yields "inflammatory Signaling Modulation", and lower-casing the whole
+ * string yields "ampk signaling".
+ *
+ * A token is left alone unless it looks like an ordinary capitalised word —
+ * one leading capital followed only by lower-case letters. That preserves
+ * AMPK, NF-κB, GABA-A and mixed-case chemistry.
+ */
+function humanizePhrase(value: string): string {
+  return value
+    .split(/\s+/)
+    .map((token) => (/^[A-Z][a-z]+$/.test(token) ? token.toLowerCase() : token))
+    .join(' ')
+}
+
+/**
+ * Strip a trailing period so clauses can be joined without doubling it, and
+ * trim the trailing conjunction fragments that appear in some safety cells.
+ */
+function clause(value: unknown): string {
+  return text(value).replace(/\s*[.;]+\s*$/, '')
+}
+
+/**
+ * Returns a summary, or '' when the record supports nothing truthful.
+ */
+export function buildProfileSummary(record: Record<string, unknown> | null | undefined): string {
+  if (!record || typeof record !== 'object') return ''
+
+  const name = text(record.name)
+  if (!name) return ''
+
+  const scientificName = text(record.scientific_name || record.latin_name || record.botanical_name)
+  const grade = text(record.evidence_grade)
+  const gradeLabel = CANONICAL_GRADE_LABEL[grade as CanonicalEvidenceGrade]
+  const rationale = clause(record.evidence_rationale)
+  const mechanisms = list(record.mechanisms, 3)
+  const effects = list(Array.isArray(record.effects) && record.effects.length ? record.effects : record.primary_effects, 3)
+  // Some contraindication cells are a full explanatory sentence. Those read as
+  // a run-on once joined, so short entries are preferred and a long one is only
+  // used when nothing shorter exists.
+  const allContraindications = list(record.contraindications).map(clause)
+  const shortContraindications = allContraindications.filter((item) => item.length <= 60)
+  const contraindications = shortContraindications.length
+    ? shortContraindications.slice(0, 2)
+    // Nothing short enough: take one and cut it at the explanatory clause, so
+    // the summary names the caution without swallowing its whole rationale.
+    : allContraindications.slice(0, 1).map((item) => clause(item.split(/\s+(?:because|such as)\s+/i)[0]))
+  const safety = clause(record.safety)
+
+  const sentences: string[] = []
+
+  // 1. Identity and where the evidence stands.
+  const subject = scientificName ? `${name} (${scientificName})` : name
+  if (gradeLabel) {
+    // "Grade C: Limited Evidence" reads badly inline; split the label so the
+    // rating and its meaning become one natural clause.
+    const [ratingPart, meaningPart] = gradeLabel.split(/:\s*/)
+    sentences.push(
+      meaningPart
+        ? `${subject} carries a ${ratingPart} rating — ${humanizePhrase(meaningPart).toLowerCase()}.`
+        : `${subject} carries a ${ratingPart} rating.`,
+    )
+  } else {
+    sentences.push(`${subject} has no evidence grade assigned in our dataset.`)
+  }
+
+  // 2. What that grade rests on. Already a complete sentence about counts and
+  //    design, derived from the cited literature.
+  if (rationale && !/^no study design has been recorded/i.test(rationale)) {
+    sentences.push(`${rationale}.`)
+  }
+
+  // 3. Mechanism, explicitly labelled as mechanism. Listing a pathway without
+  //    that qualifier is how a target becomes mistaken for a benefit.
+  if (mechanisms.length) {
+    sentences.push(
+      `Recorded activity centres on ${joinNatural(mechanisms.map(humanizePhrase))}, which describes mechanism rather than demonstrated benefit.`,
+    )
+  } else if (effects.length) {
+    sentences.push(`Recorded contexts of use: ${joinNatural(effects.map(humanizePhrase))}.`)
+  }
+
+  // 4. Safety, preferring the specific contraindications over prose.
+  if (contraindications.length) {
+    // Only the leading character is lowered here. `humanizePhrase` would
+    // destroy proper nouns that appear in cautions — "Apiaceae" is a botanical
+    // family, not a Title Case word to be normalised away.
+    sentences.push(`Noted cautions include ${joinNatural(contraindications.map(lowerFirst))}.`)
+  } else if (safety) {
+    sentences.push(`${safety}.`)
+  }
+
+  return sentences.join(' ')
+}
+
+/**
+ * Generated placeholders that a real summary should replace. Anything not
+ * matching here is treated as authored prose and left alone.
+ */
+const PLACEHOLDER_SUMMARY = [
+  /\b(?:botanical|compound)\s+profile\s+with\s+evidence,\s+safety,\s+and\s+practical\s+fit\.?$/i,
+  /\bprofile\s+with\s+mechanism,?\s+safety,?\s+and\s+practical\s+context\b/i,
+  /^no summary available yet\.?$/i,
+]
+
+export function isPlaceholderSummary(value: unknown): boolean {
+  const summary = text(value)
+  if (!summary) return true
+  return PLACEHOLDER_SUMMARY.some((pattern) => pattern.test(summary))
+}

--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -126,7 +126,7 @@
   {
     "slug": "23-epi-26-deoxyactein",
     "name": "23-epi-26-deoxyactein",
-    "summary": "23-epi-26-deoxyactein compound profile with evidence, safety, and practical fit.",
+    "summary": "23-epi-26-deoxyactein carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on added as site-safe referenced entity during workbook readiness pass and limited, which describes mechanism rather than demonstrated benefit. Safety notes are not source-complete in this workbook row; avoid broad safety claims and hold for interaction, population, and formulation review.",
     "description": "23-epi-26-deoxyactein compound profile with evidence, safety, and practical fit.",
     "effects": [],
     "primary_effects": [],
@@ -215,7 +215,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "5-htp",
@@ -332,7 +333,7 @@
   {
     "slug": "acarbose",
     "name": "Acarbose",
-    "summary": "Acarbose compound profile with evidence, safety, and practical fit.",
+    "summary": "Acarbose carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include type 1 diabetes or diabetic ketoacidosis and cirrhosis or significant hepatic impairment.",
     "description": "Acarbose compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
@@ -456,7 +457,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "acemannan",
@@ -579,7 +581,7 @@
   {
     "slug": "acetate",
     "name": "acetate",
-    "summary": "acetate compound profile with evidence, safety, and practical fit.",
+    "summary": "acetate carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, glucose metabolism support and lipid metabolism support, which describes mechanism rather than demonstrated benefit. generally safe; excessive intake may cause GI irritation or enamel erosion.",
     "description": "acetate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "glucose_AMPK"
@@ -685,7 +687,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "acetyl-11-keto-beta-boswellic-acid",
@@ -932,7 +935,7 @@
   {
     "slug": "acetyl-l-carnitine",
     "name": "Acetyl-L-Carnitine",
-    "summary": "Acetyl-L-Carnitine compound profile with evidence, safety, and practical fit.",
+    "summary": "Acetyl-L-Carnitine carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, mitochondrial support and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include caution in seizure disorders.",
     "description": "Acetyl-L-Carnitine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mitochondrial metabolism",
@@ -1068,7 +1071,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "acetylshikonin",
@@ -1933,7 +1937,7 @@
   {
     "slug": "agmatine-sulfate",
     "name": "Agmatine sulfate",
-    "summary": "Agmatine sulfate compound profile with evidence, safety, and practical fit.",
+    "summary": "Agmatine sulfate carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance.",
     "description": "Agmatine sulfate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NO synthase imidazoline receptors"
@@ -2045,7 +2049,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ajoene",
@@ -2637,7 +2642,7 @@
   {
     "slug": "alpha-gpc",
     "name": "Alpha-GPC",
-    "summary": "Alpha-GPC compound profile with evidence, safety, and practical fit.",
+    "summary": "Alpha-GPC carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a uncontrolled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, neurotransmitter modulation and cellular protection, which describes mechanism rather than demonstrated benefit. Noted cautions include known hypersensitivity to alpha-GPC or its excipients.",
     "description": "Alpha-GPC compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cholinergic system",
@@ -2764,12 +2769,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "uncontrolled-trial",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "alpha-lipoic-acid",
     "name": "Alpha-Lipoic Acid",
-    "summary": "Alpha-Lipoic Acid compound profile with evidence, safety, and practical fit.",
+    "summary": "Alpha-Lipoic Acid carries a Grade A rating — strong evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on oxidative stress modulation, mitochondrial support and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include caution with hypoglycemic agents.",
     "description": "Alpha-Lipoic Acid compound profile with evidence, safety, and practical fit.",
     "effects": [
       "oxidative stress",
@@ -2893,7 +2899,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "single-human-study-for-grade-a"
+    "evidence_grade_backing_gap": "single-human-study-for-grade-a",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "alpha-mangostin",
@@ -3153,7 +3160,7 @@
   {
     "slug": "anandamide",
     "name": "Anandamide",
-    "summary": "Anandamide compound profile with evidence, safety, and practical fit.",
+    "summary": "Anandamide carries a Grade C rating — limited evidence. Recorded activity centres on endogenous CB1 agonism, FAAH degradation and endocannabinoid, which describes mechanism rather than demonstrated benefit. not applicable as direct supplement context; unstable compound.",
     "description": "Anandamide compound profile with evidence, safety, and practical fit.",
     "effects": [
       "CB1 receptor",
@@ -3256,7 +3263,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "andrographis",
@@ -3389,7 +3397,7 @@
   {
     "slug": "andrographolide",
     "name": "Andrographolide",
-    "summary": "Andrographolide compound profile with evidence, safety, and practical fit.",
+    "summary": "Andrographolide carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a systematic review, drawn from 2 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and mitochondrial support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy.",
     "description": "Andrographolide compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NF-κB",
@@ -3520,7 +3528,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "anethole",
@@ -3908,7 +3917,7 @@
   {
     "slug": "arabinoxylan",
     "name": "Arabinoxylan",
-    "summary": "Arabinoxylan compound profile with evidence, safety, and practical fit.",
+    "summary": "Arabinoxylan carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on metabolic regulation, vascular function support and glucose metabolism support, which describes mechanism rather than demonstrated benefit. May worsen bloating in sensitive users; titrate fiber gradually.",
     "description": "Arabinoxylan compound profile with evidence, safety, and practical fit.",
     "effects": [
       "fiber_LDL"
@@ -4012,7 +4021,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "l-arginine",
@@ -4590,7 +4600,7 @@
   {
     "slug": "artichoke-extract",
     "name": "Artichoke Extract",
-    "summary": "Artichoke Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Artichoke Extract carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include avoid artichoke leaf extract with bile-duct obstruction or other obstructive biliary disease.",
     "description": "Artichoke Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "bile flow",
@@ -4720,7 +4730,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ashitaba-extract",
@@ -4849,7 +4860,7 @@
   {
     "slug": "ashwagandha-extract-ksm-66",
     "name": "Ashwagandha KSM-66 extract",
-    "summary": "Ashwagandha KSM-66 extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Ashwagandha KSM-66 extract carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and previous ashwagandha-associated liver injury.",
     "description": "Ashwagandha KSM-66 extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "HPA axis",
@@ -4977,7 +4988,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ashwagandha-root-extract",
@@ -5471,7 +5483,7 @@
   {
     "slug": "astaxanthin",
     "name": "Astaxanthin",
-    "summary": "Astaxanthin compound profile with evidence, safety, and practical fit.",
+    "summary": "Astaxanthin carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and mitochondrial support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy or breastfeeding due to insufficient safety data.",
     "description": "Astaxanthin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "oxidative stress pathways",
@@ -5603,7 +5615,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "astragalin",
@@ -6374,7 +6387,7 @@
   {
     "slug": "bacopa-extract-bacoside-standardized",
     "name": "Bacopa extract standardized",
-    "summary": "Bacopa extract standardized compound profile with evidence, safety, and practical fit.",
+    "summary": "Bacopa extract standardized carries a Grade B rating — moderate evidence. Recorded activity centres on oxidative stress modulation, neurotransmitter modulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Safety evidence: short-term human trials of Bacopa extracts most often report gastrointestinal adverse effects, but preparations and reporting vary. Pregnancy, breastfeeding, surgery, long-term use, organ impairment, and clinically significant medication interactions remain insufficiently characterized.",
     "description": "Bacopa extract standardized compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cholinergic system",
@@ -6490,7 +6503,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bacopaside-ii",
@@ -7174,7 +7188,7 @@
   {
     "slug": "banaba-leaf-extract",
     "name": "Banaba Leaf Extract",
-    "summary": "Banaba Leaf Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Banaba Leaf Extract carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Hypoglycemia risk possible; caution antidiabetic drugs.",
     "description": "Banaba Leaf Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
@@ -7281,7 +7295,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bcaa",
@@ -7500,7 +7515,7 @@
   {
     "slug": "beetroot-extract",
     "name": "Beetroot extract",
-    "summary": "Beetroot extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Beetroot extract carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on oxidative stress modulation, vascular function support and endothelial function support, which describes mechanism rather than demonstrated benefit. Noted cautions include caution with hypotension or blood pressure medication use due to additive blood-pressure-lowering effects that can cause dizziness or fainting.",
     "description": "Beetroot extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "nitric oxide pathway",
@@ -7621,12 +7636,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "beetroot-nitrate",
     "name": "Beetroot nitrate",
-    "summary": "Beetroot nitrate compound profile with evidence, safety, and practical fit.",
+    "summary": "Beetroot nitrate carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on mitochondrial support, vascular function support and endothelial function support, which describes mechanism rather than demonstrated benefit. Safety evidence: systematic-review evidence, with limited negative-effect and interaction reporting. Nitrate-rich beetroot can lower blood pressure, but a clinically significant nitrate-drug or PDE-5 interaction magnitude should not be inferred from that effect alone.",
     "description": "Beetroot nitrate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NO pathway"
@@ -7740,7 +7756,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "berbamine",
@@ -7858,7 +7875,7 @@
   {
     "slug": "berberine",
     "name": "Berberine",
-    "summary": "Berberine compound profile with evidence, safety, and practical fit.",
+    "summary": "Berberine carries a Grade A rating — strong evidence. Strongest recorded design is a meta-analysis, drawn from 6 recorded studies, 6 in people. No disagreement is recorded across them. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and breastfeeding.",
     "description": "Berberine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "AMPK",
@@ -7987,12 +8004,13 @@
     "evidence_recorded_study_count": 6,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "berberine-hcl",
     "name": "Berberine",
-    "summary": "Berberine compound profile with evidence, safety, and practical fit.",
+    "summary": "Berberine carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on mitochondrial support, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and breastfeeding.",
     "description": "Berberine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "AMPK",
@@ -8128,7 +8146,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bergapten",
@@ -8253,7 +8272,7 @@
   {
     "slug": "bhb",
     "name": "beta- hydroxybutyrate",
-    "summary": "beta- hydroxybutyrate compound profile with evidence, safety, and practical fit.",
+    "summary": "beta- hydroxybutyrate carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, stress response modulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. May cause GI distress and electrolyte imbalance.",
     "description": "beta- hydroxybutyrate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "HDAC AMPK"
@@ -8359,12 +8378,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "beta-alanine",
     "name": "Beta-Alanine",
-    "summary": "Beta-Alanine compound profile with evidence, safety, and practical fit.",
+    "summary": "Beta-Alanine carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on increases muscle carnosine and buffering intracellular pH., which describes mechanism rather than demonstrated benefit. Noted cautions include generally safe and dose-splitting reduces side effects.",
     "description": "Beta-Alanine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "muscle carnosine system",
@@ -8472,7 +8492,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "beta-caryophyllene",
@@ -8596,7 +8617,7 @@
   {
     "slug": "beta-ecdysterone",
     "name": "beta-ecdysterone",
-    "summary": "beta-ecdysterone compound profile with evidence, safety, and practical fit.",
+    "summary": "beta-ecdysterone carries a Grade B rating — moderate evidence. Recorded activity centres on activates protein synthesis via PI3K/Akt pathway, which describes mechanism rather than demonstrated benefit. Limited safety data but generally well tolerated.",
     "description": "beta-ecdysterone compound profile with evidence, safety, and practical fit.",
     "effects": [
       "PI3K Akt"
@@ -8686,7 +8707,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "beta-elemene",
@@ -8805,7 +8827,7 @@
   {
     "slug": "beta-glucans",
     "name": "Beta-glucans",
-    "summary": "Beta-glucans compound profile with evidence, safety, and practical fit.",
+    "summary": "Beta-glucans carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. May cause GI symptoms; immune-modulation claims need cautious framing with immunosuppressant use.",
     "description": "Beta-glucans compound profile with evidence, safety, and practical fit.",
     "effects": [
       "immune cells",
@@ -8923,12 +8945,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "beta-sitosterol",
     "name": "Beta-sitosterol",
-    "summary": "Beta-sitosterol compound profile with evidence, safety, and practical fit.",
+    "summary": "Beta-sitosterol carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Avoid with sitosterolemia; long-term high intake may affect sterol handling.",
     "description": "Beta-sitosterol compound profile with evidence, safety, and practical fit.",
     "effects": [
       "intestinal cholesterol transport"
@@ -9038,7 +9061,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "betaine",
@@ -9157,7 +9181,7 @@
   {
     "slug": "betaine-anhydrous",
     "name": "Betaine anhydrous",
-    "summary": "Betaine anhydrous compound profile with evidence, safety, and practical fit.",
+    "summary": "Betaine anhydrous carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on vascular function support and lipid metabolism, which describes mechanism rather than demonstrated benefit. Safety evidence: regulatory review with limited human intervention data. Safety was not established for the proposed 2.5 g/day novel-food use; long-term, pregnancy, lactation, kidney-disease, and medication-interaction evidence remains insufficient.",
     "description": "Betaine anhydrous compound profile with evidence, safety, and practical fit.",
     "effects": [
       "methylation cycle",
@@ -9265,7 +9289,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "betaine-hcl",
@@ -9757,7 +9782,7 @@
   {
     "slug": "probiotic-strain-bifidobacterium",
     "name": "Bifidobacterium Probiotic",
-    "summary": "Bifidobacterium Probiotic compound profile with evidence, safety, and practical fit.",
+    "summary": "Bifidobacterium Probiotic carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include use only with clinician oversight in severe immunocompromise and critical illness.",
     "description": "Bifidobacterium Probiotic compound profile with evidence, safety, and practical fit.",
     "effects": [
       "gut health",
@@ -9877,7 +9902,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bilberry-extract",
@@ -10624,7 +10650,7 @@
   {
     "slug": "black-seed-oil",
     "name": "Black Seed Oil",
-    "summary": "Black Seed Oil compound profile with evidence, safety, and practical fit.",
+    "summary": "Black Seed Oil carries a Avoid / Insufficient Evidence rating. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy due to insufficient safety data and discontinue before scheduled surgery due to bleeding risk.",
     "description": "Black Seed Oil compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
@@ -10749,12 +10775,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "boron",
     "name": "Boron",
-    "summary": "Boron compound profile with evidence, safety, and practical fit.",
+    "summary": "Boron carries a Grade C rating — limited evidence. Strongest recorded design is a uncontrolled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on metabolic regulation, hormonal signaling context and endocrine, which describes mechanism rather than demonstrated benefit. low doses generally tolerated; high doses may cause GI/neurologic toxicity.",
     "description": "Boron compound profile with evidence, safety, and practical fit.",
     "effects": [
       "bone metabolism",
@@ -10857,12 +10884,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "uncontrolled-trial",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "boswellia",
     "name": "Boswellia",
-    "summary": "Boswellia compound profile with evidence, safety, and practical fit.",
+    "summary": "Boswellia carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 3 recorded studies, 3 in people. No disagreement is recorded across them. Recorded activity centres on inflammatory signaling modulation and inflammatory, which describes mechanism rather than demonstrated benefit. Noted cautions include known allergy to boswellia or other Burseraceae-family plants.",
     "description": "Boswellia compound profile with evidence, safety, and practical fit.",
     "effects": [
       "5-LOX",
@@ -10974,12 +11002,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "boswellia-akba-standardized",
     "name": "Boswellia AKBA standardized",
-    "summary": "Boswellia AKBA standardized compound profile with evidence, safety, and practical fit.",
+    "summary": "Boswellia AKBA standardized carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation and inflammatory, which describes mechanism rather than demonstrated benefit. Safety evidence: limited short-term human evidence for specific Boswellia extracts. Osteoarthritis trials did not show a clear excess of adverse events, but formulations and reporting varied; pregnancy, breastfeeding, surgery, bleeding, liver, kidney, long-term use, and medication-specific interaction safety remain insufficient.",
     "description": "Boswellia AKBA standardized compound profile with evidence, safety, and practical fit.",
     "effects": [
       "5-lipoxygenase",
@@ -11085,7 +11114,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "boswellic-acid",
@@ -11208,7 +11238,7 @@
   {
     "slug": "boswellic-acids",
     "name": "boswellic acids",
-    "summary": "boswellic acids compound profile with evidence, safety, and practical fit.",
+    "summary": "boswellic acids carries a Grade B rating — moderate evidence. Recorded activity centres on inflammatory signaling modulation and inflammatory, which describes mechanism rather than demonstrated benefit. Well tolerated with mild GI symptoms.",
     "description": "boswellic acids compound profile with evidence, safety, and practical fit.",
     "effects": [
       "5- LOX"
@@ -11304,7 +11334,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bpc-157",
@@ -11447,7 +11478,7 @@
   {
     "slug": "bromelain",
     "name": "Bromelain",
-    "summary": "Bromelain compound profile with evidence, safety, and practical fit.",
+    "summary": "Bromelain carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation and inflammatory, which describes mechanism rather than demonstrated benefit. Bleeding/allergy considerations matter; avoid around surgery unless clinician-directed.",
     "description": "Bromelain compound profile with evidence, safety, and practical fit.",
     "effects": [
       "inflammatory mediators",
@@ -11545,7 +11576,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "burdock-root",
@@ -11789,7 +11821,7 @@
   {
     "slug": "butyrate",
     "name": "butyrate",
-    "summary": "butyrate compound profile with evidence, safety, and practical fit.",
+    "summary": "butyrate carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, glucose metabolism support and lipid metabolism support, which describes mechanism rather than demonstrated benefit. Generally well tolerated with mild GI symptoms.",
     "description": "butyrate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "HDAC inhibition"
@@ -11893,12 +11925,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cacao",
     "name": "Cacao",
-    "summary": "Cacao compound profile with evidence, safety, and practical fit.",
+    "summary": "Cacao carries a Grade B rating — moderate evidence. Recorded activity centres on vascular function support, endothelial function support and endothelial function, which describes mechanism rather than demonstrated benefit. generally safe; chocolate forms add sugar/calories.",
     "description": "Cacao compound profile with evidence, safety, and practical fit.",
     "effects": [
       "nitric oxide",
@@ -12001,7 +12034,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cafestol",
@@ -12283,7 +12317,7 @@
   {
     "slug": "caffeine",
     "name": "Caffeine",
-    "summary": "Caffeine compound profile with evidence, safety, and practical fit.",
+    "summary": "Caffeine carries a Grade B rating — moderate evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 2 in people. Recorded activity centres on neurotransmitter modulation, vascular function support and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include cardiac arrhythmia or a recent heart attack warrants clinician guidance due to increased risk of palpitations and abnormal heart rhythm.",
     "description": "Caffeine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "adenosine A1 receptor",
@@ -12424,7 +12458,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "caffeine-l-theanine",
@@ -12669,7 +12704,7 @@
   {
     "slug": "calcium-d-glucarate",
     "name": "calcium d-glucarate",
-    "summary": "calcium d-glucarate compound profile with evidence, safety, and practical fit.",
+    "summary": "calcium d-glucarate carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation, hormonal signaling context and metabolic, which describes mechanism rather than demonstrated benefit. Generally well tolerated with limited human data.",
     "description": "calcium d-glucarate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "beta-glucuronidase"
@@ -12768,7 +12803,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "calycosin",
@@ -12909,7 +12945,7 @@
   {
     "slug": "cannabidiol",
     "name": "Cannabidiol",
-    "summary": "Cannabidiol compound profile with evidence, safety, and practical fit.",
+    "summary": "Cannabidiol carries a Grade B rating — moderate evidence. Recorded activity centres on endocannabinoid modulation, 5-HT1A activity and TRPV1 activation, which describes mechanism rather than demonstrated benefit. Noted cautions include liver.",
     "description": "Cannabidiol compound profile with evidence, safety, and practical fit.",
     "effects": [
       "5-HT1A",
@@ -13024,7 +13060,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "capsaicin",
@@ -14142,7 +14179,7 @@
   {
     "slug": "cbg",
     "name": "CBG",
-    "summary": "CBG compound profile with evidence, safety, and practical fit.",
+    "summary": "CBG carries a Grade C rating — limited evidence. Recorded activity centres on weak CB1/CB2 interaction, alpha-2 adrenergic and TRP channel activity preclinical and endocannabinoid, which describes mechanism rather than demonstrated benefit. insufficient human safety data.",
     "description": "CBG compound profile with evidence, safety, and practical fit.",
     "effects": [
       "CB1/CB2",
@@ -14247,7 +14284,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "celastrol",
@@ -15378,7 +15416,7 @@
   {
     "slug": "chondroitin",
     "name": "Chondroitin",
-    "summary": "Chondroitin compound profile with evidence, safety, and practical fit.",
+    "summary": "Chondroitin carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Findings across those studies disagree. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Use caution with anticoagulants or bleeding-risk contexts.",
     "description": "Chondroitin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cartilage extracellular matrix",
@@ -15474,12 +15512,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "chromium",
     "name": "Chromium",
-    "summary": "Chromium compound profile with evidence, safety, and practical fit.",
+    "summary": "Chromium carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 4 recorded studies, 2 in people. Findings across those studies disagree. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include liver and kidney.",
     "description": "Chromium compound profile with evidence, safety, and practical fit.",
     "effects": [
       "insulin signaling",
@@ -15585,12 +15624,13 @@
     "evidence_recorded_study_count": 4,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "chromium-picolinate",
     "name": "chromium picolinate",
-    "summary": "chromium picolinate compound profile with evidence, safety, and practical fit.",
+    "summary": "chromium picolinate carries a Grade B rating — moderate evidence. Strongest recorded design is a regulatory or official guidance, drawn from 2 recorded studies, none of which measured an outcome in people. Findings across those studies disagree. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include kidney.",
     "description": "chromium picolinate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "insulin receptor"
@@ -15693,12 +15733,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "regulatory-guidance",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-human-study-recorded"
+    "evidence_grade_backing_gap": "no-human-study-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cimifugoside",
     "name": "Cimifugoside",
-    "summary": "Cimifugoside compound profile with evidence, safety, and practical fit.",
+    "summary": "Cimifugoside carries a Grade C rating — limited evidence. Recorded activity centres on added as site-safe referenced entity during workbook readiness pass and limited, which describes mechanism rather than demonstrated benefit. Safety notes are not source-complete in this workbook row; avoid broad safety claims and hold for interaction, population, and formulation review.",
     "description": "Cimifugoside compound profile with evidence, safety, and practical fit.",
     "effects": [],
     "primary_effects": [],
@@ -15787,7 +15828,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cinnamaldehyde",
@@ -15907,7 +15949,7 @@
   {
     "slug": "cinnamon-extract",
     "name": "Cinnamon extract",
-    "summary": "Cinnamon extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Cinnamon extract carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include existing liver disease or elevated liver enzymes due to cassia-type cinnamon's coumarin content which can exceed established safety intake limits with regular use and has been linked to liver-enzyme elevation or liver injury case reports.",
     "description": "Cinnamon extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "GLUT4"
@@ -16021,7 +16063,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cdp-choline",
@@ -16268,7 +16311,7 @@
   {
     "slug": "citrulline-malate",
     "name": "Citrulline Malate",
-    "summary": "Citrulline Malate compound profile with evidence, safety, and practical fit.",
+    "summary": "Citrulline Malate carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on mitochondrial support, vascular function support and endothelial function support, which describes mechanism rather than demonstrated benefit. Noted cautions include limited data.",
     "description": "Citrulline Malate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "nitric oxide pathways",
@@ -16378,7 +16421,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cjc-1295",
@@ -16516,7 +16560,7 @@
   {
     "slug": "coconut-oil",
     "name": "Coconut Oil",
-    "summary": "Coconut Oil compound profile with evidence, safety, and practical fit.",
+    "summary": "Coconut Oil carries a Grade B rating — moderate evidence. Recorded activity centres on vascular function support, lipid metabolism support and lipid metabolism, which describes mechanism rather than demonstrated benefit. High saturated fat intake may raise LDL cholesterol in some users.",
     "description": "Coconut Oil compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
@@ -16619,7 +16663,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-human-study-recorded"
+    "evidence_grade_backing_gap": "no-human-study-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "coconut-water-powder",
@@ -16981,7 +17026,7 @@
   {
     "slug": "coq10",
     "name": "Coenzyme Q10",
-    "summary": "Coenzyme Q10 compound profile with evidence, safety, and practical fit.",
+    "summary": "Coenzyme Q10 carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 3 in people. No disagreement is recorded across them. Recorded activity centres on oxidative stress modulation, mitochondrial support and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include warfarin or another vitamin-K antagonist without clinician monitoring.",
     "description": "Coenzyme Q10 compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
@@ -17103,12 +17148,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "collagen-peptides",
     "name": "Collagen Peptides",
-    "summary": "Collagen Peptides compound profile with evidence, safety, and practical fit.",
+    "summary": "Collagen Peptides carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include known allergy to the source protein.",
     "description": "Collagen Peptides compound profile with evidence, safety, and practical fit.",
     "effects": [
       "connective tissue",
@@ -17218,7 +17264,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "columbamine",
@@ -17588,7 +17635,7 @@
   {
     "slug": "copper",
     "name": "Copper",
-    "summary": "Copper compound profile with evidence, safety, and practical fit.",
+    "summary": "Copper carries a Grade B rating — moderate evidence. Recorded activity centres on oxidative stress modulation, metabolic regulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include liver.",
     "description": "Copper compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cytochrome c oxidase",
@@ -17693,7 +17740,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "coptisine",
@@ -17819,7 +17867,7 @@
   {
     "slug": "cordycepin",
     "name": "cordycepin",
-    "summary": "cordycepin compound profile with evidence, safety, and practical fit.",
+    "summary": "cordycepin carries a Grade C rating — limited evidence. Recorded activity centres on mitochondrial support, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Limited human safety data.",
     "description": "cordycepin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "AMPK"
@@ -17925,12 +17973,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cordyceps",
     "name": "Cordyceps",
-    "summary": "Cordyceps compound profile with evidence, safety, and practical fit.",
+    "summary": "Cordyceps carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on mitochondrial support, immune signaling modulation and mitochondrial, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy or breastfeeding due to insufficient safety data.",
     "description": "Cordyceps compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cellular energy pathways",
@@ -18048,12 +18097,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cordyceps-militaris",
     "name": "cordyceps militaris",
-    "summary": "cordyceps militaris compound profile with evidence, safety, and practical fit.",
+    "summary": "cordyceps militaris carries a Grade B rating — moderate evidence. Recorded activity centres on mitochondrial support and mitochondrial, which describes mechanism rather than demonstrated benefit. Safety evidence: limited product-specific human trials. Two small studies found no group differences in measured safety indices or adverse-event incidence, but long-term, pregnancy, breastfeeding, autoimmune, transplant, and broader medication-interaction safety remain insufficient.",
     "description": "cordyceps militaris compound profile with evidence, safety, and practical fit.",
     "effects": [
       "ATP synthesis"
@@ -18158,7 +18208,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "corosolic-acid",
@@ -18644,7 +18695,7 @@
   {
     "slug": "creatine-monohydrate",
     "name": "Creatine monohydrate",
-    "summary": "Creatine monohydrate compound profile with evidence, safety, and practical fit.",
+    "summary": "Creatine monohydrate carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on mitochondrial support, metabolic regulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Safety evidence: systematic review evidence shows a small serum-creatinine increase without a significant decline in glomerular filtration in studied users. Evidence in pre-existing kidney disease, pregnancy, breastfeeding, and use beyond studied durations remains limited.",
     "description": "Creatine monohydrate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cellular energy metabolism",
@@ -18760,7 +18811,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "crocetin",
@@ -19189,7 +19241,7 @@
   {
     "slug": "curcumin-piperine",
     "name": "Curcumin + piperine",
-    "summary": "Curcumin + piperine compound profile with evidence, safety, and practical fit.",
+    "summary": "Curcumin + piperine carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation and inflammatory, which describes mechanism rather than demonstrated benefit. Noted cautions include previous turmeric- or curcumin-associated liver injury.",
     "description": "Curcumin + piperine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory_COX"
@@ -19295,12 +19347,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "curcumin-phytosome",
     "name": "Curcumin phytosome",
-    "summary": "Curcumin phytosome compound profile with evidence, safety, and practical fit.",
+    "summary": "Curcumin phytosome carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include previous turmeric- or curcumin-associated liver injury.",
     "description": "Curcumin phytosome compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NF-κB",
@@ -19425,7 +19478,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "curcumol",
@@ -19921,7 +19975,7 @@
   {
     "slug": "d-mannose",
     "name": "D-Mannose",
-    "summary": "D-Mannose compound profile with evidence, safety, and practical fit.",
+    "summary": "D-Mannose carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on prevents bacterial adhesion (E. coli) to urinary tract epithelium., which describes mechanism rather than demonstrated benefit. Noted cautions include caution in diabetes.",
     "description": "D-Mannose compound profile with evidence, safety, and practical fit.",
     "effects": [
       "urothelium",
@@ -20015,7 +20069,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "d-ribose",
@@ -21572,7 +21627,7 @@
   {
     "slug": "digestive-enzymes",
     "name": "Digestive enzymes",
-    "summary": "Digestive enzymes compound profile with evidence, safety, and practical fit.",
+    "summary": "Digestive enzymes carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on macronutrient breakdown via proteases, lipases and and amylases, which describes mechanism rather than demonstrated benefit. Use clinician guidance for true pancreatic insufficiency or active pancreatic disease.",
     "description": "Digestive enzymes compound profile with evidence, safety, and practical fit.",
     "effects": [
       "protein digestion",
@@ -21683,7 +21738,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "dihydrokavain",
@@ -21937,7 +21993,7 @@
   {
     "slug": "dim",
     "name": "diindolylmethane",
-    "summary": "diindolylmethane compound profile with evidence, safety, and practical fit.",
+    "summary": "diindolylmethane carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, hormonal signaling context and endocrine, which describes mechanism rather than demonstrated benefit. Generally safe with limited long-term data.",
     "description": "diindolylmethane compound profile with evidence, safety, and practical fit.",
     "effects": [
       "CYP1A1 CYP1B1"
@@ -22038,7 +22094,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "diosgenin",
@@ -22502,7 +22559,7 @@
   {
     "slug": "echinacea",
     "name": "Echinacea",
-    "summary": "Echinacea compound profile with evidence, safety, and practical fit.",
+    "summary": "Echinacea carries a Grade B rating — moderate evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Findings across those studies disagree. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include long-term use beyond eight weeks is not well studied.",
     "description": "Echinacea compound profile with evidence, safety, and practical fit.",
     "effects": [
       "immune signaling"
@@ -22618,7 +22675,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "echinacoside",
@@ -22927,7 +22985,7 @@
   {
     "slug": "egcg-caffeine",
     "name": "EGCG + Caffeine",
-    "summary": "EGCG + Caffeine compound profile with evidence, safety, and practical fit.",
+    "summary": "EGCG + Caffeine carries a Grade B rating — moderate evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, vascular function support and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include previous green-tea-extract-associated liver injury and high-dose EGCG extract use without clinical supervision.",
     "description": "EGCG + Caffeine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "stimulant_CNS",
@@ -23051,7 +23109,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "electrolyte-blend",
@@ -25271,7 +25330,7 @@
   {
     "slug": "exogenous-ketones",
     "name": "exogenous ketones",
-    "summary": "exogenous ketones compound profile with evidence, safety, and practical fit.",
+    "summary": "exogenous ketones carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, stress response modulation and metabolic, which describes mechanism rather than demonstrated benefit. Common GI distress and poor palatability.",
     "description": "exogenous ketones compound profile with evidence, safety, and practical fit.",
     "effects": [
       "BHB energy metabolism"
@@ -25372,12 +25431,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "melatonin-extended-release",
     "name": "Extended-release melatonin",
-    "summary": "Extended-release melatonin compound profile with evidence, safety, and practical fit.",
+    "summary": "Extended-release melatonin carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on hormonal signaling context, serotonergic and endocrine, which describes mechanism rather than demonstrated benefit. Safety evidence: extended release may prolong exposure and next-day drowsiness, but formulation-specific comparative safety evidence is limited. Headache and dizziness occur in melatonin trials; driving, concurrent sedatives, pregnancy, breastfeeding, pediatric use, and chronic use require individualized review.",
     "description": "Extended-release melatonin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "melatonin receptors",
@@ -25488,7 +25548,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "fadogia-agrestis",
@@ -25826,7 +25887,7 @@
   {
     "slug": "fenugreek",
     "name": "Fenugreek",
-    "summary": "Fenugreek compound profile with evidence, safety, and practical fit.",
+    "summary": "Fenugreek carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 1 in people. Recorded activity centres on metabolic regulation, hormonal signaling context and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy due to documented uterine-stimulant effects and birth-defect risk at supplemental doses.",
     "description": "Fenugreek compound profile with evidence, safety, and practical fit.",
     "effects": [
       "insulin signaling",
@@ -25945,12 +26006,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "fenugreek-extract",
     "name": "Fenugreek Extract",
-    "summary": "Fenugreek Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Fenugreek Extract carries a Avoid / Insufficient Evidence rating. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, hormonal signaling context and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy due to traditional uterine-stimulant use and reported association with birth defects at supplement doses.",
     "description": "Fenugreek Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
@@ -26073,7 +26135,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ferulic-acid",
@@ -26930,7 +26993,7 @@
   {
     "slug": "fos",
     "name": "Fructooligosaccharides",
-    "summary": "Fructooligosaccharides compound profile with evidence, safety, and practical fit.",
+    "summary": "Fructooligosaccharides carries a Grade B rating — moderate evidence. Strongest recorded design is a meta-analysis, drawn from 1 recorded study, 1 in people. Recorded activity centres on fermentable oligosaccharides selectively increase beneficial gut bacteria and SCFA production., which describes mechanism rather than demonstrated benefit. Noted cautions include contraindicated with known hypersensitivity or mechanical bowel obstruction.",
     "description": "Fructooligosaccharides compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Digestive Health"
@@ -27032,12 +27095,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "fucoxanthin",
     "name": "Fucoxanthin",
-    "summary": "Fucoxanthin compound profile with evidence, safety, and practical fit.",
+    "summary": "Fucoxanthin carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include seaweed-derived extracts can carry meaningful iodine content so people with hyperthyroidism or hypothyroidism or Hashimoto thyroiditis should consult a clinician before use.",
     "description": "Fucoxanthin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "UCP1",
@@ -27153,12 +27217,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "fukinolic-acid",
     "name": "Fukinolic acid",
-    "summary": "Fukinolic acid compound profile with evidence, safety, and practical fit.",
+    "summary": "Fukinolic acid carries a Grade C rating — limited evidence. Recorded activity centres on added as site-safe referenced entity during workbook readiness pass and limited, which describes mechanism rather than demonstrated benefit. Safety notes are not source-complete in this workbook row; avoid broad safety claims and hold for interaction, population, and formulation review.",
     "description": "Fukinolic acid compound profile with evidence, safety, and practical fit.",
     "effects": [],
     "primary_effects": [],
@@ -27247,7 +27312,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "gaba",
@@ -27910,7 +27976,7 @@
   {
     "slug": "garcinia-cambogia-extract",
     "name": "Garcinia Cambogia Extract",
-    "summary": "Garcinia Cambogia Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Garcinia Cambogia Extract carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on mitochondrial support, metabolic regulation and metabolic, which describes mechanism rather than demonstrated benefit. Noted cautions include documented case reports of drug-induced liver injury including acute hepatitis or fulminant liver failure requiring transplant usually after two to seven months of continuous use.",
     "description": "Garcinia Cambogia Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "ATP citrate lyase"
@@ -28025,7 +28091,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "garcinol",
@@ -28292,7 +28359,7 @@
   {
     "slug": "garlic-extract",
     "name": "Garlic Extract",
-    "summary": "Garlic Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Garlic Extract carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, vascular function support and lipid metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include antidiabetic medications due to additive hypoglycemia risk.",
     "description": "Garlic Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NO HMG-CoA reductase"
@@ -28415,7 +28482,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "gelatin",
@@ -28786,7 +28854,7 @@
   {
     "slug": "gingerol",
     "name": "gingerol",
-    "summary": "gingerol compound profile with evidence, safety, and practical fit.",
+    "summary": "gingerol carries a Grade B rating — moderate evidence. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Safety evidence: human review evidence for oral ginger preparations, not isolated gingerol. Isolated-gingerol dose-response, pregnancy, breastfeeding, bleeding, surgery, liver, kidney, and medication-interaction safety remains insufficient.",
     "description": "gingerol compound profile with evidence, safety, and practical fit.",
     "effects": [
       "COX-2 PGE2"
@@ -28893,7 +28961,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "gingerols",
@@ -30016,7 +30085,7 @@
   {
     "slug": "glucomannan",
     "name": "Glucomannan",
-    "summary": "Glucomannan compound profile with evidence, safety, and practical fit.",
+    "summary": "Glucomannan carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 4 recorded studies, 4 in people. Findings across those studies disagree. Recorded activity centres on metabolic regulation, vascular function support and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Must be taken with adequate water; separate from medications if absorption timing matters.",
     "description": "Glucomannan compound profile with evidence, safety, and practical fit.",
     "effects": [
       "fiber_LDL",
@@ -30127,7 +30196,8 @@
     "evidence_recorded_study_count": 4,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "glucomoringin",
@@ -30256,7 +30326,7 @@
   {
     "slug": "glucosamine",
     "name": "Glucosamine",
-    "summary": "Glucosamine compound profile with evidence, safety, and practical fit.",
+    "summary": "Glucosamine carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Findings across those studies disagree. Recorded activity centres on inflammatory signaling modulation, AMPK and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include shellfish allergy unless a vegetarian or corn-fermented source is confirmed.",
     "description": "Glucosamine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cartilage matrix",
@@ -30373,7 +30443,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "glutamine",
@@ -31774,7 +31845,7 @@
   {
     "slug": "green-tea-extract-egcg",
     "name": "Green tea extract / EGCG",
-    "summary": "Green tea extract / EGCG compound profile with evidence, safety, and practical fit.",
+    "summary": "Green tea extract / EGCG carries a Grade B rating — moderate evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 1 in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include verify caffeine content if stimulant-sensitive.",
     "description": "Green tea extract / EGCG compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
@@ -31894,7 +31965,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "guggulsterone",
@@ -33099,7 +33171,7 @@
   {
     "slug": "hmb",
     "name": "HMB",
-    "summary": "HMB compound profile with evidence, safety, and practical fit.",
+    "summary": "HMB carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 1 in people. Recorded activity centres on stress response modulation, mTOR signaling and mTOR, which describes mechanism rather than demonstrated benefit. Noted cautions include limited data.",
     "description": "HMB compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Exercise Performance",
@@ -33219,7 +33291,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "holy-basil-extract",
@@ -33847,7 +33920,7 @@
   {
     "slug": "hyaluronic-acid",
     "name": "Hyaluronic Acid",
-    "summary": "Hyaluronic Acid compound profile with evidence, safety, and practical fit.",
+    "summary": "Hyaluronic Acid carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a uncontrolled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include limited data.",
     "description": "Hyaluronic Acid compound profile with evidence, safety, and practical fit.",
     "effects": [
       "synovial fluid",
@@ -33945,7 +34018,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "uncontrolled-trial",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "hydroxytyrosol",
@@ -34429,7 +34503,7 @@
   {
     "slug": "icariin",
     "name": "icariin",
-    "summary": "icariin compound profile with evidence, safety, and practical fit.",
+    "summary": "icariin carries a Grade C rating — limited evidence. Recorded activity centres on vascular function support, endothelial function support and endothelial function, which describes mechanism rather than demonstrated benefit. Limited human safety data available.",
     "description": "icariin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "PDE5 NO"
@@ -34530,7 +34604,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "imperatorin",
@@ -35249,7 +35324,7 @@
   {
     "slug": "inulin",
     "name": "Inulin",
-    "summary": "Inulin compound profile with evidence, safety, and practical fit.",
+    "summary": "Inulin carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on metabolic regulation, lipid metabolism support and metabolic, which describes mechanism rather than demonstrated benefit. Can cause gas/bloating; start low, especially with IBS or FODMAP sensitivity.",
     "description": "Inulin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "SCFA"
@@ -35348,7 +35423,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "iodine",
@@ -36361,7 +36437,7 @@
   {
     "slug": "kava",
     "name": "Kava",
-    "summary": "Kava compound profile with evidence, safety, and practical fit.",
+    "summary": "Kava carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Findings across those studies disagree. Recorded activity centres on oxidative stress modulation, neurotransmitter modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include liver.",
     "description": "Kava compound profile with evidence, safety, and practical fit.",
     "effects": [
       "GABA-A",
@@ -36475,7 +36551,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "kavain",
@@ -37036,7 +37113,7 @@
   {
     "slug": "l-carnitine",
     "name": "L-Carnitine",
-    "summary": "L-Carnitine compound profile with evidence, safety, and practical fit.",
+    "summary": "L-Carnitine carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on mitochondrial support, metabolic regulation and lipid metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include seizure disorder without clinician review and fishy body odor and dose-dependent GI upset are common.",
     "description": "L-Carnitine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "CPT1"
@@ -37156,7 +37233,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "l-citrulline",
@@ -37271,7 +37349,7 @@
   {
     "slug": "l-theanine",
     "name": "L-theanine",
-    "summary": "L-theanine compound profile with evidence, safety, and practical fit.",
+    "summary": "L-theanine carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 4 recorded studies, 4 in people. No disagreement is recorded across them. Recorded activity centres on neurotransmitter modulation, vascular function support and stress response modulation, which describes mechanism rather than demonstrated benefit. Safety evidence: a systematic review of short-term trials reported no serious adverse events, but study populations and dosing varied. Long-term use, pregnancy, breastfeeding, surgery, organ impairment, and clinically significant medication interactions remain insufficiently characterized.",
     "description": "A 2025 systematic review identified 13 human trials of standalone L-theanine for sleep-related outcomes and reported possible benefits across subjective and objective measures. Trial designs, doses, and populations varied, and better studies in people with clinical insomnia are still needed; this supports cautious sleep-support language, not an insomnia-treatment claim.",
     "effects": [
       "GABA",
@@ -37389,7 +37467,8 @@
     "evidence_recorded_study_count": 4,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "l-theanine-sleep",
@@ -37645,7 +37724,7 @@
   {
     "slug": "probiotic-strain-lactobacillus",
     "name": "Lactobacillus Probiotic",
-    "summary": "Lactobacillus Probiotic compound profile with evidence, safety, and practical fit.",
+    "summary": "Lactobacillus Probiotic carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include use only with clinician oversight in severe immunocompromise and critical illness.",
     "description": "Lactobacillus Probiotic compound profile with evidence, safety, and practical fit.",
     "effects": [
       "gut health",
@@ -37758,7 +37837,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "lagerstroemin",
@@ -38845,7 +38925,7 @@
   {
     "slug": "licorice-root",
     "name": "Licorice Root",
-    "summary": "Licorice Root compound profile with evidence, safety, and practical fit.",
+    "summary": "Licorice Root carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. hypertension, hypokalemia, edema/pseudoaldosteronism; chronic use risk.",
     "description": "Licorice Root compound profile with evidence, safety, and practical fit.",
     "effects": [
       "11β-HSD2",
@@ -38957,7 +39037,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ligustilide",
@@ -39546,7 +39627,7 @@
   {
     "slug": "lutein",
     "name": "Lutein",
-    "summary": "Lutein compound profile with evidence, safety, and practical fit.",
+    "summary": "Lutein carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on oxidative stress modulation, stress response modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy or breastfeeding due to insufficient safety data for supplemental doses beyond dietary intake.",
     "description": "Lutein compound profile with evidence, safety, and practical fit.",
     "effects": [
       "macula",
@@ -39663,7 +39744,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "luteolin",
@@ -41230,7 +41312,7 @@
   {
     "slug": "manganese",
     "name": "Manganese",
-    "summary": "Manganese compound profile with evidence, safety, and practical fit.",
+    "summary": "Manganese carries a Grade B rating — moderate evidence. Recorded activity centres on oxidative stress modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. excess exposure may cause neurotoxicity/manganism; risk higher with chronic high exposure.",
     "description": "Manganese compound profile with evidence, safety, and practical fit.",
     "effects": [
       "MnSOD",
@@ -41339,7 +41421,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "mangiferin",
@@ -43976,7 +44059,7 @@
   {
     "slug": "mucuna-pruriens",
     "name": "Mucuna pruriens",
-    "summary": "Mucuna pruriens compound profile with evidence, safety, and practical fit.",
+    "summary": "Mucuna pruriens carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on neurotransmitter modulation and dopaminergic, which describes mechanism rather than demonstrated benefit. Noted cautions include concurrent MAOI antidepressants due to a documented risk of a severe pressor crisis from combined dopamine and monoamine surge.",
     "description": "Mucuna pruriens compound profile with evidence, safety, and practical fit.",
     "effects": [
       "dopaminergic pathways"
@@ -44089,7 +44172,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "mulberroside-a",
@@ -45827,7 +45911,7 @@
   {
     "slug": "nicotinamide-riboside",
     "name": "Nicotinamide riboside",
-    "summary": "Nicotinamide riboside compound profile with evidence, safety, and practical fit.",
+    "summary": "Nicotinamide riboside carries a Grade B rating — moderate evidence. Recorded activity centres on SIRT1 signaling and SIRT1, which describes mechanism rather than demonstrated benefit. Mild GI upset, headache, or flushing possible; long-term clinical outcome safety is still limited.",
     "description": "Nicotinamide riboside compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Mitochondrial Health",
@@ -45924,12 +46008,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "nr",
     "name": "Nicotinamide riboside",
-    "summary": "Nicotinamide riboside compound profile with evidence, safety, and practical fit.",
+    "summary": "Nicotinamide riboside carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on mitochondrial support, metabolic regulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Long-term outcome evidence is still emerging; avoid disease-treatment claims.",
     "description": "Nicotinamide riboside compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NAD+ metabolism",
@@ -46042,7 +46127,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "nicotine",
@@ -46529,7 +46615,7 @@
   {
     "slug": "oleamide",
     "name": "Oleamide",
-    "summary": "Oleamide compound profile with evidence, safety, and practical fit.",
+    "summary": "Oleamide carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation, neurotransmitter modulation and lipid metabolism support, which describes mechanism rather than demonstrated benefit. insufficient human safety data.",
     "description": "Oleamide compound profile with evidence, safety, and practical fit.",
     "effects": [
       "GABAergic pathways",
@@ -46639,7 +46725,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "oleanolic-acid",
@@ -47566,7 +47653,7 @@
   {
     "slug": "omega-3",
     "name": "Omega-3 fatty acids",
-    "summary": "Omega-3 fatty acids compound profile with evidence, safety, and practical fit.",
+    "summary": "Omega-3 fatty acids carries a Grade A rating — strong evidence. Strongest recorded design is a meta-analysis, drawn from 6 recorded studies, 6 in people. No disagreement is recorded across them. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Safety evidence: mild gastrointestinal adverse effects occur, while clinically significant bleeding is not established at common studied doses. Higher-dose, long-term marine omega-3 trials show an atrial-fibrillation signal; anticoagulant use and fish-source allergy warrant product-specific review.",
     "description": "Omega-3 fatty acids compound profile with evidence, safety, and practical fit.",
     "effects": [
       "lipid metabolism",
@@ -47694,7 +47781,8 @@
     "evidence_recorded_study_count": 6,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ononin",
@@ -47827,7 +47915,7 @@
   {
     "slug": "oral-rehydration-salts",
     "name": "Oral rehydration salts",
-    "summary": "Oral rehydration salts compound profile with evidence, safety, and practical fit.",
+    "summary": "Oral rehydration salts carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on oxidative stress modulation, metabolic regulation and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Use medical care for severe dehydration, infants, confusion, or persistent vomiting.",
     "description": "Oral rehydration salts compound profile with evidence, safety, and practical fit.",
     "effects": [
       "intestinal sodium-glucose transport",
@@ -47935,7 +48023,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "oregon-grape-root",
@@ -48045,7 +48134,7 @@
   {
     "slug": "ornithine",
     "name": "ornithine",
-    "summary": "ornithine compound profile with evidence, safety, and practical fit.",
+    "summary": "ornithine carries a Grade B rating — moderate evidence. Recorded activity centres on neurotransmitter modulation, hormonal signaling context and stress response modulation, which describes mechanism rather than demonstrated benefit. generally safe; mild GI effects reported.",
     "description": "ornithine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep_GABA"
@@ -48150,7 +48239,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "orotic-acid",
@@ -49006,7 +49096,7 @@
   {
     "slug": "palmitoylethanolamide",
     "name": "Palmitoylethanolamide",
-    "summary": "Palmitoylethanolamide compound profile with evidence, safety, and practical fit.",
+    "summary": "Palmitoylethanolamide carries a Grade B rating — moderate evidence. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. well tolerated with minimal reported adverse effects.",
     "description": "Palmitoylethanolamide compound profile with evidence, safety, and practical fit.",
     "effects": [
       "PPAR-alpha",
@@ -49119,7 +49209,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "panax-ginseng-extract",
@@ -50190,7 +50281,7 @@
   {
     "slug": "peppermint-oil",
     "name": "Peppermint Oil",
-    "summary": "Peppermint Oil compound profile with evidence, safety, and practical fit.",
+    "summary": "Peppermint Oil carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 4 recorded studies, 4 in people. No disagreement is recorded across them. Recorded activity centres on antispasmodic effect on GI smooth muscle., which describes mechanism rather than demonstrated benefit. Noted cautions include hiatal hernia due to worsened reflux symptoms.",
     "description": "Peppermint Oil compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Digestive Health",
@@ -50300,12 +50391,13 @@
     "evidence_recorded_study_count": 4,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "phenylalanine",
     "name": "Phenylalanine",
-    "summary": "Phenylalanine compound profile with evidence, safety, and practical fit.",
+    "summary": "Phenylalanine carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on neurotransmitter modulation and catecholaminergic, which describes mechanism rather than demonstrated benefit. Noted cautions include ssri.",
     "description": "Phenylalanine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "dopamine",
@@ -50402,7 +50494,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "phloretin",
@@ -50526,7 +50619,7 @@
   {
     "slug": "phosphatidic-acid",
     "name": "phosphatidic acid",
-    "summary": "phosphatidic acid compound profile with evidence, safety, and practical fit.",
+    "summary": "phosphatidic acid carries a Grade B rating — moderate evidence. Recorded activity centres on mitochondrial support, mTOR signaling and mTOR, which describes mechanism rather than demonstrated benefit. Well tolerated with minimal adverse effects.",
     "description": "phosphatidic acid compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mTOR"
@@ -50627,7 +50720,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "phosphatidylcholine",
@@ -50985,7 +51079,7 @@
   {
     "slug": "plant-sterols",
     "name": "Plant Sterols",
-    "summary": "Plant Sterols compound profile with evidence, safety, and practical fit.",
+    "summary": "Plant Sterols carries a Grade A rating — strong evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, vascular function support and lipid metabolism support, which describes mechanism rather than demonstrated benefit. Avoid with sitosterolemia; consider overall dietary context.",
     "description": "Plant Sterols compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
@@ -51093,7 +51187,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "plumbagin",
@@ -51469,7 +51564,7 @@
   {
     "slug": "potassium",
     "name": "Potassium",
-    "summary": "Potassium compound profile with evidence, safety, and practical fit.",
+    "summary": "Potassium carries a Grade A rating — strong evidence. Strongest recorded design is a meta-analysis, drawn from 1 recorded study, 1 in people. Recorded activity centres on cellular protection, vascular function support and cardiovascular, which describes mechanism rather than demonstrated benefit. Noted cautions include caution with ACE inhibitors/renal disease.",
     "description": "Potassium compound profile with evidence, safety, and practical fit.",
     "effects": [
       "membrane potential",
@@ -51572,12 +51667,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "single-human-study-for-grade-a"
+    "evidence_grade_backing_gap": "single-human-study-for-grade-a",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "electrolytes-potassium",
     "name": "Potassium electrolytes",
-    "summary": "Potassium electrolytes compound profile with evidence, safety, and practical fit.",
+    "summary": "Potassium electrolytes carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on cellular protection, vascular function support and cardiovascular, which describes mechanism rather than demonstrated benefit. Noted cautions include baseline serum potassium above the normal range.",
     "description": "Potassium electrolytes compound profile with evidence, safety, and practical fit.",
     "effects": [
       "cardiovascular function",
@@ -51696,12 +51792,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "pqq",
     "name": "PQQ",
-    "summary": "PQQ compound profile with evidence, safety, and practical fit.",
+    "summary": "PQQ carries a Avoid / Insufficient Evidence rating. Recorded activity centres on oxidative stress modulation, mitochondrial support and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy or breastfeeding was excluded from EFSA's novel food safety evaluation and should be avoided without clinician guidance.",
     "description": "PQQ compound profile with evidence, safety, and practical fit.",
     "effects": [
       "PGC-1α",
@@ -51817,12 +51914,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "pregnenolone",
     "name": "Pregnenolone",
-    "summary": "Pregnenolone compound profile with evidence, safety, and practical fit.",
+    "summary": "Pregnenolone carries a Grade C rating — limited evidence. Recorded activity centres on neurotransmitter modulation, hormonal signaling context and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. small trials report tolerability, but evidence is limited and endocrine, mood, and drug-interaction risks require clinician review.",
     "description": "Pregnenolone compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mood",
@@ -51925,7 +52023,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "proanthocyanidins",
@@ -52028,7 +52127,7 @@
   {
     "slug": "probiotic-multistrain",
     "name": "Probiotic Multistrain",
-    "summary": "Probiotic Multistrain compound profile with evidence, safety, and practical fit.",
+    "summary": "Probiotic Multistrain carries a Grade A rating — strong evidence. Recorded activity centres on immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include severely immunocompromised and recently postoperative.",
     "description": "Probiotic Multistrain compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Digestive Health",
@@ -52138,7 +52237,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "probiotics",
@@ -52517,7 +52617,7 @@
   {
     "slug": "proline",
     "name": "proline",
-    "summary": "proline compound profile with evidence, safety, and practical fit.",
+    "summary": "proline carries a Grade B rating — moderate evidence. Recorded activity centres on inflammatory signaling modulation and liver_detoxification, which describes mechanism rather than demonstrated benefit. generally safe; excessive intake may cause GI discomfort; well tolerated; excessive intake may cause GI upset.",
     "description": "proline compound profile with evidence, safety, and practical fit.",
     "effects": [
       "involved in collagen synthesis and connective tissue repair"
@@ -52615,12 +52715,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "propionate",
     "name": "propionate",
-    "summary": "propionate compound profile with evidence, safety, and practical fit.",
+    "summary": "propionate carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, glucose metabolism support and lipid metabolism support, which describes mechanism rather than demonstrated benefit. generally safe; mild GI discomfort possible; generally well tolerated; mild gastrointestinal discomfort possible.",
     "description": "propionate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "glucose_AMPK"
@@ -52724,7 +52825,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "protodioscin",
@@ -52948,7 +53050,7 @@
   {
     "slug": "psyllium-husk",
     "name": "Psyllium husk",
-    "summary": "Psyllium husk compound profile with evidence, safety, and practical fit.",
+    "summary": "Psyllium husk carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, vascular function support and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include difficulty swallowing or known esophageal narrowing or dysfunction.",
     "description": "Psyllium husk compound profile with evidence, safety, and practical fit.",
     "effects": [
       "bile acid binding"
@@ -53067,7 +53169,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "pt-141",
@@ -53470,7 +53573,7 @@
   {
     "slug": "pumpkin-seed-oil",
     "name": "Pumpkin seed oil",
-    "summary": "Pumpkin seed oil compound profile with evidence, safety, and practical fit.",
+    "summary": "Pumpkin seed oil carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Use caution with seed allergy or anticoagulant medication plans.",
     "description": "Pumpkin seed oil compound profile with evidence, safety, and practical fit.",
     "effects": [
       "prostate symptoms",
@@ -53582,7 +53685,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "punicalagin",
@@ -53702,7 +53806,7 @@
   {
     "slug": "putrescine",
     "name": "putrescine",
-    "summary": "putrescine compound profile with evidence, safety, and practical fit.",
+    "summary": "putrescine carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, vascular function support and endothelial function support, which describes mechanism rather than demonstrated benefit. generally safe at dietary levels; excessive intake may cause GI discomfort; safe at dietary levels; excessive intake may cause gastrointestinal discomfort.",
     "description": "putrescine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Cardiovascular Health",
@@ -53814,7 +53918,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "pycnogenol",
@@ -54070,7 +54175,7 @@
   {
     "slug": "pyridoxal-5-phosphate",
     "name": "Pyridoxal-5-phosphate",
-    "summary": "Pyridoxal-5-phosphate compound profile with evidence, safety, and practical fit.",
+    "summary": "Pyridoxal-5-phosphate carries a Grade B rating — moderate evidence. Recorded activity centres on metabolic regulation, neurotransmitter modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Active B6 forms still carry dose-related neuropathy concerns.",
     "description": "Pyridoxal-5-phosphate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "serotonin synthesis",
@@ -54184,7 +54289,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "quercetin-phytosome",
@@ -54434,7 +54540,7 @@
   {
     "slug": "red-yeast-rice",
     "name": "Red Yeast Rice",
-    "summary": "Red Yeast Rice compound profile with evidence, safety, and practical fit.",
+    "summary": "Red Yeast Rice carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a regulatory or official guidance, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, vascular function support and lipid metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include liver.",
     "description": "Red Yeast Rice compound profile with evidence, safety, and practical fit.",
     "effects": [
       "HMG-CoA reductase"
@@ -54538,12 +54644,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "regulatory-guidance",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "resistant-starch",
     "name": "Resistant Starch",
-    "summary": "Resistant Starch compound profile with evidence, safety, and practical fit.",
+    "summary": "Resistant Starch carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Titrate gradually to reduce gas and bloating.",
     "description": "Resistant Starch compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Metabolic Health",
@@ -54646,7 +54753,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "rhein",
@@ -55544,7 +55652,7 @@
   {
     "slug": "saccharomyces-boulardii",
     "name": "Saccharomyces boulardii",
-    "summary": "Saccharomyces boulardii compound profile with evidence, safety, and practical fit.",
+    "summary": "Saccharomyces boulardii carries a Grade B rating — moderate evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 3 in people. No disagreement is recorded across them. Recorded activity centres on immune signaling modulation, gut_microbiome and liver_detoxification, which describes mechanism rather than demonstrated benefit. Fungemia risk is rare but important in central-line or severe immunocompromise contexts.",
     "description": "Saccharomyces boulardii compound profile with evidence, safety, and practical fit.",
     "effects": [
       "intestinal pathogens",
@@ -55651,12 +55759,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "saffron-extract",
     "name": "Saffron Extract",
-    "summary": "Saffron Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Saffron Extract carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include caution with blood pressure medications.",
     "description": "Saffron Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
@@ -55782,7 +55891,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "safranal",
@@ -56389,7 +56499,7 @@
   {
     "slug": "sam-e",
     "name": "SAM-e",
-    "summary": "SAM-e compound profile with evidence, safety, and practical fit.",
+    "summary": "SAM-e carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and vascular function support, which describes mechanism rather than demonstrated benefit. Can precipitate mania in bipolar disorder; review with psychiatric medications.",
     "description": "SAM-e compound profile with evidence, safety, and practical fit.",
     "effects": [
       "methylation pathways",
@@ -56494,7 +56604,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "saw-palmetto-extract",
@@ -57611,7 +57722,7 @@
   {
     "slug": "serine",
     "name": "serine",
-    "summary": "serine compound profile with evidence, safety, and practical fit.",
+    "summary": "serine carries a Grade B rating — moderate evidence. Recorded activity centres on cellular protection, neuroprotective activity and neuroprotective, which describes mechanism rather than demonstrated benefit. well tolerated; high doses may cause mild GI upset; generally safe; high doses may cause mild GI discomfort.",
     "description": "serine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "supports phosphatidylserine synthesis and neuronal membrane function"
@@ -57710,7 +57821,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "serrapeptase",
@@ -57952,7 +58064,7 @@
   {
     "slug": "shilajit",
     "name": "Shilajit",
-    "summary": "Shilajit compound profile with evidence, safety, and practical fit.",
+    "summary": "Shilajit carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on mitochondrial support, endocrine and mitochondrial, which describes mechanism rather than demonstrated benefit. heavy metal contamination risk; limited safety data.",
     "description": "Shilajit compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mitochondrial pathways proposed"
@@ -58053,7 +58165,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "shilajit-extract",
@@ -58172,7 +58285,7 @@
   {
     "slug": "shogaol",
     "name": "shogaol",
-    "summary": "shogaol compound profile with evidence, safety, and practical fit.",
+    "summary": "shogaol carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and inflammatory, which describes mechanism rather than demonstrated benefit. Limited human safety data available.",
     "description": "shogaol compound profile with evidence, safety, and practical fit.",
     "effects": [
       "NF-kB"
@@ -58273,7 +58386,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "silibinin",
@@ -58872,7 +58986,7 @@
   {
     "slug": "silymarin",
     "name": "Silymarin",
-    "summary": "Silymarin compound profile with evidence, safety, and practical fit.",
+    "summary": "Silymarin carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and cellular protection, which describes mechanism rather than demonstrated benefit. Same safety family as milk thistle; keep liver claims conservative.",
     "description": "Silymarin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "hepatocytes",
@@ -58987,12 +59101,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "skullcap",
     "name": "Skullcap",
-    "summary": "Skullcap compound profile with evidence, safety, and practical fit.",
+    "summary": "Skullcap carries a Avoid / Insufficient Evidence rating. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include liver.",
     "description": "Skullcap compound profile with evidence, safety, and practical fit.",
     "effects": [
       "GABA-A receptor",
@@ -59104,7 +59219,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "slippery-elm",
@@ -59404,7 +59520,7 @@
   {
     "slug": "electrolytes-sodium",
     "name": "Sodium electrolytes",
-    "summary": "Sodium electrolytes compound profile with evidence, safety, and practical fit.",
+    "summary": "Sodium electrolytes carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include hypertension or sodium-sensitive blood pressure without clinician guidance.",
     "description": "Sodium electrolytes compound profile with evidence, safety, and practical fit.",
     "effects": [
       "fluid balance",
@@ -59518,12 +59634,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "spermidine",
     "name": "spermidine",
-    "summary": "spermidine compound profile with evidence, safety, and practical fit.",
+    "summary": "spermidine carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation, mTOR signaling and autophagy support, which describes mechanism rather than demonstrated benefit. Limited human safety data but generally well tolerated.",
     "description": "spermidine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mTOR autophagy"
@@ -59633,12 +59750,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "spirulina",
     "name": "Spirulina",
-    "summary": "Spirulina compound profile with evidence, safety, and practical fit.",
+    "summary": "Spirulina carries a Avoid / Insufficient Evidence rating. Strongest recorded design is a uncontrolled trial, drawn from 2 recorded studies, 1 in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and lipid metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include phenylketonuria due to phenylalanine content.",
     "description": "Spirulina compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Oxidative Stress",
@@ -59764,7 +59882,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "uncontrolled-trial",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "stigmasterol",
@@ -60358,7 +60477,7 @@
   {
     "slug": "taurine-blend",
     "name": "Taurine Blend",
-    "summary": "Taurine Blend compound profile with evidence, safety, and practical fit.",
+    "summary": "Taurine Blend carries a Grade B rating — moderate evidence. Recorded activity centres on cellular hydration regulation, calcium signaling and cardiac/muscle support, which describes mechanism rather than demonstrated benefit. Safety evidence: human taurine trials report no significant adverse-effect difference from control in studied settings, but this blend formulation is unspecified. Isolated-taurine findings cannot establish the safety of unknown co-ingredients, doses, or long-term use.",
     "description": "Taurine Blend compound profile with evidence, safety, and practical fit.",
     "effects": [
       "calcium signaling",
@@ -60464,7 +60583,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "tb-500",
@@ -62589,7 +62709,7 @@
   {
     "slug": "tudca",
     "name": "TUDCA",
-    "summary": "TUDCA compound profile with evidence, safety, and practical fit.",
+    "summary": "TUDCA carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on oxidative stress modulation, mitochondrial support and metabolic regulation, which describes mechanism rather than demonstrated benefit. Should not be framed as liver-disease treatment; medical conditions need clinician care.",
     "description": "TUDCA compound profile with evidence, safety, and practical fit.",
     "effects": [
       "ER stress bile acid signaling"
@@ -62698,12 +62818,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "turkesterone",
     "name": "turkesterone",
-    "summary": "turkesterone compound profile with evidence, safety, and practical fit.",
+    "summary": "turkesterone carries a Grade B rating — moderate evidence. Recorded activity centres on hormonal signaling context and endocrine, which describes mechanism rather than demonstrated benefit. well tolerated with no significant adverse effects reported.",
     "description": "turkesterone compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Hormonal Health",
@@ -62801,7 +62922,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "turmeric-curcumin-piperine",
@@ -63085,7 +63207,7 @@
   {
     "slug": "coenzyme-q10-ubiquinol",
     "name": "Ubiquinol CoQ10",
-    "summary": "Ubiquinol CoQ10 compound profile with evidence, safety, and practical fit.",
+    "summary": "Ubiquinol CoQ10 carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on oxidative stress modulation, mitochondrial support and vascular function support, which describes mechanism rather than demonstrated benefit. May affect anticoagulation management; coordinate use with warfarin or high-risk cardiovascular medication plans.",
     "description": "Ubiquinol CoQ10 compound profile with evidence, safety, and practical fit.",
     "effects": [
       "mitochondrial ETC",
@@ -63199,12 +63321,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "uc-ii-collagen",
     "name": "Uc Ii Collagen",
-    "summary": "Uc Ii Collagen compound profile with evidence, safety, and practical fit.",
+    "summary": "Uc Ii Collagen carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Safety evidence: one 180-day trial of a specific undenatured type II collagen product. Safety outcomes did not differ from placebo or glucosamine-chondroitin, but product-source allergy, pregnancy, breastfeeding, autoimmune disease, longer-term use, organ impairment, and medication-interaction safety remain insufficient.",
     "description": "Uc Ii Collagen compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Inflammation",
@@ -63312,7 +63435,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "umbelliferone",
@@ -64449,7 +64573,7 @@
   {
     "slug": "valerian-root-extract",
     "name": "Valerian Root Extract",
-    "summary": "Valerian Root Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Valerian Root Extract carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 2 in people. Recorded activity centres on neurotransmitter modulation, stress response modulation and gabaergic, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance and children under 12 without medical supervision.",
     "description": "Valerian Root Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "GABA signaling"
@@ -64570,7 +64694,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "valine",
@@ -65281,7 +65406,7 @@
   {
     "slug": "vitamin-b6",
     "name": "Vitamin B6",
-    "summary": "Vitamin B6 compound profile with evidence, safety, and practical fit.",
+    "summary": "Vitamin B6 carries a Grade A rating — strong evidence. Recorded activity centres on metabolic regulation, neurotransmitter modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Avoid chronic high-dose use; neuropathy risk is the key safety limiter.",
     "description": "Vitamin B6 compound profile with evidence, safety, and practical fit.",
     "effects": [
       "amino acid metabolism",
@@ -65393,7 +65518,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "vitamin-c",
@@ -65529,7 +65655,7 @@
   {
     "slug": "vitamin-d",
     "name": "Vitamin D",
-    "summary": "Vitamin D compound profile with evidence, safety, and practical fit.",
+    "summary": "Vitamin D carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a meta-analysis, drawn from 5 recorded studies, 5 in people. No disagreement is recorded across them. Recorded activity centres on metabolic regulation, immune signaling modulation and metabolic, which describes mechanism rather than demonstrated benefit. Noted cautions include hypercalcemia or vitamin D toxicity.",
     "description": "Vitamin D compound profile with evidence, safety, and practical fit.",
     "effects": [
       "vitamin D receptor",
@@ -65644,7 +65770,8 @@
     "evidence_recorded_study_count": 5,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "vitamin-d3",
@@ -66136,7 +66263,7 @@
   {
     "slug": "protein-whey-isolate",
     "name": "Whey protein isolate",
-    "summary": "Whey protein isolate compound profile with evidence, safety, and practical fit.",
+    "summary": "Whey protein isolate carries a Grade D rating — preliminary / theoretical evidence. Recorded activity centres on mTOR signaling and mTOR, which describes mechanism rather than demonstrated benefit. Noted cautions include cow's-milk protein allergy.",
     "description": "Whey protein isolate compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Exercise Performance",
@@ -66244,7 +66371,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "wild-dagga",
@@ -66355,7 +66483,7 @@
   {
     "slug": "willow-bark-extract",
     "name": "Willow Bark Extract",
-    "summary": "Willow Bark Extract compound profile with evidence, safety, and practical fit.",
+    "summary": "Willow Bark Extract carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include active GI ulcer or reflux disease and asthma with known aspirin or NSAID sensitivity.",
     "description": "Willow Bark Extract compound profile with evidence, safety, and practical fit.",
     "effects": [
       "Inflammation",
@@ -66472,7 +66600,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "withaferin-a",
@@ -67455,7 +67584,7 @@
   {
     "slug": "yohimbine",
     "name": "Yohimbine",
-    "summary": "Yohimbine compound profile with evidence, safety, and practical fit.",
+    "summary": "Yohimbine carries a Grade B rating — moderate evidence. Strongest recorded design is a meta-analysis, drawn from 1 recorded study, 1 in people. Recorded activity centres on metabolic regulation, vascular function support and adrenergic, which describes mechanism rather than demonstrated benefit. Noted cautions include severe kidney or liver disease reduces clearance.",
     "description": "Yohimbine compound profile with evidence, safety, and practical fit.",
     "effects": [
       "alpha-2 adrenergic receptor"
@@ -67573,12 +67702,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "zeaxanthin",
     "name": "Zeaxanthin",
-    "summary": "Zeaxanthin compound profile with evidence, safety, and practical fit.",
+    "summary": "Zeaxanthin carries a Grade D rating — preliminary / theoretical evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 2 in people. Recorded activity centres on oxidative stress modulation, stress response modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Generally well tolerated at common supplemental doses.",
     "description": "Zeaxanthin compound profile with evidence, safety, and practical fit.",
     "effects": [
       "macula",
@@ -67684,12 +67814,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "zinc",
     "name": "Zinc",
-    "summary": "Zinc compound profile with evidence, safety, and practical fit.",
+    "summary": "Zinc carries a Grade A rating — strong evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and inflammatory, which describes mechanism rather than demonstrated benefit. Noted cautions include avoid high-dose long-term use.",
     "description": "Zinc compound profile with evidence, safety, and practical fit.",
     "effects": [
       "immune function",
@@ -67795,7 +67926,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "zinc-carnosine",

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -2,7 +2,7 @@
   {
     "slug": "acerola",
     "name": "Acerola",
-    "summary": "Acerola botanical profile with evidence, safety, and practical fit.",
+    "summary": "Acerola (Malpighia emarginata) carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include kidney stone risk and iron overload conditions.",
     "description": "Acerola botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -112,12 +112,13 @@
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Malpighia emarginata"
+    "scientific_name": "Malpighia emarginata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "agarikon",
     "name": "Agarikon",
-    "summary": "Agarikon botanical profile with evidence, safety, and practical fit.",
+    "summary": "Agarikon carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Agarikon botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune",
@@ -223,12 +224,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ajwain",
     "name": "Ajwain",
-    "summary": "Ajwain botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ajwain (Trachyspermum ammi) carries a Grade C rating — limited evidence. Recorded activity centres on digestive support and aromatic support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy.",
     "description": "Ajwain botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -328,7 +330,8 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Trachyspermum ammi"
+    "scientific_name": "Trachyspermum ammi",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "aloe-vera",
@@ -471,7 +474,7 @@
   {
     "slug": "panax-quinquefolius",
     "name": "American Ginseng",
-    "summary": "American Ginseng botanical profile with evidence, safety, and practical fit.",
+    "summary": "American Ginseng (Panax quinquefolius) carries a Grade B rating — moderate evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include antidiabetics.",
     "description": "American Ginseng botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -576,12 +579,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Panax quinquefolius"
+    "scientific_name": "Panax quinquefolius",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "american-yellow-lotus",
     "name": "American Yellow Lotus",
-    "summary": "American Yellow Lotus botanical profile with evidence, safety, and practical fit.",
+    "summary": "American Yellow Lotus carries a Grade C rating — limited evidence. Recorded activity centres on oxidative stress modulation, neurotransmitter modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "American Yellow Lotus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -695,12 +699,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "andrographis-paniculata",
     "name": "Andrographis Paniculata",
-    "summary": "Andrographis Paniculata botanical profile with evidence, safety, and practical fit.",
+    "summary": "Andrographis Paniculata (Andrographis paniculata) carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Andrographis Paniculata botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "respiratory"
@@ -812,12 +817,13 @@
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Andrographis paniculata"
+    "scientific_name": "Andrographis paniculata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "anemarrhena-asphodeloides",
     "name": "Anemarrhena Asphodeloides",
-    "summary": "Anemarrhena Asphodeloides botanical profile with evidence, safety, and practical fit.",
+    "summary": "Anemarrhena Asphodeloides (Anemarrhena asphodeloides) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Anemarrhena Asphodeloides botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -945,12 +951,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Anemarrhena asphodeloides"
+    "scientific_name": "Anemarrhena asphodeloides",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "angelica-archangelica",
     "name": "Angelica Archangelica",
-    "summary": "Angelica Archangelica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Angelica Archangelica (Angelica archangelica) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on NF-kB modulation, Nrf2 activation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Angelica Archangelica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -1065,12 +1072,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Angelica archangelica"
+    "scientific_name": "Angelica archangelica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "angelica-dahurica",
     "name": "Angelica Dahurica",
-    "summary": "Angelica Dahurica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Angelica Dahurica (Angelica dahurica) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Angelica Dahurica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -1184,12 +1192,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Angelica dahurica"
+    "scientific_name": "Angelica dahurica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "angelica-pubescens",
     "name": "Angelica Pubescens",
-    "summary": "Angelica Pubescens botanical profile with evidence, safety, and practical fit.",
+    "summary": "Angelica Pubescens (Angelica pubescens) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Angelica Pubescens botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -1298,12 +1307,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Angelica pubescens"
+    "scientific_name": "Angelica pubescens",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "angelica-root",
     "name": "Angelica Root",
-    "summary": "Angelica Root botanical profile with evidence, safety, and practical fit.",
+    "summary": "Angelica Root carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on digestive support and traditional cycle support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Angelica Root botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -1403,12 +1413,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "angelica-sinensis",
     "name": "Angelica Sinensis",
-    "summary": "Angelica Sinensis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Angelica Sinensis (Angelica sinensis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, vascular function support and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and bleeding disorders.",
     "description": "Angelica Sinensis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -1531,12 +1542,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Angelica sinensis"
+    "scientific_name": "Angelica sinensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "anise-hyssop",
     "name": "Anise Hyssop",
-    "summary": "Anise Hyssop botanical profile with evidence, safety, and practical fit.",
+    "summary": "Anise Hyssop carries a Grade C rating — limited evidence. Recorded activity centres on endocannabinoid_modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include concentrated essential oil or extract.",
     "description": "Anise Hyssop botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -1640,12 +1652,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "arjuna",
     "name": "Arjuna",
-    "summary": "Arjuna botanical profile with evidence, safety, and practical fit.",
+    "summary": "Arjuna carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include unstable angina and heart failure without clinician oversight.",
     "description": "Arjuna botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -1774,12 +1787,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "artemisia-absinthium",
     "name": "Artemisia Absinthium",
-    "summary": "Artemisia Absinthium botanical profile with evidence, safety, and practical fit.",
+    "summary": "Artemisia Absinthium (Artemisia absinthium) carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Artemisia Absinthium botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -1888,12 +1902,13 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Artemisia absinthium"
+    "scientific_name": "Artemisia absinthium",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "artemisia-annua",
     "name": "Artemisia Annua",
-    "summary": "Artemisia Annua botanical profile with evidence, safety, and practical fit.",
+    "summary": "Artemisia Annua (Artemisia annua) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding unless medically indicated and serious infection without medical care.",
     "description": "Artemisia Annua botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antiviral",
@@ -2017,12 +2032,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Artemisia annua"
+    "scientific_name": "Artemisia annua",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "artemisia-capillaris",
     "name": "Artemisia Capillaris",
-    "summary": "Artemisia Capillaris botanical profile with evidence, safety, and practical fit.",
+    "summary": "Artemisia Capillaris (Artemisia capillaris) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on NF-kB modulation, Nrf2 activation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Artemisia Capillaris botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "liver-protective",
@@ -2136,7 +2152,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Artemisia capillaris"
+    "scientific_name": "Artemisia capillaris",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "artichoke",
@@ -2261,7 +2278,7 @@
   {
     "slug": "ashitaba",
     "name": "Ashitaba",
-    "summary": "Ashitaba botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ashitaba (Angelica keiskei) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and AMPK, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance and anticoagulant use without review.",
     "description": "Ashitaba botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -2374,12 +2391,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Angelica keiskei"
+    "scientific_name": "Angelica keiskei",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ashoka",
     "name": "Ashoka",
-    "summary": "Ashoka botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ashoka (Saraca asoca) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy or breastfeeding without clinician guidance.",
     "description": "Ashoka botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "hormonal",
@@ -2486,7 +2504,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Saraca asoca"
+    "scientific_name": "Saraca asoca",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "withania-somnifera",
@@ -2881,7 +2900,7 @@
   {
     "slug": "astragalus",
     "name": "Astragalus",
-    "summary": "Astragalus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Astragalus carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include transplant/immunosuppression without clinician guidance and autoimmune flare risk.",
     "description": "Astragalus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune_support",
@@ -3001,12 +3020,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "astragalus-membranaceus",
     "name": "Astragalus Membranaceus",
-    "summary": "Astragalus Membranaceus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Astragalus Membranaceus (Astragalus membranaceus) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Astragalus Membranaceus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune_support",
@@ -3144,12 +3164,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Astragalus membranaceus"
+    "scientific_name": "Astragalus membranaceus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "atractylodes",
     "name": "Atractylodes",
-    "summary": "Atractylodes botanical profile with evidence, safety, and practical fit.",
+    "summary": "Atractylodes carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Atractylodes botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -3253,12 +3274,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "atractylodes-macrocephala",
     "name": "Atractylodes Macrocephala",
-    "summary": "Atractylodes Macrocephala botanical profile with evidence, safety, and practical fit.",
+    "summary": "Atractylodes Macrocephala (Atractylodes macrocephala) carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 1 recorded study, 1 in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Atractylodes Macrocephala botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -3374,7 +3396,8 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Atractylodes macrocephala"
+    "scientific_name": "Atractylodes macrocephala",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bacopa",
@@ -3501,7 +3524,7 @@
   {
     "slug": "bael",
     "name": "Bael",
-    "summary": "Bael botanical profile with evidence, safety, and practical fit.",
+    "summary": "Bael (Aegle marmelos) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include diabetes medication or insulin.",
     "description": "Bael botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -3606,12 +3629,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Aegle marmelos"
+    "scientific_name": "Aegle marmelos",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "lagerstroemia-speciosa",
     "name": "Banaba",
-    "summary": "Banaba botanical profile with evidence, safety, and practical fit.",
+    "summary": "Banaba carries a Grade B rating — moderate evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, AMPK signaling and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include antidiabetics.",
     "description": "Banaba botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -3721,12 +3745,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-human-study-recorded"
+    "evidence_grade_backing_gap": "no-human-study-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bayberry",
     "name": "Bayberry",
-    "summary": "Bayberry botanical profile with evidence, safety, and practical fit.",
+    "summary": "Bayberry (Myrica cerifera) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 2 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Bayberry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -3834,12 +3859,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Myrica cerifera"
+    "scientific_name": "Myrica cerifera",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "berberis",
     "name": "Berberis",
-    "summary": "Berberis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Berberis carries a Grade A rating — strong evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and breastfeeding.",
     "description": "Berberis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -3978,12 +4004,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-human-study-recorded"
+    "evidence_grade_backing_gap": "no-human-study-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "berberis-vulgaris",
     "name": "Berberis Vulgaris",
-    "summary": "Berberis Vulgaris botanical profile with evidence, safety, and practical fit.",
+    "summary": "Berberis Vulgaris (Berberis vulgaris) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, AMPK signaling and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Berberis Vulgaris botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -4105,7 +4132,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Berberis vulgaris"
+    "scientific_name": "Berberis vulgaris",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "momordica-charantia",
@@ -4336,7 +4364,7 @@
   {
     "slug": "piper-nigrum",
     "name": "Black Pepper",
-    "summary": "Black Pepper botanical profile with evidence, safety, and practical fit.",
+    "summary": "Black Pepper (Piper nigrum) carries a Grade B rating — moderate evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include many medications (CYP interactions).",
     "description": "Black Pepper botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "bioavailability_enhancer",
@@ -4438,7 +4466,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Piper nigrum"
+    "scientific_name": "Piper nigrum",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "black-seed",
@@ -4576,7 +4605,7 @@
   {
     "slug": "black-tea",
     "name": "Black Tea",
-    "summary": "Black Tea botanical profile with evidence, safety, and practical fit.",
+    "summary": "Black Tea (Camellia sinensis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include severe caffeine sensitivity and pregnancy caffeine limits.",
     "description": "Black Tea botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -4705,12 +4734,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Camellia sinensis"
+    "scientific_name": "Camellia sinensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "blue-lotus",
     "name": "Blue Lotus",
-    "summary": "Blue Lotus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Blue Lotus (Nymphaea caerulea) carries a Grade C rating — limited evidence. Recorded activity centres on stress response modulation and dopaminergic, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and sedative-sensitive users.",
     "description": "Blue Lotus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -4814,12 +4844,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Nymphaea caerulea"
+    "scientific_name": "Nymphaea caerulea",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "blueberry",
     "name": "Blueberry",
-    "summary": "Blueberry botanical profile with evidence, safety, and practical fit.",
+    "summary": "Blueberry carries a Grade A rating — strong evidence. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulant use without review for high-dose extracts and diabetes medication monitoring if large intake changes.",
     "description": "Blueberry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -4953,12 +4984,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-claims-recorded"
+    "evidence_grade_backing_gap": "no-claims-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "boldo",
     "name": "Boldo",
-    "summary": "Boldo botanical profile with evidence, safety, and practical fit.",
+    "summary": "Boldo (Peumus boldus) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on digestive support and hepatobiliary support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy or breastfeeding without clinician guidance.",
     "description": "Boldo botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -5058,12 +5090,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Peumus boldus"
+    "scientific_name": "Peumus boldus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "boswellia-serrata",
     "name": "Boswellia",
-    "summary": "Boswellia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Boswellia (Boswellia serrata) carries a Grade A rating — strong evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 2 in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include nSAIDs (caution).",
     "description": "Boswellia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -5161,12 +5194,13 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Boswellia serrata"
+    "scientific_name": "Boswellia serrata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "boswellia-carterii",
     "name": "Boswellia Carterii",
-    "summary": "Boswellia Carterii botanical profile with evidence, safety, and practical fit.",
+    "summary": "Boswellia Carterii (Boswellia carterii) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Boswellia Carterii botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -5274,7 +5308,8 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Boswellia carterii"
+    "scientific_name": "Boswellia carterii",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "brassica-juncea",
@@ -5508,7 +5543,7 @@
   {
     "slug": "buckwheat",
     "name": "Buckwheat",
-    "summary": "Buckwheat botanical profile with evidence, safety, and practical fit.",
+    "summary": "Buckwheat (Fagopyrum esculentum) carries a Grade A rating — strong evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Buckwheat botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -5641,12 +5676,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Fagopyrum esculentum"
+    "scientific_name": "Fagopyrum esculentum",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bupleurum",
     "name": "Bupleurum",
-    "summary": "Bupleurum botanical profile with evidence, safety, and practical fit.",
+    "summary": "Bupleurum carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, stress response modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include active liver disease or elevated liver enzymes.",
     "description": "Bupleurum botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "liver_support",
@@ -5762,7 +5798,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "bupleurum-falcatum",
@@ -5883,7 +5920,7 @@
   {
     "slug": "burdock",
     "name": "Burdock",
-    "summary": "Burdock botanical profile with evidence, safety, and practical fit.",
+    "summary": "Burdock (Arctium lappa) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include asteraceae allergy and pregnancy/breastfeeding without clinician guidance.",
     "description": "Burdock botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -5987,7 +6024,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Arctium lappa"
+    "scientific_name": "Arctium lappa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "butterbur",
@@ -6100,7 +6138,7 @@
   {
     "slug": "theobroma-cacao",
     "name": "Cacao",
-    "summary": "Cacao botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cacao (Theobroma cacao) carries a Grade A rating — strong evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on vascular function support, endothelial function support and endothelial function, which describes mechanism rather than demonstrated benefit. Noted cautions include caffeine sensitivity.",
     "description": "Cacao botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "stimulant"
@@ -6208,12 +6246,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Theobroma cacao"
+    "scientific_name": "Theobroma cacao",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "calamus",
     "name": "Calamus",
-    "summary": "Calamus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Calamus (Acorus calamus) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and children.",
     "description": "Calamus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -6318,12 +6357,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Acorus calamus"
+    "scientific_name": "Acorus calamus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "calendula",
     "name": "Calendula",
-    "summary": "Calendula botanical profile with evidence, safety, and practical fit.",
+    "summary": "Calendula (Calendula officinalis) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include asteraceae allergy and open/infected wounds without medical care.",
     "description": "Calendula botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -6436,12 +6476,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Calendula officinalis"
+    "scientific_name": "Calendula officinalis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "eschscholzia-californica",
     "name": "California Poppy",
-    "summary": "California Poppy botanical profile with evidence, safety, and practical fit.",
+    "summary": "California Poppy carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation, stress response modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include cNS depressants.",
     "description": "California Poppy botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -6537,7 +6578,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "capsicum-annuum",
@@ -6654,7 +6696,7 @@
   {
     "slug": "capsicum-frutescens",
     "name": "Capsicum Frutescens",
-    "summary": "Capsicum Frutescens botanical profile with evidence, safety, and practical fit.",
+    "summary": "Capsicum Frutescens (Capsicum frutescens) carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 4 recorded studies, 3 in people. No disagreement is recorded across them. Recorded activity centres on metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include caution reflux/GERD and gastritis/ulcers.",
     "description": "Capsicum Frutescens botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "Cognition",
@@ -6758,12 +6800,13 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Capsicum frutescens"
+    "scientific_name": "Capsicum frutescens",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "caraway",
     "name": "Caraway",
-    "summary": "Caraway botanical profile with evidence, safety, and practical fit.",
+    "summary": "Caraway (Carum carvi) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on digestive support and aromatic support, which describes mechanism rather than demonstrated benefit. Noted cautions include known allergy to Apiaceae family plants.",
     "description": "Caraway botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -6863,12 +6906,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Carum carvi"
+    "scientific_name": "Carum carvi",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "elettaria-cardamomum",
     "name": "Cardamom",
-    "summary": "Cardamom botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cardamom carries a Grade B rating — moderate evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 2 in people. Recorded activity centres on oxidative stress modulation, vascular function support and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include limited data.",
     "description": "Cardamom botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -6974,12 +7018,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "carob",
     "name": "Carob",
-    "summary": "Carob botanical profile with evidence, safety, and practical fit.",
+    "summary": "Carob (Ceratonia siliqua) carries a Grade C rating — limited evidence. Strongest recorded design is a uncontrolled trial, drawn from 3 recorded studies, 1 in people. Recorded activity centres on metabolic regulation and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include severe constipation/obstruction risk and carob allergy.",
     "description": "Carob botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -7086,12 +7131,13 @@
     "evidence_strongest_design": "uncontrolled-trial",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Ceratonia siliqua"
+    "scientific_name": "Ceratonia siliqua",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cassia-alata",
     "name": "Cassia Alata",
-    "summary": "Cassia Alata botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cassia Alata (Senna alata) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include digoxin or other cardiac glycoside medication.",
     "description": "Cassia Alata botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -7198,12 +7244,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Senna alata"
+    "scientific_name": "Senna alata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cat-s-claw",
     "name": "Cat's Claw",
-    "summary": "Cat's Claw botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cat's Claw (Uncaria tomentosa) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Cat's Claw botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -7309,12 +7356,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Uncaria tomentosa"
+    "scientific_name": "Uncaria tomentosa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "catuba",
     "name": "Catuba",
-    "summary": "Catuba botanical profile with evidence, safety, and practical fit.",
+    "summary": "Catuba carries a Grade C rating — limited evidence. Recorded activity centres on stress response modulation and mitochondrial function, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Catuba botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "libido",
@@ -7423,12 +7471,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cayenne",
     "name": "Cayenne",
-    "summary": "Cayenne botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cayenne (Capsicum annuum) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Cayenne botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -7532,12 +7581,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Capsicum annuum"
+    "scientific_name": "Capsicum annuum",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "celastrus-paniculatus",
     "name": "Celastrus Paniculatus",
-    "summary": "Celastrus Paniculatus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Celastrus Paniculatus (Celastrus paniculatus) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and neurotransmitter modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include sedative or benzodiazepine medication.",
     "description": "Celastrus Paniculatus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
@@ -7668,7 +7718,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Celastrus paniculatus"
+    "scientific_name": "Celastrus paniculatus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "chaga",
@@ -7903,7 +7954,7 @@
   {
     "slug": "chinese-skullcap",
     "name": "Chinese Skullcap",
-    "summary": "Chinese Skullcap botanical profile with evidence, safety, and practical fit.",
+    "summary": "Chinese Skullcap (Scutellaria baicalensis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include liver disease and pregnancy/breastfeeding.",
     "description": "Chinese Skullcap botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -8029,12 +8080,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Scutellaria baicalensis"
+    "scientific_name": "Scutellaria baicalensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "chuanxiong",
     "name": "Chuanxiong",
-    "summary": "Chuanxiong botanical profile with evidence, safety, and practical fit.",
+    "summary": "Chuanxiong (Ligusticum chuanxiong) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, vascular function support and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and bleeding disorders.",
     "description": "Chuanxiong botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -8148,12 +8200,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Ligusticum chuanxiong"
+    "scientific_name": "Ligusticum chuanxiong",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cichorium-intybus",
     "name": "Cichorium Intybus",
-    "summary": "Cichorium Intybus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cichorium Intybus (Cichorium intybus) carries a Grade A rating — strong evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Cichorium Intybus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -8272,7 +8325,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Cichorium intybus"
+    "scientific_name": "Cichorium intybus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cinnamomum-verum",
@@ -8387,7 +8441,7 @@
   {
     "slug": "cissus",
     "name": "Cissus",
-    "summary": "Cissus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cissus carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance and diabetes medications without monitoring.",
     "description": "Cissus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -8497,12 +8551,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cistanche",
     "name": "Cistanche",
-    "summary": "Cistanche botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cistanche carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on neuroprotective activity and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without guidance and diarrhea-prone conditions.",
     "description": "Cistanche botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -8607,12 +8662,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cistanche-deserticola",
     "name": "Cistanche Deserticola",
-    "summary": "Cistanche Deserticola botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cistanche Deserticola (Cistanche deserticola) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on neuroprotective activity, Nrf2 activation and Nrf2, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without guidance and diarrhea-prone conditions.",
     "description": "Cistanche Deserticola botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "energy",
@@ -8734,7 +8790,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Cistanche deserticola"
+    "scientific_name": "Cistanche deserticola",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "citicoline",
@@ -8864,7 +8921,7 @@
   {
     "slug": "citrus-bergamia",
     "name": "Citrus Bergamia",
-    "summary": "Citrus Bergamia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Citrus Bergamia (Citrus bergamia) carries a Grade A rating — strong evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on metabolic regulation, vascular function support and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Citrus Bergamia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cardiovascular",
@@ -8997,7 +9054,8 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "single-human-study-for-grade-a",
-    "scientific_name": "Citrus bergamia"
+    "scientific_name": "Citrus bergamia",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "citrus-sinensis",
@@ -9241,7 +9299,7 @@
   {
     "slug": "cnidium-monnieri",
     "name": "Cnidium Monnieri",
-    "summary": "Cnidium Monnieri botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cnidium Monnieri (Cnidium monnieri) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Cnidium Monnieri botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "reproductive",
@@ -9345,12 +9403,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Cnidium monnieri"
+    "scientific_name": "Cnidium monnieri",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "codonopsis",
     "name": "Codonopsis",
-    "summary": "Codonopsis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Codonopsis (Codonopsis pilosula) carries a Grade C rating — limited evidence. Recorded activity centres on immune signaling modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Codonopsis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -9456,12 +9515,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Codonopsis pilosula"
+    "scientific_name": "Codonopsis pilosula",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "coffea-arabica",
     "name": "Coffee",
-    "summary": "Coffee botanical profile with evidence, safety, and practical fit.",
+    "summary": "Coffee (Coffea arabica) carries a Grade A rating — strong evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on vascular function support and mitochondrial function, which describes mechanism rather than demonstrated benefit. Noted cautions include cardiovascular disease and stimulants.",
     "description": "Coffee botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "energy",
@@ -9569,12 +9629,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Coffea arabica"
+    "scientific_name": "Coffea arabica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "coffee-cherry",
     "name": "Coffee Cherry",
-    "summary": "Coffee Cherry botanical profile with evidence, safety, and practical fit.",
+    "summary": "Coffee Cherry carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include uncontrolled hypertension and arrhythmias.",
     "description": "Coffee Cherry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -9703,12 +9764,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "coleus-forskohlii",
     "name": "Coleus Forskohlii",
-    "summary": "Coleus Forskohlii botanical profile with evidence, safety, and practical fit.",
+    "summary": "Coleus Forskohlii carries a Grade C rating — limited evidence. Recorded activity centres on neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and hypotension.",
     "description": "Coleus Forskohlii botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive"
@@ -9812,12 +9874,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "commiphora-mukul",
     "name": "Commiphora Mukul",
-    "summary": "Commiphora Mukul botanical profile with evidence, safety, and practical fit.",
+    "summary": "Commiphora Mukul (Commiphora mukul) carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Commiphora Mukul botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -9943,12 +10006,13 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Commiphora mukul"
+    "scientific_name": "Commiphora mukul",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "coptis",
     "name": "Coptis",
-    "summary": "Coptis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Coptis carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, mitochondrial support and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Coptis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -10073,12 +10137,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "coptis-chinensis",
     "name": "Coptis Chinensis",
-    "summary": "Coptis Chinensis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Coptis Chinensis (Coptis chinensis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, AMPK signaling and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Coptis Chinensis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antimicrobial",
@@ -10200,7 +10265,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Coptis chinensis"
+    "scientific_name": "Coptis chinensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cordyceps-sinensis",
@@ -10323,7 +10389,7 @@
   {
     "slug": "coriandrum-sativum",
     "name": "Coriandrum Sativum",
-    "summary": "Coriandrum Sativum botanical profile with evidence, safety, and practical fit.",
+    "summary": "Coriandrum Sativum (Coriandrum sativum) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, neurotransmitter modulation and Nrf2 activation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Coriandrum Sativum botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -10452,12 +10518,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Coriandrum sativum"
+    "scientific_name": "Coriandrum sativum",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cornus-officinalis",
     "name": "Cornus Officinalis",
-    "summary": "Cornus Officinalis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cornus Officinalis (Cornus officinalis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Cornus Officinalis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "reproductive",
@@ -10581,12 +10648,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Cornus officinalis"
+    "scientific_name": "Cornus officinalis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "corydalis",
     "name": "Corydalis",
-    "summary": "Corydalis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Corydalis carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and liver disease.",
     "description": "Corydalis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -10692,7 +10760,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cranberry",
@@ -10933,7 +11002,7 @@
   {
     "slug": "curcuma-wenyujin",
     "name": "Curcuma Wenyujin",
-    "summary": "Curcuma Wenyujin botanical profile with evidence, safety, and practical fit.",
+    "summary": "Curcuma Wenyujin (Curcuma wenyujin) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy.",
     "description": "Curcuma Wenyujin botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -11037,12 +11106,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Curcuma wenyujin"
+    "scientific_name": "Curcuma wenyujin",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "curcuma-zedoaria",
     "name": "Curcuma Zedoaria",
-    "summary": "Curcuma Zedoaria botanical profile with evidence, safety, and practical fit.",
+    "summary": "Curcuma Zedoaria (Curcuma zedoaria) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Curcuma Zedoaria botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -11152,12 +11222,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Curcuma zedoaria"
+    "scientific_name": "Curcuma zedoaria",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "curcumin",
     "name": "Curcumin",
-    "summary": "Curcumin botanical profile with evidence, safety, and practical fit.",
+    "summary": "Curcumin (Curcuma longa) carries a Grade A rating — strong evidence. Strongest recorded design is a meta-analysis, drawn from 11 recorded studies, 8 in people. No disagreement is recorded across them. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulants.",
     "description": "Curcumin botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -11268,12 +11339,13 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Curcuma longa"
+    "scientific_name": "Curcuma longa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "curry-leaf",
     "name": "Curry Leaf",
-    "summary": "Curry Leaf botanical profile with evidence, safety, and practical fit.",
+    "summary": "Curry Leaf (Murraya koenigii) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Curry Leaf botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -11386,12 +11458,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Murraya koenigii"
+    "scientific_name": "Murraya koenigii",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cyclea-peltata",
     "name": "Cyclea Peltata",
-    "summary": "Cyclea Peltata botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cyclea Peltata (Cyclea peltata) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Cyclea Peltata botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -11501,12 +11574,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Cyclea peltata"
+    "scientific_name": "Cyclea peltata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "cymbopogon-citratus",
     "name": "Cymbopogon Citratus",
-    "summary": "Cymbopogon Citratus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Cymbopogon Citratus (Cymbopogon citratus) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, neurotransmitter modulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding supplement dosing without guidance and internal essential-oil use.",
     "description": "Cymbopogon Citratus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -11624,12 +11698,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Cymbopogon citratus"
+    "scientific_name": "Cymbopogon citratus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "damiana",
     "name": "Damiana",
-    "summary": "Damiana botanical profile with evidence, safety, and practical fit.",
+    "summary": "Damiana (Turnera diffusa) carries a Grade C rating — limited evidence. Recorded activity centres on stress response modulation and dopaminergic, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and seizure disorder without clinician review.",
     "description": "Damiana botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "libido",
@@ -11735,12 +11810,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Turnera diffusa"
+    "scientific_name": "Turnera diffusa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "dandelion",
     "name": "Dandelion",
-    "summary": "Dandelion botanical profile with evidence, safety, and practical fit.",
+    "summary": "Dandelion (Taraxacum officinale) carries a Grade A rating — strong evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on NF-kB modulation, Nrf2 activation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include asteraceae allergy and bile duct obstruction.",
     "description": "Dandelion botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -11861,12 +11937,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Taraxacum officinale"
+    "scientific_name": "Taraxacum officinale",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "danshen",
     "name": "Danshen",
-    "summary": "Danshen botanical profile with evidence, safety, and practical fit.",
+    "summary": "Danshen (Salvia miltiorrhiza) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and anticoagulant/antiplatelet therapy without clinician review.",
     "description": "Danshen botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cardiovascular"
@@ -11971,12 +12048,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Salvia miltiorrhiza"
+    "scientific_name": "Salvia miltiorrhiza",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "daphne-odora",
     "name": "Daphne Odora",
-    "summary": "Daphne Odora botanical profile with evidence, safety, and practical fit.",
+    "summary": "Daphne Odora (Daphne odora) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Daphne Odora botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -12084,12 +12162,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Daphne odora"
+    "scientific_name": "Daphne odora",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "dendrobium",
     "name": "Dendrobium",
-    "summary": "Dendrobium botanical profile with evidence, safety, and practical fit.",
+    "summary": "Dendrobium carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include blood pressure medication.",
     "description": "Dendrobium botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -12191,12 +12270,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "dong-quai",
     "name": "Dong Quai",
-    "summary": "Dong Quai botanical profile with evidence, safety, and practical fit.",
+    "summary": "Dong Quai (Angelica sinensis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, vascular function support and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and bleeding disorders.",
     "description": "Dong Quai botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -12313,7 +12393,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Angelica sinensis"
+    "scientific_name": "Angelica sinensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "echinacea-purpurea",
@@ -12542,7 +12623,7 @@
   {
     "slug": "elecampane",
     "name": "Elecampane",
-    "summary": "Elecampane botanical profile with evidence, safety, and practical fit.",
+    "summary": "Elecampane (Inula helenium) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on traditional respiratory support and digestive support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy because of traditional use as a uterine stimulant.",
     "description": "Elecampane botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -12644,12 +12725,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Inula helenium"
+    "scientific_name": "Inula helenium",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "elephantopus-scaber",
     "name": "Elephantopus Scaber",
-    "summary": "Elephantopus Scaber botanical profile with evidence, safety, and practical fit.",
+    "summary": "Elephantopus Scaber carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Elephantopus Scaber botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -12758,7 +12840,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "eleuthero",
@@ -12892,7 +12975,7 @@
   {
     "slug": "embelia-ribes",
     "name": "Embelia Ribes",
-    "summary": "Embelia Ribes botanical profile with evidence, safety, and practical fit.",
+    "summary": "Embelia Ribes carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 1 in people. Recorded activity centres on NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Embelia Ribes botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antimicrobial",
@@ -12996,7 +13079,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "epimedium",
@@ -13248,7 +13332,7 @@
   {
     "slug": "eucalyptus",
     "name": "Eucalyptus",
-    "summary": "Eucalyptus botanical profile with evidence, safety, and practical fit.",
+    "summary": "Eucalyptus carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include infants/young children for oil exposure near face and asthma/bronchospasm sensitivity.",
     "description": "Eucalyptus botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -13353,12 +13437,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "eucommia",
     "name": "Eucommia",
-    "summary": "Eucommia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Eucommia carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance and hypotension or hypoglycemia risk.",
     "description": "Eucommia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic",
@@ -13462,7 +13547,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "evening-primrose",
@@ -13793,7 +13879,7 @@
   {
     "slug": "feverfew",
     "name": "Feverfew",
-    "summary": "Feverfew botanical profile with evidence, safety, and practical fit.",
+    "summary": "Feverfew (Tanacetum parthenium) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and asteraceae/ragweed allergy.",
     "description": "Feverfew botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -13912,12 +13998,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Tanacetum parthenium"
+    "scientific_name": "Tanacetum parthenium",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ficus-carica",
     "name": "Ficus Carica",
-    "summary": "Ficus Carica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ficus Carica carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, hormonal signaling context and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Ficus Carica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -14033,12 +14120,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "fingerroot",
     "name": "Fingerroot",
-    "summary": "Fingerroot botanical profile with evidence, safety, and practical fit.",
+    "summary": "Fingerroot carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, cellular protection and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include diabetes medication.",
     "description": "Fingerroot botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -14150,12 +14238,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "fraxinus-rhynchophylla",
     "name": "Fraxinus Rhynchophylla",
-    "summary": "Fraxinus Rhynchophylla botanical profile with evidence, safety, and practical fit.",
+    "summary": "Fraxinus Rhynchophylla carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, vascular function support and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Fraxinus Rhynchophylla botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -14275,12 +14364,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "galangal",
     "name": "Galangal",
-    "summary": "Galangal botanical profile with evidence, safety, and practical fit.",
+    "summary": "Galangal carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulant or antiplatelet medication.",
     "description": "Galangal botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -14380,12 +14470,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "garcinia-indica",
     "name": "Garcinia Indica",
-    "summary": "Garcinia Indica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Garcinia Indica carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Garcinia Indica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -14505,12 +14596,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "garcinia-mangostana",
     "name": "Garcinia Mangostana",
-    "summary": "Garcinia Mangostana botanical profile with evidence, safety, and practical fit.",
+    "summary": "Garcinia Mangostana carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance and bleeding disorder/anticoagulant use without review.",
     "description": "Garcinia Mangostana botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -14624,7 +14716,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "allium-sativum",
@@ -14876,7 +14969,7 @@
   {
     "slug": "gastrodia",
     "name": "Gastrodia",
-    "summary": "Gastrodia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Gastrodia carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on stress response modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without guidance and sedative use without review.",
     "description": "Gastrodia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "neuroprotective",
@@ -14985,7 +15078,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ginger",
@@ -15333,7 +15427,7 @@
   {
     "slug": "goldenseal",
     "name": "Goldenseal",
-    "summary": "Goldenseal botanical profile with evidence, safety, and practical fit.",
+    "summary": "Goldenseal carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, mitochondrial support and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and infants/newborns.",
     "description": "Goldenseal botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -15451,12 +15545,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "gotu-kola",
     "name": "Gotu Kola (Centella asiatica)",
-    "summary": "Gotu Kola (Centella asiatica) botanical profile with evidence, safety, and practical fit.",
+    "summary": "Gotu Kola (Centella asiatica) (Centella asiatica) carries a Grade B rating — moderate evidence. Recorded activity centres on oxidative stress modulation, neurotransmitter modulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include sedatives.",
     "description": "Gotu Kola (Centella asiatica) botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "microcirculation",
@@ -15577,12 +15672,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Centella asiatica"
+    "scientific_name": "Centella asiatica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "vitis-vinifera",
     "name": "Grape",
-    "summary": "Grape botanical profile with evidence, safety, and practical fit.",
+    "summary": "Grape (Vitis vinifera) carries a Grade B rating — moderate evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulants.",
     "description": "Grape botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -15707,12 +15803,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Vitis vinifera"
+    "scientific_name": "Vitis vinifera",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "grapefruit",
     "name": "Grapefruit",
-    "summary": "Grapefruit botanical profile with evidence, safety, and practical fit.",
+    "summary": "Grapefruit carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation and mitochondrial function, which describes mechanism rather than demonstrated benefit. Noted cautions include narrow-therapeutic-index drugs and and complex cardiovascular/transplant regimens.",
     "description": "Grapefruit botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -15820,12 +15917,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "camellia-sinensis",
     "name": "Green Tea",
-    "summary": "Green Tea botanical profile with evidence, safety, and practical fit.",
+    "summary": "Green Tea (Camellia sinensis) carries a Grade A rating — strong evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include stimulants and hepatotoxic drugs.",
     "description": "Green Tea botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -15951,12 +16049,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "single-human-study-for-grade-a",
-    "scientific_name": "Camellia sinensis"
+    "scientific_name": "Camellia sinensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "green-tea-extract",
     "name": "Green Tea Extract",
-    "summary": "Green Tea Extract botanical profile with evidence, safety, and practical fit.",
+    "summary": "Green Tea Extract (Camellia sinensis) carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 4 recorded studies, 2 in people. Recorded activity centres on metabolic regulation, vascular function support and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include liver disease and stimulants.",
     "description": "Green Tea Extract botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -16063,12 +16162,13 @@
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Camellia sinensis"
+    "scientific_name": "Camellia sinensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "guarana",
     "name": "Guarana",
-    "summary": "Guarana botanical profile with evidence, safety, and practical fit.",
+    "summary": "Guarana carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and adenosinergic, which describes mechanism rather than demonstrated benefit. Noted cautions include uncontrolled hypertension and arrhythmia.",
     "description": "Guarana botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -16182,12 +16282,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "guayusa",
     "name": "Guayusa",
-    "summary": "Guayusa botanical profile with evidence, safety, and practical fit.",
+    "summary": "Guayusa carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 1 in people. Recorded activity centres on oxidative stress modulation, oxidative stress and mitochondrial function, which describes mechanism rather than demonstrated benefit. Noted cautions include uncontrolled hypertension and arrhythmia.",
     "description": "Guayusa botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -16300,12 +16401,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "gudmar",
     "name": "Gudmar",
-    "summary": "Gudmar botanical profile with evidence, safety, and practical fit.",
+    "summary": "Gudmar carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation, AMPK signaling and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Gudmar botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -16418,7 +16520,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "gymnema-sylvestre",
@@ -16533,7 +16636,7 @@
   {
     "slug": "harpagophytum-procumbens",
     "name": "Harpagophytum Procumbens",
-    "summary": "Harpagophytum Procumbens botanical profile with evidence, safety, and practical fit.",
+    "summary": "Harpagophytum Procumbens carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Harpagophytum Procumbens botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -16642,7 +16745,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "crataegus-monogyna",
@@ -17009,7 +17113,7 @@
   {
     "slug": "holy-basil-purple",
     "name": "Holy Basil Purple",
-    "summary": "Holy Basil Purple botanical profile with evidence, safety, and practical fit.",
+    "summary": "Holy Basil Purple carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Holy Basil Purple botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "adaptogen",
@@ -17131,12 +17235,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "holy-basil-seed",
     "name": "Holy Basil Seed",
-    "summary": "Holy Basil Seed botanical profile with evidence, safety, and practical fit.",
+    "summary": "Holy Basil Seed carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Holy Basil Seed botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -17241,12 +17346,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "honeysuckle",
     "name": "Honeysuckle",
-    "summary": "Honeysuckle botanical profile with evidence, safety, and practical fit.",
+    "summary": "Honeysuckle carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Honeysuckle botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -17357,12 +17463,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "hops",
     "name": "Hops",
-    "summary": "Hops botanical profile with evidence, safety, and practical fit.",
+    "summary": "Hops (Humulus lupulus) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 4 recorded studies, 1 in people. Recorded activity centres on stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without guidance and severe depression.",
     "description": "Hops botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -17466,12 +17573,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Humulus lupulus"
+    "scientific_name": "Humulus lupulus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "horse-chestnut",
     "name": "Horse Chestnut",
-    "summary": "Horse Chestnut botanical profile with evidence, safety, and practical fit.",
+    "summary": "Horse Chestnut carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Horse Chestnut botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -17582,12 +17690,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "houttuynia",
     "name": "Houttuynia",
-    "summary": "Houttuynia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Houttuynia carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Houttuynia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune",
@@ -17693,12 +17802,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "huperzia-serrata",
     "name": "Huperzia Serrata",
-    "summary": "Huperzia Serrata botanical profile with evidence, safety, and practical fit.",
+    "summary": "Huperzia Serrata carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation, neuroprotective activity and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Huperzia Serrata botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive"
@@ -17805,7 +17915,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "hypericum-perforatum",
@@ -17928,7 +18039,7 @@
   {
     "slug": "berberis-aristata",
     "name": "Indian Barberry",
-    "summary": "Indian Barberry botanical profile with evidence, safety, and practical fit.",
+    "summary": "Indian Barberry (Berberis aristata) carries a Grade A rating — strong evidence. Recorded activity centres on metabolic regulation, AMPK signaling and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include cYP3A4 substrates and metformin (additive).",
     "description": "Indian Barberry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -18045,12 +18156,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-claims-recorded",
-    "scientific_name": "Berberis aristata"
+    "scientific_name": "Berberis aristata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "isatis",
     "name": "Isatis",
-    "summary": "Isatis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Isatis carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Isatis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune"
@@ -18154,7 +18266,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "japanese-knotweed",
@@ -18297,7 +18410,7 @@
   {
     "slug": "jatamansi",
     "name": "Jatamansi",
-    "summary": "Jatamansi botanical profile with evidence, safety, and practical fit.",
+    "summary": "Jatamansi carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on stress response modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Jatamansi botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -18402,12 +18515,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "jujube",
     "name": "Jujube",
-    "summary": "Jujube botanical profile with evidence, safety, and practical fit.",
+    "summary": "Jujube carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, stress response modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include diabetes/glucose management if using sweet fruit products and pregnancy supplement dosing without guidance.",
     "description": "Jujube botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -18519,12 +18633,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "juniper",
     "name": "Juniper",
-    "summary": "Juniper botanical profile with evidence, safety, and practical fit.",
+    "summary": "Juniper carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on digestive support, urinary support and aromatic support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and kidney disease.",
     "description": "Juniper botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -18628,12 +18743,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "kanna",
     "name": "Kanna",
-    "summary": "Kanna botanical profile with evidence, safety, and practical fit.",
+    "summary": "Kanna carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation, stress response modulation and serotonergic, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and bipolar/mania risk.",
     "description": "Kanna botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "mood_support",
@@ -18747,7 +18863,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "piper-methysticum",
@@ -18864,7 +18981,7 @@
   {
     "slug": "kuding-tea",
     "name": "Kuding Tea",
-    "summary": "Kuding Tea botanical profile with evidence, safety, and practical fit.",
+    "summary": "Kuding Tea carries a Grade C rating — limited evidence. Recorded activity centres on oxidative stress modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Kuding Tea botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -18979,12 +19096,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "kudzu",
     "name": "Kudzu",
-    "summary": "Kudzu botanical profile with evidence, safety, and practical fit.",
+    "summary": "Kudzu carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding caution and hormone-sensitive cancers or conditions.",
     "description": "Kudzu botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -19103,12 +19221,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "tyrosine",
     "name": "L-Tyrosine",
-    "summary": "L-Tyrosine botanical profile with evidence, safety, and practical fit.",
+    "summary": "L-Tyrosine carries a Grade A rating — strong evidence. Strongest recorded design is a randomized controlled trial, drawn from 4 recorded studies, 1 in people. Recorded activity centres on neurotransmitter modulation, stress response modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include mAO inhibitors and thyroid meds.",
     "description": "L-Tyrosine botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
@@ -19227,7 +19346,8 @@
     "evidence_recorded_study_count": 4,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "single-human-study-for-grade-a"
+    "evidence_grade_backing_gap": "single-human-study-for-grade-a",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "lavandula-angustifolia",
@@ -19337,7 +19457,7 @@
   {
     "slug": "lawsonia-inermis",
     "name": "Lawsonia Inermis",
-    "summary": "Lawsonia Inermis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Lawsonia Inermis carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Lawsonia Inermis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "skin-support",
@@ -19441,7 +19561,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "melissa-officinalis",
@@ -19573,7 +19694,7 @@
   {
     "slug": "lemon-verbena",
     "name": "Lemon Verbena",
-    "summary": "Lemon Verbena botanical profile with evidence, safety, and practical fit.",
+    "summary": "Lemon Verbena carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, stress response modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance and kidney disease caution at high doses.",
     "description": "Lemon Verbena botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -19680,12 +19801,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "lemongrass",
     "name": "Lemongrass",
-    "summary": "Lemongrass botanical profile with evidence, safety, and practical fit.",
+    "summary": "Lemongrass carries a Grade C rating — limited evidence. Recorded activity centres on metabolic regulation, vascular function support and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding supplement dosing without guidance and internal essential-oil use.",
     "description": "Lemongrass botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -19797,12 +19919,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "licorice",
     "name": "Licorice",
-    "summary": "Licorice botanical profile with evidence, safety, and practical fit.",
+    "summary": "Licorice (Glycyrrhiza glabra) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include hypertension and kidney disease.",
     "description": "Licorice botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -19918,12 +20041,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Glycyrrhiza glabra"
+    "scientific_name": "Glycyrrhiza glabra",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ligusticum-chuanxiong",
     "name": "Ligusticum Chuanxiong",
-    "summary": "Ligusticum Chuanxiong botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ligusticum Chuanxiong (Ligusticum chuanxiong) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, vascular function support and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Ligusticum Chuanxiong botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cardiovascular",
@@ -20044,7 +20168,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Ligusticum chuanxiong"
+    "scientific_name": "Ligusticum chuanxiong",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "hericium-erinaceus",
@@ -20262,7 +20387,7 @@
   {
     "slug": "lithospermum-erythrorhizon",
     "name": "Lithospermum Erythrorhizon",
-    "summary": "Lithospermum Erythrorhizon botanical profile with evidence, safety, and practical fit.",
+    "summary": "Lithospermum Erythrorhizon carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Lithospermum Erythrorhizon botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "skin-support",
@@ -20371,12 +20496,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "lobelia-inflata",
     "name": "Lobelia Inflata",
-    "summary": "Lobelia Inflata botanical profile with evidence, safety, and practical fit.",
+    "summary": "Lobelia Inflata carries a Grade C rating — limited evidence. Recorded activity centres on neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Lobelia Inflata botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "respiratory",
@@ -20477,12 +20603,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "longan",
     "name": "Longan",
-    "summary": "Longan botanical profile with evidence, safety, and practical fit.",
+    "summary": "Longan carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, stress response modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Longan botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -20589,12 +20716,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "luo-han-guo",
     "name": "Luo Han Guo",
-    "summary": "Luo Han Guo botanical profile with evidence, safety, and practical fit.",
+    "summary": "Luo Han Guo carries a Grade C rating — limited evidence. Recorded activity centres on oxidative stress modulation, metabolic regulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Luo Han Guo botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "respiratory",
@@ -20707,7 +20835,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "maca",
@@ -20943,7 +21072,7 @@
   {
     "slug": "maitake-d-fraction",
     "name": "Maitake D-fraction",
-    "summary": "Maitake D-fraction botanical profile with evidence, safety, and practical fit.",
+    "summary": "Maitake D-fraction carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Maitake D-fraction botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune"
@@ -21054,12 +21183,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "mangifera-indica",
     "name": "Mangifera Indica",
-    "summary": "Mangifera Indica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Mangifera Indica carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Mangifera Indica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -21190,12 +21320,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "mangosteen",
     "name": "Mangosteen",
-    "summary": "Mangosteen botanical profile with evidence, safety, and practical fit.",
+    "summary": "Mangosteen (Garcinia mangostana) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician guidance and bleeding disorder/anticoagulant use without review.",
     "description": "Mangosteen botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -21303,12 +21434,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Garcinia mangostana"
+    "scientific_name": "Garcinia mangostana",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "maral-root",
     "name": "Maral Root",
-    "summary": "Maral Root botanical profile with evidence, safety, and practical fit.",
+    "summary": "Maral Root carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include hormone-sensitive cancer.",
     "description": "Maral Root botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "adaptogen",
@@ -21413,12 +21545,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "marshmallow",
     "name": "Marshmallow",
-    "summary": "Marshmallow botanical profile with evidence, safety, and practical fit.",
+    "summary": "Marshmallow carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include difficulty swallowing and severe GI obstruction risk.",
     "description": "Marshmallow botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -21524,7 +21657,8 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "milk-oats",
@@ -21875,7 +22009,7 @@
   {
     "slug": "morinda-citrifolia",
     "name": "Morinda Citrifolia",
-    "summary": "Morinda Citrifolia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Morinda Citrifolia (Morinda citrifolia) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Morinda Citrifolia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -22007,12 +22141,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Morinda citrifolia"
+    "scientific_name": "Morinda citrifolia",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "moringa",
     "name": "Moringa",
-    "summary": "Moringa botanical profile with evidence, safety, and practical fit.",
+    "summary": "Moringa (Moringa oleifera) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding caution for concentrated extracts and especially non-leaf parts.",
     "description": "Moringa botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -22149,12 +22284,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Moringa oleifera"
+    "scientific_name": "Moringa oleifera",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "morus-alba",
     "name": "Morus Alba",
-    "summary": "Morus Alba botanical profile with evidence, safety, and practical fit.",
+    "summary": "Morus Alba (Morus alba) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, AMPK signaling and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include hypoglycemia risk and pregnancy/breastfeeding without clinician guidance.",
     "description": "Morus Alba botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -22273,12 +22409,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Morus alba"
+    "scientific_name": "Morus alba",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "mucuna",
     "name": "Mucuna",
-    "summary": "Mucuna botanical profile with evidence, safety, and practical fit.",
+    "summary": "Mucuna (Mucuna pruriens) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on oxidative stress modulation, mitochondrial support and neurotransmitter modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include psychosis/bipolar risk and melanoma history caution.",
     "description": "Mucuna botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "dopamine_support",
@@ -22409,12 +22546,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Mucuna pruriens"
+    "scientific_name": "Mucuna pruriens",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "mugwort",
     "name": "Mugwort",
-    "summary": "Mugwort botanical profile with evidence, safety, and practical fit.",
+    "summary": "Mugwort carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on digestive support and traditional cycle support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and seizure disorder.",
     "description": "Mugwort botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive"
@@ -22516,12 +22654,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "muira-puama",
     "name": "Muira Puama",
-    "summary": "Muira Puama botanical profile with evidence, safety, and practical fit.",
+    "summary": "Muira Puama carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on stress response modulation and mitochondrial function, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Muira Puama botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "libido",
@@ -22622,12 +22761,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "mulberry-leaf",
     "name": "Mulberry Leaf",
-    "summary": "Mulberry Leaf botanical profile with evidence, safety, and practical fit.",
+    "summary": "Mulberry Leaf carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 1 recorded study, 1 in people. Recorded activity centres on metabolic regulation, AMPK signaling and glucose metabolism support, which describes mechanism rather than demonstrated benefit. Noted cautions include hypoglycemia risk and pregnancy/breastfeeding without clinician guidance.",
     "description": "Mulberry Leaf botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -22745,12 +22885,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "myristica-fragrans",
     "name": "Myristica Fragrans",
-    "summary": "Myristica Fragrans botanical profile with evidence, safety, and practical fit.",
+    "summary": "Myristica Fragrans carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Myristica Fragrans botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -22852,12 +22993,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "myrtle",
     "name": "Myrtle",
-    "summary": "Myrtle botanical profile with evidence, safety, and practical fit.",
+    "summary": "Myrtle carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, stress response modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy especially first trimester without clinician guidance due to limited safety data.",
     "description": "Myrtle botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antimicrobial",
@@ -22969,12 +23111,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "neem",
     "name": "Neem",
-    "summary": "Neem botanical profile with evidence, safety, and practical fit.",
+    "summary": "Neem carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/trying to conceive and children.",
     "description": "Neem botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antimicrobial",
@@ -23092,12 +23235,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "nelumbo-nucifera",
     "name": "Nelumbo Nucifera",
-    "summary": "Nelumbo Nucifera botanical profile with evidence, safety, and practical fit.",
+    "summary": "Nelumbo Nucifera (Nelumbo nucifera) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, stress response modulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Nelumbo Nucifera botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sedative",
@@ -23225,12 +23369,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Nelumbo nucifera"
+    "scientific_name": "Nelumbo nucifera",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "nettle-root",
     "name": "Nettle Root",
-    "summary": "Nettle Root botanical profile with evidence, safety, and practical fit.",
+    "summary": "Nettle Root carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, hormonal signaling context and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy.",
     "description": "Nettle Root botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -23328,7 +23473,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "nigella-sativa",
@@ -23473,7 +23619,7 @@
   {
     "slug": "noni",
     "name": "Noni",
-    "summary": "Noni botanical profile with evidence, safety, and practical fit.",
+    "summary": "Noni (Morinda citrifolia) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include liver disease and kidney disease/hyperkalemia risk.",
     "description": "Noni botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -23586,12 +23732,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Morinda citrifolia"
+    "scientific_name": "Morinda citrifolia",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "notoginseng",
     "name": "Notoginseng",
-    "summary": "Notoginseng botanical profile with evidence, safety, and practical fit.",
+    "summary": "Notoginseng carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and anticoagulant/antiplatelet use without clinician review.",
     "description": "Notoginseng botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cardiovascular",
@@ -23704,12 +23851,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "oatstraw",
     "name": "Oatstraw",
-    "summary": "Oatstraw botanical profile with evidence, safety, and practical fit.",
+    "summary": "Oatstraw carries a Grade C rating — limited evidence. Recorded activity centres on stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding caution and low documented interaction burden.",
     "description": "Oatstraw botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "nervous_system",
@@ -23813,12 +23961,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ocimum-basilicum",
     "name": "Ocimum Basilicum",
-    "summary": "Ocimum Basilicum botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ocimum Basilicum carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Ocimum Basilicum botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -23954,12 +24103,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ocotea-odorifera",
     "name": "Ocotea Odorifera",
-    "summary": "Ocotea Odorifera botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ocotea Odorifera carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include any internal use of concentrated extract or essential oil.",
     "description": "Ocotea Odorifera botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -24059,7 +24209,8 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "olea-europaea",
@@ -24199,7 +24350,7 @@
   {
     "slug": "ophiopogon",
     "name": "Ophiopogon",
-    "summary": "Ophiopogon botanical profile with evidence, safety, and practical fit.",
+    "summary": "Ophiopogon carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on demulcent support and traditional respiratory support, which describes mechanism rather than demonstrated benefit. Noted cautions include known allergy to the plant family.",
     "description": "Ophiopogon botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "respiratory",
@@ -24300,7 +24451,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "orange-peel",
@@ -24429,7 +24581,7 @@
   {
     "slug": "oregano",
     "name": "Oregano",
-    "summary": "Oregano botanical profile with evidence, safety, and practical fit.",
+    "summary": "Oregano carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on neurotransmitter modulation, cellular protection and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding for medicinal-dose essential oil and lamiaceae allergy.",
     "description": "Oregano botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -24542,12 +24694,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "paeonia-lactiflora",
     "name": "Paeonia Lactiflora",
-    "summary": "Paeonia Lactiflora botanical profile with evidence, safety, and practical fit.",
+    "summary": "Paeonia Lactiflora (Paeonia lactiflora) carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy without clinician guidance and anticoagulant use without review.",
     "description": "Paeonia Lactiflora botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -24666,12 +24819,13 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Paeonia lactiflora"
+    "scientific_name": "Paeonia lactiflora",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "paeonia-suffruticosa",
     "name": "Paeonia Suffruticosa",
-    "summary": "Paeonia Suffruticosa botanical profile with evidence, safety, and practical fit.",
+    "summary": "Paeonia Suffruticosa (Paeonia suffruticosa) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, vascular function support and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Paeonia Suffruticosa botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -24795,12 +24949,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Paeonia suffruticosa"
+    "scientific_name": "Paeonia suffruticosa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "papaya-leaf",
     "name": "Papaya Leaf",
-    "summary": "Papaya Leaf botanical profile with evidence, safety, and practical fit.",
+    "summary": "Papaya Leaf carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and papaya/latex allergy.",
     "description": "Papaya Leaf botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -24911,12 +25066,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "parsley",
     "name": "Parsley",
-    "summary": "Parsley botanical profile with evidence, safety, and practical fit.",
+    "summary": "Parsley (Petroselinum crispum) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and neurotransmitter modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Parsley botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -25039,7 +25195,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Petroselinum crispum"
+    "scientific_name": "Petroselinum crispum",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "passiflora-incarnata",
@@ -25157,7 +25314,7 @@
   {
     "slug": "pastinaca-sativa",
     "name": "Pastinaca Sativa",
-    "summary": "Pastinaca Sativa botanical profile with evidence, safety, and practical fit.",
+    "summary": "Pastinaca Sativa (Pastinaca sativa) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Pastinaca Sativa botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "digestive",
@@ -25263,12 +25420,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Pastinaca sativa"
+    "scientific_name": "Pastinaca sativa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "pau-d-arco",
     "name": "Pau D'arco",
-    "summary": "Pau D'arco botanical profile with evidence, safety, and practical fit.",
+    "summary": "Pau D'arco carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation and immune signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulant or antiplatelet medication.",
     "description": "Pau D'arco botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune",
@@ -25374,7 +25532,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "peppermint",
@@ -25492,7 +25651,7 @@
   {
     "slug": "perilla",
     "name": "Perilla",
-    "summary": "Perilla botanical profile with evidence, safety, and practical fit.",
+    "summary": "Perilla carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding supplement use without guidance and anticoagulant use without review.",
     "description": "Perilla botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -25594,12 +25753,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "phellodendron",
     "name": "Phellodendron",
-    "summary": "Phellodendron botanical profile with evidence, safety, and practical fit.",
+    "summary": "Phellodendron carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 2 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, mitochondrial support and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Phellodendron botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -25723,12 +25883,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "phellodendron-amurense",
     "name": "Phellodendron Amurense",
-    "summary": "Phellodendron Amurense botanical profile with evidence, safety, and practical fit.",
+    "summary": "Phellodendron Amurense (Phellodendron amurense) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Phellodendron Amurense botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antimicrobial",
@@ -25855,12 +26016,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Phellodendron amurense"
+    "scientific_name": "Phellodendron amurense",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "phosphatidylserine",
     "name": "Phosphatidylserine",
-    "summary": "Phosphatidylserine botanical profile with evidence, safety, and practical fit.",
+    "summary": "Phosphatidylserine carries a Grade B rating — moderate evidence. Strongest recorded design is a uncontrolled trial, drawn from 3 recorded studies, 1 in people. Recorded activity centres on cellular protection, hormonal signaling context and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulants (theoretical).",
     "description": "Phosphatidylserine botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
@@ -25975,7 +26137,8 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "uncontrolled-trial",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "piper-longum",
@@ -26108,7 +26271,7 @@
   {
     "slug": "plantago-lanceolata",
     "name": "Plantago Lanceolata",
-    "summary": "Plantago Lanceolata botanical profile with evidence, safety, and practical fit.",
+    "summary": "Plantago Lanceolata (Plantago lanceolata) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Plantago Lanceolata botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "respiratory",
@@ -26220,12 +26383,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Plantago lanceolata"
+    "scientific_name": "Plantago lanceolata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "plantago-major",
     "name": "Plantago Major",
-    "summary": "Plantago Major botanical profile with evidence, safety, and practical fit.",
+    "summary": "Plantago Major (Plantago major) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Plantago Major botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "wound_healing",
@@ -26337,12 +26501,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Plantago major"
+    "scientific_name": "Plantago major",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "plumbago-zeylanica",
     "name": "Plumbago Zeylanica",
-    "summary": "Plumbago Zeylanica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Plumbago Zeylanica (Plumbago zeylanica) carries a Grade C rating — limited evidence. Recorded activity centres on oxidative stress modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Plumbago Zeylanica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -26456,12 +26621,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Plumbago zeylanica"
+    "scientific_name": "Plumbago zeylanica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "polygala",
     "name": "Polygala",
-    "summary": "Polygala botanical profile with evidence, safety, and practical fit.",
+    "summary": "Polygala carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 2 recorded studies, 1 in people. Recorded activity centres on stress response modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without guidance and gastritis/ulcer sensitivity.",
     "description": "Polygala botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
@@ -26570,7 +26736,8 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "pomegranate",
@@ -26704,7 +26871,7 @@
   {
     "slug": "poria",
     "name": "Poria",
-    "summary": "Poria botanical profile with evidence, safety, and practical fit.",
+    "summary": "Poria (Wolfiporia extensa) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Poria botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "immune_support",
@@ -26821,12 +26988,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Wolfiporia extensa"
+    "scientific_name": "Wolfiporia extensa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "psoralea-corylifolia",
     "name": "Psoralea Corylifolia",
-    "summary": "Psoralea Corylifolia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Psoralea Corylifolia (Psoralea corylifolia) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 2 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and liver disease.",
     "description": "Psoralea Corylifolia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "bone_health",
@@ -26952,7 +27120,8 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Psoralea corylifolia"
+    "scientific_name": "Psoralea corylifolia",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "psyllium",
@@ -27080,7 +27249,7 @@
   {
     "slug": "pueraria-lobata",
     "name": "Pueraria Lobata",
-    "summary": "Pueraria Lobata botanical profile with evidence, safety, and practical fit.",
+    "summary": "Pueraria Lobata (Pueraria lobata) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, hormonal signaling context and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Pueraria Lobata botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "hormonal",
@@ -27201,12 +27370,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Pueraria lobata"
+    "scientific_name": "Pueraria lobata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "pueraria-mirifica",
     "name": "Pueraria Mirifica",
-    "summary": "Pueraria Mirifica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Pueraria Mirifica (Pueraria mirifica) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Pueraria Mirifica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "hormonal"
@@ -27308,12 +27478,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Pueraria mirifica"
+    "scientific_name": "Pueraria mirifica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "punarnava",
     "name": "Punarnava",
-    "summary": "Punarnava botanical profile with evidence, safety, and practical fit.",
+    "summary": "Punarnava carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Punarnava botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -27416,12 +27587,13 @@
     "evidence_recorded_study_count": 0,
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "quercetin",
     "name": "Quercetin",
-    "summary": "Quercetin botanical profile with evidence, safety, and practical fit.",
+    "summary": "Quercetin carries a Grade B rating — moderate evidence. Strongest recorded design is a systematic review, drawn from 6 recorded studies, 3 in people. No disagreement is recorded across them. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include antibiotics (quinolones) and anticoagulants.",
     "description": "Quercetin botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -27541,12 +27713,13 @@
     "evidence_recorded_study_count": 6,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "raspberry-leaf",
     "name": "Raspberry Leaf",
-    "summary": "Raspberry Leaf botanical profile with evidence, safety, and practical fit.",
+    "summary": "Raspberry Leaf carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and Nrf2 activation, which describes mechanism rather than demonstrated benefit. Noted cautions include high-risk pregnancy and early pregnancy without clinician guidance.",
     "description": "Raspberry Leaf botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory"
@@ -27660,12 +27833,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "red-clover",
     "name": "Red Clover",
-    "summary": "Red Clover botanical profile with evidence, safety, and practical fit.",
+    "summary": "Red Clover (Trifolium pratense) carries a Grade C rating — limited evidence. Strongest recorded design is a meta-analysis, drawn from 3 recorded studies, 1 in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and hormonal signaling context, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and hormone-sensitive cancer/condition without clinician review.",
     "description": "Red Clover botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -27781,12 +27955,13 @@
     "evidence_strongest_design": "meta-analysis",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Trifolium pratense"
+    "scientific_name": "Trifolium pratense",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "rehmannia-glutinosa",
     "name": "Rehmannia Glutinosa",
-    "summary": "Rehmannia Glutinosa botanical profile with evidence, safety, and practical fit.",
+    "summary": "Rehmannia Glutinosa (Rehmannia glutinosa) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and AMPK signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Rehmannia Glutinosa botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "adrenal_support",
@@ -27907,12 +28082,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Rehmannia glutinosa"
+    "scientific_name": "Rehmannia glutinosa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "rehmannia-prepared",
     "name": "Rehmannia Prepared",
-    "summary": "Rehmannia Prepared botanical profile with evidence, safety, and practical fit.",
+    "summary": "Rehmannia Prepared (Rehmannia glutinosa) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, metabolic regulation and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Rehmannia Prepared botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -28023,12 +28199,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Rehmannia glutinosa"
+    "scientific_name": "Rehmannia glutinosa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "ganoderma-lucidum",
     "name": "Reishi",
-    "summary": "Reishi botanical profile with evidence, safety, and practical fit.",
+    "summary": "Reishi (Ganoderma lucidum) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and mitochondrial function, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulants and immunosuppressants.",
     "description": "Reishi botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -28130,7 +28307,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Ganoderma lucidum"
+    "scientific_name": "Ganoderma lucidum",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "reishi",
@@ -28255,7 +28433,7 @@
   {
     "slug": "resveratrol",
     "name": "Resveratrol",
-    "summary": "Resveratrol botanical profile with evidence, safety, and practical fit.",
+    "summary": "Resveratrol carries a Grade B rating — moderate evidence. Strongest recorded design is a systematic review, drawn from 6 recorded studies, 4 in people. No disagreement is recorded across them. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and mitochondrial support, which describes mechanism rather than demonstrated benefit. Noted cautions include anticoagulants.",
     "description": "Resveratrol botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -28384,7 +28562,8 @@
     "evidence_recorded_study_count": 6,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "rheum-palmatum",
@@ -28631,7 +28810,7 @@
   {
     "slug": "rice-bran",
     "name": "Rice Bran",
-    "summary": "Rice Bran botanical profile with evidence, safety, and practical fit.",
+    "summary": "Rice Bran carries a Grade A rating — strong evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Rice Bran botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -28762,12 +28941,13 @@
     "evidence_recorded_study_count": 2,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
-    "evidence_grade_backing_gap": "no-human-study-recorded"
+    "evidence_grade_backing_gap": "no-human-study-recorded",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "rooibos",
     "name": "Rooibos",
-    "summary": "Rooibos botanical profile with evidence, safety, and practical fit.",
+    "summary": "Rooibos (Aspalathus linearis) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 2 recorded studies, 1 in people. Recorded activity centres on oxidative stress modulation, AMPK signaling and Nrf2 activation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Rooibos botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -28887,7 +29067,8 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Aspalathus linearis"
+    "scientific_name": "Aspalathus linearis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "rose-hips",
@@ -29011,7 +29192,7 @@
   {
     "slug": "roselle-seed",
     "name": "Roselle Seed",
-    "summary": "Roselle Seed botanical profile with evidence, safety, and practical fit.",
+    "summary": "Roselle Seed carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and vascular function support, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Roselle Seed botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant"
@@ -29124,12 +29305,13 @@
     "evidence_recorded_study_count": 1,
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "rosemary",
     "name": "Rosemary",
-    "summary": "Rosemary botanical profile with evidence, safety, and practical fit.",
+    "summary": "Rosemary (Salvia rosmarinus) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Rosemary botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -29260,7 +29442,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Salvia rosmarinus"
+    "scientific_name": "Salvia rosmarinus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "saffron",
@@ -29391,7 +29574,7 @@
   {
     "slug": "sage",
     "name": "Sage",
-    "summary": "Sage botanical profile with evidence, safety, and practical fit.",
+    "summary": "Sage (Salvia officinalis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy and seizure disorder.",
     "description": "Sage botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
@@ -29530,12 +29713,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Salvia officinalis"
+    "scientific_name": "Salvia officinalis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "salacia-reticulata",
     "name": "Salacia",
-    "summary": "Salacia botanical profile with evidence, safety, and practical fit.",
+    "summary": "Salacia (Salacia reticulata) carries a Grade B rating — moderate evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include antidiabetics.",
     "description": "Salacia botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -29640,7 +29824,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": false,
     "evidence_grade_backing_gap": "no-human-study-recorded",
-    "scientific_name": "Salacia reticulata"
+    "scientific_name": "Salacia reticulata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "salvia-miltiorrhiza",
@@ -29993,7 +30178,7 @@
   {
     "slug": "schisandra-berry",
     "name": "Schisandra Berry",
-    "summary": "Schisandra Berry botanical profile with evidence, safety, and practical fit.",
+    "summary": "Schisandra Berry (Schisandra chinensis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without guidance and active reflux/ulcer sensitivity.",
     "description": "Schisandra Berry botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "adaptogen",
@@ -30102,7 +30287,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Schisandra chinensis"
+    "scientific_name": "Schisandra chinensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "schisandra-chinensis",
@@ -30610,7 +30796,7 @@
   {
     "slug": "shankhpushpi",
     "name": "Shankhpushpi",
-    "summary": "Shankhpushpi botanical profile with evidence, safety, and practical fit.",
+    "summary": "Shankhpushpi carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on stress response modulation and neuroprotective activity, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Shankhpushpi botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "cognitive_support",
@@ -30719,12 +30905,13 @@
     "evidence_recorded_study_count": 3,
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
-    "evidence_grade_backing_gap": null
+    "evidence_grade_backing_gap": null,
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "shatavari",
     "name": "Shatavari",
-    "summary": "Shatavari botanical profile with evidence, safety, and practical fit.",
+    "summary": "Shatavari (Asparagus racemosus) carries a Grade C rating — limited evidence. Recorded activity centres on hormonal signaling context and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/lactation use should be clinician-guided and hormone-sensitive conditions without review.",
     "description": "Shatavari botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "adaptogen",
@@ -30836,7 +31023,8 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Asparagus racemosus"
+    "scientific_name": "Asparagus racemosus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "scutellaria-lateriflora",
@@ -30944,7 +31132,7 @@
   {
     "slug": "sophora-alopecuroides",
     "name": "Sophora Alopecuroides",
-    "summary": "Sophora Alopecuroides botanical profile with evidence, safety, and practical fit.",
+    "summary": "Sophora Alopecuroides (Sophora alopecuroides) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 3 recorded studies, 1 in people. Recorded activity centres on NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Sophora Alopecuroides botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -31051,12 +31239,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Sophora alopecuroides"
+    "scientific_name": "Sophora alopecuroides",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "sophora-flavescens",
     "name": "Sophora Flavescens",
-    "summary": "Sophora Flavescens botanical profile with evidence, safety, and practical fit.",
+    "summary": "Sophora Flavescens (Sophora flavescens) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and NF-kB modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and liver disease.",
     "description": "Sophora Flavescens botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -31176,7 +31365,8 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Sophora flavescens"
+    "scientific_name": "Sophora flavescens",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "soursop",
@@ -31290,7 +31480,7 @@
   {
     "slug": "soybean",
     "name": "Soybean",
-    "summary": "Soybean botanical profile with evidence, safety, and practical fit.",
+    "summary": "Soybean (Glycine max) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include soy allergy and hormone-sensitive conditions without clinician review.",
     "description": "Soybean botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -31415,7 +31605,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Glycine max"
+    "scientific_name": "Glycine max",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "st-johns-wort",
@@ -31535,7 +31726,7 @@
   {
     "slug": "stellera-chamaejasme",
     "name": "Stellera Chamaejasme",
-    "summary": "Stellera Chamaejasme botanical profile with evidence, safety, and practical fit.",
+    "summary": "Stellera Chamaejasme (Stellera chamaejasme) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Stellera Chamaejasme botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -31642,12 +31833,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Stellera chamaejasme"
+    "scientific_name": "Stellera chamaejasme",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "stephania-cepharantha",
     "name": "Stephania Cepharantha",
-    "summary": "Stephania Cepharantha botanical profile with evidence, safety, and practical fit.",
+    "summary": "Stephania Cepharantha (Stephania cepharantha) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Stephania Cepharantha botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -31754,12 +31946,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Stephania cepharantha"
+    "scientific_name": "Stephania cepharantha",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "stephania-japonica",
     "name": "Stephania Japonica",
-    "summary": "Stephania Japonica botanical profile with evidence, safety, and practical fit.",
+    "summary": "Stephania Japonica (Stephania japonica) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Stephania Japonica botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -31871,12 +32064,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Stephania japonica"
+    "scientific_name": "Stephania japonica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "stephania-tetrandra",
     "name": "Stephania Tetrandra",
-    "summary": "Stephania Tetrandra botanical profile with evidence, safety, and practical fit.",
+    "summary": "Stephania Tetrandra (Stephania tetrandra) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Stephania Tetrandra botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -31988,12 +32182,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Stephania tetrandra"
+    "scientific_name": "Stephania tetrandra",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "suma",
     "name": "Suma",
-    "summary": "Suma botanical profile with evidence, safety, and practical fit.",
+    "summary": "Suma (Pfaffia paniculata) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include hormone replacement therapy or hormonal contraceptives or other hormone-altering medication.",
     "description": "Suma botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -32098,7 +32293,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Pfaffia paniculata"
+    "scientific_name": "Pfaffia paniculata",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "syzygium-aromaticum",
@@ -32225,7 +32421,7 @@
   {
     "slug": "tamarind",
     "name": "Tamarind",
-    "summary": "Tamarind botanical profile with evidence, safety, and practical fit.",
+    "summary": "Tamarind (Tamarindus indica) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on oxidative stress modulation, metabolic regulation and oxidative stress, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Tamarind botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "antioxidant",
@@ -32338,12 +32534,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Tamarindus indica"
+    "scientific_name": "Tamarindus indica",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "artemisia-dracunculus",
     "name": "Tarragon",
-    "summary": "Tarragon botanical profile with evidence, safety, and practical fit.",
+    "summary": "Tarragon (Artemisia dracunculus) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 2 recorded studies, none of which measured an outcome in people. Recorded activity centres on metabolic regulation, glucose metabolism support and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include antidiabetics.",
     "description": "Tarragon botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "metabolic"
@@ -32440,7 +32637,8 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Artemisia dracunculus"
+    "scientific_name": "Artemisia dracunculus",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "terminalia-arjuna",
@@ -32678,7 +32876,7 @@
   {
     "slug": "thyme",
     "name": "Thyme",
-    "summary": "Thyme botanical profile with evidence, safety, and practical fit.",
+    "summary": "Thyme (Thymus vulgaris) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and cellular protection, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding for medicinal-dose essential oil and significant GI irritation.",
     "description": "Thyme botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -32797,12 +32995,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Thymus vulgaris"
+    "scientific_name": "Thymus vulgaris",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "tongkat-ali",
     "name": "Tongkat Ali",
-    "summary": "Tongkat Ali botanical profile with evidence, safety, and practical fit.",
+    "summary": "Tongkat Ali (Eurycoma longifolia) carries a Grade C rating — limited evidence. Strongest recorded design is a systematic review, drawn from 4 recorded studies, 3 in people. No disagreement is recorded across them. Recorded activity centres on hormonal signaling context, stress response modulation and endocrine, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy or breastfeeding without clinician guidance due to insufficient safety data.",
     "description": "Tongkat Ali botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "testosterone_support",
@@ -32915,12 +33114,13 @@
     "evidence_strongest_design": "systematic-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Eurycoma longifolia"
+    "scientific_name": "Eurycoma longifolia",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "tribulus-terrestris",
     "name": "Tribulus (Tribulus terrestris)",
-    "summary": "Tribulus (Tribulus terrestris) botanical profile with evidence, safety, and practical fit.",
+    "summary": "Tribulus (Tribulus terrestris) (Tribulus terrestris) carries a Grade B rating — moderate evidence. Strongest recorded design is a randomized controlled trial, drawn from 2 recorded studies, 1 in people. Findings across those studies disagree. Recorded activity centres on vascular function support and endocrine, which describes mechanism rather than demonstrated benefit. Noted cautions include hormone-sensitive conditions (uncertain) and none well established.",
     "description": "Tribulus (Tribulus terrestris) botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -33022,7 +33222,8 @@
     "evidence_strongest_design": "rct",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Tribulus terrestris"
+    "scientific_name": "Tribulus terrestris",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "tripterygium-wilfordii",
@@ -33628,7 +33829,7 @@
   {
     "slug": "verbena-officinalis",
     "name": "Verbena Officinalis",
-    "summary": "Verbena Officinalis botanical profile with evidence, safety, and practical fit.",
+    "summary": "Verbena Officinalis (Verbena officinalis) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 3 recorded studies, none of which measured an outcome in people. Recorded activity centres on stress response modulation, NF-kB modulation and NF-kB, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Verbena Officinalis botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "nervine",
@@ -33741,12 +33942,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Verbena officinalis"
+    "scientific_name": "Verbena officinalis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "white-peony",
     "name": "White Peony",
-    "summary": "White Peony botanical profile with evidence, safety, and practical fit.",
+    "summary": "White Peony (Paeonia lactiflora) carries a Grade C rating — limited evidence. Strongest recorded design is a narrative review, drawn from 1 recorded study, none of which measured an outcome in people. Recorded activity centres on inflammatory signaling modulation, immune signaling modulation and stress response modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy without clinician guidance and anticoagulant use without review.",
     "description": "White Peony botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -33860,12 +34062,13 @@
     "evidence_strongest_design": "narrative-review",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Paeonia lactiflora"
+    "scientific_name": "Paeonia lactiflora",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "wild-yam",
     "name": "Wild Yam",
-    "summary": "Wild Yam botanical profile with evidence, safety, and practical fit.",
+    "summary": "Wild Yam (Dioscorea villosa) carries a Grade C rating — limited evidence. Recorded activity centres on PI3K/Akt modulation, PPARγ activation and glucose metabolism, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding without clinician supervision and known allergy to the plant/family.",
     "description": "Wild Yam botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti_inflammatory",
@@ -33978,12 +34181,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Dioscorea villosa"
+    "scientific_name": "Dioscorea villosa",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "wormwood",
     "name": "Wormwood",
-    "summary": "Wormwood botanical profile with evidence, safety, and practical fit.",
+    "summary": "Wormwood (Artemisia absinthium) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, neurotransmitter modulation and neurotransmitter signaling, which describes mechanism rather than demonstrated benefit. Noted cautions include pregnancy/breastfeeding and seizure disorder.",
     "description": "Wormwood botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "sleep"
@@ -34096,12 +34300,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Artemisia absinthium"
+    "scientific_name": "Artemisia absinthium",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "yarrow",
     "name": "Yarrow",
-    "summary": "Yarrow botanical profile with evidence, safety, and practical fit.",
+    "summary": "Yarrow (Achillea millefolium) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, which describes mechanism rather than demonstrated benefit. Noted cautions include asteraceae/ragweed allergy and pregnancy.",
     "description": "Yarrow botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -34205,12 +34410,13 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Achillea millefolium"
+    "scientific_name": "Achillea millefolium",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "yerba-mate",
     "name": "Yerba Mate",
-    "summary": "Yerba Mate botanical profile with evidence, safety, and practical fit.",
+    "summary": "Yerba Mate (Ilex paraguariensis) carries a Grade C rating — limited evidence. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and metabolic regulation, which describes mechanism rather than demonstrated benefit. Noted cautions include uncontrolled hypertension and arrhythmia.",
     "description": "Yerba Mate botanical profile with evidence, safety, and practical fit.",
     "effects": [
       "anti-inflammatory",
@@ -34341,7 +34547,8 @@
     "evidence_strongest_design": "unclassified",
     "evidence_grade_backed": true,
     "evidence_grade_backing_gap": null,
-    "scientific_name": "Ilex paraguariensis"
+    "scientific_name": "Ilex paraguariensis",
+    "summary_source": "composed-from-record"
   },
   {
     "slug": "yohimbe",

--- a/scripts/data/normalize-evidence-grades.ts
+++ b/scripts/data/normalize-evidence-grades.ts
@@ -25,6 +25,7 @@ import {
   gradeIsBackedByEvidence,
   type EvidenceRationale,
 } from '../../lib/evidence-rationale'
+import { buildProfileSummary, isPlaceholderSummary } from '../../lib/profile-summary'
 import { normalizeStudyClass, strongestStudyClass, STUDY_CLASS_INFO } from '../../lib/study-class'
 
 const ROOT = process.cwd()
@@ -112,6 +113,7 @@ function normalizeProfiles(file: string, claimsBySlug: Map<string, Row[]>, sourc
       total: 0,
       adjusted: 0,
       rationaleCards: 0,
+      summariesWritten: 0,
       reasons: {} as Record<string, number>,
       changes: [] as Row[],
       unbacked: [] as Row[],
@@ -123,6 +125,7 @@ function normalizeProfiles(file: string, claimsBySlug: Map<string, Row[]>, sourc
   const unbacked: Row[] = []
   let adjusted = 0
   let rationaleCards = 0
+  let summariesWritten = 0
 
   const next = rows.map((row) => {
     const authored = sourceGrade(row)
@@ -162,7 +165,9 @@ function normalizeProfiles(file: string, claimsBySlug: Map<string, Row[]>, sourc
       })
     }
 
-    return {
+    // The summary is composed last so it can draw on the grade and rationale
+    // decided above. Only generated filler is replaced; authored prose stands.
+    const enriched = {
       ...row,
       evidence_grade: result.grade,
       evidence_grade_source: String(authored ?? ''),
@@ -182,10 +187,20 @@ function normalizeProfiles(file: string, claimsBySlug: Map<string, Row[]>, sourc
       evidence_grade_backed: backing.backed,
       evidence_grade_backing_gap: backing.reason,
     }
+
+    if (isPlaceholderSummary(enriched.summary)) {
+      const composed = buildProfileSummary(enriched)
+      if (composed) {
+        summariesWritten += 1
+        return { ...enriched, summary: composed, summary_source: 'composed-from-record' }
+      }
+    }
+
+    return enriched
   })
 
   writeJson(file, next)
-  return { file, total: rows.length, adjusted, rationaleCards, reasons, changes, unbacked }
+  return { file, total: rows.length, adjusted, rationaleCards, summariesWritten, reasons, changes, unbacked }
 }
 
 function normalizeClaims() {
@@ -239,6 +254,7 @@ function main() {
     profiles: profiles.reduce((sum, p) => sum + p.total, 0),
     adjusted: profiles.reduce((sum, p) => sum + p.adjusted, 0),
     rationaleCards: profiles.reduce((sum, p) => sum + p.rationaleCards, 0),
+    summariesWritten: profiles.reduce((sum, p) => sum + p.summariesWritten, 0),
     claims: claims.total,
   }
   const unbacked = profiles.flatMap((p) => p.unbacked)
@@ -267,6 +283,7 @@ function main() {
     console.log(`  ${String(count).padStart(5)}  ${reason}`)
   }
   console.log(`\nRationale cards       ${totals.rationaleCards}`)
+  console.log(`Summaries composed    ${totals.summariesWritten}`)
   const unbackedIndexable = unbacked.filter((row) => row.indexable)
   console.log(`A/B grades unbacked   ${unbacked.length} (${unbackedIndexable.length} indexable)`)
   const gapCounts: Record<string, number> = {}


### PR DESCRIPTION
## I had this wrong

339 profiles — **248 of them indexable** — carried a generated placeholder as their summary:

> `"Acerola botanical profile with evidence, safety, and practical fit."`

I previously reported this as evidence that half the indexable corpus was low quality, and floated deindexing them. **That was wrong.** Checking what those pages actually contain:

| Field | Present |
|---|---:|
| mechanisms | 248/248 |
| effects | 248/248 |
| dosage text | 248/248 |
| evidence grade | 248/248 |
| safety text | 247/248 |
| contraindications | 238/248 |
| evidence rationale card | 190/248 |
| scientific name | 112/248 |

Acerola has a botanical name, a Grade C rating backed by an RCT, four mechanisms, four specific contraindications and three cited studies. **Only the sentence introducing all of it said nothing.** The fix is to write the sentence, not drop the pages.

## What it produces

> Acerola (*Malpighia emarginata*) carries a Grade C rating — limited evidence. Strongest recorded design is a randomized controlled trial, drawn from 3 recorded studies, 1 in people. Recorded activity centres on inflammatory signaling modulation, oxidative stress modulation and immune signaling modulation, **which describes mechanism rather than demonstrated benefit**. Noted cautions include kidney stone risk and iron overload conditions.

Every clause traces to a field already on the record. No claim is introduced that the record does not already make; a clause whose source field is missing is **omitted rather than guessed at**; mechanism is always labelled as mechanism so a pathway cannot read as a proven benefit; and generation is deterministic so a rebuild never silently rewords a page.

## Three details that took a second pass

- **Acronyms.** Lowering the first character alone gives `"inflammatory Signaling Modulation"`; lowering everything gives `"ampk signaling"`. Only ordinary capitalised words are folded, so `AMPK` and `NF-κB` survive.
- **Proper nouns.** That same fold must not touch safety cautions — `"Apiaceae"` is a botanical family, not a word to normalise.
- **Run-ons.** Some contraindication cells carry their whole rationale. Short entries are preferred; a long one is cut at its explanatory clause.

## Result

**Boilerplate summaries 339 → 0.** The `berberine` / `berberine-hcl` identical-prose conflict also resolved itself, since both now have distinct summaries.

Only authored prose is left alone, and the generator runs in the pipeline, so this holds across rebuilds rather than being a one-off edit.

**Indexability is untouched at `PUBLISH 445`** — the summary is composed *after* scoring, so a longer summary cannot promote a page into the index on its own.

## Verification

- `vitest lib/__tests__/profile-summary.test.ts` — 11 passed
- Idempotent: rerun composes 0 new
- `tsc --noEmit` — 0 errors
- Full suite — 52 failing files, identical to main, zero new
- Data diff confined to `summary` and `summary_source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q6dk9xa1jngoNqWPmXNsR