### PR TITLE
feat(research): build prioritized research-gap queue

### DIFF
--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env npx tsx
+/** Build one prioritized remediation queue from the canonical research reports. */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
+const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
+
+function readJson(name: string): Record<string, any> {
+  const file = path.join(REPORT_DIR, name)
+  if (!fs.existsSync(file)) return {}
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+const topology = readJson('source-integrity.json')
+const strength = readJson('claim-evidence-strength.json')
+const queue = new Map<string, { url: string; score: number; reasons: Array<{ kind: string; weight: number; detail?: string }> }>()
+
+function add(url: string, kind: string, weight: number, detail?: string) {
+  if (!url) return
+  const item = queue.get(url) ?? { url, score: 0, reasons: [] }
+  item.score += weight
+  item.reasons.push({ kind, weight, ...(detail ? { detail } : {}) })
+  queue.set(url, item)
+}
+
+for (const item of topology.claimTopology?.unsupportedClaims ?? []) {
+  add(item.url, 'unsupported-approved-claim', 100, item.claimId)
+}
+for (const item of topology.claimTopology?.danglingRefs ?? []) {
+  add(item.url, 'dangling-claim-source-edge', 100, `${item.claimId} -> ${item.sourceRefId}`)
+}
+for (const item of topology.claimTopology?.singleSourceClaims ?? []) {
+  add(item.url, 'single-source-approved-claim', 5, item.claimId)
+}
+for (const profile of topology.claimTopology?.concentratedProfiles ?? []) {
+  const weight = Math.round(20 + Number(profile.sourceDependencyShare ?? 0) * 30)
+  add(profile.url, 'high-source-dependency', weight, `${Math.round(Number(profile.sourceDependencyShare ?? 0) * 100)}% of approved claims depend on one source`)
+}
+for (const profile of topology.claimTopology?.reviewDominatedProfiles ?? []) {
+  add(profile.url, 'narrative-review-dominated-profile', 15)
+}
+for (const profile of topology.claimTopology?.noPrimaryHumanProfiles ?? []) {
+  add(profile.url, 'approved-claims-without-primary-human-study', 20)
+}
+for (const claim of strength.highConfidenceWeakOutcome ?? []) {
+  add(claim.url, 'high-confidence-weak-outcome-claim', 40, String(claim.claimId ?? ''))
+}
+for (const claim of strength.narrativeOnlyOutcomeClaims ?? []) {
+  add(claim.url, 'narrative-only-outcome-claim', 25, String(claim.claimId ?? ''))
+}
+for (const claim of strength.noClassifiedEvidence ?? []) {
+  add(claim.url, 'unclassified-linked-evidence', 20, String(claim.claimId ?? ''))
+}
+
+const ranked = [...queue.values()]
+  .map((item) => ({
+    ...item,
+    score: Math.round(item.score),
+    reasonCounts: item.reasons.reduce<Record<string, number>>((counts, reason) => {
+      counts[reason.kind] = (counts[reason.kind] ?? 0) + 1
+      return counts
+    }, {}),
+  }))
+  .sort((a, b) => b.score - a.score || b.reasons.length - a.reasons.length || a.url.localeCompare(b.url))
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  scoring: {
+    note: 'Scores prioritize structural invalidity first, then claim-strength and concentration weaknesses. They are triage weights, not evidence grades.',
+    weights: {
+      unsupportedApprovedClaim: 100,
+      danglingClaimSourceEdge: 100,
+      highConfidenceWeakOutcome: 40,
+      highSourceDependency: '20 + dependency share × 30',
+      narrativeOnlyOutcome: 25,
+      noPrimaryHumanStudy: 20,
+      unclassifiedLinkedEvidence: 20,
+      narrativeReviewDominatedProfile: 15,
+      singleSourceApprovedClaim: 5,
+    },
+  },
+  summary: {
+    profilesWithResearchGaps: ranked.length,
+    critical: ranked.filter((item) => item.score >= 100).length,
+    high: ranked.filter((item) => item.score >= 60 && item.score < 100).length,
+    medium: ranked.filter((item) => item.score >= 25 && item.score < 60).length,
+    low: ranked.filter((item) => item.score < 25).length,
+  },
+  queue: ranked,
+}
+
+fs.mkdirSync(REPORT_DIR, { recursive: true })
+fs.writeFileSync(OUTPUT, `${JSON.stringify(report, null, 2)}\n`)
+
+console.log('\nPrioritized research-gap queue')
+console.log('='.repeat(72))
+console.log(`Profiles with gaps  ${report.summary.profilesWithResearchGaps}`)
+console.log(`Critical            ${report.summary.critical}`)
+console.log(`High                ${report.summary.high}`)
+console.log(`Medium              ${report.summary.medium}`)
+console.log(`Low                 ${report.summary.low}`)
+for (const item of ranked.slice(0, 10)) {
+  console.log(`  ${String(item.score).padStart(3)} · ${item.url} · ${item.reasons.length} finding(s)`)
+}
+console.log(`\nReport: ${path.relative(ROOT, OUTPUT)}`)

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -1,11 +1,5 @@
 #!/usr/bin/env npx tsx
