### PR TITLE
Make structured support auditing predicate agnostic

### DIFF
--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -26,6 +26,13 @@ export type ClaimSupportTier =
   | 'human-supported'
   | 'non-outcome'
 
+export type StructuredSupportTier =
+  | 'unsupported'
+  | 'unclassified'
+  | 'narrative-only'
+  | 'single-study'
+  | 'adequate'
+
 export type ClaimQualityAnalysis = {
   url: string
   claimId: string
@@ -45,7 +52,9 @@ export type ClaimQualityAnalysis = {
   designs: StudyClass[]
   outcomeClaim: boolean
   supportTier: ClaimSupportTier
+  structuredSupportTier: StructuredSupportTier
   weakStructuredClaim: boolean
+  highConfidenceWeakStructured: boolean
   highConfidenceWeakOutcome: boolean
   singleStudy: boolean
   aliasCollapsed: boolean
@@ -119,6 +128,18 @@ function buildProfileContext(record: ResearchProfile, cache: PubmedCache): Profi
   return { record, cache, sources, sourcesById, identities, studyGroups, studyDesigns }
 }
 
+function classifyStructuredSupport(
+  studyCount: number,
+  classifiedStudyCount: number,
+  narrativeCount: number,
+): StructuredSupportTier {
+  if (studyCount === 0) return 'unsupported'
+  if (classifiedStudyCount === 0) return 'unclassified'
+  if (narrativeCount === classifiedStudyCount) return 'narrative-only'
+  if (studyCount === 1) return 'single-study'
+  return 'adequate'
+}
+
 function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearchContext): ClaimQualityAnalysis {
   const refs = uniqueSourceRefs(claim)
   const validRefs = refs.filter((ref) => context.sourcesById.has(ref))
@@ -135,6 +156,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   const reviewStatus = String(claim.reviewStatus ?? '').trim().toLowerCase()
   const approved = reviewStatus === 'approved'
   const strongHumanSupport = primaryHuman + synthesis > 0
+  const structuredSupportTier = classifyStructuredSupport(studyIds.length, classified.length, narrative)
 
   let supportTier: ClaimSupportTier = 'non-outcome'
   if (studyIds.length === 0) supportTier = 'unsupported'
@@ -143,7 +165,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   else if (outcomeClaim && !strongHumanSupport) supportTier = 'indirect-only'
   else if (outcomeClaim) supportTier = 'human-supported'
 
-  const weakStructuredClaim = outcomeClaim && supportTier !== 'human-supported'
+  const weakStructuredClaim = structuredSupportTier !== 'adequate'
   const weakOutcome = supportTier === 'narrative-only' || supportTier === 'indirect-only'
 
   return {
@@ -165,7 +187,9 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
     designs,
     outcomeClaim,
     supportTier,
+    structuredSupportTier,
     weakStructuredClaim,
+    highConfidenceWeakStructured: confidence >= 0.75 && weakStructuredClaim,
     highConfidenceWeakOutcome:
       outcomeClaim && confidence >= 0.75 && (weakOutcome || supportTier === 'unclassified' || supportTier === 'unsupported'),
     singleStudy: studyIds.length === 1,

--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -15,14 +15,12 @@ const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
   return counts
 }, {})
 const structuredTierCounts = structuredClaimAnalyses.reduce<Record<string, number>>((counts, claim) => {
-  counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
+  counts[claim.structuredSupportTier] = (counts[claim.structuredSupportTier] ?? 0) + 1
   return counts
 }, {})
 const unapproved = structuredClaimAnalyses.filter((claim) => !claim.approved)
-const unapprovedUnsupported = unapproved.filter((claim) => claim.supportTier === 'unsupported')
-const unapprovedWeakOutcome = unapproved.filter((claim) =>
-  claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
-)
+const unapprovedUnsupported = unapproved.filter((claim) => claim.structuredSupportTier === 'unsupported')
+const unapprovedWeakStructured = unapproved.filter((claim) => claim.weakStructuredClaim)
 
 const report = {
   generatedAt: new Date().toISOString(),
@@ -32,15 +30,17 @@ const report = {
     unapprovedClaims: unapproved.length,
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
     supportTiers: tierCounts,
-    allStructuredSupportTiers: structuredTierCounts,
+    structuredSupportTiers: structuredTierCounts,
+    weakApprovedStructuredClaims: claims.filter((claim) => claim.weakStructuredClaim).length,
+    highConfidenceWeakStructuredClaims: structuredClaimAnalyses.filter((claim) => claim.highConfidenceWeakStructured).length,
     highConfidenceWeakOutcome: claims.filter((claim) => claim.highConfidenceWeakOutcome).length,
     unapprovedUnsupportedStructuredClaims: unapprovedUnsupported.length,
-    unapprovedWeakOutcomeClaims: unapprovedWeakOutcome.length,
+    unapprovedWeakStructuredClaims: unapprovedWeakStructured.length,
   },
   claims,
   editorialBacklog: {
     unsupportedStructuredClaims: unapprovedUnsupported,
-    weakOutcomeClaims: unapprovedWeakOutcome,
+    weakStructuredClaims: unapprovedWeakStructured,
   },
 }
 
