### PR TITLE
Audit weak support across all structured claims

### DIFF
--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -26,6 +26,13 @@ export type ClaimSupportTier =
   | 'human-supported'
   | 'non-outcome'
 
+export type StructuredSupportTier =
+  | 'unsupported'
+  | 'unclassified'
+  | 'narrative-only'
+  | 'single-study'
+  | 'adequate'
+
 export type ClaimQualityAnalysis = {
   url: string
   claimId: string
@@ -43,6 +50,9 @@ export type ClaimQualityAnalysis = {
   designs: StudyClass[]
   outcomeClaim: boolean
   supportTier: ClaimSupportTier
+  structuredSupportTier: StructuredSupportTier
+  weakStructuredSupport: boolean
+  highConfidenceWeakStructured: boolean
   highConfidenceWeakOutcome: boolean
   singleStudy: boolean
   aliasCollapsed: boolean
@@ -55,6 +65,7 @@ export type ProfileQualityAnalysis = {
   claimCount: number
   approvedClaimCount: number
   supportedApprovedClaimCount: number
+  weakStructuredClaimCount: number
   designMix: Record<string, number>
   primaryHuman: number
   synthesis: number
@@ -62,6 +73,7 @@ export type ProfileQualityAnalysis = {
   narrativeToPrimaryHumanRatio: number | null
   narrativeDominatedVsPrimaryHuman: boolean
   unsupportedApprovedClaims: string[]
+  weakStructuredClaims: string[]
   singleStudyApprovedClaims: string[]
   aliasCollapsedClaims: string[]
   danglingSourceRefs: Array<{ claimId: string; sourceRefId: string }>
@@ -113,6 +125,18 @@ function buildProfileContext(record: ResearchProfile, cache: PubmedCache): Profi
   return { record, cache, sources, sourcesById, identities, studyGroups, studyDesigns }
 }
 
+function structuredSupportTier(
+  studyCount: number,
+  classifiedStudyCount: number,
+  narrativeCount: number,
+): StructuredSupportTier {
+  if (studyCount === 0) return 'unsupported'
+  if (classifiedStudyCount === 0) return 'unclassified'
+  if (narrativeCount === classifiedStudyCount) return 'narrative-only'
+  if (studyCount === 1) return 'single-study'
+  return 'adequate'
+}
+
 function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearchContext): ClaimQualityAnalysis {
   const refs = uniqueSourceRefs(claim)
   const validRefs = refs.filter((ref) => context.sourcesById.has(ref))
@@ -127,6 +151,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   const outcomeClaim = predicate === 'supports_outcome'
   const confidence = Number(claim.confidence ?? 0)
   const strongHumanSupport = primaryHuman + synthesis > 0
+  const structuredTier = structuredSupportTier(studyIds.length, classified.length, narrative)
 
   let supportTier: ClaimSupportTier = 'non-outcome'
   if (studyIds.length === 0) supportTier = 'unsupported'
@@ -136,6 +161,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   else if (outcomeClaim) supportTier = 'human-supported'
 
   const weakOutcome = supportTier === 'narrative-only' || supportTier === 'indirect-only'
+  const weakStructuredSupport = structuredTier !== 'adequate'
 
   return {
     url,
@@ -154,6 +180,9 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
     designs,
     outcomeClaim,
     supportTier,
+    structuredSupportTier: structuredTier,
+    weakStructuredSupport,
+    highConfidenceWeakStructured: confidence >= 0.75 && weakStructuredSupport,
     highConfidenceWeakOutcome:
       outcomeClaim && confidence >= 0.75 && (weakOutcome || supportTier === 'unclassified' || supportTier === 'unsupported'),
     singleStudy: studyIds.length === 1,
@@ -181,6 +210,7 @@ function analyzeProfile(
   }
 
   const unsupportedApprovedClaims: string[] = []
+  const weakStructuredClaims: string[] = []
   const singleStudyApprovedClaims: string[] = []
   const aliasCollapsedClaims: string[] = []
   const danglingSourceRefs: Array<{ claimId: string; sourceRefId: string }> = []
@@ -190,6 +220,7 @@ function analyzeProfile(
 
   for (const analysis of claims) {
     if (analysis.supportTier === 'unsupported') unsupportedApprovedClaims.push(analysis.claimId)
+    if (analysis.weakStructuredSupport) weakStructuredClaims.push(analysis.claimId)
     if (analysis.singleStudy) singleStudyApprovedClaims.push(analysis.claimId)
     if (analysis.aliasCollapsed) aliasCollapsedClaims.push(analysis.claimId)
     for (const sourceRefId of analysis.danglingSourceRefs) {
@@ -228,6 +259,7 @@ function analyzeProfile(
     claimCount: allClaims.length,
     approvedClaimCount: approved.length,
     supportedApprovedClaimCount,
+    weakStructuredClaimCount: weakStructuredClaims.length,
     designMix,
     primaryHuman,
     synthesis,
@@ -235,6 +267,7 @@ function analyzeProfile(
     narrativeToPrimaryHumanRatio: narrativeToPrimaryHumanRatio === null ? null : round(narrativeToPrimaryHumanRatio),
     narrativeDominatedVsPrimaryHuman,
     unsupportedApprovedClaims,
+    weakStructuredClaims,
     singleStudyApprovedClaims,
     aliasCollapsedClaims,
     danglingSourceRefs,

--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -14,6 +14,10 @@ const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
   counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
   return counts
 }, {})
+const structuredTierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
+  counts[claim.structuredSupportTier] = (counts[claim.structuredSupportTier] ?? 0) + 1
+  return counts
+}, {})
 
 const report = {
   generatedAt: new Date().toISOString(),
@@ -21,6 +25,9 @@ const report = {
     approvedClaims: claims.length,
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
     supportTiers: tierCounts,
+    structuredSupportTiers: structuredTierCounts,
+    weakStructuredClaims: claims.filter((claim) => claim.weakStructuredSupport).length,
+    highConfidenceWeakStructured: claims.filter((claim) => claim.highConfidenceWeakStructured).length,
     highConfidenceWeakOutcome: claims.filter((claim) => claim.highConfidenceWeakOutcome).length,
   },
   claims,
@@ -31,10 +38,13 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nClaim-level evidence strength')
 console.log('='.repeat(72))
-console.log(`Approved claims               ${report.summary.approvedClaims}`)
-console.log(`Outcome claims                ${report.summary.outcomeClaims}`)
-for (const [tier, count] of Object.entries(tierCounts).sort((a, b) => b[1] - a[1])) {
-  console.log(`${tier.padEnd(29)} ${count}`)
+console.log(`Approved claims                  ${report.summary.approvedClaims}`)
+console.log(`Outcome claims                   ${report.summary.outcomeClaims}`)
+console.log(`Weak structured claims           ${report.summary.weakStructuredClaims}`)
+console.log(`High-confidence weak structured  ${report.summary.highConfidenceWeakStructured}`)
+console.log(`High-confidence weak outcomes    ${report.summary.highConfidenceWeakOutcome}`)
+console.log('\nStructured support tiers:')
+for (const [tier, count] of Object.entries(structuredTierCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${tier.padEnd(26)} ${count}`)
 }
-console.log(`High-confidence weak outcomes ${report.summary.highConfidenceWeakOutcome}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -21,7 +21,7 @@ function add(url: string, kind: string, weight: number, detail?: string) {
 }
 
 for (const claim of claimAnalyses) {
-  if (claim.supportTier === 'unsupported') {
+  if (claim.structuredSupportTier === 'unsupported') {
     add(claim.url, 'unsupported-approved-claim', 100, claim.claimId)
   }
   for (const sourceRefId of claim.danglingSourceRefs) {
@@ -31,16 +31,29 @@ for (const claim of claimAnalyses) {
     add(claim.url, 'single-study-approved-claim', 5, claim.claimId)
   }
 
-  const tier = claim.supportTier
-  if (tier === 'unsupported' || tier === 'human-supported' || tier === 'non-outcome') continue
-  const baseWeight = tier === 'narrative-only' ? 25 : 20
-  const confidenceBonus = claim.highConfidenceWeakOutcome ? 15 : 0
-  add(
-    claim.url,
-    `claim-support-${tier}`,
-    baseWeight + confidenceBonus,
-    `${claim.claimId}${confidenceBonus ? ' · high confidence' : ''}`,
-  )
+  if (claim.structuredSupportTier === 'unclassified') {
+    add(
+      claim.url,
+      'claim-support-unclassified',
+      20 + (claim.highConfidenceWeakStructured ? 15 : 0),
+      `${claim.claimId}${claim.highConfidenceWeakStructured ? ' · high confidence' : ''}`,
+    )
+  } else if (claim.structuredSupportTier === 'narrative-only') {
+    const baseWeight = claim.outcomeClaim ? 25 : 15
+    add(
+      claim.url,
+      'claim-support-narrative-only',
+      baseWeight + (claim.highConfidenceWeakStructured ? 15 : 0),
+      `${claim.claimId} · ${claim.predicate}${claim.highConfidenceWeakStructured ? ' · high confidence' : ''}`,
+    )
+  } else if (claim.supportTier === 'indirect-only') {
+    add(
+      claim.url,
+      'claim-support-indirect-only',
+      20 + (claim.highConfidenceWeakOutcome ? 15 : 0),
+      `${claim.claimId}${claim.highConfidenceWeakOutcome ? ' · high confidence' : ''}`,
+    )
+  }
 }
 
 for (const profile of profileAnalyses) {
@@ -80,13 +93,15 @@ const report = {
   generatedAt: new Date().toISOString(),
   source: 'lib/research-quality-analysis.ts',
   scoring: {
-    note: 'Scores prioritize structural invalidity first, then claim-support weakness, effective-study concentration, and evidence-mix imbalance. They are triage weights, not evidence grades.',
+    note: 'Scores prioritize structural invalidity first, then canonical structured-claim weakness, effective-study concentration, and evidence-mix imbalance. They are triage weights, not evidence grades.',
     weights: {
       unsupportedApprovedClaim: 100,
       danglingClaimSourceEdge: 100,
       highStudyDependency: '25 + dominant supported-claim share × 30 + concentration bonus (max 15)',
-      narrativeOnlyClaimSupport: 25,
-      indirectOrUnclassifiedClaimSupport: 20,
+      narrativeOnlyOutcomeSupport: 25,
+      narrativeOnlyOtherStructuredSupport: 15,
+      indirectOutcomeSupport: 20,
+      unclassifiedStructuredSupport: 20,
       highConfidenceWeakClaimBonus: 15,
       noPrimaryHumanStudy: 20,
       narrativeReviewDominatedProfile: 20,
@@ -95,6 +110,8 @@ const report = {
   },
   summary: {
     profilesWithResearchGaps: ranked.length,
+    weakStructuredClaims: claimAnalyses.filter((claim) => claim.weakStructuredSupport).length,
+    highConfidenceWeakStructuredClaims: claimAnalyses.filter((claim) => claim.highConfidenceWeakStructured).length,
     critical: ranked.filter((item) => item.score >= 100).length,
     high: ranked.filter((item) => item.score >= 60 && item.score < 100).length,
     medium: ranked.filter((item) => item.score >= 25 && item.score < 60).length,
@@ -108,11 +125,13 @@ fs.writeFileSync(OUTPUT, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nPrioritized research-gap queue')
 console.log('='.repeat(72))
-console.log(`Profiles with gaps  ${report.summary.profilesWithResearchGaps}`)
-console.log(`Critical            ${report.summary.critical}`)
-console.log(`High                ${report.summary.high}`)
-console.log(`Medium              ${report.summary.medium}`)
-console.log(`Low                 ${report.summary.low}`)
+console.log(`Profiles with gaps                ${report.summary.profilesWithResearchGaps}`)
+console.log(`Weak structured claims            ${report.summary.weakStructuredClaims}`)
+console.log(`High-confidence weak structured   ${report.summary.highConfidenceWeakStructuredClaims}`)
+console.log(`Critical                          ${report.summary.critical}`)
+console.log(`High                              ${report.summary.high}`)
+console.log(`Medium                            ${report.summary.medium}`)
+console.log(`Low                               ${report.summary.low}`)
 for (const item of ranked.slice(0, 10)) {
   console.log(`  ${String(item.score).padStart(3)} · ${item.url} · ${item.reasons.length} finding(s)`)
 }


### PR DESCRIPTION
Closed in favor of a fresh branch from current main because concurrent research-quality work changed the same canonical analyzer. The remaining gap is specifically non-outcome structured claims: main's `weakStructuredClaim` currently only evaluates `supports_outcome` claims.