### PR TITLE
cleanup: narrow description audit to prose quality

### DIFF
--- a/scripts/audit/description-quality-check.mjs
+++ b/scripts/audit/description-quality-check.mjs
@@ -1,192 +1,143 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs'
+import { hasMeaningfulText, normalizeStructuredText } from '../../lib/data-quality.mjs'
 
-function ensureDirExists(dirPath) {
-  if (!fs.existsSync(dirPath)) {
-    fs.mkdirSync(dirPath, { recursive: true });
-  }
-}
+const DESCRIPTION_PLACEHOLDERS = [
+  /evidence-aware botanical profile/i,
+  /evidence-aware compound profile/i,
+]
 
-const QUALITY_PATTERNS = [
-  { regex: /placeholder/i, name: 'Placeholder' },
+const DESCRIPTION_LEAK_PATTERNS = [
   { regex: /\bTODO\b/i, name: 'TODO' },
   { regex: /\bFIXME\b/i, name: 'FIXME' },
   { regex: /\blorem\b/i, name: 'Lorem Ipsum' },
   { regex: /\btest\b/i, name: 'Test String' },
-  { regex: /evidence-aware botanical profile/i, name: 'Default Botanical Template' },
-  { regex: /evidence-aware compound profile/i, name: 'Default Compound Template' },
   { regex: /lean bulk/i, name: 'Leaked "Lean bulk"' },
   { regex: /ingestion row/i, name: 'Leaked "ingestion row"' },
   { regex: /batch import/i, name: 'Leaked "batch import"' },
-  { regex: /workbook row/i, name: 'Leaked "workbook row"' }
-];
+  { regex: /workbook row/i, name: 'Leaked "workbook row"' },
+]
 
