### PR TITLE
Add predicate-agnostic structured support tiers

### DIFF
--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -26,6 +26,13 @@ export type ClaimSupportTier =
   | 'human-supported'
   | 'non-outcome'
 
+export type StructuredSupportTier =
+  | 'unsupported'
+  | 'unclassified'
+  | 'narrative-only'
+  | 'single-study'
+  | 'adequate'
+
 export type ClaimQualityAnalysis = {
   url: string
   claimId: string
@@ -45,7 +52,9 @@ export type ClaimQualityAnalysis = {
   designs: StudyClass[]
   outcomeClaim: boolean
   supportTier: ClaimSupportTier
+  structuredSupportTier: StructuredSupportTier
   weakStructuredClaim: boolean
+  highConfidenceWeakStructured: boolean
   highConfidenceWeakOutcome: boolean
   singleStudy: boolean
   aliasCollapsed: boolean
@@ -119,6 +128,18 @@ function buildProfileContext(record: ResearchProfile, cache: PubmedCache): Profi
   return { record, cache, sources, sourcesById, identities, studyGroups, studyDesigns }
 }
 
+function classifyStructuredSupport(
+  studyCount: number,
+  classifiedStudyCount: number,
+  narrativeCount: number,
+): StructuredSupportTier {
+  if (studyCount === 0) return 'unsupported'
+  if (classifiedStudyCount === 0) return 'unclassified'
+  if (narrativeCount === classifiedStudyCount) return 'narrative-only'
+  if (studyCount === 1) return 'single-study'
+  return 'adequate'
+}
+
 function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearchContext): ClaimQualityAnalysis {
   const refs = uniqueSourceRefs(claim)
   const validRefs = refs.filter((ref) => context.sourcesById.has(ref))
@@ -135,6 +156,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   const reviewStatus = String(claim.reviewStatus ?? '').trim().toLowerCase()
   const approved = reviewStatus === 'approved'
   const strongHumanSupport = primaryHuman + synthesis > 0
+  const structuredSupportTier = classifyStructuredSupport(studyIds.length, classified.length, narrative)
 
   let supportTier: ClaimSupportTier = 'non-outcome'
   if (studyIds.length === 0) supportTier = 'unsupported'
@@ -143,7 +165,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   else if (outcomeClaim && !strongHumanSupport) supportTier = 'indirect-only'
   else if (outcomeClaim) supportTier = 'human-supported'
 
-  const weakStructuredClaim = outcomeClaim && supportTier !== 'human-supported'
+  const weakStructuredClaim = structuredSupportTier !== 'adequate'
   const weakOutcome = supportTier === 'narrative-only' || supportTier === 'indirect-only'
 
   return {
@@ -165,7 +187,9 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
     designs,
     outcomeClaim,
     supportTier,
+    structuredSupportTier,
     weakStructuredClaim,
+    highConfidenceWeakStructured: confidence >= 0.75 && weakStructuredClaim,
     highConfidenceWeakOutcome:
       outcomeClaim && confidence >= 0.75 && (weakOutcome || supportTier === 'unclassified' || supportTier === 'unsupported'),
     singleStudy: studyIds.length === 1,


### PR DESCRIPTION
Canonical analyzer only: classify unsupported, unclassified, narrative-only, single-study, and adequate support independently of claim predicate; expose weak/high-confidence weak structured-claim flags across approved and unapproved claims.