### PR TITLE
cleanup: centralize profile completeness scoring

### DIFF
--- a/lib/__tests__/profile-completeness.test.ts
+++ b/lib/__tests__/profile-completeness.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { evaluateProfileCompleteness } from '@/lib/profile-completeness.mjs'
+
+describe('canonical profile completeness', () => {
+  it('scores one shared seven-field model', () => {
+    const result = evaluateProfileCompleteness({
+      slug: 'example',
+      description: 'A real evidence-aware description with useful detail.',
+      contraindications: ['Avoid with anticoagulants.'],
+      evidence_grade: 'B',
+      mechanisms: ['GABA modulation'],
+      effects: ['sleep support'],
+      dosage: '300 mg',
+      interactions: ['warfarin'],
+    })
+
+    expect(result.completeness).toBe(1)
+    expect(result.missingFields).toEqual([])
+  })
+
+  it('treats governed safety abstention as reviewed rather than missing', () => {
+    const result = evaluateProfileCompleteness(
+      { slug: 'reviewed-empty', contraindications: [] },
+      { documentedSafetyExceptions: new Set(['reviewed-empty']) },
+    )
+    expect(result.details.safety).toBe('DOCUMENTED_EXCEPTION')
+    expect(result.missingFields).not.toContain('safety')
+  })
+
+  it('can consume the legacy safety field without changing the model', () => {
+    const item = { slug: 'legacy', safety: 'Avoid in pregnancy.' }
+    const result = evaluateProfileCompleteness(item, { safetyValue: item.safety })
+    expect(result.details.safety).toBe('FILLED')
+  })
+})

--- a/lib/profile-completeness.mjs
+++ b/lib/profile-completeness.mjs
@@ -1,0 +1,69 @@
+import { collectionHasMeaningfulText, hasMeaningfulText, isMissingLike } from './data-quality.mjs'
+
+export const PROFILE_COMPLETENESS_FIELDS = [
+  'description', 'safety', 'evidence_level', 'mechanism', 'best_for', 'dosing', 'interactions',
+]
+
+const DESCRIPTION_PLACEHOLDERS = [
+  /evidence-aware botanical profile with mechanism/i,
+  /evidence-aware compound profile with mechanism/i,
+]
+
+function hasDescription(item) {
+  return hasMeaningfulText(item.description ?? item.summary, DESCRIPTION_PLACEHOLDERS)
+}
+
+function hasEvidenceLevel(item) {
+  return !isMissingLike(item.evidence_tier ?? item.evidence_grade ?? item.evidenceLevel ?? item.evidence_level)
+}
+
+function hasMechanism(item) {
+  const value = item.mechanisms ?? item.canonical_mechanisms ?? item.mechanism
+  return Array.isArray(value) ? value.length > 0 : !isMissingLike(value)
+}
+
+function hasBestFor(item) {
+  return collectionHasMeaningfulText(item.effects ?? item.primary_effects ?? item.best_for ?? item.bestFor)
+}
+
+function hasDosing(item) {
+  const value = item.dosage ?? item.typical_dosage ?? item.dosing ?? item.dosage_range
+  return Array.isArray(value) ? value.length > 0 : !isMissingLike(value)
+}
+
+function hasInteractions(item, interactionEdgesMap) {
+  if (collectionHasMeaningfulText(item.interactions)) return true
+  const edges = interactionEdgesMap?.[item.slug]
+  return Array.isArray(edges) && edges.length > 0
+}
+
+export function evaluateProfileCompleteness(item, options = {}) {
+  const {
+    interactionEdgesMap = {},
+    documentedSafetyExceptions = new Set(),
+    safetyValue = item.contraindications ?? item.safety,
+  } = options
+
+  const safetyFilled = collectionHasMeaningfulText(safetyValue)
+  const safetyDocumentedException = !safetyFilled && documentedSafetyExceptions.has(item.slug)
+  const state = {
+    description: hasDescription(item),
+    safety: safetyFilled || safetyDocumentedException,
+    evidence_level: hasEvidenceLevel(item),
+    mechanism: hasMechanism(item),
+    best_for: hasBestFor(item),
+    dosing: hasDosing(item),
+    interactions: hasInteractions(item, interactionEdgesMap),
+  }
+  const missingFields = PROFILE_COMPLETENESS_FIELDS.filter((field) => !state[field])
+  const details = Object.fromEntries(PROFILE_COMPLETENESS_FIELDS.map((field) => [
+    field,
+    field === 'safety' && safetyDocumentedException ? 'DOCUMENTED_EXCEPTION' : state[field] ? 'FILLED' : 'EMPTY',
+  ]))
+
+  return {
+    completeness: (PROFILE_COMPLETENESS_FIELDS.length - missingFields.length) / PROFILE_COMPLETENESS_FIELDS.length,
+    missingFields,
+    details,
+  }
+}

