### PR TITLE
research: canonicalize study dependency topology

### DIFF
--- a/lib/__tests__/research-coverage.test.ts
+++ b/lib/__tests__/research-coverage.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canonicalStudyIdentityMap,
+  uniqueClaimStudyIdentities,
+  type ResearchProfile,
+} from '@/lib/research-coverage'
+
+describe('canonical study identity', () => {
+  it('collapses source rows connected by DOI/PMID aliases', () => {
+    const record: ResearchProfile = {
+      sources: [
+        { id: 'a', doi: '10.1000/XYZ', pmid: '12345678' },
+        { id: 'b', pmid: '12345678' },
+        { id: 'c', doi: '10.1000/xyz' },
+        { id: 'd', pmid: '87654321' },
+      ],
+    }
+
+    const identities = canonicalStudyIdentityMap(record)
+    expect(identities.get('a')).toBe(identities.get('b'))
+    expect(identities.get('a')).toBe(identities.get('c'))
+    expect(identities.get('d')).not.toBe(identities.get('a'))
+  })
+
+  it('does not invent identity for sources without stable identifiers', () => {
+    const record: ResearchProfile = {
+      sources: [
+        { id: 'a', title: 'Same-looking title' },
+        { id: 'b', title: 'Same-looking title' },
+      ],
+    }
+
+    const identities = canonicalStudyIdentityMap(record)
+    expect(identities.get('a')).toBe('source-ref:a')
+    expect(identities.get('b')).toBe('source-ref:b')
+  })
+
+  it('counts independent studies rather than duplicate source references', () => {
+    const record: ResearchProfile = {
+      sources: [
+        { id: 'a', doi: '10.1000/XYZ', pmid: '12345678' },
+        { id: 'b', pmid: '12345678' },
+        { id: 'c', pmid: '87654321' },
+      ],
+    }
+    const identities = canonicalStudyIdentityMap(record)
+
+    expect(uniqueClaimStudyIdentities({ sourceRefIds: ['a', 'b'] }, identities)).toHaveLength(1)
+    expect(uniqueClaimStudyIdentities({ sourceRefIds: ['a', 'b', 'c'] }, identities)).toHaveLength(2)
+  })
+})

--- a/lib/research-coverage.ts
+++ b/lib/research-coverage.ts
@@ -1,12 +1,14 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { citationIdentifiers } from './citation-identifiers.mjs'
 import { normalizeStudyClass, strongestStudyClass, type StudyClass } from './study-class'
 
 export type ResearchSource = Record<string, unknown> & {
   id?: string
   pmid?: string
   pubmedId?: string
+  doi?: string
   studyClass?: string
   studyType?: string
 }
@@ -103,4 +105,59 @@ export function sourceMap(record: ResearchProfile): Map<string, ResearchSource> 
 
 export function uniqueSourceRefs(claim: ResearchClaim): string[] {
   return [...new Set(Array.isArray(claim.sourceRefIds) ? claim.sourceRefIds.map(String).filter(Boolean) : [])]
+}
+
+/**
+ * Resolve source-row IDs to canonical study identities.
+ *
+ * A study can carry both a DOI and PMID, and legacy data can contain more than
+ * one source row for the same study. Source-row counts therefore overstate
+ * evidence independence. Alias-connected rows are collapsed into one component;
+ * rows without a stable identifier remain distinct rather than being guessed at.
+ */
+export function canonicalStudyIdentityMap(record: ResearchProfile): Map<string, string> {
+  const sources = Array.isArray(record.sources) ? record.sources : []
+  const parent = new Map<string, string>()
+
+  const find = (value: string): string => {
+    const current = parent.get(value) ?? value
+    if (current === value) {
+      parent.set(value, value)
+      return value
+    }
+    const root = find(current)
+    parent.set(value, root)
+    return root
+  }
+
+  const union = (a: string, b: string) => {
+    const rootA = find(a)
+    const rootB = find(b)
+    if (rootA === rootB) return
+    const [keep, merge] = [rootA, rootB].sort()
+    parent.set(merge, keep)
+  }
+
+  for (const source of sources) {
+    const aliases = citationIdentifiers(source)
+    for (const alias of aliases) find(alias)
+    for (let i = 1; i < aliases.length; i += 1) union(aliases[0], aliases[i])
+  }
+
+  const identities = new Map<string, string>()
+  for (const source of sources) {
+    const sourceId = String(source.id ?? '').trim()
+    if (!sourceId) continue
+    const aliases = citationIdentifiers(source)
+    identities.set(sourceId, aliases.length ? find(aliases[0]) : `source-ref:${sourceId}`)
+  }
+  return identities
+}
+
+/** Stable studies supporting a claim, after collapsing duplicate/alias source rows. */
+export function uniqueClaimStudyIdentities(
+  claim: ResearchClaim,
+  identities: Map<string, string>,
+): string[] {
+  return [...new Set(uniqueSourceRefs(claim).map((ref) => identities.get(ref)).filter((value): value is string => Boolean(value)))]
 }

