### PR TITLE
research: consolidate claim support into canonical tiers

### DIFF
--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -23,6 +23,8 @@ const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'claim-evidence-strength.j
 const cache = loadPubmedCache(ROOT)
 const claims: Array<Record<string, unknown>> = []
 
+type SupportTier = 'unsupported' | 'unclassified' | 'narrative-only' | 'indirect-only' | 'human-supported' | 'non-outcome'
+
 for (const { url, record } of listResearchProfiles(ROOT)) {
   const identities = canonicalStudyIdentityMap(record)
   const groups = canonicalStudyGroups(record)
@@ -43,6 +45,15 @@ for (const { url, record } of listResearchProfiles(ROOT)) {
     const confidence = Number(claim.confidence ?? 0)
     const strongHumanSupport = primaryHuman + synthesis > 0
 
+    let supportTier: SupportTier = 'non-outcome'
+    if (studyIds.length === 0) supportTier = 'unsupported'
+    else if (classified.length === 0) supportTier = 'unclassified'
+    else if (outcomeClaim && narrative === classified.length) supportTier = 'narrative-only'
+    else if (outcomeClaim && !strongHumanSupport) supportTier = 'indirect-only'
+    else if (outcomeClaim) supportTier = 'human-supported'
+
+    const weakOutcome = supportTier === 'narrative-only' || supportTier === 'indirect-only'
+
     claims.push({
       url,
       claimId: String(claim.id ?? 'unknown-claim'),
@@ -56,37 +67,26 @@ for (const { url, record } of listResearchProfiles(ROOT)) {
       narrative,
       designs,
       outcomeClaim,
-      unsupported: studyIds.length === 0,
-      noClassifiedEvidence: studyIds.length > 0 && classified.length === 0,
-      narrativeOnlyOutcomeClaim: outcomeClaim && classified.length > 0 && narrative === classified.length,
-      outcomeWithoutPrimaryOrSynthesis: outcomeClaim && classified.length > 0 && !strongHumanSupport,
-      highConfidenceWeakOutcome: outcomeClaim && confidence >= 0.75 && !strongHumanSupport,
+      supportTier,
+      highConfidenceWeakOutcome: outcomeClaim && confidence >= 0.75 && (weakOutcome || supportTier === 'unclassified' || supportTier === 'unsupported'),
     })
   }
 }
 
-const unsupported = claims.filter((claim) => claim.unsupported)
-const noClassifiedEvidence = claims.filter((claim) => claim.noClassifiedEvidence)
-const narrativeOnlyOutcomeClaims = claims.filter((claim) => claim.narrativeOnlyOutcomeClaim)
-const outcomeWithoutPrimaryOrSynthesis = claims.filter((claim) => claim.outcomeWithoutPrimaryOrSynthesis)
-const highConfidenceWeakOutcome = claims.filter((claim) => claim.highConfidenceWeakOutcome)
+const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
+  const tier = String(claim.supportTier)
+  counts[tier] = (counts[tier] ?? 0) + 1
+  return counts
+}, {})
 
 const report = {
   generatedAt: new Date().toISOString(),
   summary: {
     approvedClaims: claims.length,
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
-    unsupported: unsupported.length,
-    noClassifiedEvidence: noClassifiedEvidence.length,
-    narrativeOnlyOutcomeClaims: narrativeOnlyOutcomeClaims.length,
-    outcomeWithoutPrimaryOrSynthesis: outcomeWithoutPrimaryOrSynthesis.length,
-    highConfidenceWeakOutcome: highConfidenceWeakOutcome.length,
+    supportTiers: tierCounts,
+    highConfidenceWeakOutcome: claims.filter((claim) => claim.highConfidenceWeakOutcome).length,
   },
-  unsupported,
-  noClassifiedEvidence,
-  narrativeOnlyOutcomeClaims,
-  outcomeWithoutPrimaryOrSynthesis,
-  highConfidenceWeakOutcome,
   claims,
 }
 
@@ -95,11 +95,10 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nClaim-level evidence strength')
 console.log('='.repeat(72))
