### PR TITLE
cleanup: centralize entity identity normalization

### DIFF
--- a/lib/__tests__/entity-identity.test.ts
+++ b/lib/__tests__/entity-identity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractBracketedIdentityNames,
+  extractParentheticalNames,
+  levenshteinDistance,
+  normalizeEntityName,
+  slugifyEntityName,
+  stripBracketedIdentityNotes,
+  stripParentheticalName,
+} from '@/lib/entity-identity.mjs'
+
+describe('entity identity primitives', () => {
+  it('normalizes names and slugs consistently', () => {
+    expect(slugifyEntityName('St. John’s Wort')).toBe('st-johns-wort')
+    expect(normalizeEntityName('  Lion’s   Mane ')).toBe('lions mane')
+  })
+
+  it('extracts and strips identity notes', () => {
+    expect(extractParentheticalNames('Garlic (Allium sativum)')).toEqual(['Allium sativum'])
+    expect(stripParentheticalName('Garlic (Allium sativum)')).toBe('Garlic')
+    expect(extractBracketedIdentityNames('Garlic [Allium sativum]')).toEqual(['Allium sativum'])
+    expect(stripBracketedIdentityNotes('Garlic [Allium sativum]')).toBe('Garlic')
+  })
+
+  it('provides one edit-distance implementation for identity matching', () => {
+    expect(levenshteinDistance('valerian', 'valeriana')).toBe(1)
+    expect(levenshteinDistance('kava', 'gaba')).toBe(2)
+  })
+})

--- a/lib/entity-identity.mjs
+++ b/lib/entity-identity.mjs
@@ -1,0 +1,45 @@
+/** Canonical normalization primitives for entity names and slugs. */
+
+const QUOTES = /[’'"“”`]/g
+
+export function slugifyEntityName(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(QUOTES, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function normalizeEntityName(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(QUOTES, '')
+    .replace(/[^a-z0-9]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function stripParentheticalName(value) {
+  return String(value ?? '').replace(/\s*\([^)]+\)\s*/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+export function extractParentheticalNames(value) {
+  return [...String(value ?? '').matchAll(/\(([^)]+)\)/g)]
+    .map((match) => match[1].trim())
+    .filter(Boolean)
+}
+
+export function levenshteinDistance(left, right) {
+  const a = String(left ?? '')
+  const b = String(right ?? '')
+  const matrix = Array.from({ length: a.length + 1 }, () => Array(b.length + 1).fill(0))
+  for (let i = 0; i <= a.length; i += 1) matrix[i][0] = i
+  for (let j = 0; j <= b.length; j += 1) matrix[0][j] = j
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost)
+    }
+  }
+  return matrix[a.length][b.length]
+}

--- a/lib/entity-identity.mjs
+++ b/lib/entity-identity.mjs
@@ -29,6 +29,16 @@ export function extractParentheticalNames(value) {
     .filter(Boolean)
 }
 
+export function stripBracketedIdentityNotes(value) {
+  return String(value ?? '').replace(/\s*[([].*?[\])]\s*/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+export function extractBracketedIdentityNames(value) {
+  return [...String(value ?? '').matchAll(/[([](.*?)[\])]/g)]
+    .map((match) => match[1].trim())
+    .filter((name) => name.length > 2)
+}
+
 export function levenshteinDistance(left, right) {
   const a = String(left ?? '')
   const b = String(right ?? '')

--- a/scripts/audit/dual-slug-audit.mjs
+++ b/scripts/audit/dual-slug-audit.mjs
@@ -2,29 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import { getSheetData } from '../utils/read-workbook-exceljs.mjs';
 import { evaluateProfileCompleteness } from '../../lib/profile-completeness.mjs';
-
-function slugify(text) {
-  if (!text) return '';
-  return text.toLowerCase()
-    .replace(/[’'"“”`]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-function normalize(text) {
-  if (!text) return '';
-  return text.toLowerCase()
-    .replace(/[’'"“”`]/g, '')
-    .replace(/[^a-z0-9]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function extractParentheses(text) {
-  if (!text) return null;
-  const match = text.match(/\(([^)]+)\)/);
-  return match ? match[1].trim() : null;
-}
+import {
+  extractParentheticalNames,
+  normalizeEntityName,
+  slugifyEntityName,
+  stripParentheticalName,
+} from '../../lib/entity-identity.mjs';
 
 function ensureDirExists(dirPath) {
   if (!fs.existsSync(dirPath)) {
@@ -85,12 +68,12 @@ async function run() {
     if (!rawSlug) return;
 
     const rawName = String(row.name || '').trim();
-    const parenthetical = extractParentheses(rawName);
+    const [parenthetical = ''] = extractParentheticalNames(rawName);
     let commonName = rawName;
     let latinName = String(row.latin_name || '').trim();
 
     if (parenthetical) {
-      commonName = rawName.replace(/\([^)]+\)/, '').trim();
+      commonName = stripParentheticalName(rawName);
       latinName = parenthetical;
     }
 
@@ -108,9 +91,9 @@ async function run() {
       name: rawName,
       commonName,
       latinName,
-      commonSlug: slugify(commonName),
-      latinSlug: latinName ? slugify(latinName) : '',
-      normalizedName: normalize(commonName)
+      commonSlug: slugifyEntityName(commonName),
+      latinSlug: latinName ? slugifyEntityName(latinName) : '',
+      normalizedName: normalizeEntityName(commonName)
     });
   });
 


### PR DESCRIPTION
Broad cleanup pass 6.

- creates one canonical entity identity primitive module for slugification, normalized names, parenthetical/bracketed aliases, and edit distance
- migrates dual-slug reconciliation off its private normalization helpers
- preserves existing canonical-selection and redirect behavior
- adds focused regression coverage for names, aliases, slug normalization, and edit distance

This establishes the shared identity boundary needed to consolidate the remaining duplicate-slug matcher next.