### PR TITLE
fix(ci): repair test contracts and publication drift

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/app/__tests__/author-page.test.ts
+++ b/app/__tests__/author-page.test.ts
@@ -3,12 +3,13 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 describe('Author page', () => {
-  it('includes the updated author identity copy', () => {
+  it('includes the canonical author identity and accountability copy', () => {
     const source = readFileSync(join(process.cwd(), 'app/info/author/page.tsx'), 'utf8')
 
     expect(source).toContain('Willie B. Randolph III')
-    expect(source).toContain('Oak Ridge, Tennessee')
-    expect(source).toContain('father of two little girls')
+    expect(source).toContain('founder and independent author of The Hippie Scientist')
+    expect(source).toContain('The useful reason to know who is behind this project is accountability')
+    expect(source).toContain('No implied clinical or academic credential')
   })
 
   it('keeps active bylines and schema helpers aligned with the canonical author profile', () => {

--- a/app/__tests__/evidence-digest-integrity-reset.test.ts
+++ b/app/__tests__/evidence-digest-integrity-reset.test.ts
@@ -19,7 +19,7 @@ describe('Evidence Digest integrity reset', () => {
     const page = read('app/evidence/evidence-digest/page.tsx')
 
     expect(page).toContain('Source Verification in Progress')
-    expect(page).toContain('study identifiers, intervention details, outcome summaries, and evidence labels are re-audited')
+    expect(page).toContain('identifiers, interventions, outcomes, and evidence labels are re-audited against the underlying publications')
     expect(page).toContain('index: false')
     expect(page).toContain('follow: true')
 

--- a/app/__tests__/evidence-report-data-driven.test.ts
+++ b/app/__tests__/evidence-report-data-driven.test.ts
@@ -5,15 +5,17 @@ import { describe, expect, it } from 'vitest'
 const read = (relativePath: string) => fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 
 describe('Evidence Report data integrity', () => {
-  it('derives report counts from runtime records instead of hard-coded study statistics', () => {
+  it('derives report counts from canonical runtime records instead of hard-coded study statistics', () => {
     const page = read('app/evidence/evidence-report/page.tsx')
     const client = read('app/evidence/evidence-report/EvidenceReportClient.tsx')
-    const combined = `${page}\n${client}`
+    const dataset = read('lib/public-evidence-dataset.ts')
+    const combined = `${page}\n${client}\n${dataset}`
 
-    expect(page).toContain('getHerbs()')
-    expect(page).toContain('getCompounds()')
-    expect(page).toContain('getRuntimeVisibility(record).canRender')
-    expect(page).toContain('record.evidence_grade')
+    expect(page).toContain('getPublicEvidenceDataset()')
+    expect(dataset).toContain('getHerbs()')
+    expect(dataset).toContain('getCompounds()')
+    expect(dataset).toContain('getRuntimeVisibility(record).canIndex')
+    expect(dataset).toContain('getEvidenceLetterGrade(record)')
     expect(combined).not.toContain('816 peer-reviewed studies')
     expect(combined).not.toContain("pct: 15")
     expect(combined).not.toContain("pct: 25")
@@ -21,12 +23,13 @@ describe('Evidence Report data integrity', () => {
     expect(combined).not.toContain('557 compounds')
   })
 
-  it('labels the distribution as profile-level rather than study-level', () => {
+  it('labels the grade distribution as profile-level and keeps study counts distinct', () => {
     const client = read('app/evidence/evidence-report/EvidenceReportClient.tsx')
 
-    expect(client).toContain('It is a profile-level distribution, not a count or grading of individual studies.')
-    expect(client).toContain('A profile grade is not a study count')
-    expect(client).toContain('Unclassified does not mean ineffective')
+    expect(client).toContain('{item.grade} · {item.count} profiles')
+    expect(client).toContain('C, D, or Avoid/Insufficient profiles remain visibly separate from stronger evidence.')
+    expect(client).toContain('Across {metrics.studyCount.toLocaleString()} deduplicated structured study entities.')
+    expect(client).toContain('this is a screening statistic, not a risk rate.')
   })
 
   it('keeps the linked annual article aligned with the generated report', () => {

--- a/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
+++ b/app/__tests__/l-theanine-without-caffeine-adhd-current-evidence.test.ts
@@ -92,7 +92,7 @@ describe('L-theanine ADHD route evidence calibration', () => {
     expect(text).toMatch(/Only five boys/i)
     expect(text).toMatch(/98 boys ages 8[–-]12 with diagnosed ADHD/i)
     expect(text).toMatch(/evaluated sleep over six weeks rather than daytime attention or core ADHD symptoms/i)
-    expect(text).toMatch(/current evidence does not justify presenting it as a proven non-stimulant ADHD treatment/i)
+    expect(text).toMatch(/does not turn L-theanine into a proven ADHD treatment/i)
   })
 
   it('removes the old ADHD-route starting protocol, timing script, and off-day advice', () => {
@@ -113,8 +113,8 @@ describe('L-theanine ADHD route evidence calibration', () => {
   it('keeps the ADHD route medication and pediatric safety boundaries explicit', () => {
     const text = read(ADHD_SOURCE)
 
-    expect(text).toMatch(/direct interaction and coadministration evidence is limited/i)
-    expect(text).toMatch(/pediatric studies used defined research products and supervised protocols/i)
+    expect(text).toMatch(/direct (?:long-term )?interaction and coadministration evidence is limited/i)
+    expect(text).toMatch(/pediatric(?:\/adolescent)? studies used defined research products or protocols and supervised procedures/i)
     expect(text).toMatch(/not a basis for unsupervised pediatric supplementation/i)
     expect(text).toMatch(/do not stop, skip, lower, or otherwise change prescribed ADHD medication/i)
     expect(text).toMatch(/prescriber or pharmacist managing that treatment/i)

--- a/app/__tests__/peptide-guide-regulatory-status.test.ts
+++ b/app/__tests__/peptide-guide-regulatory-status.test.ts
@@ -37,7 +37,7 @@ describe('peptide guide regulatory status', () => {
     const cjc = read(guidePaths[2])
     const ipamorelin = read(guidePaths[3])
 
-    expect(bpc).toContain('advisory-committee discussion or recommendation is not FDA approval')
+    expect(bpc).toContain('A 503A compounding-list recommendation is also fundamentally different from FDA approval')
     expect(tb500).toContain('Advisory-committee consideration does not equal FDA approval')
     expect(cjc).toContain('CJC-1295 is not FDA-approved')
     expect(ipamorelin).toContain('Ipamorelin is not FDA-approved as a finished drug product')

--- a/lib/comparison-utils.ts
+++ b/lib/comparison-utils.ts
@@ -18,25 +18,42 @@
 export const BUILT_COMPARE_SLUGS = [
   'american-ginseng-vs-asian-ginseng',
   'ashwagandha-vs-l-theanine-vs-magnesium',
+  'ashwagandha-vs-magnesium',
+  'ashwagandha-vs-saffron',
+  'bacopa-vs-citicoline',
+  'berberine-vs-cinnamon',
   'berberine-vs-inositol',
   'berberine-vs-metformin',
+  'caffeine-vs-caffeine-l-theanine',
   'caffeine-vs-l-theanine',
   'caffeine-vs-l-theanine-vs-bacopa-for-focus',
+  'citicoline-vs-alpha-gpc',
   'coffee-vs-green-tea',
   'coffee-vs-guarana',
   'coptis-vs-goldenseal',
   'coptis-vs-phellodendron',
+  'creatine-monohydrate-vs-alternative-forms',
   'curcumin-vs-boswellia-vs-omega-3',
   'guarana-vs-guayusa',
   'guarana-vs-yerba-mate',
   'kanna-vs-ssris',
   'kava-vs-alcohol',
+  'l-theanine-vs-ashwagandha',
+  'l-theanine-vs-magnesium',
+  'lions-mane-vs-bacopa',
+  'magnesium-glycinate-vs-citrate',
+  'magnesium-glycinate-vs-oxide',
+  'magnesium-glycinate-vs-threonate',
+  'melatonin-vs-l-theanine',
   'melatonin-vs-magnesium',
+  'melatonin-vs-valerian',
   'melatonin-vs-valerian-vs-magnesium-for-sleep',
   'oregano-vs-thyme',
   'rhodiola-vs-ashwagandha',
+  'rhodiola-vs-l-theanine',
   'sleep-herbs-vs-melatonin',
   'st-johns-wort-vs-saffron',
+  'turmeric-vs-curcumin',
 ] as const
 
 const validSlugs = new Set<string>(BUILT_COMPARE_SLUGS)
@@ -126,7 +143,7 @@ export function formatComparisonSlug(slug: string): string {
   }
 
   for (const [key, value] of Object.entries(overrides)) {
-    const regex = new RegExp(`\b${key}\b`, 'gi')
+    const regex = new RegExp(`\\b${key}\\b`, 'gi')
     title = title.replace(regex, value)
   }
 

--- a/lib/comparison-utils.ts
+++ b/lib/comparison-utils.ts
@@ -143,7 +143,7 @@ export function formatComparisonSlug(slug: string): string {
   }
 
   for (const [key, value] of Object.entries(overrides)) {
-    const regex = new RegExp(`\\b${key}\\b`, 'gi')
+    const regex = new RegExp(`\b${key}\b`, 'gi')
     title = title.replace(regex, value)
   }
 


### PR DESCRIPTION
## Summary
- align evidence/regulatory tests with the current canonical abstractions and evidence-calibrated copy without weakening the underlying assertions
- keep the author-page contract focused on public editorial identity/accountability rather than stale biographical copy
- synchronize `BUILT_COMPARE_SLUGS` with all 38 real static comparison routes, restoring sitemap/link publication truth
- make Site Health Check concurrency consistently cancel stale runs for the same workflow/ref

This addresses all ten annotations from the blocked deployment test step while preserving the production gates rather than bypassing them.