### PR TITLE
research: canonicalize claim support strength

### DIFF
--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -1,18 +1,20 @@
 #!/usr/bin/env npx tsx
-/** Claim-level evidence strength audit. */
+/** Claim-level evidence strength audit over independent canonical studies. */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
 import {
   approvedClaims,
+  canonicalStudyClass,
+  canonicalStudyGroups,
+  canonicalStudyIdentityMap,
   listResearchProfiles,
   loadPubmedCache,
   NARRATIVE_STUDY_CLASSES,
   PRIMARY_HUMAN_STUDY_CLASSES,
-  sourceMap,
-  sourceStudyClass,
   SYNTHESIS_STUDY_CLASSES,
+  uniqueClaimStudyIdentities,
   uniqueSourceRefs,
 } from '../../lib/research-coverage'
 
@@ -22,14 +24,16 @@ const cache = loadPubmedCache(ROOT)
 const claims: Array<Record<string, unknown>> = []
 
 for (const { url, record } of listResearchProfiles(ROOT)) {
-  const sources = sourceMap(record)
+  const identities = canonicalStudyIdentityMap(record)
+  const groups = canonicalStudyGroups(record)
 
   for (const claim of approvedClaims(record)) {
     const refs = uniqueSourceRefs(claim)
-    const designs = refs
-      .map((ref) => sources.get(ref))
-      .filter(Boolean)
-      .map((source) => sourceStudyClass(source!, cache))
+    const studyIds = uniqueClaimStudyIdentities(claim, identities)
+    const designs = studyIds
+      .map((studyId) => groups.get(studyId))
+      .filter((group): group is NonNullable<typeof group> => Boolean(group))
+      .map((group) => canonicalStudyClass(group, cache))
     const classified = designs.filter((design) => design !== 'unclassified')
     const primaryHuman = classified.filter((design) => PRIMARY_HUMAN_STUDY_CLASSES.has(design)).length
     const synthesis = classified.filter((design) => SYNTHESIS_STUDY_CLASSES.has(design)).length
@@ -44,14 +48,16 @@ for (const { url, record } of listResearchProfiles(ROOT)) {
       claimId: String(claim.id ?? 'unknown-claim'),
       predicate,
       confidence,
-      sourceCount: refs.length,
-      classifiedSourceCount: classified.length,
+      sourceRefCount: refs.length,
+      studyCount: studyIds.length,
+      classifiedStudyCount: classified.length,
       primaryHuman,
       synthesis,
       narrative,
       designs,
       outcomeClaim,
-      noClassifiedEvidence: refs.length > 0 && classified.length === 0,
+      unsupported: studyIds.length === 0,
+      noClassifiedEvidence: studyIds.length > 0 && classified.length === 0,
       narrativeOnlyOutcomeClaim: outcomeClaim && classified.length > 0 && narrative === classified.length,
       outcomeWithoutPrimaryOrSynthesis: outcomeClaim && classified.length > 0 && !strongHumanSupport,
       highConfidenceWeakOutcome: outcomeClaim && confidence >= 0.75 && !strongHumanSupport,
@@ -59,6 +65,7 @@ for (const { url, record } of listResearchProfiles(ROOT)) {
   }
 }
 
+const unsupported = claims.filter((claim) => claim.unsupported)
 const noClassifiedEvidence = claims.filter((claim) => claim.noClassifiedEvidence)
 const narrativeOnlyOutcomeClaims = claims.filter((claim) => claim.narrativeOnlyOutcomeClaim)
 const outcomeWithoutPrimaryOrSynthesis = claims.filter((claim) => claim.outcomeWithoutPrimaryOrSynthesis)
@@ -69,15 +76,18 @@ const report = {
   summary: {
     approvedClaims: claims.length,
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
+    unsupported: unsupported.length,
     noClassifiedEvidence: noClassifiedEvidence.length,
     narrativeOnlyOutcomeClaims: narrativeOnlyOutcomeClaims.length,
     outcomeWithoutPrimaryOrSynthesis: outcomeWithoutPrimaryOrSynthesis.length,
     highConfidenceWeakOutcome: highConfidenceWeakOutcome.length,
   },
+  unsupported,
   noClassifiedEvidence,
   narrativeOnlyOutcomeClaims,
   outcomeWithoutPrimaryOrSynthesis,
   highConfidenceWeakOutcome,
+  claims,
 }
 
 fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true })
@@ -87,6 +97,7 @@ console.log('\nClaim-level evidence strength')
 console.log('='.repeat(72))
 console.log(`Approved claims                    ${report.summary.approvedClaims}`)
 console.log(`Outcome claims                     ${report.summary.outcomeClaims}`)
+console.log(`Unsupported claims                 ${report.summary.unsupported}`)
 console.log(`No classified linked evidence     ${report.summary.noClassifiedEvidence}`)
 console.log(`Narrative-review-only outcomes     ${report.summary.narrativeOnlyOutcomeClaims}`)
 console.log(`Outcomes without primary/synthesis ${report.summary.outcomeWithoutPrimaryOrSynthesis}`)

--- a/scripts/ci/audit-source-integrity.ts
+++ b/scripts/ci/audit-source-integrity.ts
@@ -94,7 +94,7 @@ function analyzeProfile(url: string, record: ResearchProfile, cache: PubmedCache
     const validRefs = refs.filter((ref) => sourcesById.has(ref))
     const studies = uniqueClaimStudyIdentities(claim, studyIdentities)
 
-    if (refs.length === 0) unsupportedApprovedClaims.push(claimId)
+    if (studies.length === 0) unsupportedApprovedClaims.push(claimId)
     if (studies.length === 1) singleStudyApprovedClaims.push(claimId)
     if (validRefs.length > studies.length && studies.length > 0) aliasCollapsedClaims.push(claimId)
 


### PR DESCRIPTION
Third iterative research-quality pass.

- evaluates claim evidence from independent canonical studies rather than source-row references
- reports sourceRefCount separately from true studyCount
- classifies claim designs after alias collapse
- marks claims with zero valid canonical studies as unsupported, including dangling-only claims
- preserves weak-outcome diagnostics while preventing duplicate source rows from inflating strength
- includes the full claim analysis in the canonical strength report for downstream triage

This aligns unsupported/weak claim detection with the same canonical study model used by topology and profile composition.