### PR TITLE
feat(research): audit all structured claims

### DIFF
--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -27,6 +27,8 @@ export type ClaimSupportTier =
 export type ClaimQualityAnalysis = {
   url: string
   claimId: string
+  reviewStatus: string
+  approved: boolean
   predicate: string
   confidence: number
   sourceRefCount: number
@@ -79,6 +81,7 @@ export type ResearchQualityAnalysis = {
   profiles: ReturnType<typeof listResearchProfiles>
   profileAnalyses: ProfileQualityAnalysis[]
   claimAnalyses: ClaimQualityAnalysis[]
+  structuredClaimAnalyses: ClaimQualityAnalysis[]
 }
 
 function round(value: number, digits = 3): number {
@@ -110,6 +113,8 @@ function analyzeClaim(
   const predicate = String(claim.predicate ?? '')
   const outcomeClaim = predicate === 'supports_outcome'
   const confidence = Number(claim.confidence ?? 0)
+  const reviewStatus = String(claim.reviewStatus ?? '').trim().toLowerCase()
+  const approved = reviewStatus === 'approved'
   const strongHumanSupport = primaryHuman + synthesis > 0
 
   let supportTier: ClaimSupportTier = 'non-outcome'
@@ -124,6 +129,8 @@ function analyzeClaim(
   return {
     url,
     claimId: String(claim.id ?? 'unknown-claim'),
+    reviewStatus,
+    approved,
     predicate,
     confidence,
     sourceRefCount: refs.length,
@@ -245,13 +252,17 @@ export function analyzeResearchQuality(root = process.cwd()): ResearchQualityAna
   const cache = loadPubmedCache(root)
   const profiles = listResearchProfiles(root)
   const claimAnalyses: ClaimQualityAnalysis[] = []
+  const structuredClaimAnalyses: ClaimQualityAnalysis[] = []
   const profileAnalyses: ProfileQualityAnalysis[] = []
 
   for (const { url, record } of profiles) {
-    const claims = approvedClaims(record).map((claim) => analyzeClaim(url, claim, record, cache))
-    claimAnalyses.push(...claims)
-    profileAnalyses.push(analyzeProfile(url, record, cache, claims))
+    const allClaims = Array.isArray(record.claimMap) ? record.claimMap : []
+    const structuredClaims = allClaims.map((claim) => analyzeClaim(url, claim, record, cache))
+    const approved = structuredClaims.filter((claim) => claim.approved)
+    structuredClaimAnalyses.push(...structuredClaims)
+    claimAnalyses.push(...approved)
+    profileAnalyses.push(analyzeProfile(url, record, cache, structuredClaims))
   }
 
-  return { cache, profiles, profileAnalyses, claimAnalyses }
+  return { cache, profiles, profileAnalyses, claimAnalyses, structuredClaimAnalyses }
 }

--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -8,22 +8,40 @@ import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 
 const ROOT = process.cwd()
 const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'claim-evidence-strength.json')
-const { claimAnalyses: claims } = analyzeResearchQuality(ROOT)
+const { claimAnalyses: claims, structuredClaimAnalyses } = analyzeResearchQuality(ROOT)
 
 const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
   counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
   return counts
 }, {})
+const structuredTierCounts = structuredClaimAnalyses.reduce<Record<string, number>>((counts, claim) => {
+  counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
+  return counts
+}, {})
+const unapproved = structuredClaimAnalyses.filter((claim) => !claim.approved)
+const unapprovedUnsupported = unapproved.filter((claim) => claim.supportTier === 'unsupported')
+const unapprovedWeakOutcome = unapproved.filter((claim) =>
+  claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
+)
 
 const report = {
   generatedAt: new Date().toISOString(),
   summary: {
+    structuredClaims: structuredClaimAnalyses.length,
     approvedClaims: claims.length,
+    unapprovedClaims: unapproved.length,
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
     supportTiers: tierCounts,
+    allStructuredSupportTiers: structuredTierCounts,
     highConfidenceWeakOutcome: claims.filter((claim) => claim.highConfidenceWeakOutcome).length,
+    unapprovedUnsupportedStructuredClaims: unapprovedUnsupported.length,
+    unapprovedWeakOutcomeClaims: unapprovedWeakOutcome.length,
   },
   claims,
+  editorialBacklog: {
+    unsupportedStructuredClaims: unapprovedUnsupported,
+    weakOutcomeClaims: unapprovedWeakOutcome,
+  },
 }
 
 fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true })
@@ -31,10 +49,14 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nClaim-level evidence strength')
 console.log('='.repeat(72))
+console.log(`Structured claims             ${report.summary.structuredClaims}`)
 console.log(`Approved claims               ${report.summary.approvedClaims}`)
+console.log(`Unapproved claims             ${report.summary.unapprovedClaims}`)
 console.log(`Outcome claims                ${report.summary.outcomeClaims}`)
 for (const [tier, count] of Object.entries(tierCounts).sort((a, b) => b[1] - a[1])) {
   console.log(`${tier.padEnd(29)} ${count}`)
 }
 console.log(`High-confidence weak outcomes ${report.summary.highConfidenceWeakOutcome}`)
+console.log(`Unapproved unsupported claims ${report.summary.unapprovedUnsupportedStructuredClaims}`)
+console.log(`Unapproved weak outcomes      ${report.summary.unapprovedWeakOutcomeClaims}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -9,7 +9,7 @@ import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
-const { profileAnalyses, claimAnalyses } = analyzeResearchQuality(ROOT)
+const { profileAnalyses, claimAnalyses, structuredClaimAnalyses } = analyzeResearchQuality(ROOT)
 const queue = new Map<string, { url: string; score: number; reasons: Array<{ kind: string; weight: number; detail?: string }> }>()
 
 function add(url: string, kind: string, weight: number, detail?: string) {
@@ -41,6 +41,16 @@ for (const claim of claimAnalyses) {
     baseWeight + confidenceBonus,
     `${claim.claimId}${confidenceBonus ? ' · high confidence' : ''}`,
   )
+}
+
+for (const claim of structuredClaimAnalyses.filter((item) => !item.approved)) {
+  if (claim.supportTier === 'unsupported') {
+    add(claim.url, 'unsupported-unapproved-structured-claim', 4, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
+    continue
+  }
+  if (claim.outcomeClaim && ['unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier)) {
+    add(claim.url, `unapproved-claim-support-${claim.supportTier}`, 3, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
+  }
 }
 
 for (const profile of profileAnalyses) {
@@ -80,7 +90,7 @@ const report = {
   generatedAt: new Date().toISOString(),
   source: 'lib/research-quality-analysis.ts',
   scoring: {
-    note: 'Scores prioritize structural invalidity first, then claim-support weakness, effective-study concentration, and evidence-mix imbalance. They are triage weights, not evidence grades.',
+    note: 'Scores prioritize structural invalidity first, then approved-claim weakness, effective-study concentration, evidence-mix imbalance, and finally low-weight editorial backlog for unapproved structured claims. They are triage weights, not evidence grades.',
     weights: {
       unsupportedApprovedClaim: 100,
       danglingClaimSourceEdge: 100,
@@ -91,6 +101,8 @@ const report = {
       noPrimaryHumanStudy: 20,
       narrativeReviewDominatedProfile: 20,
       singleStudyApprovedClaim: 5,
+      unsupportedUnapprovedStructuredClaim: 4,
+      weakUnapprovedOutcomeClaim: 3,
     },
   },
   summary: {


### PR DESCRIPTION
Superseded after main gained the canonical per-profile research context optimization. The structured-claim coverage changes are being reapplied on top of the newer analyzer rather than forcing a conflict.