@@ -49,14 +49,17 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nClaim-level evidence strength')
 console.log('='.repeat(72))
-console.log(`Structured claims             ${report.summary.structuredClaims}`)
-console.log(`Approved claims               ${report.summary.approvedClaims}`)
-console.log(`Unapproved claims             ${report.summary.unapprovedClaims}`)
-console.log(`Outcome claims                ${report.summary.outcomeClaims}`)
-for (const [tier, count] of Object.entries(tierCounts).sort((a, b) => b[1] - a[1])) {
-  console.log(`${tier.padEnd(29)} ${count}`)
+console.log(`Structured claims                  ${report.summary.structuredClaims}`)
+console.log(`Approved claims                    ${report.summary.approvedClaims}`)
+console.log(`Unapproved claims                  ${report.summary.unapprovedClaims}`)
+console.log(`Outcome claims                     ${report.summary.outcomeClaims}`)
+console.log(`Weak approved structured claims    ${report.summary.weakApprovedStructuredClaims}`)
+console.log(`High-confidence weak structured    ${report.summary.highConfidenceWeakStructuredClaims}`)
+console.log(`High-confidence weak outcomes      ${report.summary.highConfidenceWeakOutcome}`)
+console.log(`Unapproved unsupported claims      ${report.summary.unapprovedUnsupportedStructuredClaims}`)
+console.log(`Unapproved weak structured claims  ${report.summary.unapprovedWeakStructuredClaims}`)
+console.log('\nStructured support tiers:')
+for (const [tier, count] of Object.entries(structuredTierCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${tier.padEnd(26)} ${count}`)
 }
-console.log(`High-confidence weak outcomes ${report.summary.highConfidenceWeakOutcome}`)
-console.log(`Unapproved unsupported claims ${report.summary.unapprovedUnsupportedStructuredClaims}`)
-console.log(`Unapproved weak outcomes      ${report.summary.unapprovedWeakOutcomeClaims}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -21,7 +21,7 @@ function add(url: string, kind: string, weight: number, detail?: string) {
 }
 
 for (const claim of claimAnalyses) {
-  if (claim.supportTier === 'unsupported') {
+  if (claim.structuredSupportTier === 'unsupported') {
     add(claim.url, 'unsupported-approved-claim', 100, claim.claimId)
   }
   for (const sourceRefId of claim.danglingSourceRefs) {
@@ -31,25 +31,44 @@ for (const claim of claimAnalyses) {
     add(claim.url, 'single-study-approved-claim', 5, claim.claimId)
   }
 
-  const tier = claim.supportTier
-  if (tier === 'unsupported' || tier === 'human-supported' || tier === 'non-outcome') continue
-  const baseWeight = tier === 'narrative-only' ? 25 : 20
-  const confidenceBonus = claim.highConfidenceWeakOutcome ? 15 : 0
-  add(
-    claim.url,
-    `claim-support-${tier}`,
-    baseWeight + confidenceBonus,
-    `${claim.claimId}${confidenceBonus ? ' · high confidence' : ''}`,
-  )
+  if (claim.structuredSupportTier === 'unclassified') {
+    add(
+      claim.url,
+      'claim-support-unclassified',
+      20 + (claim.highConfidenceWeakStructured ? 15 : 0),
+      `${claim.claimId} · ${claim.predicate}${claim.highConfidenceWeakStructured ? ' · high confidence' : ''}`,
+    )
+  } else if (claim.structuredSupportTier === 'narrative-only') {
+    add(
+      claim.url,
+      'claim-support-narrative-only',
+      (claim.outcomeClaim ? 25 : 15) + (claim.highConfidenceWeakStructured ? 15 : 0),
+      `${claim.claimId} · ${claim.predicate}${claim.highConfidenceWeakStructured ? ' · high confidence' : ''}`,
+    )
+  } else if (claim.supportTier === 'indirect-only') {
+    add(
+      claim.url,
+      'claim-support-indirect-only',
+      20 + (claim.highConfidenceWeakOutcome ? 15 : 0),
+      `${claim.claimId}${claim.highConfidenceWeakOutcome ? ' · high confidence' : ''}`,
+    )
+  }
 }
 
 for (const claim of structuredClaimAnalyses.filter((item) => !item.approved)) {
-  if (claim.supportTier === 'unsupported') {
+  if (claim.structuredSupportTier === 'unsupported') {
     add(claim.url, 'unsupported-unapproved-structured-claim', 4, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
     continue
   }
-  if (claim.outcomeClaim && ['unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier)) {
-    add(claim.url, `unapproved-claim-support-${claim.supportTier}`, 3, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
+  if (claim.structuredSupportTier === 'unclassified' || claim.structuredSupportTier === 'narrative-only') {
+    add(
+      claim.url,
+      `unapproved-claim-support-${claim.structuredSupportTier}`,
+      3,
+      `${claim.claimId} · ${claim.predicate} · ${claim.reviewStatus || 'unreviewed'}`,
+    )
+  } else if (claim.supportTier === 'indirect-only') {
+    add(claim.url, 'unapproved-claim-support-indirect-only', 3, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
   }
 }
 
@@ -90,23 +109,28 @@ const report = {
   generatedAt: new Date().toISOString(),
   source: 'lib/research-quality-analysis.ts',
   scoring: {
-    note: 'Scores prioritize structural invalidity first, then approved-claim weakness, effective-study concentration, evidence-mix imbalance, and finally low-weight editorial backlog for unapproved structured claims. They are triage weights, not evidence grades.',
+    note: 'Scores prioritize structural invalidity first, then predicate-agnostic structured-support weakness, effective-study concentration, evidence-mix imbalance, and finally low-weight editorial backlog for unapproved structured claims. They are triage weights, not evidence grades.',
     weights: {
       unsupportedApprovedClaim: 100,
       danglingClaimSourceEdge: 100,
       highStudyDependency: '25 + dominant supported-claim share × 30 + concentration bonus (max 15)',
-      narrativeOnlyClaimSupport: 25,
-      indirectOrUnclassifiedClaimSupport: 20,
+      narrativeOnlyOutcomeSupport: 25,
+      narrativeOnlyOtherStructuredSupport: 15,
+      indirectOutcomeSupport: 20,
+      unclassifiedStructuredSupport: 20,
       highConfidenceWeakClaimBonus: 15,
       noPrimaryHumanStudy: 20,
       narrativeReviewDominatedProfile: 20,
       singleStudyApprovedClaim: 5,
       unsupportedUnapprovedStructuredClaim: 4,
-      weakUnapprovedOutcomeClaim: 3,
+      weakUnapprovedStructuredClaim: 3,
     },
   },
   summary: {
     profilesWithResearchGaps: ranked.length,
+    weakApprovedStructuredClaims: claimAnalyses.filter((claim) => claim.weakStructuredClaim).length,
+    weakUnapprovedStructuredClaims: structuredClaimAnalyses.filter((claim) => !claim.approved && claim.weakStructuredClaim).length,
+    highConfidenceWeakStructuredClaims: structuredClaimAnalyses.filter((claim) => claim.highConfidenceWeakStructured).length,
     critical: ranked.filter((item) => item.score >= 100).length,
     high: ranked.filter((item) => item.score >= 60 && item.score < 100).length,
     medium: ranked.filter((item) => item.score >= 25 && item.score < 60).length,
@@ -116,15 +140,18 @@ const report = {
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
-fs.writeFileSync(OUTPUT, `${JSON.stringify(report, null,2)}\n`)
+fs.writeFileSync(OUTPUT, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nPrioritized research-gap queue')
 console.log('='.repeat(72))
-console.log(`Profiles with gaps  ${report.summary.profilesWithResearchGaps}`)
-console.log(`Critical            ${report.summary.critical}`)
-console.log(`High                ${report.summary.high}`)
-console.log(`Medium              ${report.summary.medium}`)
-console.log(`Low                 ${report.summary.low}`)
+console.log(`Profiles with gaps                ${report.summary.profilesWithResearchGaps}`)
+console.log(`Weak approved structured claims   ${report.summary.weakApprovedStructuredClaims}`)
+console.log(`Weak unapproved structured claims ${report.summary.weakUnapprovedStructuredClaims}`)
+console.log(`High-confidence weak structured   ${report.summary.highConfidenceWeakStructuredClaims}`)
+console.log(`Critical                          ${report.summary.critical}`)
+console.log(`High                              ${report.summary.high}`)
+console.log(`Medium                            ${report.summary.medium}`)
+console.log(`Low                               ${report.summary.low}`)
 for (const item of ranked.slice(0, 10)) {
   console.log(`  ${String(item.score).padStart(3)} · ${item.url} · ${item.reasons.length} finding(s)`)
 }


### PR DESCRIPTION
Closed to split the change into conflict-resistant atomic merges. Concurrent work is updating the report consumers, while the canonical analyzer itself remains unchanged; the predicate-agnostic support model will land first, then consumers will follow from the new main.