### PR TITLE
cleanup: centralize structured value usefulness

### DIFF
--- a/lib/__tests__/data-quality.test.ts
+++ b/lib/__tests__/data-quality.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   collectionHasMeaningfulText,
   hasMeaningfulText,
+  hasUsefulStructuredValue,
   isMissingLike,
   normalizeStructuredText,
 } from '@/lib/data-quality.mjs'
@@ -27,5 +28,15 @@ describe('canonical data quality primitives', () => {
   it('handles arrays through the same predicate', () => {
     expect(collectionHasMeaningfulText(['placeholder', 'Avoid with anticoagulants.'])).toBe(true)
     expect(collectionHasMeaningfulText(['placeholder', 'research-only'])).toBe(false)
+  })
+
+  it('recognizes useful structured values consistently', () => {
+    expect(hasUsefulStructuredValue(null)).toBe(false)
+    expect(hasUsefulStructuredValue('N/A')).toBe(false)
+    expect(hasUsefulStructuredValue([])).toBe(false)
+    expect(hasUsefulStructuredValue({})).toBe(false)
+    expect(hasUsefulStructuredValue(0)).toBe(true)
+    expect(hasUsefulStructuredValue(['x'])).toBe(true)
+    expect(hasUsefulStructuredValue({ value: 'x' })).toBe(true)
   })
 })

--- a/lib/data-quality.mjs
+++ b/lib/data-quality.mjs
@@ -20,6 +20,14 @@ export function isMissingLike(value) {
   return MISSING_LIKE_VALUES.has(normalizeStructuredText(value).toLowerCase())
 }
 
+export function hasUsefulStructuredValue(value) {
+  if (value === undefined || value === null) return false
+  if (typeof value === 'string' || typeof value === 'number') return !isMissingLike(value)
+  if (Array.isArray(value)) return value.length > 0
+  if (typeof value === 'object') return Object.keys(value).length > 0
+  return Boolean(value)
+}
+
 export function hasMeaningfulText(value, extraPatterns = []) {
   const text = normalizeStructuredText(value)
   if (isMissingLike(text)) return false

--- a/scripts/data/ai-entity-artifacts.mjs
+++ b/scripts/data/ai-entity-artifacts.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { hasUsefulStructuredValue } from '../../lib/data-quality.mjs'
 import { buildAiEntityArtifacts as buildBaseAiEntityArtifacts } from './ai-entity-enrichment-lib.mjs'
 
 function normalizeSchemaTypes(value) {
@@ -43,13 +44,6 @@ async function normalizeArtifactDirectory(directory) {
     }))
 }
 
-function hasUsefulValue(value) {
-  if (value === undefined || value === null || value === '') return false
-  if (Array.isArray(value)) return value.length > 0
-  if (typeof value === 'object') return Object.keys(value).length > 0
-  return true
-}
-
 function mergeSummaryWithDetail(summary, detail) {
   if (!detail || typeof detail !== 'object' || Array.isArray(detail)) return summary
 
@@ -59,7 +53,7 @@ function mergeSummaryWithDetail(summary, detail) {
     // root value, but let the richer detail payload fill fields that were
     // intentionally omitted or collapsed by summary generation (citations,
     // claims, review provenance, relationships, safety detail, identifiers).
-    if (hasUsefulValue(value) || !hasUsefulValue(merged[key])) {
+    if (hasUsefulStructuredValue(value) || !hasUsefulStructuredValue(merged[key])) {
       merged[key] = value
     }
   }


### PR DESCRIPTION
Broad cleanup pass 4.

- adds one canonical predicate for whether scalar/container structured data is usefully populated
- removes the AI entity hydration layer's private duplicate implementation
- aligns summary/detail merge behavior with the same missing-like vocabulary used by content and workbook audits
- extends canonical data-quality regression coverage

This continues consolidating low-level data semantics before tackling the larger slug identity scripts.