### PR TITLE
refactor(research): make coverage gate live

### DIFF
--- a/scripts/ci/validate-research-coverage.ts
+++ b/scripts/ci/validate-research-coverage.ts
@@ -1,34 +1,15 @@
 #!/usr/bin/env npx tsx
-/**
- * Hard gate for structural research-coverage defects.
- *
- * The topology audit intentionally reports editorial weaknesses such as
- * single-source dependence and review-heavy evidence without blocking. This
- * gate is narrower: it blocks only graph states that cannot be valid.
- *
- * Run the topology audit first so ops/reports/source-integrity.json is current.
- */
+/** Hard gate for structurally invalid approved-claim evidence edges. */
 
-import fs from 'node:fs'
-import path from 'node:path'
+import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 
-const ROOT = process.cwd()
-const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'source-integrity.json')
-
-if (!fs.existsSync(REPORT_PATH)) {
-  console.error('[research-coverage] Missing source-integrity report. Run npm run audit:source-integrity first.')
-  process.exit(1)
-}
-
-const report = JSON.parse(fs.readFileSync(REPORT_PATH, 'utf8')) as {
-  claimTopology?: {
-    unsupportedClaims?: Array<{ url: string; claimId: string }>
-    danglingRefs?: Array<{ url: string; claimId: string; sourceRefId: string }>
-  }
-}
-
-const unsupported = report.claimTopology?.unsupportedClaims ?? []
-const dangling = report.claimTopology?.danglingRefs ?? []
+const { claimAnalyses } = analyzeResearchQuality(process.cwd())
+const unsupported = claimAnalyses
+  .filter((claim) => claim.supportTier === 'unsupported')
+  .map((claim) => ({ url: claim.url, claimId: claim.claimId }))
+const dangling = claimAnalyses.flatMap((claim) =>
+  claim.danglingSourceRefs.map((sourceRefId) => ({ url: claim.url, claimId: claim.claimId, sourceRefId })),
+)
 const failures = unsupported.length + dangling.length
 
 console.log('\nResearch coverage structural gate')
@@ -42,13 +23,11 @@ if (failures === 0) {
 }
 
 console.error(`\n[research-coverage] FAILED — ${failures} structurally invalid claim evidence edge(s).`)
-
 for (const item of unsupported.slice(0, 25)) {
   console.error(`  unsupported · ${item.url} · ${item.claimId}`)
 }
 for (const item of dangling.slice(0, 25)) {
   console.error(`  dangling · ${item.url} · ${item.claimId} -> ${item.sourceRefId}`)
 }
-
-if (failures > 50) console.error(`  ...and ${failures - 50} more; see ${path.relative(ROOT, REPORT_PATH)}`)
+if (failures > 50) console.error(`  ...and ${failures - 50} more`)
 process.exit(1)


### PR DESCRIPTION
Removes the hard coverage gate's dependency on `ops/reports/source-integrity.json`. Unsupported approved claims and dangling evidence refs are now evaluated directly from `analyzeResearchQuality()`, eliminating stale-report disagreement between diagnostics and release gating.