### PR TITLE
fix(matrices): isolate browser-safe client contract

### DIFF
--- a/src/components/matrices/ResearchMatricesClient.tsx
+++ b/src/components/matrices/ResearchMatricesClient.tsx
@@ -7,7 +7,7 @@ import {
   rowsForRiskMatrix,
   type ResearchMatrixRow,
   type RiskMatrixId,
-} from '@/lib/research-matrices'
+} from '@/lib/research-matrices.shared'
 
 type MatrixView = 'evidence' | RiskMatrixId
 

--- a/src/lib/__tests__/research-matrices-client-boundary.test.ts
+++ b/src/lib/__tests__/research-matrices-client-boundary.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('research matrix client boundary', () => {
+  it('keeps the client component on the browser-safe shared contract', () => {
+    const client = fs.readFileSync(
+      path.join(process.cwd(), 'src/components/matrices/ResearchMatricesClient.tsx'),
+      'utf8',
+    )
+
+    expect(client).toContain("from '@/lib/research-matrices.shared'")
+    expect(client).not.toContain("from '@/lib/research-matrices'")
+  })
+
+  it('keeps filesystem-backed runtime loading out of the shared contract', () => {
+    const shared = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/research-matrices.shared.ts'),
+      'utf8',
+    )
+    const server = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/research-matrices.ts'),
+      'utf8',
+    )
+
+    expect(shared).not.toContain('runtime-record-index')
+    expect(shared).not.toContain('node:fs')
+    expect(shared).not.toContain('node:path')
+    expect(server).toContain("from '@/lib/runtime-record-index'")
+    expect(server).toContain("from './research-matrices.shared'")
+  })
+})

--- a/src/lib/research-matrices.shared.ts
+++ b/src/lib/research-matrices.shared.ts
@@ -1,0 +1,33 @@
+import type { CanonicalEvidenceGrade } from '../../lib/evidence-grade'
+
+export const RISK_MATRIX_DEFINITIONS = [
+  { id: 'interaction', title: 'Interaction Matrix', signal: null, description: 'Structured interaction and safety signals across the research inventory.' },
+  { id: 'sedation', title: 'Sedation Risk Matrix', signal: 'Sedation', description: 'Screens for sedation, drowsiness, or CNS-depressant signals.' },
+  { id: 'stimulation', title: 'Stimulation Risk Matrix', signal: 'Stimulation', description: 'Screens for stimulant, agitation, insomnia, or jitteriness signals.' },
+  { id: 'serotonergic', title: 'Serotonergic Caution Matrix', signal: 'Serotonergic', description: 'Screens for serotonergic, SSRI/SNRI, or MAOI-related cautions.' },
+  { id: 'blood-pressure', title: 'Blood Pressure Effects Matrix', signal: 'Cardiovascular', description: 'Screens for blood-pressure, rhythm, heart-rate, or related cardiovascular signals; it does not infer direction.' },
+  { id: 'bleeding', title: 'Bleeding Risk Matrix', signal: 'Bleeding', description: 'Screens for bleeding, anticoagulant, or antiplatelet cautions.' },
+  { id: 'liver', title: 'Liver Caution Matrix', signal: 'Liver', description: 'Screens for liver or hepatotoxicity-related cautions.' },
+  { id: 'pregnancy', title: 'Pregnancy Evidence / Safety Matrix', signal: 'Pregnancy / breastfeeding', description: 'Screens for pregnancy, lactation, or breastfeeding cautions in the structured dataset.' },
+] as const
+
+export type RiskMatrixId = (typeof RISK_MATRIX_DEFINITIONS)[number]['id']
+
+export interface ResearchMatrixRow {
+  slug: string
+  name: string
+  entityType: 'herb' | 'compound'
+  href: string
+  evidenceGrade: CanonicalEvidenceGrade | 'Unassigned'
+  humanEvidenceCount: number
+  outcomes: string[]
+  mechanisms: string[]
+  safetySignals: string[]
+}
+
+export const rowsForRiskMatrix = (rows: ResearchMatrixRow[], matrixId: RiskMatrixId) => {
+  const definition = RISK_MATRIX_DEFINITIONS.find((item) => item.id === matrixId)
+  if (!definition) return []
+  if (!definition.signal) return rows.filter((row) => row.safetySignals.length > 0)
+  return rows.filter((row) => row.safetySignals.includes(definition.signal))
+}

--- a/src/lib/research-matrices.ts
+++ b/src/lib/research-matrices.ts
@@ -4,12 +4,7 @@ import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { getUnifiedRuntimeRecords } from '@/lib/runtime-record-index'
 import { normalizeEffect, normalizeSafetySignals, uniqueNormalized } from '@/lib/botanical-atlas-taxonomy'
 import type { RuntimeRecord } from '@/types/content'
