### PR TITLE
fix(forms): handle zero-cardinality static export

### DIFF
--- a/app/guides/forms/[slug]/__tests__/static-export-forms.test.ts
+++ b/app/guides/forms/[slug]/__tests__/static-export-forms.test.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('forms route static-export contract', () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), 'app/guides/forms/[slug]/page.tsx'),
+    'utf8',
+  )
+
+  it('provides a sentinel static param when governance yields no indexable form pages', () => {
+    expect(source).toContain("const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'")
+    expect(source).toContain('return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]')
+  })
+
+  it('keeps the sentinel and any unknown slug out of rendered content', () => {
+    expect(source).toContain("import { notFound } from 'next/navigation'")
+    expect(source).toContain('if (!record) notFound()')
+  })
+})

--- a/app/guides/forms/[slug]/page.tsx
+++ b/app/guides/forms/[slug]/page.tsx
@@ -11,9 +11,12 @@ import {
   loadIndexableFormIngredients,
 } from '../form-data'
 
+const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'
+
 export async function generateStaticParams() {
   const ingredients = await loadIndexableFormIngredients()
-  return ingredients.map((record) => ({ slug: cleanFormValue(record.slug) }))
+  const realParams = ingredients.map((record) => ({ slug: cleanFormValue(record.slug) }))
+  return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {


### PR DESCRIPTION
## Summary
- provide a sentinel static param when governed form data yields zero indexable routes
- preserve 404 behavior for the sentinel and any unknown slug
- add a regression test for the zero-cardinality static-export contract

This continues the production-build blocker walk without weakening governance or creating duplicate/indexable fallback content.