### PR TITLE
SEO: harden AI claim integrity and evidence concentration

### DIFF
--- a/docs/ai-claim-integrity.md
+++ b/docs/ai-claim-integrity.md
@@ -1,0 +1,51 @@
+# AI Claim Integrity Standard
+
+## Purpose
+
+AI-search optimization only helps if retrieved claims are internally consistent and traceable to evidence. This standard defines the canonical QA layer for preventing contradictory, weakly sourced, or overly concentrated evidence from becoming high-confidence AI snippets.
+
+## Canonical checks
+
+### Claim consistency
+
+Run `node scripts/ci/audit-ai-claim-integrity.mjs`.
+
+It flags:
+
+- strong-evidence labels that coexist with preliminary, mixed, limited, theoretical, animal-only, or research-pending language;
+- positive efficacy language that coexists with unsupported/no-clear-benefit language;
+- multiple materially different evidence labels on one profile;
+- strong-evidence labels that have no obvious human-study signal in the record.
+
+The audit is advisory by default. `--strict` upgrades warnings to release-blocking failures. Contradictions classified as errors fail in either mode.
+
+### Evidence concentration
+
+Run `node scripts/ci/audit-ai-evidence-concentration.mjs` after AI entity artifacts are built.
+
+It flags:
+
+- claim nodes with no source linkage;
+- claim nodes dependent on only one source;
+- profiles dominated by narrative reviews instead of primary human research or systematic reviews;
+- profiles where one source supports at least 75% of claim nodes.
+
+This does not assume that one-study evidence is false. It identifies concentration risk so answer surfaces can preserve uncertainty instead of presenting apparent consensus.
+
+## Editorial interpretation
+
+A flagged record should be resolved in the source-of-truth data, not patched only in rendered copy. Preferred resolution order:
+
+1. Determine whether the claims actually conflict or merely address different populations, formulations, doses, outcomes, or time windows.
+2. Split materially different claims instead of flattening them into one profile-level conclusion.
+3. Attach the correct source IDs to each atomic claim.
+4. Downgrade evidence language when independent human replication is absent.
+5. Preserve legitimate conflicting evidence explicitly.
+6. Prefer systematic synthesis plus primary human studies over narrative-review-only support for strong clinical conclusions.
+7. Rebuild AI entity artifacts and rerun both audits.
+
+## AI-search rule
+
+No AI-specific page, schema field, FAQ, snippet block, or `llms.txt` instruction may make a claim stronger than the governed source record and its claim-level evidence.
+
+The goal is not to manufacture certainty for answer engines. The goal is to make the site's real level of certainty easier to retrieve, understand, and cite.