-function run() {
-  const herbsPath = 'public/data/herbs.json';
-  const compoundsPath = 'public/data/compounds.json';
-
-  if (!fs.existsSync(herbsPath) || !fs.existsSync(compoundsPath)) {
-    console.error('Error: Required JSON files public/data/herbs.json or compounds.json are missing.');
-    process.exit(1);
-  }
-
-  const herbs = JSON.parse(fs.readFileSync(herbsPath, 'utf8'));
-  const compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'));
-
-  const allItems = [
-    ...herbs.map(h => ({ ...h, type: 'herb' })),
-    ...compounds.map(c => ({ ...c, type: 'compound' }))
-  ];
-
-  const totalScanned = allItems.length;
-  const issues = [];
-  const descriptionMap = {}; // description text -> array of items
-
-  allItems.forEach(item => {
-    const desc = (item.description || '').trim();
-    if (!desc) {
-      issues.push({
-        slug: item.slug,
-        name: item.name,
-        type: item.type,
-        issue: 'Empty Description',
-        value: '',
-        severity: 'HIGH'
-      });
-      return;
-    }
-
-    // 1. Group for exact duplicates checking
-    const normalizedDesc = desc.toLowerCase().replace(/\s+/g, ' ');
-    if (!descriptionMap[normalizedDesc]) {
-      descriptionMap[normalizedDesc] = [];
-    }
-    descriptionMap[normalizedDesc].push(item);
-
-    // 2. Length check (< 40 characters)
-    if (desc.length < 40) {
-      issues.push({
-        slug: item.slug,
-        name: item.name,
-        type: item.type,
-        issue: `Short Description (${desc.length} chars)`,
-        value: desc,
-        severity: 'MEDIUM'
-      });
-    }
-
-    // 3. Pattern/label check
-    QUALITY_PATTERNS.forEach(pat => {
-      if (pat.regex.test(desc)) {
-        issues.push({
-          slug: item.slug,
-          name: item.name,
-          type: item.type,
-          issue: `Flagged Pattern: "${pat.name}"`,
-          value: desc,
-          severity: pat.name.startsWith('Leaked') ? 'CRITICAL' : 'HIGH'
-        });
-      }
-    });
-  });
-
-  // Find exact duplicates
-  const duplicatesList = [];
-  Object.entries(descriptionMap).forEach(([descText, items]) => {
-    if (items.length > 1) {
-      duplicatesList.push({
-        description: items[0].description,
-        count: items.length,
-        items: items.map(item => ({ name: item.name, slug: item.slug, type: item.type }))
-      });
-
-      // Add duplicate issue for each item
-      items.forEach(item => {
-        issues.push({
-          slug: item.slug,
-          name: item.name,
-          type: item.type,
-          issue: `Duplicate Description (shared with ${items.length - 1} other profiles)`,
-          value: item.description,
-          severity: 'HIGH'
-        });
-      });
-    }
-  });
-
-  // Ensure reports dir exists
-  ensureDirExists('reports');
-
-  // Generate description-quality.md
-  let md = `# Description Quality Audit Report
-
-Generated on: ${new Date().toISOString()}
-
-## Summary Statistics
-
-- **Total Profiles Scanned**: ${totalScanned}
-- **Total Quality Issues Flagged**: ${issues.length}
-- **Critical Issues (Leaked Labels)**: ${issues.filter(i => i.severity === 'CRITICAL').length}
-- **High Severity (Empty / Template / Duplicates)**: ${issues.filter(i => i.severity === 'HIGH').length}
-- **Medium Severity (Short descriptions)**: ${issues.filter(i => i.severity === 'MEDIUM').length}
-- **Unique Duplicate Description Clusters**: ${duplicatesList.length}
-
-## Critical Leaks & Pipeline Warnings
-
-| Profile Name | Slug | Type | Identified Leak / Issue | Description Text |
-| --- | --- | --- | --- | --- |
-`;
-
-  const criticalIssues = issues.filter(i => i.severity === 'CRITICAL');
-  if (criticalIssues.length > 0) {
-    criticalIssues.forEach(i => {
-      md += `| **${i.name}** | \`${i.slug}\` | ${i.type} | ${i.issue} | \`${i.value}\` |\n`;
-    });
-  } else {
-    md += `| *None* | *None* | *None* | *No critical pipeline leaks detected!* | - |\n`;
-  }
-
-  md += `
-## Duplicate Description Clusters
-
-The following description strings are shared identically across multiple profiles:
-
-| Duplicate Count | Shared Profiles | Shared Description Text |
-| --- | --- | --- |
-`;
-
-  if (duplicatesList.length > 0) {
-    // Sort duplicates worst first (most items sharing)
-    duplicatesList.sort((a, b) => b.count - a.count);
-    duplicatesList.forEach(dup => {
-      const profilesStr = dup.items.map(item => `**${item.name}** (\`${item.slug}\` - ${item.type})`).join('<br>');
-      md += `| ${dup.count} | ${profilesStr} | \`${dup.description}\` |\n`;
-    });
-  } else {
-    md += `| *None* | *No duplicate description clusters found!* | - |\n`;
-  }
-
-  md += `
-## Worst Offenders List (High & Medium Severity Issues)
-
-Top 30 worst quality issues identified during description audit:
-
-| Profile Name | Slug | Type | Severity | Identified Quality Issue | Description Value |
-| --- | --- | --- | --- | --- | --- |
-`;
-
-  const otherIssues = issues.filter(i => i.severity !== 'CRITICAL')
-    .sort((a, b) => {
-      const sevOrder = { HIGH: 1, MEDIUM: 2 };
-      return sevOrder[a.severity] - sevOrder[b.severity] || a.name.localeCompare(b.name);
-    });
-
-  otherIssues.slice(0, 30).forEach(i => {
-    md += `| **${i.name}** | \`${i.slug}\` | ${i.type} | **${i.severity}** | ${i.issue} | \`${i.value || '*empty*'}\` |\n`;
-  });
-
-  fs.writeFileSync('reports/description-quality.md', md);
-  console.log('Wrote reports/description-quality.md.');
+function issueFor(item, issue, value, severity) {
+  return { slug: item.slug, name: item.name, type: item.type, issue, value, severity }
 }
 
-run();
+function run() {
+  const herbsPath = 'public/data/herbs.json'
+  const compoundsPath = 'public/data/compounds.json'
+  if (!fs.existsSync(herbsPath) || !fs.existsSync(compoundsPath)) {
+    console.error('Error: Required JSON files public/data/herbs.json or compounds.json are missing.')
+    process.exit(1)
+  }
+
+  const allItems = [
+    ...JSON.parse(fs.readFileSync(herbsPath, 'utf8')).map((item) => ({ ...item, type: 'herb' })),
+    ...JSON.parse(fs.readFileSync(compoundsPath, 'utf8')).map((item) => ({ ...item, type: 'compound' })),
+  ]
+
+  const issues = []
+  const descriptionMap = new Map()
+
+  for (const item of allItems) {
+    const description = normalizeStructuredText(item.description)
+
+    // Completeness is owned by content-gap-report/profile-completeness. This
+    // audit only records the bad description once, then focuses on qualities
+    // unique to prose: length, leaks, and duplicate text.
+    if (!hasMeaningfulText(description, DESCRIPTION_PLACEHOLDERS)) {
+      issues.push(issueFor(item, 'Missing or placeholder description', description, 'HIGH'))
+      continue
+    }
+
+    const normalized = description.toLowerCase()
+    const group = descriptionMap.get(normalized) ?? []
+    group.push(item)
+    descriptionMap.set(normalized, group)
+
+    if (description.length < 40) {
+      issues.push(issueFor(item, `Short Description (${description.length} chars)`, description, 'MEDIUM'))
+    }
+
+    for (const pattern of DESCRIPTION_LEAK_PATTERNS) {
+      if (!pattern.regex.test(description)) continue
+      issues.push(issueFor(
+        item,
+        `Flagged Pattern: "${pattern.name}"`,
+        description,
+        pattern.name.startsWith('Leaked') ? 'CRITICAL' : 'HIGH',
+      ))
+    }
+  }
+
+  const duplicatesList = []
+  for (const items of descriptionMap.values()) {
+    if (items.length <= 1) continue
+    const description = normalizeStructuredText(items[0].description)
+    duplicatesList.push({
+      description,
+      count: items.length,
+      items: items.map((item) => ({ name: item.name, slug: item.slug, type: item.type })),
+    })
+    for (const item of items) {
+      issues.push(issueFor(
+        item,
+        `Duplicate Description (shared with ${items.length - 1} other profiles)`,
+        description,
+        'HIGH',
+      ))
+    }
+  }
+
+  fs.mkdirSync('reports', { recursive: true })
+  const criticalIssues = issues.filter((issue) => issue.severity === 'CRITICAL')
+  const otherIssues = issues
+    .filter((issue) => issue.severity !== 'CRITICAL')
+    .sort((a, b) => ({ HIGH: 1, MEDIUM: 2 }[a.severity] - { HIGH: 1, MEDIUM: 2 }[b.severity]) || String(a.name).localeCompare(String(b.name)))
+  duplicatesList.sort((a, b) => b.count - a.count)
+
+  const lines = [
+    '# Description Quality Audit Report', '',
+    `Generated on: ${new Date().toISOString()}`, '',
+    'This audit intentionally does not independently score overall profile completeness. Missing/template description state is canonicalized by `lib/profile-completeness.mjs`; this report owns description-specific prose quality.', '',
+    '## Summary Statistics', '',
+    `- **Total Profiles Scanned**: ${allItems.length}`,
+    `- **Total Description Quality Issues Flagged**: ${issues.length}`,
+    `- **Critical Issues (Leaked Labels)**: ${criticalIssues.length}`,
+    `- **High Severity (Missing/template/leaks/duplicates)**: ${issues.filter((issue) => issue.severity === 'HIGH').length}`,
+    `- **Medium Severity (Short descriptions)**: ${issues.filter((issue) => issue.severity === 'MEDIUM').length}`,
+    `- **Unique Duplicate Description Clusters**: ${duplicatesList.length}`, '',
+    '## Critical Leaks & Pipeline Warnings', '',
+    '| Profile Name | Slug | Type | Identified Leak / Issue | Description Text |',
+    '| --- | --- | --- | --- | --- |',
+  ]
+
+  if (criticalIssues.length) {
+    for (const issue of criticalIssues) lines.push(`| **${issue.name}** | \`${issue.slug}\` | ${issue.type} | ${issue.issue} | \`${issue.value}\` |`)
+  } else {
+    lines.push('| *None* | *None* | *None* | *No critical pipeline leaks detected!* | - |')
+  }
+
+  lines.push('', '## Duplicate Description Clusters', '',
+    '| Duplicate Count | Shared Profiles | Shared Description Text |',
+    '| --- | --- | --- |')
+  if (duplicatesList.length) {
+    for (const duplicate of duplicatesList) {
+      const profiles = duplicate.items.map((item) => `**${item.name}** (\`${item.slug}\` - ${item.type})`).join('<br>')
+      lines.push(`| ${duplicate.count} | ${profiles} | \`${duplicate.description}\` |`)
+    }
+  } else {
+    lines.push('| *None* | *No duplicate description clusters found!* | - |')
+  }
+
+  lines.push('', '## Worst Offenders List', '',
+    '| Profile Name | Slug | Type | Severity | Identified Quality Issue | Description Value |',
+    '| --- | --- | --- | --- | --- | --- |')
+  for (const issue of otherIssues.slice(0, 30)) {
+    lines.push(`| **${issue.name}** | \`${issue.slug}\` | ${issue.type} | **${issue.severity}** | ${issue.issue} | \`${issue.value || '*empty*'}\` |`)
+  }
+  lines.push('')
+
+  fs.writeFileSync('reports/description-quality.md', lines.join('\n'))
+  console.log(`[description-quality] Scanned ${allItems.length} profiles; wrote reports/description-quality.md`)
+}
+
+run()


### PR DESCRIPTION
Broad cleanup pass 3.

- removes the description audit's second independent completeness model
- reuses canonical missing/placeholder normalization
- keeps description-specific responsibilities: short prose, duplicate clusters, TODO/FIXME/template leaks, and pipeline-text leakage
- documents the ownership boundary so future audits do not regrow completeness logic
- trims repeated helper/report boilerplate

Overall profile completeness remains owned by lib/profile-completeness.mjs and the content-gap audit.