### PR TITLE
research: canonicalize profile study-design topology

### DIFF
--- a/lib/__tests__/research-coverage.test.ts
+++ b/lib/__tests__/research-coverage.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  canonicalStudyClass,
+  canonicalStudyGroups,
   canonicalStudyIdentityMap,
   uniqueClaimStudyIdentities,
   type ResearchProfile,
@@ -48,5 +50,21 @@ describe('canonical study identity', () => {
 
     expect(uniqueClaimStudyIdentities({ sourceRefIds: ['a', 'b'] }, identities)).toHaveLength(1)
     expect(uniqueClaimStudyIdentities({ sourceRefIds: ['a', 'b', 'c'] }, identities)).toHaveLength(2)
+  })
+
+  it('derives study design once per canonical study and keeps the strongest classification', () => {
+    const record: ResearchProfile = {
+      sources: [
+        { id: 'a', doi: '10.1000/XYZ', pmid: '12345678', studyClass: 'narrative-review' },
+        { id: 'b', pmid: '12345678', studyClass: 'randomized controlled trial' },
+        { id: 'c', pmid: '87654321', studyClass: 'narrative-review' },
+      ],
+    }
+
+    const groups = canonicalStudyGroups(record)
+    expect(groups).toHaveLength(2)
+    const merged = [...groups.values()].find((group) => group.length === 2)
+    expect(merged).toBeDefined()
+    expect(canonicalStudyClass(merged ?? [], {})).toBe('rct')
   })
 })

--- a/lib/__tests__/research-coverage.test.ts
+++ b/lib/__tests__/research-coverage.test.ts
@@ -62,7 +62,7 @@ describe('canonical study identity', () => {
     }
 
     const groups = canonicalStudyGroups(record)
-    expect(groups).toHaveLength(2)
+    expect(groups.size).toBe(2)
     const merged = [...groups.values()].find((group) => group.length === 2)
     expect(merged).toBeDefined()
     expect(canonicalStudyClass(merged ?? [], {})).toBe('rct')

--- a/lib/research-coverage.ts
+++ b/lib/research-coverage.ts
@@ -107,14 +107,6 @@ export function uniqueSourceRefs(claim: ResearchClaim): string[] {
   return [...new Set(Array.isArray(claim.sourceRefIds) ? claim.sourceRefIds.map(String).filter(Boolean) : [])]
 }
 
-/**
- * Resolve source-row IDs to canonical study identities.
- *
- * A study can carry both a DOI and PMID, and legacy data can contain more than
- * one source row for the same study. Source-row counts therefore overstate
- * evidence independence. Alias-connected rows are collapsed into one component;
- * rows without a stable identifier remain distinct rather than being guessed at.
- */
 export function canonicalStudyIdentityMap(record: ResearchProfile): Map<string, string> {
   const sources = Array.isArray(record.sources) ? record.sources : []
   const parent = new Map<string, string>()
@@ -154,7 +146,25 @@ export function canonicalStudyIdentityMap(record: ResearchProfile): Map<string, 
   return identities
 }
 
-/** Stable studies supporting a claim, after collapsing duplicate/alias source rows. */
+export function canonicalStudyGroups(record: ResearchProfile): Map<string, ResearchSource[]> {
+  const identities = canonicalStudyIdentityMap(record)
+  const groups = new Map<string, ResearchSource[]>()
+  for (const source of Array.isArray(record.sources) ? record.sources : []) {
+    const sourceId = String(source.id ?? '').trim()
+    if (!sourceId) continue
+    const identity = identities.get(sourceId)
+    if (!identity) continue
+    const group = groups.get(identity) ?? []
+    group.push(source)
+    groups.set(identity, group)
+  }
+  return groups
+}
+
+export function canonicalStudyClass(group: ResearchSource[], cache: PubmedCache): StudyClass {
+  return strongestStudyClass(group.map((source) => sourceStudyClass(source, cache)))
+}
+
 export function uniqueClaimStudyIdentities(
   claim: ResearchClaim,
   identities: Map<string, string>,

--- a/scripts/ci/audit-source-integrity.ts
+++ b/scripts/ci/audit-source-integrity.ts
@@ -5,6 +5,8 @@ import path from 'node:path'
 
 import {
   approvedClaims,
+  canonicalStudyClass,
+  canonicalStudyGroups,
   canonicalStudyIdentityMap,
   designFromPublicationTypes,
   listResearchProfiles,
@@ -12,7 +14,6 @@ import {
   NARRATIVE_STUDY_CLASSES,
   PRIMARY_HUMAN_STUDY_CLASSES,
   sourceMap,
-  sourceStudyClass,
   SYNTHESIS_STUDY_CLASSES,
   uniqueClaimStudyIdentities,
   uniqueSourceRefs,
@@ -67,13 +68,14 @@ function analyzeProfile(url: string, record: ResearchProfile, cache: PubmedCache
   const approved = approvedClaims(record)
   const sourcesById = sourceMap(record)
   const studyIdentities = canonicalStudyIdentityMap(record)
+  const studyGroups = canonicalStudyGroups(record)
   const designMix: Record<string, number> = {}
   let primaryHuman = 0
   let synthesis = 0
   let narrativeReview = 0
 
-  for (const source of sources) {
-    const design = sourceStudyClass(source, cache)
+  for (const group of studyGroups.values()) {
+    const design = canonicalStudyClass(group, cache)
     designMix[design] = (designMix[design] ?? 0) + 1
     if (PRIMARY_HUMAN_STUDY_CLASSES.has(design)) primaryHuman += 1
     if (SYNTHESIS_STUDY_CLASSES.has(design)) synthesis += 1
@@ -110,7 +112,7 @@ function analyzeProfile(url: string, record: ResearchProfile, cache: PubmedCache
   return {
     url,
     sourceCount: sources.length,
-    canonicalStudyCount: new Set(studyIdentities.values()).size,
+    canonicalStudyCount: studyGroups.size,
     claimCount: allClaims.length,
     approvedClaimCount: approved.length,
     designMix,


### PR DESCRIPTION
Second iterative topology consolidation pass.

- groups duplicate/alias source rows into canonical studies before design classification
- calculates narrative-review dominance from independent studies, not raw rows
- calculates primary-human and synthesis counts from canonical studies
- keeps strongest available classification when duplicate rows disagree
- reuses the same canonical grouping primitives introduced for dependency topology
- adds regression coverage for design grouping

This prevents duplicate citation rows from distorting profile research composition.