### PR TITLE
fix(data): preserve invariant state during derived refresh

### DIFF
--- a/scripts/__tests__/runtime-summary-governance-boundary.test.ts
+++ b/scripts/__tests__/runtime-summary-governance-boundary.test.ts
@@ -20,6 +20,45 @@ describe('runtime summary governance boundary', () => {
     expect(readHerbs).toBeGreaterThan(holds)
   })
 
+  it('supports a derived-only refresh that preserves already-governed runtime state', () => {
+    const summarySource = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+    const enforcementSource = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/enforce-production-content-invariants.mjs'),
+      'utf8',
+    )
+
+    expect(summarySource).toContain("process.argv.includes('--preserve-governed-state')")
+    expect(summarySource).toContain('if (PRESERVE_GOVERNED_STATE)')
+    expect(summarySource).toContain('skipping mutating pre-summary stages')
+    expect(enforcementSource).toContain(
+      'build-runtime-summary-indexes.mjs --data-dir=public/data --preserve-governed-state',
+    )
+  })
+
+  it('keeps mutating governance and citation replay outside preserve-governed-state mode', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),
+      'utf8',
+    )
+
+    const preserveBranch = source.indexOf('if (PRESERVE_GOVERNED_STATE)')
+    const mutatingBranch = source.indexOf('} else {', preserveBranch)
+    const postprocess = source.indexOf("import('./postprocess-workbook-payloads.mjs')", mutatingBranch)
+    const governance = source.indexOf("import('./apply-governance-overlay.mjs')", mutatingBranch)
+    const citationExport = source.indexOf('exportCanonicalCitationsToRuntime', mutatingBranch)
+    const readHerbs = source.indexOf("readJson(path.join(DATA_DIR, 'herbs.json'))")
+
+    expect(preserveBranch).toBeGreaterThan(-1)
+    expect(mutatingBranch).toBeGreaterThan(preserveBranch)
+    expect(postprocess).toBeGreaterThan(mutatingBranch)
+    expect(governance).toBeGreaterThan(postprocess)
+    expect(citationExport).toBeGreaterThan(governance)
+    expect(readHerbs).toBeGreaterThan(citationExport)
+  })
+
   it('keeps the current AI entity artifact authority after governance replay', () => {
     const source = fs.readFileSync(
       path.join(process.cwd(), 'scripts/data/build-runtime-summary-indexes.mjs'),

--- a/scripts/data/build-runtime-summary-indexes.mjs
+++ b/scripts/data/build-runtime-summary-indexes.mjs
@@ -15,6 +15,7 @@ const DATA_DIR_ARG = process.argv.find((arg) => arg.startsWith('--data-dir='))
 const DATA_DIR = DATA_DIR_ARG
   ? DATA_DIR_ARG.split('=')[1]
   : 'public/data'
+const PRESERVE_GOVERNED_STATE = process.argv.includes('--preserve-governed-state')
 
 const SUMMARY_DIR = path.join(DATA_DIR, 'summary-indexes')
 await fs.mkdir(SUMMARY_DIR, { recursive: true })
@@ -204,53 +205,60 @@ function buildAlphaEntityShards(records) {
 async function main() {
   const totalTimer = createStageTimer('summary-index-build')
 
-  // This builder is the production boundary immediately before route/sitemap/static
-  // metadata generation. Normalize and govern the freshly generated runtime payloads
-  // here so every downstream artifact consumes the same authority state.
-  const postprocessTimer = createStageTimer('workbook-payload-postprocess')
-  await import('./postprocess-workbook-payloads.mjs')
-  postprocessTimer.finish()
+  if (PRESERVE_GOVERNED_STATE) {
+    // Invariant enforcement has already scrubbed and demoted the runtime payloads.
+    // A derived-only refresh must never re-run stages that can republish, rehydrate,
+    // or otherwise mutate that governed state before summaries/routes are rebuilt.
+    console.log('[summary-indexes] preserving governed runtime state; skipping mutating pre-summary stages')
+  } else {
+    // This builder is the production boundary immediately before route/sitemap/static
+    // metadata generation. Normalize and govern the freshly generated runtime payloads
+    // here so every downstream artifact consumes the same authority state.
+    const postprocessTimer = createStageTimer('workbook-payload-postprocess')
+    await import('./postprocess-workbook-payloads.mjs')
+    postprocessTimer.finish()
 
-  const governanceTimer = createStageTimer('governance-overlay')
-  await import('./apply-governance-overlay.mjs')
-  governanceTimer.finish()
+    const governanceTimer = createStageTimer('governance-overlay')
+    await import('./apply-governance-overlay.mjs')
+    governanceTimer.finish()
 
-  // The generic overlay uses a broad record-level source gate. A small set of
-  // source-backed cluster-member routes has a stricter, dedicated trust contract,
-  // so restore that explicit authority before applying any deliberate editorial holds.
-  const clusterTimer = createStageTimer('cluster-member-governance-reconciliation')
-  const clusterReport = await reconcileValidatedClusterMemberGovernance({ dataDir: DATA_DIR })
-  clusterTimer.finish({ corrected: clusterReport.total })
-  if (clusterReport.total > 0) {
-    console.log(
-      `[summary-indexes] restored validated cluster-member authority: ${[
-        ...clusterReport.herbs.map((slug) => `herb:${slug}`),
-        ...clusterReport.compounds.map((slug) => `compound:${slug}`),
-      ].join(', ')}`,
-    )
+    // The generic overlay uses a broad record-level source gate. A small set of
+    // source-backed cluster-member routes has a stricter, dedicated trust contract,
+    // so restore that explicit authority before applying any deliberate editorial holds.
+    const clusterTimer = createStageTimer('cluster-member-governance-reconciliation')
+    const clusterReport = await reconcileValidatedClusterMemberGovernance({ dataDir: DATA_DIR })
+    clusterTimer.finish({ corrected: clusterReport.total })
+    if (clusterReport.total > 0) {
+      console.log(
+        `[summary-indexes] restored validated cluster-member authority: ${[
+          ...clusterReport.herbs.map((slug) => `herb:${slug}`),
+          ...clusterReport.compounds.map((slug) => `compound:${slug}`),
+        ].join(', ')}`,
+      )
+    }
+
+    // Curated allowlists and validated cluster trust express editorial priority, but an
+    // explicit content hold (hidden_until_grounded/research_only) outranks either until grounded.
+    const holdTimer = createStageTimer('deliberate-governance-hold-reconciliation')
+    const holdReport = await reconcileDeliberateGovernanceHolds({ dataDir: DATA_DIR })
+    holdTimer.finish({ corrected: holdReport.total })
+    if (holdReport.total > 0) {
+      console.log(
+        `[summary-indexes] preserved deliberate governance holds: ${[
+          ...holdReport.herbs.map((slug) => `herb:${slug}`),
+          ...holdReport.compounds.map((slug) => `compound:${slug}`),
+        ].join(', ')}`,
+      )
+    }
+
+    const citationTimer = createStageTimer('canonical-citation-export')
+    const citationReport = exportCanonicalCitationsToRuntime({ dataDir: DATA_DIR })
+    citationTimer.finish({
+      profiles: citationReport.profilesWithCanonicalClaims,
+      updated: citationReport.updated.length,
+      missingDetails: citationReport.skippedMissingDetail.length,
+    })
   }
-
-  // Curated allowlists and validated cluster trust express editorial priority, but an
-  // explicit content hold (hidden_until_grounded/research_only) outranks either until grounded.
-  const holdTimer = createStageTimer('deliberate-governance-hold-reconciliation')
-  const holdReport = await reconcileDeliberateGovernanceHolds({ dataDir: DATA_DIR })
-  holdTimer.finish({ corrected: holdReport.total })
-  if (holdReport.total > 0) {
-    console.log(
-      `[summary-indexes] preserved deliberate governance holds: ${[
-        ...holdReport.herbs.map((slug) => `herb:${slug}`),
-        ...holdReport.compounds.map((slug) => `compound:${slug}`),
-      ].join(', ')}`,
-    )
-  }
-
-  const citationTimer = createStageTimer('canonical-citation-export')
-  const citationReport = exportCanonicalCitationsToRuntime({ dataDir: DATA_DIR })
-  citationTimer.finish({
-    profiles: citationReport.profilesWithCanonicalClaims,
-    updated: citationReport.updated.length,
-    missingDetails: citationReport.skippedMissingDetail.length,
-  })
 
   const herbs = await readJson(path.join(DATA_DIR, 'herbs.json'))
   const compounds = await readJson(path.join(DATA_DIR, 'compounds.json'))

--- a/scripts/data/enforce-production-content-invariants.mjs
+++ b/scripts/data/enforce-production-content-invariants.mjs
@@ -111,10 +111,14 @@ const report = {
 // The deploy pipeline normally builds derived maps before Next.js. When this
 // enforcement is invoked from the final production-build step, a demotion would
 // otherwise leave those maps stale. Refresh them only when a demotion happened.
+// Crucially, the summary refresh runs in preserve-governed-state mode: the
+// invariant gate is authoritative at this point and no downstream derived-data
+// builder may re-run mutating governance/postprocess stages that could republish
+// a record the gate just demoted.
 if (refreshDerived && demotions.length) {
   console.log(`[production-invariants] refreshing derived route/search/sitemap data after ${demotions.length} demotion(s)`)
   run('node scripts/data/build-related-runtime-maps.mjs --data-dir=public/data')
-  run('node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data')
+  run('node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data --preserve-governed-state')
   run('node scripts/data/build-route-manifest.mjs --data-dir=public/data')
   run('node scripts/data/build-internal-link-engine.mjs --data-dir=public/data')
   run('node scripts/data/build-sitemap-manifest.mjs --data-dir=public/data')


### PR DESCRIPTION
Closes #3298

## Relevant URLs / files
- `scripts/data/enforce-production-content-invariants.mjs`
- `scripts/data/build-runtime-summary-indexes.mjs`
- `scripts/__tests__/runtime-summary-governance-boundary.test.ts`

## Acceptance criteria
- Invariant enforcement remains authoritative after `--refresh-derived`.
- Summary/search/route/sitemap refresh does not rerun mutating workbook postprocess, governance replay, cluster authority restoration, hold reconciliation, or canonical citation export.
- `validate-production-content-invariants` remains strict and passes after derived refresh.
- Build/Lighthouse are no longer blocked by publication-state resurrection.
- Existing full summary-build behavior remains unchanged when preserve mode is not requested.

## Validation commands
- `npm run typecheck`
- `npm run lint`
- `npx vitest run scripts/__tests__/runtime-summary-governance-boundary.test.ts`
- `node scripts/data/build-runtime-from-workbook.mjs --out public/data`
- `node scripts/data/enforce-production-content-invariants.mjs --data-dir=public/data --refresh-derived`
- `node scripts/ci/validate-production-content-invariants.mjs --data-dir=public/data`
- `npm run build:deploy`
- GitHub Actions: Production Content Invariants, Production Content Lint, Build Check, Lighthouse CI, CI

## Before → after metrics
- Before: enforcement can demote 274 profiles and immediately reach 0 blockers, but derived refresh reruns mutating governance stages and validation returns 353 blocking findings.
- After target: post-refresh blocking findings = 0; derived summaries/routes reflect the already-governed collection state.

## Generator/source-of-truth decision
- Production-content invariant enforcement remains authoritative at the final publication boundary.
- `build-runtime-summary-indexes.mjs` retains its normal mutating governance behavior for ordinary runtime builds.
- A new explicit `--preserve-governed-state` mode is only used by the post-enforcement derived refresh, where mutation would violate the already-established publication state.

## Regression contract
- Do not weaken or allowlist production content invariants.
- Do not republish records demoted by the invariant gate.
- Do not change scientific claims, evidence grades, safety semantics, or editorial source requirements.
- Preserve existing full-build governance/citation behavior outside derived-refresh mode.