### PR TITLE
refactor(research): centralize quality policy

### DIFF
--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -1,0 +1,151 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type ResearchGapReason = {
+  kind: string
+  weight: number
+  detail?: string
+}
+
+export type ResearchGapItem = {
+  url: string
+  score: number
+  reasons: ResearchGapReason[]
+  reasonCounts: Record<string, number>
+}
+
+export type StructuralCoverageFailure = {
+  kind: 'unsupported-approved-claim' | 'dangling-claim-source-edge'
+  url: string
+  claimId: string
+  sourceRefId?: string
+}
+
+export const RESEARCH_GAP_WEIGHTS = {
+  unsupportedApprovedClaim: 100,
+  danglingClaimSourceEdge: 100,
+  narrativeOnlyClaimSupport: 25,
+  indirectOrUnclassifiedClaimSupport: 20,
+  highConfidenceWeakClaimBonus: 15,
+  noPrimaryHumanStudy: 20,
+  narrativeReviewDominatedProfile: 20,
+  singleStudyApprovedClaim: 5,
+  unsupportedUnapprovedStructuredClaim: 4,
+  weakUnapprovedOutcomeClaim: 3,
+} as const
+
+export function structuralCoverageFailures(analysis: ResearchQualityAnalysis): StructuralCoverageFailure[] {
+  const failures: StructuralCoverageFailure[] = []
+  for (const claim of analysis.claimAnalyses) {
+    if (claim.supportTier === 'unsupported') {
+      failures.push({ kind: 'unsupported-approved-claim', url: claim.url, claimId: claim.claimId })
+    }
+    for (const sourceRefId of claim.danglingSourceRefs) {
+      failures.push({ kind: 'dangling-claim-source-edge', url: claim.url, claimId: claim.claimId, sourceRefId })
+    }
+  }
+  return failures
+}
+
+export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): ResearchGapItem[] {
+  const queue = new Map<string, { url: string; score: number; reasons: ResearchGapReason[] }>()
+
+  const add = (url: string, kind: string, weight: number, detail?: string) => {
+    if (!url) return
+    const item = queue.get(url) ?? { url, score: 0, reasons: [] }
+    item.score += weight
+    item.reasons.push({ kind, weight, ...(detail ? { detail } : {}) })
+    queue.set(url, item)
+  }
+
+  for (const claim of analysis.claimAnalyses) {
+    if (claim.supportTier === 'unsupported') {
+      add(claim.url, 'unsupported-approved-claim', RESEARCH_GAP_WEIGHTS.unsupportedApprovedClaim, claim.claimId)
+    }
+    for (const sourceRefId of claim.danglingSourceRefs) {
+      add(
+        claim.url,
+        'dangling-claim-source-edge',
+        RESEARCH_GAP_WEIGHTS.danglingClaimSourceEdge,
+        `${claim.claimId} -> ${sourceRefId}`,
+      )
+    }
+    if (claim.singleStudy) {
+      add(claim.url, 'single-study-approved-claim', RESEARCH_GAP_WEIGHTS.singleStudyApprovedClaim, claim.claimId)
+    }
+
+    const tier = claim.supportTier
+    if (tier === 'unsupported' || tier === 'human-supported' || tier === 'non-outcome') continue
+    const baseWeight = tier === 'narrative-only'
+      ? RESEARCH_GAP_WEIGHTS.narrativeOnlyClaimSupport
+      : RESEARCH_GAP_WEIGHTS.indirectOrUnclassifiedClaimSupport
+    const confidenceBonus = claim.highConfidenceWeakOutcome ? RESEARCH_GAP_WEIGHTS.highConfidenceWeakClaimBonus : 0
+    add(
+      claim.url,
+      `claim-support-${tier}`,
+      baseWeight + confidenceBonus,
+      `${claim.claimId}${confidenceBonus ? ' · high confidence' : ''}`,
+    )
+  }
+
+  for (const claim of analysis.structuredClaimAnalyses.filter((item) => !item.approved)) {
+    if (claim.supportTier === 'unsupported') {
+      add(
+        claim.url,
+        'unsupported-unapproved-structured-claim',
+        RESEARCH_GAP_WEIGHTS.unsupportedUnapprovedStructuredClaim,
+        `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`,
+      )
+      continue
+    }
+    if (claim.outcomeClaim && ['unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier)) {
+      add(
+        claim.url,
+        `unapproved-claim-support-${claim.supportTier}`,
+        RESEARCH_GAP_WEIGHTS.weakUnapprovedOutcomeClaim,
+        `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`,
+      )
+    }
+  }
+
+  for (const profile of analysis.profileAnalyses) {
+    if (profile.overDependentOnSingleStudy) {
+      const share = profile.dominantStudySupportedClaimShare
+      const concentrationBonus = Math.round(Math.min(15, profile.studyConcentrationIndex * 20))
+      add(
+        profile.url,
+        'high-study-dependency',
+        Math.round(25 + share * 30 + concentrationBonus),
+        `${Math.round(share * 100)}% of supported approved claims depend on one canonical study; effective study count ${profile.effectiveStudyCount}`,
+      )
+    }
+    if (profile.narrativeDominatedVsPrimaryHuman) {
+      const ratio = profile.narrativeToPrimaryHumanRatio === null
+        ? 'no primary-human studies'
+        : `${profile.narrativeToPrimaryHumanRatio}:1 narrative-to-primary-human ratio`
+      add(
+        profile.url,
+        'narrative-review-dominated-profile',
+        RESEARCH_GAP_WEIGHTS.narrativeReviewDominatedProfile,
+        ratio,
+      )
+    }
+    if (profile.noPrimaryHuman) {
+      add(
+        profile.url,
+        'approved-claims-without-primary-human-study',
+        RESEARCH_GAP_WEIGHTS.noPrimaryHumanStudy,
+      )
+    }
+  }
+
+  return [...queue.values()]
+    .map((item) => ({
+      ...item,
+      score: Math.round(item.score),
+      reasonCounts: item.reasons.reduce<Record<string, number>>((counts, reason) => {
+        counts[reason.kind] = (counts[reason.kind] ?? 0) + 1
+        return counts
+      }, {}),
+    }))
+    .sort((a, b) => b.score - a.score || b.reasons.length - a.reasons.length || a.url.localeCompare(b.url))
+}

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -1,108 +1,25 @@
 #!/usr/bin/env npx tsx
-/** Build one prioritized remediation queue directly from canonical research-quality analysis. */
+/** Build the prioritized remediation queue from canonical research-quality policy. */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
+import { buildResearchGapQueue, RESEARCH_GAP_WEIGHTS } from '../../lib/research-quality-policy'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
-const { profileAnalyses, claimAnalyses, structuredClaimAnalyses } = analyzeResearchQuality(ROOT)
-const queue = new Map<string, { url: string; score: number; reasons: Array<{ kind: string; weight: number; detail?: string }> }>()
-
-function add(url: string, kind: string, weight: number, detail?: string) {
-  if (!url) return
-  const item = queue.get(url) ?? { url, score: 0, reasons: [] }
-  item.score += weight
-  item.reasons.push({ kind, weight, ...(detail ? { detail } : {}) })
-  queue.set(url, item)
-}
-
-for (const claim of claimAnalyses) {
-  if (claim.supportTier === 'unsupported') {
-    add(claim.url, 'unsupported-approved-claim', 100, claim.claimId)
-  }
-  for (const sourceRefId of claim.danglingSourceRefs) {
-    add(claim.url, 'dangling-claim-source-edge', 100, `${claim.claimId} -> ${sourceRefId}`)
-  }
-  if (claim.singleStudy) {
-    add(claim.url, 'single-study-approved-claim', 5, claim.claimId)
-  }
-
-  const tier = claim.supportTier
-  if (tier === 'unsupported' || tier === 'human-supported' || tier === 'non-outcome') continue
-  const baseWeight = tier === 'narrative-only' ? 25 : 20
-  const confidenceBonus = claim.highConfidenceWeakOutcome ? 15 : 0
-  add(
-    claim.url,
-    `claim-support-${tier}`,
-    baseWeight + confidenceBonus,
-    `${claim.claimId}${confidenceBonus ? ' · high confidence' : ''}`,
-  )
-}
-
-for (const claim of structuredClaimAnalyses.filter((item) => !item.approved)) {
-  if (claim.supportTier === 'unsupported') {
-    add(claim.url, 'unsupported-unapproved-structured-claim', 4, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
-    continue
-  }
-  if (claim.outcomeClaim && ['unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier)) {
-    add(claim.url, `unapproved-claim-support-${claim.supportTier}`, 3, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
-  }
-}
-
-for (const profile of profileAnalyses) {
-  if (profile.overDependentOnSingleStudy) {
-    const share = profile.dominantStudySupportedClaimShare
-    const concentrationBonus = Math.round(Math.min(15, profile.studyConcentrationIndex * 20))
-    add(
-      profile.url,
-      'high-study-dependency',
-      Math.round(25 + share * 30 + concentrationBonus),
-      `${Math.round(share * 100)}% of supported approved claims depend on one canonical study; effective study count ${profile.effectiveStudyCount}`,
-    )
-  }
-  if (profile.narrativeDominatedVsPrimaryHuman) {
-    const ratio = profile.narrativeToPrimaryHumanRatio === null
-      ? 'no primary-human studies'
-      : `${profile.narrativeToPrimaryHumanRatio}:1 narrative-to-primary-human ratio`
-    add(profile.url, 'narrative-review-dominated-profile', 20, ratio)
-  }
-  if (profile.noPrimaryHuman) {
-    add(profile.url, 'approved-claims-without-primary-human-study', 20)
-  }
-}
-
-const ranked = [...queue.values()]
-  .map((item) => ({
-    ...item,
-    score: Math.round(item.score),
-    reasonCounts: item.reasons.reduce<Record<string, number>>((counts, reason) => {
-      counts[reason.kind] = (counts[reason.kind] ?? 0) + 1
-      return counts
-    }, {}),
-  }))
-  .sort((a, b) => b.score - a.score || b.reasons.length - a.reasons.length || a.url.localeCompare(b.url))
+const ranked = buildResearchGapQueue(analyzeResearchQuality(ROOT))
 
 const report = {
   generatedAt: new Date().toISOString(),
-  source: 'lib/research-quality-analysis.ts',
+  source: 'lib/research-quality-analysis.ts + lib/research-quality-policy.ts',
   scoring: {
     note: 'Scores prioritize structural invalidity first, then approved-claim weakness, effective-study concentration, evidence-mix imbalance, and finally low-weight editorial backlog for unapproved structured claims. They are triage weights, not evidence grades.',
     weights: {
-      unsupportedApprovedClaim: 100,
-      danglingClaimSourceEdge: 100,
+      ...RESEARCH_GAP_WEIGHTS,
       highStudyDependency: '25 + dominant supported-claim share × 30 + concentration bonus (max 15)',
-      narrativeOnlyClaimSupport: 25,
-      indirectOrUnclassifiedClaimSupport: 20,
-      highConfidenceWeakClaimBonus: 15,
-      noPrimaryHumanStudy: 20,
-      narrativeReviewDominatedProfile: 20,
-      singleStudyApprovedClaim: 5,
-      unsupportedUnapprovedStructuredClaim: 4,
-      weakUnapprovedOutcomeClaim: 3,
     },
   },
   summary: {
@@ -116,7 +33,7 @@ const report = {
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
-fs.writeFileSync(OUTPUT, `${JSON.stringify(report, null,2)}\n`)
+fs.writeFileSync(OUTPUT, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nPrioritized research-gap queue')
 console.log('='.repeat(72))

--- a/scripts/ci/validate-research-coverage.ts
+++ b/scripts/ci/validate-research-coverage.ts
@@ -2,32 +2,28 @@
 /** Hard gate for structurally invalid approved-claim evidence edges. */
 
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
+import { structuralCoverageFailures } from '../../lib/research-quality-policy'
 
-const { claimAnalyses } = analyzeResearchQuality(process.cwd())
-const unsupported = claimAnalyses
-  .filter((claim) => claim.supportTier === 'unsupported')
-  .map((claim) => ({ url: claim.url, claimId: claim.claimId }))
-const dangling = claimAnalyses.flatMap((claim) =>
-  claim.danglingSourceRefs.map((sourceRefId) => ({ url: claim.url, claimId: claim.claimId, sourceRefId })),
-)
-const failures = unsupported.length + dangling.length
+const failures = structuralCoverageFailures(analyzeResearchQuality(process.cwd()))
+const unsupported = failures.filter((failure) => failure.kind === 'unsupported-approved-claim')
+const dangling = failures.filter((failure) => failure.kind === 'dangling-claim-source-edge')
 
 console.log('\nResearch coverage structural gate')
 console.log('='.repeat(72))
 console.log(`Approved claims with no source refs  ${unsupported.length}`)
 console.log(`Claim refs to missing profile source ${dangling.length}`)
 
-if (failures === 0) {
+if (failures.length === 0) {
   console.log('\n[research-coverage] PASS — every approved claim has a valid evidence edge.')
   process.exit(0)
 }
 
-console.error(`\n[research-coverage] FAILED — ${failures} structurally invalid claim evidence edge(s).`)
+console.error(`\n[research-coverage] FAILED — ${failures.length} structurally invalid claim evidence edge(s).`)
 for (const item of unsupported.slice(0, 25)) {
   console.error(`  unsupported · ${item.url} · ${item.claimId}`)
 }
 for (const item of dangling.slice(0, 25)) {
   console.error(`  dangling · ${item.url} · ${item.claimId} -> ${item.sourceRefId}`)
 }
-if (failures > 50) console.error(`  ...and ${failures - 50} more`)
+if (failures.length > 50) console.error(`  ...and ${failures.length - 50} more`)
 process.exit(1)


### PR DESCRIPTION
Moves research-gap interpretation/scoring and structural coverage failure extraction into `lib/research-quality-policy.ts`. The gap builder and coverage gate are now thin CLI/report adapters over the same canonical analysis + policy, removing another duplicated layer of research logic and magic weights from executable scripts.