-console.log(`Approved claims                    ${report.summary.approvedClaims}`)
-console.log(`Outcome claims                     ${report.summary.outcomeClaims}`)
-console.log(`Unsupported claims                 ${report.summary.unsupported}`)
-console.log(`No classified linked evidence     ${report.summary.noClassifiedEvidence}`)
-console.log(`Narrative-review-only outcomes     ${report.summary.narrativeOnlyOutcomeClaims}`)
-console.log(`Outcomes without primary/synthesis ${report.summary.outcomeWithoutPrimaryOrSynthesis}`)
-console.log(`High-confidence weak outcomes      ${report.summary.highConfidenceWeakOutcome}`)
+console.log(`Approved claims               ${report.summary.approvedClaims}`)
+console.log(`Outcome claims                ${report.summary.outcomeClaims}`)
+for (const [tier, count] of Object.entries(tierCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`${tier.padEnd(29)} ${count}`)
+}
+console.log(`High-confidence weak outcomes ${report.summary.highConfidenceWeakOutcome}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -50,14 +50,20 @@ for (const profile of topology.claimTopology?.reviewDominatedProfiles ?? []) {
 for (const profile of topology.claimTopology?.noPrimaryHumanProfiles ?? []) {
   add(profile.url, 'approved-claims-without-primary-human-study', 20)
 }
-for (const claim of strength.highConfidenceWeakOutcome ?? []) {
-  add(claim.url, 'high-confidence-weak-outcome-claim', 40, String(claim.claimId ?? ''))
-}
-for (const claim of strength.narrativeOnlyOutcomeClaims ?? []) {
-  add(claim.url, 'narrative-only-outcome-claim', 25, String(claim.claimId ?? ''))
-}
-for (const claim of strength.noClassifiedEvidence ?? []) {
-  add(claim.url, 'unclassified-linked-evidence', 20, String(claim.claimId ?? ''))
+
+for (const claim of strength.claims ?? []) {
+  const tier = String(claim.supportTier ?? '')
+  if (tier === 'unsupported' || tier === 'human-supported' || tier === 'non-outcome') continue
+
+  const baseWeight = tier === 'narrative-only' ? 25 : 20
+  const confidenceBonus = claim.highConfidenceWeakOutcome ? 15 : 0
+  const weight = baseWeight + confidenceBonus
+  add(
+    claim.url,
+    `claim-support-${tier}`,
+    weight,
+    `${String(claim.claimId ?? '')}${confidenceBonus ? ' · high confidence' : ''}`,
+  )
 }
 
 const ranked = [...queue.values()]
@@ -74,15 +80,15 @@ const ranked = [...queue.values()]
 const report = {
   generatedAt: new Date().toISOString(),
   scoring: {
-    note: 'Scores prioritize structural invalidity first, then claim-strength and canonical-study concentration weaknesses. They are triage weights, not evidence grades.',
+    note: 'Scores prioritize structural invalidity first, then mutually exclusive claim-support tiers and canonical-study concentration. They are triage weights, not evidence grades.',
     weights: {
       unsupportedApprovedClaim: 100,
       danglingClaimSourceEdge: 100,
-      highConfidenceWeakOutcome: 40,
       highStudyDependency: '20 + dependency share × 30',
-      narrativeOnlyOutcome: 25,
+      narrativeOnlyClaimSupport: 25,
+      indirectOrUnclassifiedClaimSupport: 20,
+      highConfidenceWeakClaimBonus: 15,
       noPrimaryHumanStudy: 20,
-      unclassifiedLinkedEvidence: 20,
       narrativeReviewDominatedProfile: 15,
       singleStudyApprovedClaim: 5,
     },


### PR DESCRIPTION
Fourth iterative consolidation pass.

- replaces overlapping weak-claim arrays with one mutually exclusive supportTier per claim
- tiers: unsupported, unclassified, narrative-only, indirect-only, human-supported, non-outcome
- keeps high-confidence weakness as a priority modifier rather than a second competing category
- updates the research-gap queue to consume each weak claim once
- removes double-counting between narrative-only / weak-outcome / unclassified buckets
- keeps unsupported structural claims owned by topology, preserving one canonical responsibility per pipeline stage

This materially reduces overlapping audit machinery and makes downstream triage deterministic.