### PR TITLE
refactor(research): centralize claim-quality analysis

### DIFF
--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -1,0 +1,219 @@
+import {
+  approvedClaims,
+  canonicalStudyClass,
+  canonicalStudyGroups,
+  canonicalStudyIdentityMap,
+  listResearchProfiles,
+  loadPubmedCache,
+  NARRATIVE_STUDY_CLASSES,
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  sourceMap,
+  SYNTHESIS_STUDY_CLASSES,
+  uniqueClaimStudyIdentities,
+  uniqueSourceRefs,
+  type PubmedCache,
+  type ResearchClaim,
+  type ResearchProfile,
+} from './research-coverage'
+
+export type ClaimSupportTier =
+  | 'unsupported'
+  | 'unclassified'
+  | 'narrative-only'
+  | 'indirect-only'
+  | 'human-supported'
+  | 'non-outcome'
+
+export type ClaimQualityAnalysis = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  sourceRefCount: number
+  validSourceRefCount: number
+  danglingSourceRefs: string[]
+  studyCount: number
+  classifiedStudyCount: number
+  primaryHuman: number
+  synthesis: number
+  narrative: number
+  designs: string[]
+  outcomeClaim: boolean
+  supportTier: ClaimSupportTier
+  highConfidenceWeakOutcome: boolean
+  singleStudy: boolean
+  aliasCollapsed: boolean
+}
+
+export type ProfileQualityAnalysis = {
+  url: string
+  sourceCount: number
+  canonicalStudyCount: number
+  claimCount: number
+  approvedClaimCount: number
+  designMix: Record<string, number>
+  primaryHuman: number
+  synthesis: number
+  narrativeReview: number
+  unsupportedApprovedClaims: string[]
+  singleStudyApprovedClaims: string[]
+  aliasCollapsedClaims: string[]
+  danglingSourceRefs: Array<{ claimId: string; sourceRefId: string }>
+  mostUsedStudyIdentity: string | null
+  mostUsedStudyClaimCount: number
+  studyDependencyShare: number
+  reviewDominated: boolean
+  noPrimaryHuman: boolean
+}
+
+export type ResearchQualityAnalysis = {
+  cache: PubmedCache
+  profiles: ReturnType<typeof listResearchProfiles>
+  profileAnalyses: ProfileQualityAnalysis[]
+  claimAnalyses: ClaimQualityAnalysis[]
+}
+
+function analyzeClaim(
+  url: string,
+  claim: ResearchClaim,
+  record: ResearchProfile,
+  cache: PubmedCache,
+): ClaimQualityAnalysis {
+  const sourcesById = sourceMap(record)
+  const identities = canonicalStudyIdentityMap(record)
+  const groups = canonicalStudyGroups(record)
+  const refs = uniqueSourceRefs(claim)
+  const validRefs = refs.filter((ref) => sourcesById.has(ref))
+  const danglingSourceRefs = refs.filter((ref) => !sourcesById.has(ref))
+  const studyIds = uniqueClaimStudyIdentities(claim, identities)
+  const designs = studyIds
+    .map((studyId) => groups.get(studyId))
+    .filter((group): group is NonNullable<typeof group> => Boolean(group))
+    .map((group) => canonicalStudyClass(group, cache))
+  const classified = designs.filter((design) => design !== 'unclassified')
+  const primaryHuman = classified.filter((design) => PRIMARY_HUMAN_STUDY_CLASSES.has(design)).length
+  const synthesis = classified.filter((design) => SYNTHESIS_STUDY_CLASSES.has(design)).length
+  const narrative = classified.filter((design) => NARRATIVE_STUDY_CLASSES.has(design)).length
+  const predicate = String(claim.predicate ?? '')
+  const outcomeClaim = predicate === 'supports_outcome'
+  const confidence = Number(claim.confidence ?? 0)
+  const strongHumanSupport = primaryHuman + synthesis > 0
+
+  let supportTier: ClaimSupportTier = 'non-outcome'
+  if (studyIds.length === 0) supportTier = 'unsupported'
+  else if (classified.length === 0) supportTier = 'unclassified'
+  else if (outcomeClaim && narrative === classified.length) supportTier = 'narrative-only'
+  else if (outcomeClaim && !strongHumanSupport) supportTier = 'indirect-only'
+  else if (outcomeClaim) supportTier = 'human-supported'
+
+  const weakOutcome = supportTier === 'narrative-only' || supportTier === 'indirect-only'
+
+  return {
+    url,
+    claimId: String(claim.id ?? 'unknown-claim'),
+    predicate,
+    confidence,
+    sourceRefCount: refs.length,
+    validSourceRefCount: validRefs.length,
+    danglingSourceRefs,
+    studyCount: studyIds.length,
+    classifiedStudyCount: classified.length,
+    primaryHuman,
+    synthesis,
+    narrative,
+    designs,
+    outcomeClaim,
+    supportTier,
+    highConfidenceWeakOutcome:
+      outcomeClaim && confidence >= 0.75 && (weakOutcome || supportTier === 'unclassified' || supportTier === 'unsupported'),
+    singleStudy: studyIds.length === 1,
+    aliasCollapsed: validRefs.length > studyIds.length && studyIds.length > 0,
+  }
+}
+
+function analyzeProfile(
+  url: string,
+  record: ResearchProfile,
+  cache: PubmedCache,
+  claims: ClaimQualityAnalysis[],
+): ProfileQualityAnalysis {
+  const sources = Array.isArray(record.sources) ? record.sources : []
+  const allClaims = Array.isArray(record.claimMap) ? record.claimMap : []
+  const approved = approvedClaims(record)
+  const studyGroups = canonicalStudyGroups(record)
+  const designMix: Record<string, number> = {}
+  let primaryHuman = 0
+  let synthesis = 0
+  let narrativeReview = 0
+
+  for (const group of studyGroups.values()) {
+    const design = canonicalStudyClass(group, cache)
+    designMix[design] = (designMix[design] ?? 0) + 1
+    if (PRIMARY_HUMAN_STUDY_CLASSES.has(design)) primaryHuman += 1
+    if (SYNTHESIS_STUDY_CLASSES.has(design)) synthesis += 1
+    if (NARRATIVE_STUDY_CLASSES.has(design)) narrativeReview += 1
+  }
+
+  const claimById = new Map(claims.map((claim) => [claim.claimId, claim]))
+  const unsupportedApprovedClaims: string[] = []
+  const singleStudyApprovedClaims: string[] = []
+  const aliasCollapsedClaims: string[] = []
+  const danglingSourceRefs: Array<{ claimId: string; sourceRefId: string }> = []
+  const studyUse = new Map<string, number>()
+  const identities = canonicalStudyIdentityMap(record)
+
+  for (const claim of approved) {
+    const claimId = String(claim.id ?? 'unknown-claim')
+    const analysis = claimById.get(claimId)
+    if (!analysis) continue
+
+    if (analysis.supportTier === 'unsupported') unsupportedApprovedClaims.push(claimId)
+    if (analysis.singleStudy) singleStudyApprovedClaims.push(claimId)
+    if (analysis.aliasCollapsed) aliasCollapsedClaims.push(claimId)
+    for (const sourceRefId of analysis.danglingSourceRefs) danglingSourceRefs.push({ claimId, sourceRefId })
+    for (const study of uniqueClaimStudyIdentities(claim, identities)) {
+      studyUse.set(study, (studyUse.get(study) ?? 0) + 1)
+    }
+  }
+
+  const mostUsed = [...studyUse.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0] ?? null
+  const mostUsedStudyClaimCount = mostUsed?.[1] ?? 0
+  const studyDependencyShare = approved.length ? mostUsedStudyClaimCount / approved.length : 0
+  const classified = primaryHuman + synthesis + narrativeReview
+
+  return {
+    url,
+    sourceCount: sources.length,
+    canonicalStudyCount: studyGroups.size,
+    claimCount: allClaims.length,
+    approvedClaimCount: approved.length,
+    designMix,
+    primaryHuman,
+    synthesis,
+    narrativeReview,
+    unsupportedApprovedClaims,
+    singleStudyApprovedClaims,
+    aliasCollapsedClaims,
+    danglingSourceRefs,
+    mostUsedStudyIdentity: mostUsed?.[0] ?? null,
+    mostUsedStudyClaimCount,
+    studyDependencyShare: Number(studyDependencyShare.toFixed(3)),
+    reviewDominated: classified >= 3 && narrativeReview / classified >= 0.6,
+    noPrimaryHuman: approved.length > 0 && primaryHuman === 0,
+  }
+}
+
+export function analyzeResearchQuality(root = process.cwd()): ResearchQualityAnalysis {
+  const cache = loadPubmedCache(root)
+  const profiles = listResearchProfiles(root)
+  const claimAnalyses: ClaimQualityAnalysis[] = []
+  const profileAnalyses: ProfileQualityAnalysis[] = []
+
+  for (const { url, record } of profiles) {
+    const claims = approvedClaims(record).map((claim) => analyzeClaim(url, claim, record, cache))
+    claimAnalyses.push(...claims)
+    profileAnalyses.push(analyzeProfile(url, record, cache, claims))
+  }
+
+  return { cache, profiles, profileAnalyses, claimAnalyses }
+}