--- a/scripts/ci/audit-ai-claim-integrity.mjs
+++ b/scripts/ci/audit-ai-claim-integrity.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const DATASETS = [
+  ['herb', path.join(ROOT, 'public', 'data', 'herbs.json')],
+  ['compound', path.join(ROOT, 'public', 'data', 'compounds.json')],
+]
+const strict = process.argv.includes('--strict')
+
+const STRONG = /\b(?:grade\s*)?a\b|strong human evidence|high confidence|well[- ]established|robust evidence/i
+const WEAK = /preliminary|mixed evidence|limited evidence|insufficient|unclear|weak evidence|theoretical|animal evidence|in[- ]vitro|mechanistic only|research pending/i
+const NEGATIVE = /not supported|unsupported|no good evidence|insufficient evidence|does not support|failed to show|no clear benefit/i
+const POSITIVE = /effective|efficacious|clinically proven|proven to|shown to improve|strong evidence for|supports the use/i
+const GRADE_FIELDS = ['evidence_grade', 'evidenceGrade', 'evidenceLevel', 'evidence_level', 'evidenceTier', 'evidence_tier']
+const CLAIM_FIELDS = [
+  'summary', 'description', 'clinicalUse', 'clinical_use', 'best_for', 'bestFor', 'primary_effects', 'effects',
+  'evidence_summary', 'evidenceSummary', 'evidence_notes', 'evidenceNotes', 'limitations', 'research_gaps', 'researchGaps',
+]
+
+function readJson(file) {
+  if (!existsSync(file)) return null
+  try { return JSON.parse(readFileSync(file, 'utf8')) } catch { return null }
+}
+
+function rowsFrom(parsed, kind) {
+  if (Array.isArray(parsed)) return parsed
+  if (Array.isArray(parsed?.[`${kind}s`])) return parsed[`${kind}s`]
+  if (Array.isArray(parsed?.items)) return parsed.items
+  if (parsed && typeof parsed === 'object') return Object.values(parsed).filter(Boolean)
+  return []
+}
+
+function flatten(value, out = []) {
+  if (value == null) return out
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    out.push(String(value))
+    return out
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) flatten(item, out)
+    return out
+  }
+  if (typeof value === 'object') {
+    for (const item of Object.values(value)) flatten(item, out)
+  }
+  return out
+}
+
+function textFor(record, fields) {
+  return fields.flatMap((field) => flatten(record?.[field])).join(' | ')
+}
+
+function evidenceLabels(record) {
+  return GRADE_FIELDS.map((field) => record?.[field]).filter((v) => v != null && String(v).trim()).map(String)
+}
+
+const findings = []
+const totals = { profiles: 0, contradictoryStrength: 0, positiveNegative: 0, multiGrade: 0, strongWithoutHumanSignal: 0 }
+
+for (const [kind, file] of DATASETS) {
+  const parsed = readJson(file)
+  if (!parsed) {
+    findings.push({ severity: 'warn', kind, slug: '-', issue: `dataset unavailable or invalid: ${path.relative(ROOT, file)}` })
+    continue
+  }
+
+  for (const record of rowsFrom(parsed, kind)) {
+    if (!record || typeof record !== 'object') continue
+    totals.profiles++
+    const slug = String(record.slug || record.id || record.name || 'unknown')
+    const labels = evidenceLabels(record)
+    const claimText = textFor(record, CLAIM_FIELDS)
+    const allText = flatten(record).join(' | ')
+
+    const hasStrong = STRONG.test([...labels, claimText].join(' | '))
+    const hasWeak = WEAK.test(claimText)
+    if (hasStrong && hasWeak) {
+      totals.contradictoryStrength++
+      findings.push({ severity: 'error', kind, slug, issue: 'strong evidence signal conflicts with preliminary/mixed/limited language' })
+    }
+
+    if (POSITIVE.test(claimText) && NEGATIVE.test(claimText)) {
+      totals.positiveNegative++
+      findings.push({ severity: 'error', kind, slug, issue: 'positive efficacy language coexists with unsupported/no-clear-benefit language' })
+    }
+
+    const normalizedLabels = [...new Set(labels.map((value) => value.trim().toLowerCase()))]
+    if (normalizedLabels.length > 1) {
+      const materiallyDifferent = normalizedLabels.some((a) => normalizedLabels.some((b) => a !== b && !(a.includes(b) || b.includes(a))))
+      if (materiallyDifferent) {
+        totals.multiGrade++
+        findings.push({ severity: 'warn', kind, slug, issue: `multiple evidence labels: ${labels.join(', ')}` })
+      }
+    }
+
+    if (hasStrong) {
+      const humanSignal = /randomi[sz]ed|controlled trial|clinical trial|human study|human evidence|meta-analysis|systematic review|participants?|subjects?|patients?/i.test(allText)
+      if (!humanSignal) {
+        totals.strongWithoutHumanSignal++
+        findings.push({ severity: 'warn', kind, slug, issue: 'strong evidence label without an obvious human-study signal in the record' })
+      }
+    }
+  }
+}
+
+const errors = findings.filter((f) => f.severity === 'error')
+const warnings = findings.filter((f) => f.severity === 'warn')
+
+console.log(`[audit-ai-claim-integrity] profiles: ${totals.profiles}`)
+console.log(`[audit-ai-claim-integrity] contradictory evidence strength: ${totals.contradictoryStrength}`)
+console.log(`[audit-ai-claim-integrity] positive/negative efficacy conflicts: ${totals.positiveNegative}`)
+console.log(`[audit-ai-claim-integrity] multiple evidence labels: ${totals.multiGrade}`)
+console.log(`[audit-ai-claim-integrity] strong labels without human-study signal: ${totals.strongWithoutHumanSignal}`)
+
+for (const finding of findings.slice(0, 200)) {
+  console.log(`${finding.severity.toUpperCase()} ${finding.kind}/${finding.slug}: ${finding.issue}`)
+}
+if (findings.length > 200) console.log(`[audit-ai-claim-integrity] ${findings.length - 200} additional findings omitted from console output`)
+
+if (errors.length || warnings.length) {
+  console.log(`[audit-ai-claim-integrity] findings: ${errors.length} error(s), ${warnings.length} warning(s)${strict ? ' (strict mode)' : ' (advisory mode)'}`)
+}
+
+if (errors.length > 0 || (strict && warnings.length > 0)) process.exit(1)

