### PR TITLE
fix(timing): handle empty governed static routes

### DIFF
--- a/app/guides/timing/[slug]/__tests__/static-export-timing.test.ts
+++ b/app/guides/timing/[slug]/__tests__/static-export-timing.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const routePaths = [
+  'app/guides/timing/[slug]/page.tsx',
+  'app/guides/timing/[slug]/morning-or-night/page.tsx',
+  'app/guides/timing/[slug]/with-or-without-food/page.tsx',
+]
+
+describe('timing guide static-export contracts', () => {
+  for (const routePath of routePaths) {
+    it(`${routePath} provides a 404-safe sentinel when its governed dataset is empty`, () => {
+      const source = fs.readFileSync(path.join(process.cwd(), routePath), 'utf8')
+      expect(source).toContain("const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'")
+      expect(source).toContain('return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]')
+      expect(source).toContain("import { notFound } from 'next/navigation'")
+      expect(source).toContain('if (!record) notFound()')
+    })
+  }
+})

--- a/app/guides/timing/[slug]/morning-or-night/page.tsx
+++ b/app/guides/timing/[slug]/morning-or-night/page.tsx
@@ -10,9 +10,12 @@ import {
   loadDaypartTimingIngredients,
 } from '../../timing-data'
 
+const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'
+
 export async function generateStaticParams() {
   const ingredients = await loadDaypartTimingIngredients()
-  return ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
+  const realParams = ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
+  return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {

--- a/app/guides/timing/[slug]/page.tsx
+++ b/app/guides/timing/[slug]/page.tsx
@@ -11,6 +11,8 @@ import {
   type RuntimeIngredient,
 } from '../timing-data'
 
+const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'
+
 function hasDaypartDecision(timing: string): boolean {
   return /\b(morning|afternoon|evening|night|nighttime|bedtime|before bed|daytime|earlier in the day|later in the day)\b/i.test(timing)
 }
@@ -23,7 +25,8 @@ function getFoodDecision(record: RuntimeIngredient, timing: string): string {
 
 export async function generateStaticParams() {
   const ingredients = await loadIndexableTimingIngredients()
-  return ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
+  const realParams = ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
+  return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {

--- a/app/guides/timing/[slug]/with-or-without-food/page.tsx
+++ b/app/guides/timing/[slug]/with-or-without-food/page.tsx
@@ -10,9 +10,12 @@ import {
   loadFoodTimingIngredients,
 } from '../../timing-data'
 
+const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'
+
 export async function generateStaticParams() {
   const ingredients = await loadFoodTimingIngredients()
-  return ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
+  const realParams = ingredients.map((record) => ({ slug: cleanTimingValue(record.slug) }))
+  return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {


### PR DESCRIPTION
## Summary
- make the parent timing guide route safe when governance yields zero indexable records
- make the morning-or-night and with-or-without-food subroutes independently safe when their narrower datasets are empty
- retain `notFound()` behavior so sentinel params never become content
- add a regression test covering the whole timing route family

This prevents the same Next.js static-export zero-cardinality failure from reappearing one timing route at a time.