### PR TITLE
fix(tests): close remaining contract and safety gaps

### DIFF
--- a/app/__tests__/peptide-guide-regulatory-status.test.ts
+++ b/app/__tests__/peptide-guide-regulatory-status.test.ts
@@ -49,7 +49,8 @@ describe('peptide guide regulatory status', () => {
     const cjc = read(guidePaths[2])
     const ipamorelin = read(guidePaths[3])
 
-    expect(bpc).toMatch(/no or only limited safety information/i)
+    expect(bpc).toMatch(/no or only limited safety-related information/i)
+    expect(bpc).toMatch(/lacks sufficient information to know whether compounded use would cause harm in humans/i)
     expect(tb500).toMatch(/not identified human exposure data/i)
     expect(cjc).toMatch(/increased heart rate and a systemic vasodilatory reaction/i)
     expect(ipamorelin).toMatch(/serious adverse events, including deaths/i)

--- a/app/__tests__/profile-toc-accessibility.test.ts
+++ b/app/__tests__/profile-toc-accessibility.test.ts
@@ -6,12 +6,12 @@ const source = readFileSync(join(process.cwd(), 'components/ui/ProfileTOC.tsx'),
 
 describe('ProfileTOC accessibility contract', () => {
   it('keeps mobile controls and jump links at least 44px tall', () => {
-    expect(source.match(/min-h-11/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(source.match(/min-h-(?:11|12)/g)?.length).toBeGreaterThanOrEqual(2)
   })
 
   it('provides visible keyboard focus treatment', () => {
     expect(source.match(/focus-visible:ring-2/g)?.length).toBeGreaterThanOrEqual(2)
-    expect(source).toContain('focus-visible:ring-brand-600')
+    expect(source).toContain('focus-visible:ring-[color:var(--hs-gold)]')
   })
 
   it('preserves desktop sticky navigation', () => {

--- a/app/__tests__/see-also-cluster-accessibility.test.ts
+++ b/app/__tests__/see-also-cluster-accessibility.test.ts
@@ -13,7 +13,7 @@ describe('SeeAlsoCluster accessibility contract', () => {
 
   it('provides visible keyboard focus treatment and directional cues', () => {
     expect(source).toContain('focus-visible:ring-2')
-    expect(source).toContain('focus-visible:ring-brand-600')
+    expect(source).toContain('focus-visible:ring-[color:var(--hs-gold)]')
     expect(source).toContain('{entry.label} →')
   })
 })

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -4,7 +4,7 @@ import { buildPageMetadata } from '@/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Research Tools | The Hippie Scientist',
-  description: 'Interactive evidence, comparison, safety, and botanical research tools from The Hippie Scientist.',
+  description: 'Interactive research tools for comparing botanicals, evidence, activity, compounds, and safety context.',
   path: '/tools/',
 })
 

--- a/components/__tests__/AffiliateProductCard.regional.test.tsx
+++ b/components/__tests__/AffiliateProductCard.regional.test.tsx
@@ -22,7 +22,7 @@ describe('AffiliateProductCard regional URLs', () => {
       />,
     )
 
-    expect(screen.getByRole('link', { name: /check current price/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /view product details for test magnesium/i })).toHaveAttribute(
       'href',
       'https://www.amazon.co.uk/test-magnesium',
     )
@@ -42,7 +42,7 @@ describe('AffiliateProductCard regional URLs', () => {
       />,
     )
 
-    expect(screen.getByRole('link', { name: /check current price/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /view product details for test theanine/i })).toHaveAttribute(
       'href',
       'https://www.amazon.com/test-theanine',
     )
@@ -58,7 +58,7 @@ describe('AffiliateProductCard regional URLs', () => {
       />,
     )
 
-    expect(screen.getByRole('link', { name: /check current price/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /view product details for test rhodiola/i })).toHaveAttribute(
       'rel',
       'sponsored nofollow noopener noreferrer',
     )

--- a/lib/metadata-experiment-policy.ts
+++ b/lib/metadata-experiment-policy.ts
@@ -42,7 +42,7 @@ export function classifyMetadataIntent(query: string): MetadataIntent {
   if (/\b(vs|versus|compare|comparison|alternative)\b/.test(value)) return 'comparison'
   if (/\b(dose|dosage|how much|mg|gram)\b/.test(value)) return 'dose'
   if (/\b(when|morning|night|time to take|before bed|with food|empty stomach)\b/.test(value)) return 'timing'
-  if (/\b(safe|safety|interaction|side effect|risk|contraindication|warning)\b/.test(value)) return 'safety'
+  if (/\b(safe|safety|interaction|side effects?|risks?|contraindications?|warnings?)\b/.test(value)) return 'safety'
   if (/\b(best brand|buy|quality|extract|form|glycinate|citrate|standardized|third party|coa)\b/.test(value)) return 'product-quality'
   return 'general'
 }

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -164,7 +164,7 @@ function hasSafetyCaution(record: RuntimeRecord): boolean {
     cleanString(record.safety_level),
   ].join(' ').toLowerCase()
 
-  return /\b(avoid|contraindicat|caution|interaction|pregnan|breastfeed|liver|kidney|bleed|sedat|stimul|risk|toxic|monitor)\b/.test(text)
+  return /\b(avoid(?:ance)?|contraindicat(?:e|ed|es|ion|ions)?|caution(?:s|ary)?|interactions?|pregnan(?:t|cy)|breastfeed(?:ing)?|liver|kidney|bleed(?:ing)?|sedat(?:e|ed|ion|ive)?|stimul(?:ant|ation)?|risks?|toxic(?:ity)?|monitor(?:ing)?)\b/.test(text)
 }
 
 function hasExplicitClaimOverreachFlag(record: RuntimeRecord): boolean {


### PR DESCRIPTION
## Summary
- fix plural safety-intent classification (`side effects`, `risks`, `warnings`, etc.)
- fix aggregate safety-caution detection for normal inflected terms such as pregnancy and contraindications
- realign `/tools` metadata with the route manifest
- update accessibility contract tests to the current design-token focus ring and 44px+ sizing
- update affiliate regional URL tests to the current descriptive CTA accessible names
- keep the BPC-157 safety test anchored to the current FDA safety-risk wording

This addresses all ten annotations from deployment run 31922510229 without weakening the safety, accessibility, affiliate, or metadata contracts.