--- a/scripts/ci/audit-ai-evidence-concentration.mjs
+++ b/scripts/ci/audit-ai-evidence-concentration.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const ENTITY_ROOT = path.join(ROOT, 'public', 'data', 'ai-entities')
+const strict = process.argv.includes('--strict')
+
+function filesUnder(dir, out = []) {
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) filesUnder(full, out)
+    else if (entry.name.endsWith('.json') && entry.name !== 'manifest.json') out.push(full)
+  }
+  return out
+}
+
+function readJson(file) {
+  try { return JSON.parse(readFileSync(file, 'utf8')) } catch { return null }
+}
+
+function nodes(doc) {
+  if (Array.isArray(doc?.['@graph'])) return doc['@graph']
+  if (Array.isArray(doc)) return doc
+  return doc ? [doc] : []
+}
+
+function typeList(node) {
+  const t = node?.['@type']
+  return Array.isArray(t) ? t.map(String) : t ? [String(t)] : []
+}
+
+function strings(value, out = []) {
+  if (value == null) return out
+  if (typeof value === 'string' || typeof value === 'number') { out.push(String(value)); return out }
+  if (Array.isArray(value)) { for (const item of value) strings(item, out); return out }
+  if (typeof value === 'object') { for (const item of Object.values(value)) strings(item, out) }
+  return out
+}
+
+function sourceIds(node) {
+  const ids = []
+  const candidates = [node?.citation, node?.citations, node?.source, node?.sources, node?.sourceIds, node?.sourceRefs, node?.primaryPmids, node?.pmids]
+  for (const candidate of candidates) {
+    for (const s of strings(candidate)) {
+      const normalized = s.trim()
+      if (normalized) ids.push(normalized)
+    }
+  }
+  return [...new Set(ids)]
+}
+
+function isClaim(node) {
+  const types = typeList(node).join(' ').toLowerCase()
+  return /claim|statement|observation/.test(types) || /claim/i.test(String(node?.['@id'] || '')) || node?.evidenceGrade || node?.evidenceClass
+}
+
+function isSource(node) {
+  const types = typeList(node).join(' ').toLowerCase()
+  return /scholarlyarticle|medicalscholarlyarticle|article|creativework|report/.test(types) || node?.pmid || node?.doi || node?.studyType
+}
+
+function studyClass(node) {
+  const blob = strings([node?.studyType, node?.evidenceClass, node?.name, node?.description]).join(' ').toLowerCase()
+  if (/narrative review|review article|overview/.test(blob) && !/systematic|meta-analysis/.test(blob)) return 'narrative-review'
+  if (/systematic review|meta-analysis|meta analysis/.test(blob)) return 'systematic-review'
+  if (/randomi[sz]ed|controlled trial|clinical trial|cohort|case-control|cross-sectional|human study/.test(blob)) return 'primary-human'
+  if (/animal|mouse|mice|rat|in vivo/.test(blob)) return 'animal'
+  if (/in vitro|cell|assay/.test(blob)) return 'in-vitro'
+  return 'other'
+}
+
+const findings = []
+const stats = { profiles: 0, claims: 0, oneSourceClaims: 0, zeroSourceClaims: 0, narrativeDominated: 0, singleSourceDominated: 0 }
+
+for (const file of filesUnder(ENTITY_ROOT)) {
+  const doc = readJson(file)
+  if (!doc) continue
+  stats.profiles++
+  const graph = nodes(doc)
+  const claims = graph.filter(isClaim)
+  const sources = graph.filter(isSource)
+  stats.claims += claims.length
+
+  const slug = path.basename(file, '.json')
+  const sourceClassCounts = new Map()
+  for (const source of sources) {
+    const cls = studyClass(source)
+    sourceClassCounts.set(cls, (sourceClassCounts.get(cls) || 0) + 1)
+  }
+
+  for (const claim of claims) {
+    const ids = sourceIds(claim)
+    if (ids.length === 0) {
+      stats.zeroSourceClaims++
+      findings.push({ severity: 'error', slug, issue: `claim has no source link: ${String(claim.name || claim.description || claim['@id'] || 'unnamed').slice(0, 120)}` })
+    } else if (ids.length === 1) {
+      stats.oneSourceClaims++
+      findings.push({ severity: 'warn', slug, issue: `claim depends on one source: ${String(claim.name || claim.description || claim['@id'] || 'unnamed').slice(0, 120)}` })
+    }
+  }
+
+  const narrative = sourceClassCounts.get('narrative-review') || 0
+  const primaryHuman = sourceClassCounts.get('primary-human') || 0
+  const systematic = sourceClassCounts.get('systematic-review') || 0
+  const humanRelevant = narrative + primaryHuman + systematic
+  if (humanRelevant >= 2 && narrative > primaryHuman + systematic) {
+    stats.narrativeDominated++
+    findings.push({ severity: 'warn', slug, issue: `source profile is narrative-review dominated (${narrative} narrative vs ${primaryHuman} primary-human + ${systematic} systematic)` })
+  }
+
+  const sourceFrequency = new Map()
+  for (const claim of claims) {
+    for (const id of sourceIds(claim)) sourceFrequency.set(id, (sourceFrequency.get(id) || 0) + 1)
+  }
+  const maxFrequency = Math.max(0, ...sourceFrequency.values())
+  if (claims.length >= 3 && maxFrequency / claims.length >= 0.75) {
+    stats.singleSourceDominated++
+    findings.push({ severity: 'warn', slug, issue: `one source supports ${maxFrequency}/${claims.length} claim nodes (>=75% concentration)` })
+  }
+}
+
+if (!existsSync(ENTITY_ROOT)) {
+  findings.push({ severity: 'warn', slug: '-', issue: 'AI entity artifact directory missing; run the runtime/entity build before this audit' })
+}
+
+const errors = findings.filter((f) => f.severity === 'error')
+const warnings = findings.filter((f) => f.severity === 'warn')
+console.log(`[audit-ai-evidence-concentration] profiles=${stats.profiles} claims=${stats.claims}`)
+console.log(`[audit-ai-evidence-concentration] zero-source=${stats.zeroSourceClaims} one-source=${stats.oneSourceClaims}`)
+console.log(`[audit-ai-evidence-concentration] narrative-dominated=${stats.narrativeDominated} single-source-dominated=${stats.singleSourceDominated}`)
+for (const finding of findings.slice(0, 200)) console.log(`${finding.severity.toUpperCase()} ${finding.slug}: ${finding.issue}`)
+if (findings.length > 200) console.log(`[audit-ai-evidence-concentration] ${findings.length - 200} additional findings omitted`)
+console.log(`[audit-ai-evidence-concentration] ${errors.length} error(s), ${warnings.length} warning(s)${strict ? ' (strict)' : ' (advisory)'}`)
+
+if (errors.length > 0 || (strict && warnings.length > 0)) process.exit(1)


### PR DESCRIPTION
## Summary
- adds an AI claim-integrity audit for contradictory evidence labels and efficacy language
- adds an evidence-concentration audit for zero-source claims, one-source dependence, narrative-review dominance, and single-source claim concentration
- adds the canonical editorial policy for resolving findings at the source-of-truth layer rather than patching rendered copy

## AI SEO impact
Answer engines reward extractable certainty, but contradictory or over-concentrated evidence can make the wrong snippet look authoritative. These checks make the existing profile/entity system safer to retrieve and cite without adding duplicate AI-only content.

## Behavior
- hard contradictions fail the claim-integrity audit
- concentration findings are advisory by default
- `--strict` can promote warnings into release gates once the backlog is triaged
- audits operate on existing public runtime/entity artifacts and do not invent evidence