--- a/scripts/ci/audit-source-integrity.ts
+++ b/scripts/ci/audit-source-integrity.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import {
   approvedClaims,
+  canonicalStudyIdentityMap,
   designFromPublicationTypes,
   listResearchProfiles,
   loadPubmedCache,
@@ -13,6 +14,7 @@ import {
   sourceMap,
   sourceStudyClass,
   SYNTHESIS_STUDY_CLASSES,
+  uniqueClaimStudyIdentities,
   uniqueSourceRefs,
   type PubmedCache,
   type ResearchProfile,
@@ -28,6 +30,7 @@ const CURRENT_YEAR = Number(process.env.SOURCE_AUDIT_YEAR) || new Date().getFull
 type ProfileAnalysis = {
   url: string
   sourceCount: number
+  canonicalStudyCount: number
   claimCount: number
   approvedClaimCount: number
   designMix: Record<string, number>
@@ -35,11 +38,12 @@ type ProfileAnalysis = {
   synthesis: number
   narrativeReview: number
   unsupportedApprovedClaims: string[]
-  singleSourceApprovedClaims: string[]
+  singleStudyApprovedClaims: string[]
+  aliasCollapsedClaims: string[]
   danglingSourceRefs: Array<{ claimId: string; sourceRefId: string }>
-  mostUsedSourceRef: string | null
-  mostUsedSourceClaimCount: number
-  sourceDependencyShare: number
+  mostUsedStudyIdentity: string | null
+  mostUsedStudyClaimCount: number
+  studyDependencyShare: number
   reviewDominated: boolean
   noPrimaryHuman: boolean
 }
@@ -62,6 +66,7 @@ function analyzeProfile(url: string, record: ResearchProfile, cache: PubmedCache
   const allClaims = Array.isArray(record.claimMap) ? record.claimMap : []
   const approved = approvedClaims(record)
   const sourcesById = sourceMap(record)
+  const studyIdentities = canonicalStudyIdentityMap(record)
   const designMix: Record<string, number> = {}
   let primaryHuman = 0
   let synthesis = 0
@@ -76,29 +81,36 @@ function analyzeProfile(url: string, record: ResearchProfile, cache: PubmedCache
   }
 
   const unsupportedApprovedClaims: string[] = []
-  const singleSourceApprovedClaims: string[] = []
+  const singleStudyApprovedClaims: string[] = []
+  const aliasCollapsedClaims: string[] = []
   const danglingSourceRefs: Array<{ claimId: string; sourceRefId: string }> = []
-  const sourceUse = new Map<string, number>()
+  const studyUse = new Map<string, number>()
 
   for (const claim of approved) {
     const claimId = String(claim.id ?? 'unknown-claim')
     const refs = uniqueSourceRefs(claim)
+    const validRefs = refs.filter((ref) => sourcesById.has(ref))
+    const studies = uniqueClaimStudyIdentities(claim, studyIdentities)
+
     if (refs.length === 0) unsupportedApprovedClaims.push(claimId)
-    if (refs.length === 1) singleSourceApprovedClaims.push(claimId)
+    if (studies.length === 1) singleStudyApprovedClaims.push(claimId)
+    if (validRefs.length > studies.length && studies.length > 0) aliasCollapsedClaims.push(claimId)
+
     for (const ref of refs) {
       if (!sourcesById.has(ref)) danglingSourceRefs.push({ claimId, sourceRefId: ref })
-      else sourceUse.set(ref, (sourceUse.get(ref) ?? 0) + 1)
     }
+    for (const study of studies) studyUse.set(study, (studyUse.get(study) ?? 0) + 1)
   }
 
-  const mostUsed = [...sourceUse.entries()].sort((a, b) => b[1] - a[1])[0] ?? null
-  const mostUsedSourceClaimCount = mostUsed?.[1] ?? 0
-  const sourceDependencyShare = approved.length ? mostUsedSourceClaimCount / approved.length : 0
+  const mostUsed = [...studyUse.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0] ?? null
+  const mostUsedStudyClaimCount = mostUsed?.[1] ?? 0
+  const studyDependencyShare = approved.length ? mostUsedStudyClaimCount / approved.length : 0
   const classified = primaryHuman + synthesis + narrativeReview
 
   return {
     url,
     sourceCount: sources.length,
+    canonicalStudyCount: new Set(studyIdentities.values()).size,
     claimCount: allClaims.length,
     approvedClaimCount: approved.length,
     designMix,
@@ -106,11 +118,12 @@ function analyzeProfile(url: string, record: ResearchProfile, cache: PubmedCache
     synthesis,
     narrativeReview,
     unsupportedApprovedClaims,
-    singleSourceApprovedClaims,
+    singleStudyApprovedClaims,
+    aliasCollapsedClaims,
     danglingSourceRefs,
-    mostUsedSourceRef: mostUsed?.[0] ?? null,
-    mostUsedSourceClaimCount,
-    sourceDependencyShare: Number(sourceDependencyShare.toFixed(3)),
+    mostUsedStudyIdentity: mostUsed?.[0] ?? null,
+    mostUsedStudyClaimCount,
+    studyDependencyShare: Number(studyDependencyShare.toFixed(3)),
     reviewDominated: classified >= 3 && narrativeReview / classified >= 0.6,
     noPrimaryHuman: approved.length > 0 && primaryHuman === 0,
   }
@@ -158,10 +171,11 @@ function main() {
   const profileTopology = profiles.map(({ url, record }) => analyzeProfile(url, record, cache))
   const unsupportedClaims = profileTopology.flatMap((p) => p.unsupportedApprovedClaims.map((claimId) => ({ url: p.url, claimId })))
   const danglingRefs = profileTopology.flatMap((p) => p.danglingSourceRefs.map((item) => ({ url: p.url, ...item })))
-  const singleSourceClaims = profileTopology.flatMap((p) => p.singleSourceApprovedClaims.map((claimId) => ({ url: p.url, claimId })))
+  const singleStudyClaims = profileTopology.flatMap((p) => p.singleStudyApprovedClaims.map((claimId) => ({ url: p.url, claimId })))
+  const aliasCollapsedClaims = profileTopology.flatMap((p) => p.aliasCollapsedClaims.map((claimId) => ({ url: p.url, claimId })))
   const concentratedProfiles = profileTopology
-    .filter((p) => p.approvedClaimCount >= 3 && p.sourceDependencyShare >= 0.5)
-    .sort((a, b) => b.sourceDependencyShare - a.sourceDependencyShare || b.approvedClaimCount - a.approvedClaimCount)
+    .filter((p) => p.approvedClaimCount >= 3 && p.studyDependencyShare >= 0.5)
+    .sort((a, b) => b.studyDependencyShare - a.studyDependencyShare || b.approvedClaimCount - a.approvedClaimCount)
   const reviewDominatedProfiles = profileTopology.filter((p) => p.reviewDominated)
   const noPrimaryHumanProfiles = profileTopology.filter((p) => p.noPrimaryHuman)
 
@@ -180,7 +194,8 @@ function main() {
     profiles: profileTopology.length,
     approvedClaims: profileTopology.reduce((sum, profile) => sum + profile.approvedClaimCount, 0),
     unsupportedApprovedClaims: unsupportedClaims.length,
-    singleSourceApprovedClaims: singleSourceClaims.length,
+    singleStudyApprovedClaims: singleStudyClaims.length,
+    aliasCollapsedClaims: aliasCollapsedClaims.length,
     danglingClaimSourceRefs: danglingRefs.length,
     concentratedProfiles: concentratedProfiles.length,
     reviewDominatedProfiles: reviewDominatedProfiles.length,
@@ -194,7 +209,8 @@ function main() {
     summary,
     claimTopology: {
       unsupportedClaims,
-      singleSourceClaims,
+      singleStudyClaims,
+      aliasCollapsedClaims,
       danglingRefs,
       concentratedProfiles,
       reviewDominatedProfiles,
@@ -211,7 +227,8 @@ function main() {
   console.log(`Profiles analyzed           ${summary.profiles}`)
   console.log(`Approved structured claims  ${summary.approvedClaims}`)
   console.log(`Unsupported approved claims ${summary.unsupportedApprovedClaims}`)
-  console.log(`Single-source claims        ${summary.singleSourceApprovedClaims}`)
+  console.log(`Single-study claims         ${summary.singleStudyApprovedClaims}`)
+  console.log(`Alias-collapsed claims      ${summary.aliasCollapsedClaims}`)
   console.log(`Dangling claim source refs  ${summary.danglingClaimSourceRefs}`)
   console.log(`Concentrated profiles       ${summary.concentratedProfiles}`)
   console.log(`Review-dominated profiles   ${summary.reviewDominatedProfiles}`)
@@ -225,9 +242,9 @@ function main() {
     console.log(`  ${String(count).padStart(4)}  ${STUDY_CLASS_INFO[design as StudyClass]?.label ?? design}`)
   }
   if (concentratedProfiles.length) {
-    console.log('\nHighest claim-source concentration:')
+    console.log('\nHighest claim-study concentration:')
     for (const profile of concentratedProfiles.slice(0, 10)) {
-      console.log(`  ${(profile.sourceDependencyShare * 100).toFixed(0).padStart(3)}% · ${profile.approvedClaimCount} claims · ${profile.url}`)
+      console.log(`  ${(profile.studyDependencyShare * 100).toFixed(0).padStart(3)}% · ${profile.approvedClaimCount} claims · ${profile.url}`)
     }
   }
   console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -36,12 +36,13 @@ for (const item of topology.claimTopology?.unsupportedClaims ?? []) {
 for (const item of topology.claimTopology?.danglingRefs ?? []) {
   add(item.url, 'dangling-claim-source-edge', 100, `${item.claimId} -> ${item.sourceRefId}`)
 }
-for (const item of topology.claimTopology?.singleSourceClaims ?? []) {
-  add(item.url, 'single-source-approved-claim', 5, item.claimId)
+for (const item of topology.claimTopology?.singleStudyClaims ?? []) {
+  add(item.url, 'single-study-approved-claim', 5, item.claimId)
 }
 for (const profile of topology.claimTopology?.concentratedProfiles ?? []) {
-  const weight = Math.round(20 + Number(profile.sourceDependencyShare ?? 0) * 30)
-  add(profile.url, 'high-source-dependency', weight, `${Math.round(Number(profile.sourceDependencyShare ?? 0) * 100)}% of approved claims depend on one source`)
+  const share = Number(profile.studyDependencyShare ?? 0)
+  const weight = Math.round(20 + share * 30)
+  add(profile.url, 'high-study-dependency', weight, `${Math.round(share * 100)}% of approved claims depend on one canonical study`)
 }
 for (const profile of topology.claimTopology?.reviewDominatedProfiles ?? []) {
   add(profile.url, 'narrative-review-dominated-profile', 15)
@@ -73,17 +74,17 @@ const ranked = [...queue.values()]
 const report = {
   generatedAt: new Date().toISOString(),
   scoring: {
-    note: 'Scores prioritize structural invalidity first, then claim-strength and concentration weaknesses. They are triage weights, not evidence grades.',
+    note: 'Scores prioritize structural invalidity first, then claim-strength and canonical-study concentration weaknesses. They are triage weights, not evidence grades.',
     weights: {
       unsupportedApprovedClaim: 100,
       danglingClaimSourceEdge: 100,
       highConfidenceWeakOutcome: 40,
-      highSourceDependency: '20 + dependency share × 30',
+      highStudyDependency: '20 + dependency share × 30',
       narrativeOnlyOutcome: 25,
       noPrimaryHumanStudy: 20,
       unclassifiedLinkedEvidence: 20,
       narrativeReviewDominatedProfile: 15,
-      singleSourceApprovedClaim: 5,
+      singleStudyApprovedClaim: 5,
     },
   },
   summary: {


### PR DESCRIPTION
Consolidates research coverage topology around canonical study identity rather than raw source-row IDs.

- collapses DOI/PMID alias-connected source rows into one study identity
- counts single-study approved claims correctly
- measures profile concentration by one canonical study
- surfaces alias-collapsed claims for data cleanup visibility
- updates the canonical research-gap queue terminology/scoring inputs
- adds focused tests for alias collapse and conservative fallback behavior

This is the first iterative research-topology consolidation pass requested.