--- a/scripts/audit/content-gap-report.mjs
+++ b/scripts/audit/content-gap-report.mjs
@@ -1,47 +1,15 @@
 import fs from 'node:fs'
-import { collectionHasMeaningfulText, hasMeaningfulText, isMissingLike } from '../../lib/data-quality.mjs'
+import { collectionHasMeaningfulText } from '../../lib/data-quality.mjs'
+import { evaluateProfileCompleteness } from '../../lib/profile-completeness.mjs'
 
 const REPORT_DIR = 'reports'
-const PROFILE_FIELDS = ['description', 'safety', 'evidence_level', 'mechanism', 'best_for', 'dosing', 'interactions']
-const DESCRIPTION_PLACEHOLDERS = [
-  /evidence-aware botanical profile with mechanism/i,
-  /evidence-aware compound profile with mechanism/i,
-]
 
 function ensureReportDir() {
   fs.mkdirSync(REPORT_DIR, { recursive: true })
 }
 
-function checkDescription(value) {
-  return hasMeaningfulText(value, DESCRIPTION_PLACEHOLDERS)
-}
-
 export function checkSafety(value) {
   return collectionHasMeaningfulText(value)
-}
-
-function checkEvidenceLevel(item) {
-  return !isMissingLike(item.evidence_tier ?? item.evidence_grade ?? item.evidenceLevel ?? item.evidence_level)
-}
-
-function checkMechanism(item) {
-  const value = item.mechanisms ?? item.canonical_mechanisms ?? item.mechanism
-  return Array.isArray(value) ? value.length > 0 : !isMissingLike(value)
-}
-
-function checkBestFor(item) {
-  return collectionHasMeaningfulText(item.effects ?? item.primary_effects ?? item.best_for ?? item.bestFor)
-}
-
-function checkDosing(item) {
-  const value = item.dosage ?? item.typical_dosage ?? item.dosing ?? item.dosage_range
-  return Array.isArray(value) ? value.length > 0 : !isMissingLike(value)
-}
-
-function checkInteractions(item, interactionEdgesMap) {
-  if (collectionHasMeaningfulText(item.interactions)) return true
-  const edges = interactionEdgesMap?.[item.slug]
-  return Array.isArray(edges) && edges.length > 0
 }
 
 export function loadDocumentedSafetyExceptions() {
@@ -58,29 +26,11 @@ export function loadDocumentedSafetyExceptions() {
 }
 
 function analyzeProfile(item, type, interactionEdgesMap, documentedSafetyExceptions) {
-  const safetyFilled = checkSafety(item.contraindications)
-  const safetyDocumentedException = !safetyFilled && documentedSafetyExceptions.has(item.slug)
-  const state = {
-    description: checkDescription(item.description),
-    safety: safetyFilled || safetyDocumentedException,
-    evidence_level: checkEvidenceLevel(item),
-    mechanism: checkMechanism(item),
-    best_for: checkBestFor(item),
-    dosing: checkDosing(item),
-    interactions: checkInteractions(item, interactionEdgesMap),
-  }
-  const missingFields = PROFILE_FIELDS.filter((field) => !state[field])
-
   return {
     name: item.name,
     slug: item.slug,
     type,
-    completeness: (PROFILE_FIELDS.length - missingFields.length) / PROFILE_FIELDS.length,
-    missingFields,
-    details: Object.fromEntries(PROFILE_FIELDS.map((field) => [
-      field,
-      field === 'safety' && safetyDocumentedException ? 'DOCUMENTED_EXCEPTION' : state[field] ? 'FILLED' : 'EMPTY',
-    ])),
+    ...evaluateProfileCompleteness(item, { interactionEdgesMap, documentedSafetyExceptions }),
   }
 }
 
@@ -106,14 +56,12 @@ function renderMarkdown(profiles, documentedSafetyExceptions) {
   const total = profiles.length
   const filled = (field) => profiles.filter((profile) => profile.details[field] !== 'EMPTY').length
   const pct = (count) => total ? ((count / total) * 100).toFixed(1) : '0.0'
-  const priorities = priorityRows(profiles)
-
   const lines = [
     '# Content Gap Audit Report', '',
     `Generated on: ${new Date().toISOString()}`, '',
     '## Summary Statistics', '',
     `- **Total Profiles Evaluated**: ${total}`,
-    `- **Safety Data Fill/Reviewed Rate**: ${pct(filled('safety'))}% (${filled('safety')} / ${total}); documented evidence-limited exceptions are treated as reviewed rather than missing`,
+    `- **Safety Data Fill/Reviewed Rate**: ${pct(filled('safety'))}% (${filled('safety')} / ${total})`,
     `- **Description Fill Rate**: ${pct(filled('description'))}% (${filled('description')} / ${total})`,
     `- **Mechanism Fill Rate**: ${pct(filled('mechanism'))}% (${filled('mechanism')} / ${total})`,
     `- **Interactions Fill Rate**: ${pct(filled('interactions'))}% (${filled('interactions')} / ${total})`,
@@ -123,7 +71,7 @@ function renderMarkdown(profiles, documentedSafetyExceptions) {
     '| --- | --- | --- | --- | --- |',
   ]
 
-  for (const { prioritySlug, profile } of priorities) {
+  for (const { prioritySlug, profile } of priorityRows(profiles)) {
     if (!profile) {
       lines.push(`| \`${prioritySlug}\` | *No matching profile* | - | - | - |`)
       continue

--- a/scripts/audit/dual-slug-audit.mjs
+++ b/scripts/audit/dual-slug-audit.mjs
@@ -1,11 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import { getSheetData } from '../utils/read-workbook-exceljs.mjs';
+import { evaluateProfileCompleteness } from '../../lib/profile-completeness.mjs';
 
 function slugify(text) {
   if (!text) return '';
   return text.toLowerCase()
-    .replace(/[’'""`]/g, '')
+    .replace(/[’'"“”`]/g, '')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }
@@ -13,7 +14,7 @@ function slugify(text) {
 function normalize(text) {
   if (!text) return '';
   return text.toLowerCase()
-    .replace(/[’'""`]/g, '')
+    .replace(/[’'"“”`]/g, '')
     .replace(/[^a-z0-9]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
@@ -41,47 +42,20 @@ async function run() {
     process.exit(1);
   }
 
-  // Load workbook data
   console.log(`Loading sheet 'Herb Master V3' from ${workbookPath}...`);
   const rows = await getSheetData(workbookPath, 'Herb Master V3');
 
-  // Load public herbs JSON to calculate completeness of existing profiles
   let herbsJson = [];
   if (fs.existsSync(herbsJsonPath)) {
     herbsJson = JSON.parse(fs.readFileSync(herbsJsonPath, 'utf8'));
   }
   const herbsJsonMap = new Map(herbsJson.map(h => [h.slug, h]));
-
-  const checkSafety = (val) => {
-    if (!val) return false;
-    const s = String(val).toLowerCase();
-    return !['needs review', 'safety review pending', 'placeholder', 'pending'].some(p => s.includes(p));
-  };
-  const checkDescription = (val) => {
-    if (!val) return false;
-    const s = String(val).toLowerCase();
-    return s.length >= 15 && !['evidence-aware', 'needs review', 'placeholder'].some(p => s.includes(p));
-  };
-  const checkBestFor = (val) => {
-    if (!val) return false;
-    const s = String(val).toLowerCase();
-    return !['research pending', 'research_only', 'placeholder'].some(p => s.includes(p));
-  };
   const getCompleteness = (slug) => {
-    const h = herbsJsonMap.get(slug);
-    if (!h) return -1; // doesn't exist
-    let filled = 0;
-    if (checkDescription(h.description || h.summary)) filled++;
-    if (checkSafety(h.safety)) filled++;
-    if (h.evidence_tier || h.evidence_grade) filled++;
-    if (h.canonical_mechanisms && h.canonical_mechanisms.length > 0) filled++;
-    if (checkBestFor(h.effects || h.primary_effects)) filled++;
-    if (h.dosage || h.typical_dosage) filled++;
-    if (h.interactions && h.interactions.length > 0) filled++;
-    return filled / 7;
+    const herb = herbsJsonMap.get(slug);
+    if (!herb) return -1;
+    return evaluateProfileCompleteness(herb, { safetyValue: herb.safety ?? herb.contraindications }).completeness;
   };
 
-  // Load sitemap URLs
   let sitemapUrls = [];
   if (fs.existsSync(sitemapPath)) {
     console.log(`Reading sitemap from ${sitemapPath}...`);
@@ -105,7 +79,6 @@ async function run() {
 
   console.log(`Found ${sitemapSlugs.size} herb slugs in sitemap.`);
 
-  // Step 1: Parse workbook rows into normalized Herb info
   const herbs = [];
   rows.forEach((row, idx) => {
     const rawSlug = String(row.slug || '').trim();
@@ -113,7 +86,6 @@ async function run() {
 
     const rawName = String(row.name || '').trim();
     const parenthetical = extractParentheses(rawName);
-    
     let commonName = rawName;
     let latinName = String(row.latin_name || '').trim();
 
@@ -122,7 +94,6 @@ async function run() {
       latinName = parenthetical;
     }
 
-    // Heuristics for latin name detection from slug if not set
     if (!latinName && rawSlug.includes('-')) {
       const parts = rawSlug.split('-');
       const botanicalWords = ['sativum', 'erinaceus', 'lucidum', 'chamomilla', 'officinale', 'somnifera', 'monnieri', 'rosea', 'sinensis', 'vulgaris', 'odorata'];
@@ -143,7 +114,6 @@ async function run() {
     });
   });
 
-  // Step 2: Group duplicates based on name/slug matching
   const groups = [];
   const visitedIndices = new Set();
 
@@ -185,12 +155,10 @@ async function run() {
     groups.push(group);
   }
 
-  // Step 3: Process groups to determine canonical and redirect mapping
   const redirectMap = {};
   const mappedResults = [];
   const sitemapOrphans = [];
 
-  // Sort groups deterministically by their first item's slug
   groups.sort((a, b) => a[0].slug.localeCompare(b[0].slug));
 
   groups.forEach(group => {
@@ -230,8 +198,6 @@ async function run() {
     }
 
     const targetPath = `/herbs/${bestSlug}`;
-    
-    // Legacy slugs inside this group
     const legacySlugs = new Set();
     group.forEach(item => {
       legacySlugs.add(item.slug);
@@ -257,7 +223,6 @@ async function run() {
     });
   });
 
-  // Identify sitemap slugs that were NOT mapped to any group
   sitemapSlugs.forEach(slug => {
     let found = false;
     groups.forEach(group => {
@@ -271,14 +236,11 @@ async function run() {
     }
   });
 
-  // Ensure reports dir exists
   ensureDirExists('reports');
 
-  // Write reports/slug-redirect-map.json
   fs.writeFileSync('reports/slug-redirect-map.json', JSON.stringify(redirectMap, null, 2));
   console.log(`Wrote reports/slug-redirect-map.json with ${Object.keys(redirectMap).length} mappings.`);
 
-  // Generate dual-slug-map.md
   let md = `# Dual Slug Reconciler Audit Report
 
 Generated on: ${new Date().toISOString()}


### PR DESCRIPTION
Broad cleanup pass 2.

- creates one canonical seven-field profile completeness model
- moves runtime content-gap scoring onto that shared model
- removes a second, hidden completeness implementation from dual-slug canonical selection
- supports governed safety abstentions and legacy safety-field callers without forking the scoring rules
- adds focused tests for complete profiles, governed safety exceptions, and legacy safety input

This eliminates a particularly risky duplication: slug canonicalization was choosing winners using a different definition of profile quality than the content-gap audit.