### PR TITLE
fix(compounds): keep pagination valid under static export

### DIFF
--- a/app/compounds/page/[page]/__tests__/static-export-pagination.test.ts
+++ b/app/compounds/page/[page]/__tests__/static-export-pagination.test.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('compound pagination static-export contract', () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), 'app/compounds/page/[page]/page.tsx'),
+    'utf8',
+  )
+
+  it('provides a sentinel static param when no real page 2 exists', () => {
+    expect(source).toContain("return realParams.length ? realParams : [{ page: '2' }]")
+  })
+
+  it('does not render out-of-range dynamic pages as duplicate library content', () => {
+    expect(source).toContain("import { notFound } from 'next/navigation'")
+    expect(source).toContain('if (n < 2 || n > totalPages) notFound()')
+  })
+})

--- a/app/compounds/page/[page]/page.tsx
+++ b/app/compounds/page/[page]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
 import { COMPOUNDS_PAGE_SIZE, clampPositiveInt, paginateItems } from '@/lib/pagination'
 import { toLeanProfileIndexRecords } from '@/lib/profile-index-records'
@@ -16,10 +17,14 @@ type P = {
 export async function generateStaticParams() {
   const compounds = await loadPublishedCompounds()
   const total = Math.max(1, Math.ceil(compounds.length / COMPOUNDS_PAGE_SIZE))
-
-  return Array.from({ length: Math.max(total - 1, 0) }, (_, i) => ({
+  const realParams = Array.from({ length: Math.max(total - 1, 0) }, (_, i) => ({
     page: String(i + 2),
   }))
+
+  // `output: export` requires at least one parameter for a dynamic route.
+  // When the governed library fits on page 1, build page 2 as a sentinel and
+  // immediately resolve it through notFound() below so no duplicate page ships.
+  return realParams.length ? realParams : [{ page: '2' }]
 }
 
 export async function generateMetadata({ params }: P): Promise<Metadata> {
@@ -37,6 +42,9 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
 export default async function CompoundsPageN({ params }: P) {
   const n = clampPositiveInt((await params).page, 2)
   const compounds = await loadPublishedCompounds()
+  const totalPages = Math.max(1, Math.ceil(compounds.length / COMPOUNDS_PAGE_SIZE))
+  if (n < 2 || n > totalPages) notFound()
+
   const p = paginateItems(compounds, n, COMPOUNDS_PAGE_SIZE)
   const leanCompounds = toLeanProfileIndexRecords(compounds)
   const leanPageItems = toLeanProfileIndexRecords(p.pageItems as RuntimeRecord[])


### PR DESCRIPTION
Closes #3312

## Relevant URLs / files
- `/compounds/page/[page]/`
- `app/compounds/page/[page]/page.tsx`
- `app/compounds/page/[page]/__tests__/static-export-pagination.test.ts`

## Acceptance criteria
- Static export remains valid when the governed compound inventory fits on page 1.
- No duplicate or empty `/compounds/page/2/` page is published.
- Real page 2+ routes continue to generate normally when inventory exceeds 36 compounds.
- Out-of-range pagination resolves through `notFound()` instead of clamping to duplicate content.

## Validation commands
- `npm run typecheck`
- `npm run lint`
- `npx vitest run 'app/compounds/page/[page]/__tests__/static-export-pagination.test.ts'`
- `npm run build:deploy`
- GitHub Actions: Build Check, Production Content Lint, Lighthouse CI, CI

## Before → after metrics
- Before: Next production build compiles successfully, then fails collecting page data with `Page "/compounds/page/[page]" is missing "generateStaticParams()"` when the function returns zero params.
- After target: static export proceeds past compound pagination; out-of-range pagination pages published = 0.

## Generator/source-of-truth decision
- The governed published-compound inventory remains authoritative for real pagination routes.
- A build-only page-2 sentinel exists solely to satisfy Next static-export dynamic-route requirements when there are zero real dynamic pages; `notFound()` prevents it from becoming reader-facing duplicate content.

## Regression contract
- Do not broaden the published compound inventory to manufacture a page 2.
- Do not canonicalize an invalid pagination path to duplicate content.
- Preserve the 36-item page size and normal real page 2+ generation.