-/**
- * Canonical research-quality pipeline.
- *
- * This is the single entry point for research/data integrity. Narrow validators
- * remain deliberately small implementation details; this orchestrator defines
- * their authoritative order and emits one roll-up report.
- */
+/** Canonical research-quality pipeline and unified roll-up. */
 
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -17,53 +11,16 @@ const REPORT_PATH = path.join(REPORT_DIR, 'research-quality.json')
 const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx'
 
 const checks = [
-  {
-    id: 'citation-identities',
-    label: 'Citation identity integrity',
-    command: process.execPath,
-    args: ['scripts/ci/validate-citation-identifiers.mjs'],
-  },
-  {
-    id: 'coverage-topology',
-    label: 'Research coverage topology',
-    command: NPX,
-    args: ['tsx', 'scripts/ci/audit-source-integrity.ts'],
-  },
-  {
-    id: 'coverage-structure',
-    label: 'Approved claim evidence edges',
-    command: NPX,
-    args: ['tsx', 'scripts/ci/validate-research-coverage.ts'],
-  },
-  {
-    id: 'claim-strength',
-    label: 'Claim-level evidence strength',
-    command: NPX,
-    args: ['tsx', 'scripts/ci/audit-claim-evidence-strength.ts'],
-  },
-  {
-    id: 'evidence-grades',
-    label: 'Evidence grade consistency',
-    command: NPX,
-    args: ['tsx', 'scripts/ci/validate-evidence-grade-consistency.ts'],
-  },
-  {
-    id: 'content-integrity',
-    label: 'Structured content integrity',
-    command: process.execPath,
-    args: ['scripts/ci/audit-content-integrity.mjs'],
-  },
+  { id: 'citation-identities', label: 'Citation identity integrity', command: process.execPath, args: ['scripts/ci/validate-citation-identifiers.mjs'] },
+  { id: 'coverage-topology', label: 'Research coverage topology', command: NPX, args: ['tsx', 'scripts/ci/audit-source-integrity.ts'] },
+  { id: 'coverage-structure', label: 'Approved claim evidence edges', command: NPX, args: ['tsx', 'scripts/ci/validate-research-coverage.ts'] },
+  { id: 'claim-strength', label: 'Claim-level evidence strength', command: NPX, args: ['tsx', 'scripts/ci/audit-claim-evidence-strength.ts'] },
+  { id: 'gap-priority', label: 'Prioritized research-gap queue', command: NPX, args: ['tsx', 'scripts/ci/build-research-gap-priorities.ts'] },
+  { id: 'evidence-grades', label: 'Evidence grade consistency', command: NPX, args: ['tsx', 'scripts/ci/validate-evidence-grade-consistency.ts'] },
+  { id: 'content-integrity', label: 'Structured content integrity', command: process.execPath, args: ['scripts/ci/audit-content-integrity.mjs'] },
 ] as const
 
-type CheckResult = {
-  id: string
-  label: string
-  passed: boolean
-  exitCode: number
-  durationMs: number
-  stdoutTail: string
-  stderrTail: string
-}
+type CheckResult = { id: string; label: string; passed: boolean; exitCode: number; durationMs: number; stdoutTail: string; stderrTail: string }
 
 function tail(value: string, maxLines = 24): string {
   return value.split(/\r?\n/).filter(Boolean).slice(-maxLines).join('\n')
@@ -87,28 +44,16 @@ console.log('='.repeat(76))
 
 for (const check of checks) {
   const started = Date.now()
-  const run = spawnSync(check.command, check.args, {
-    cwd: ROOT,
-    encoding: 'utf8',
-    env: process.env,
-  })
+  const run = spawnSync(check.command, check.args, { cwd: ROOT, encoding: 'utf8', env: process.env })
   const exitCode = run.status ?? 1
   const passed = exitCode === 0
   const durationMs = Date.now() - started
   const stdout = String(run.stdout ?? '')
   const stderr = String(run.stderr ?? '')
 
-  results.push({
-    id: check.id,
-    label: check.label,
-    passed,
-    exitCode,
-    durationMs,
-    stdoutTail: tail(stdout),
-    stderrTail: tail(stderr),
-  })
-
+  results.push({ id: check.id, label: check.label, passed, exitCode, durationMs, stdoutTail: tail(stdout), stderrTail: tail(stderr) })
   console.log(`${passed ? 'PASS' : 'FAIL'}  ${check.label}  (${durationMs}ms)`)
+
   if (!passed) {
     failed = true
     const detail = tail(stderr || stdout, 10)
@@ -117,20 +62,18 @@ for (const check of checks) {
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
-fs.writeFileSync(
-  REPORT_PATH,
-  `${JSON.stringify({
-    generatedAt: new Date().toISOString(),
-    passed: !failed,
-    checks: results,
-    topologySummary: readSummary('source-integrity.json'),
-    claimStrengthSummary: readSummary('claim-evidence-strength.json'),
-  }, null, 2)}\n`,
-)
+fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
+  generatedAt: new Date().toISOString(),
+  passed: !failed,
+  checks: results,
+  topologySummary: readSummary('source-integrity.json'),
+  claimStrengthSummary: readSummary('claim-evidence-strength.json'),
+  researchGapSummary: readSummary('research-gaps.json'),
+}, null, 2)}\n`)
 
 console.log(`\nRoll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
 if (failed) {
   console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.')
   process.exit(1)
 }
-console.log('\n[research-quality] PASS — citation identity, coverage topology, claim strength, evidence edges, grades, and structured integrity agree.')
+console.log('\n[research-quality] PASS — identity, topology, claim strength, gap priority, evidence edges, grades, and structured integrity agree.')


### PR DESCRIPTION
Turns raw topology findings into one ranked remediation queue. Structural defects receive highest priority, followed by high-confidence weak outcome claims, heavy source dependency, narrative-only outcomes, profiles with no primary human study, and other weaker evidence patterns. The canonical research-quality roll-up now includes this queue summary so gap triage has one source of truth.