### PR TITLE
fix(interactions): handle empty governed static routes

### DIFF
--- a/app/guides/interactions/[slug]/[medicationClass]/page.tsx
+++ b/app/guides/interactions/[slug]/[medicationClass]/page.tsx
@@ -16,6 +16,9 @@ type MedicationClass = {
   pattern: RegExp
 }
 
+const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'
+const EMPTY_STATIC_EXPORT_MEDICATION_CLASS = '__static-export-empty__'
+
 const MEDICATION_CLASSES: MedicationClass[] = [
   { slug: 'antidepressants', label: 'antidepressants', pattern: /\b(antidepressant|ssri|snri|maoi|serotonergic)\b/i },
   { slug: 'sedatives', label: 'sedatives and CNS depressants', pattern: /\b(sedative|benzodiazepine|cns depressant|sleep medication|hypnotic)\b/i },
@@ -31,13 +34,17 @@ const MEDICATION_CLASSES: MedicationClass[] = [
 
 export async function generateStaticParams() {
   const records = await loadIndexableInteractionIngredients()
-  return records.flatMap((record) => {
+  const realParams = records.flatMap((record) => {
     const slug = cleanInteractionValue(record.slug)
     const interactions = interactionValueToText(record.interactions)
     return MEDICATION_CLASSES
       .filter((medicationClass) => medicationClass.pattern.test(interactions))
       .map((medicationClass) => ({ slug, medicationClass: medicationClass.slug }))
   })
+
+  return realParams.length
+    ? realParams
+    : [{ slug: EMPTY_STATIC_EXPORT_SLUG, medicationClass: EMPTY_STATIC_EXPORT_MEDICATION_CLASS }]
 }
 
 async function resolvePage(slug: string, medicationClassSlug: string) {

--- a/app/guides/interactions/[slug]/__tests__/static-export-interactions.test.ts
+++ b/app/guides/interactions/[slug]/__tests__/static-export-interactions.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('interaction guide static-export contracts', () => {
+  it('keeps the parent interaction route buildable when governance yields no indexable records', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'app/guides/interactions/[slug]/page.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain("const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'")
+    expect(source).toContain('return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]')
+    expect(source).toContain('if (!record) notFound()')
+  })
+
+  it('keeps the medication-class route buildable when no class-specific pages survive governance', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'app/guides/interactions/[slug]/[medicationClass]/page.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain("const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'")
+    expect(source).toContain("const EMPTY_STATIC_EXPORT_MEDICATION_CLASS = '__static-export-empty__'")
+    expect(source).toContain('if (!resolved) notFound()')
+  })
+})

--- a/app/guides/interactions/[slug]/page.tsx
+++ b/app/guides/interactions/[slug]/page.tsx
@@ -10,9 +10,12 @@ import {
   loadIndexableInteractionIngredients,
 } from '../interaction-data'
 
+const EMPTY_STATIC_EXPORT_SLUG = '__static-export-empty__'
+
 export async function generateStaticParams() {
   const ingredients = await loadIndexableInteractionIngredients()
-  return ingredients.map((record) => ({ slug: cleanInteractionValue(record.slug) }))
+  const realParams = ingredients.map((record) => ({ slug: cleanInteractionValue(record.slug) }))
+  return realParams.length ? realParams : [{ slug: EMPTY_STATIC_EXPORT_SLUG }]
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {


### PR DESCRIPTION
## Summary
- make the parent interaction guide safe when governance yields zero indexable records
- make the medication-class subroute safe when no class-specific pages survive filtering
- preserve 404 behavior for sentinel params
- add regression coverage for both interaction routes

This closes the remaining zero-cardinality pattern among the governed guide datasets discovered in the route audit.