-import {
-  RISK_MATRIX_DEFINITIONS,
-  rowsForRiskMatrix,
-  type ResearchMatrixRow,
-  type RiskMatrixId,
-} from './research-matrices.shared'
+import type { ResearchMatrixRow } from './research-matrices.shared'
 
 export {
   RISK_MATRIX_DEFINITIONS,

--- a/src/lib/research-matrices.ts
+++ b/src/lib/research-matrices.ts
@@ -4,31 +4,19 @@ import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { getUnifiedRuntimeRecords } from '@/lib/runtime-record-index'
 import { normalizeEffect, normalizeSafetySignals, uniqueNormalized } from '@/lib/botanical-atlas-taxonomy'
 import type { RuntimeRecord } from '@/types/content'
+import {
+  RISK_MATRIX_DEFINITIONS,
+  rowsForRiskMatrix,
+  type ResearchMatrixRow,
+  type RiskMatrixId,
+} from './research-matrices.shared'
 
-export const RISK_MATRIX_DEFINITIONS = [
-  { id: 'interaction', title: 'Interaction Matrix', signal: null, description: 'Structured interaction and safety signals across the research inventory.' },
-  { id: 'sedation', title: 'Sedation Risk Matrix', signal: 'Sedation', description: 'Screens for sedation, drowsiness, or CNS-depressant signals.' },
-  { id: 'stimulation', title: 'Stimulation Risk Matrix', signal: 'Stimulation', description: 'Screens for stimulant, agitation, insomnia, or jitteriness signals.' },
-  { id: 'serotonergic', title: 'Serotonergic Caution Matrix', signal: 'Serotonergic', description: 'Screens for serotonergic, SSRI/SNRI, or MAOI-related cautions.' },
-  { id: 'blood-pressure', title: 'Blood Pressure Effects Matrix', signal: 'Cardiovascular', description: 'Screens for blood-pressure, rhythm, heart-rate, or related cardiovascular signals; it does not infer direction.' },
-  { id: 'bleeding', title: 'Bleeding Risk Matrix', signal: 'Bleeding', description: 'Screens for bleeding, anticoagulant, or antiplatelet cautions.' },
-  { id: 'liver', title: 'Liver Caution Matrix', signal: 'Liver', description: 'Screens for liver or hepatotoxicity-related cautions.' },
-  { id: 'pregnancy', title: 'Pregnancy Evidence / Safety Matrix', signal: 'Pregnancy / breastfeeding', description: 'Screens for pregnancy, lactation, or breastfeeding cautions in the structured dataset.' },
-] as const
-
-export type RiskMatrixId = (typeof RISK_MATRIX_DEFINITIONS)[number]['id']
-
-export interface ResearchMatrixRow {
-  slug: string
-  name: string
-  entityType: 'herb' | 'compound'
-  href: string
-  evidenceGrade: CanonicalEvidenceGrade | 'Unassigned'
-  humanEvidenceCount: number
-  outcomes: string[]
-  mechanisms: string[]
-  safetySignals: string[]
-}
+export {
+  RISK_MATRIX_DEFINITIONS,
+  rowsForRiskMatrix,
+  type ResearchMatrixRow,
+  type RiskMatrixId,
+} from './research-matrices.shared'
 
 const POPULAR_SLUG_PRIORITY = [
   'ashwagandha', 'magnesium', 'melatonin', 'l-theanine', 'creatine', 'berberine',
@@ -149,10 +137,3 @@ export const getResearchMatrixRows = cache(async (): Promise<ResearchMatrixRow[]
       return a.name.localeCompare(b.name)
     })
 })
-
-export const rowsForRiskMatrix = (rows: ResearchMatrixRow[], matrixId: RiskMatrixId) => {
-  const definition = RISK_MATRIX_DEFINITIONS.find((item) => item.id === matrixId)
-  if (!definition) return []
-  if (!definition.signal) return rows.filter((row) => row.safetySignals.length > 0)
-  return rows.filter((row) => row.safetySignals.includes(definition.signal))
-}


### PR DESCRIPTION
Closes #3305

## Relevant URLs / files
- `src/components/matrices/ResearchMatricesClient.tsx`
- `src/lib/research-matrices.ts`
- `src/lib/research-matrices.shared.ts`
- `src/lib/__tests__/research-matrices-client-boundary.test.ts`

## Acceptance criteria
- ResearchMatricesClient imports only browser-safe matrix definitions/types/filter helpers.
- Filesystem-backed runtime loading remains server-side.
- No `node:fs` / `node:path` enters the client matrix dependency graph.
- Matrix definitions, row shape, risk filtering, evidence semantics, and UI behavior remain unchanged.
- Production webpack compilation proceeds past the prior UnhandledSchemeError.

## Validation commands
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/lib/__tests__/research-matrices-client-boundary.test.ts`
- `npm run build:deploy`
- GitHub Actions: Build Check, Production Content Lint, Lighthouse CI, CI

## Before → after metrics
- Before: Next.js production build fails on `node:fs` and `node:path` imported through `ResearchMatricesClient → research-matrices → runtime-record-index → runtime-data`.
- After target: 0 Node builtin imports in the ResearchMatricesClient graph; webpack compilation passes this boundary.

## Generator/source-of-truth decision
- `src/lib/research-matrices.ts` remains the server-side source for building canonical matrix rows from runtime records.
- `src/lib/research-matrices.shared.ts` contains only serializable/browser-safe definitions, types, and pure row filtering shared with the client.

## Regression contract
- Do not move runtime filesystem reads into client code.
- Do not duplicate or alter matrix definitions between server and client.
- Do not change safety signal classification, evidence grades, or row inclusion semantics.