--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -1,81 +1,17 @@
 #!/usr/bin/env npx tsx
-/** Claim-level evidence strength audit over independent canonical studies. */
+/** Claim-level evidence strength report derived from the canonical research-quality analysis. */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
-import {
-  approvedClaims,
-  canonicalStudyClass,
-  canonicalStudyGroups,
-  canonicalStudyIdentityMap,
-  listResearchProfiles,
-  loadPubmedCache,
-  NARRATIVE_STUDY_CLASSES,
-  PRIMARY_HUMAN_STUDY_CLASSES,
-  SYNTHESIS_STUDY_CLASSES,
-  uniqueClaimStudyIdentities,
-  uniqueSourceRefs,
-} from '../../lib/research-coverage'
+import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 
 const ROOT = process.cwd()
 const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'claim-evidence-strength.json')
-const cache = loadPubmedCache(ROOT)
-const claims: Array<Record<string, unknown>> = []
-
-type SupportTier = 'unsupported' | 'unclassified' | 'narrative-only' | 'indirect-only' | 'human-supported' | 'non-outcome'
-
-for (const { url, record } of listResearchProfiles(ROOT)) {
-  const identities = canonicalStudyIdentityMap(record)
-  const groups = canonicalStudyGroups(record)
-
-  for (const claim of approvedClaims(record)) {
-    const refs = uniqueSourceRefs(claim)
-    const studyIds = uniqueClaimStudyIdentities(claim, identities)
-    const designs = studyIds
-      .map((studyId) => groups.get(studyId))
-      .filter((group): group is NonNullable<typeof group> => Boolean(group))
-      .map((group) => canonicalStudyClass(group, cache))
-    const classified = designs.filter((design) => design !== 'unclassified')
-    const primaryHuman = classified.filter((design) => PRIMARY_HUMAN_STUDY_CLASSES.has(design)).length
-    const synthesis = classified.filter((design) => SYNTHESIS_STUDY_CLASSES.has(design)).length
-    const narrative = classified.filter((design) => NARRATIVE_STUDY_CLASSES.has(design)).length
-    const predicate = String(claim.predicate ?? '')
-    const outcomeClaim = predicate === 'supports_outcome'
-    const confidence = Number(claim.confidence ?? 0)
-    const strongHumanSupport = primaryHuman + synthesis > 0
-
-    let supportTier: SupportTier = 'non-outcome'
-    if (studyIds.length === 0) supportTier = 'unsupported'
-    else if (classified.length === 0) supportTier = 'unclassified'
-    else if (outcomeClaim && narrative === classified.length) supportTier = 'narrative-only'
-    else if (outcomeClaim && !strongHumanSupport) supportTier = 'indirect-only'
-    else if (outcomeClaim) supportTier = 'human-supported'
-
-    const weakOutcome = supportTier === 'narrative-only' || supportTier === 'indirect-only'
-
-    claims.push({
-      url,
-      claimId: String(claim.id ?? 'unknown-claim'),
-      predicate,
-      confidence,
-      sourceRefCount: refs.length,
-      studyCount: studyIds.length,
-      classifiedStudyCount: classified.length,
-      primaryHuman,
-      synthesis,
-      narrative,
-      designs,
-      outcomeClaim,
-      supportTier,
-      highConfidenceWeakOutcome: outcomeClaim && confidence >= 0.75 && (weakOutcome || supportTier === 'unclassified' || supportTier === 'unsupported'),
-    })
-  }
-}
+const { claimAnalyses: claims } = analyzeResearchQuality(ROOT)
 
 const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
-  const tier = String(claim.supportTier)
-  counts[tier] = (counts[tier] ?? 0) + 1
+  counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
   return counts
 }, {})
 


### PR DESCRIPTION
Creates `lib/research-quality-analysis.ts` as the canonical low-level analyzer for approved structured claims and profile evidence topology. Rewires the claim-evidence-strength report to consume the shared analysis instead of recomputing study identities/classes/support tiers independently. This is the first consolidation step toward one authoritative research-quality pipeline.