### PR TITLE
Report weak structured support across predicates

### DIFF
--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -26,6 +26,13 @@ export type ClaimSupportTier =
   | 'human-supported'
   | 'non-outcome'
 
+export type StructuredSupportTier =
+  | 'unsupported'
+  | 'unclassified'
+  | 'narrative-only'
+  | 'single-study'
+  | 'adequate'
+
 export type ClaimQualityAnalysis = {
   url: string
   claimId: string
@@ -45,7 +52,9 @@ export type ClaimQualityAnalysis = {
   designs: StudyClass[]
   outcomeClaim: boolean
   supportTier: ClaimSupportTier
+  structuredSupportTier: StructuredSupportTier
   weakStructuredClaim: boolean
+  highConfidenceWeakStructured: boolean
   highConfidenceWeakOutcome: boolean
   singleStudy: boolean
   aliasCollapsed: boolean
@@ -119,6 +128,18 @@ function buildProfileContext(record: ResearchProfile, cache: PubmedCache): Profi
   return { record, cache, sources, sourcesById, identities, studyGroups, studyDesigns }
 }
 
+function classifyStructuredSupport(
+  studyCount: number,
+  classifiedStudyCount: number,
+  narrativeCount: number,
+): StructuredSupportTier {
+  if (studyCount === 0) return 'unsupported'
+  if (classifiedStudyCount === 0) return 'unclassified'
+  if (narrativeCount === classifiedStudyCount) return 'narrative-only'
+  if (studyCount === 1) return 'single-study'
+  return 'adequate'
+}
+
 function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearchContext): ClaimQualityAnalysis {
   const refs = uniqueSourceRefs(claim)
   const validRefs = refs.filter((ref) => context.sourcesById.has(ref))
@@ -135,6 +156,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   const reviewStatus = String(claim.reviewStatus ?? '').trim().toLowerCase()
   const approved = reviewStatus === 'approved'
   const strongHumanSupport = primaryHuman + synthesis > 0
+  const structuredSupportTier = classifyStructuredSupport(studyIds.length, classified.length, narrative)
 
   let supportTier: ClaimSupportTier = 'non-outcome'
   if (studyIds.length === 0) supportTier = 'unsupported'
@@ -143,7 +165,7 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
   else if (outcomeClaim && !strongHumanSupport) supportTier = 'indirect-only'
   else if (outcomeClaim) supportTier = 'human-supported'
 
-  const weakStructuredClaim = outcomeClaim && supportTier !== 'human-supported'
+  const weakStructuredClaim = structuredSupportTier !== 'adequate'
   const weakOutcome = supportTier === 'narrative-only' || supportTier === 'indirect-only'
 
   return {
@@ -165,7 +187,9 @@ function analyzeClaim(url: string, claim: ResearchClaim, context: ProfileResearc
     designs,
     outcomeClaim,
     supportTier,
+    structuredSupportTier,
     weakStructuredClaim,
+    highConfidenceWeakStructured: confidence >= 0.75 && weakStructuredClaim,
     highConfidenceWeakOutcome:
       outcomeClaim && confidence >= 0.75 && (weakOutcome || supportTier === 'unclassified' || supportTier === 'unsupported'),
     singleStudy: studyIds.length === 1,

--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -15,14 +15,12 @@ const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
   return counts
 }, {})
 const structuredTierCounts = structuredClaimAnalyses.reduce<Record<string, number>>((counts, claim) => {
-  counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
+  counts[claim.structuredSupportTier] = (counts[claim.structuredSupportTier] ?? 0) + 1
   return counts
 }, {})
 const unapproved = structuredClaimAnalyses.filter((claim) => !claim.approved)
-const unapprovedUnsupported = unapproved.filter((claim) => claim.supportTier === 'unsupported')
-const unapprovedWeakOutcome = unapproved.filter((claim) =>
-  claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
-)
+const unapprovedUnsupported = unapproved.filter((claim) => claim.structuredSupportTier === 'unsupported')
+const unapprovedWeakStructured = unapproved.filter((claim) => claim.weakStructuredClaim)
 
 const report = {
   generatedAt: new Date().toISOString(),
@@ -32,15 +30,17 @@ const report = {
     unapprovedClaims: unapproved.length,
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
     supportTiers: tierCounts,
-    allStructuredSupportTiers: structuredTierCounts,
+    structuredSupportTiers: structuredTierCounts,
+    weakApprovedStructuredClaims: claims.filter((claim) => claim.weakStructuredClaim).length,
+    highConfidenceWeakStructuredClaims: structuredClaimAnalyses.filter((claim) => claim.highConfidenceWeakStructured).length,
     highConfidenceWeakOutcome: claims.filter((claim) => claim.highConfidenceWeakOutcome).length,
     unapprovedUnsupportedStructuredClaims: unapprovedUnsupported.length,
-    unapprovedWeakOutcomeClaims: unapprovedWeakOutcome.length,
+    unapprovedWeakStructuredClaims: unapprovedWeakStructured.length,
   },
   claims,
   editorialBacklog: {
     unsupportedStructuredClaims: unapprovedUnsupported,
-    weakOutcomeClaims: unapprovedWeakOutcome,
+    weakStructuredClaims: unapprovedWeakStructured,
   },
 }
 
@@ -49,14 +49,17 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nClaim-level evidence strength')
 console.log('='.repeat(72))
-console.log(`Structured claims             ${report.summary.structuredClaims}`)
-console.log(`Approved claims               ${report.summary.approvedClaims}`)
-console.log(`Unapproved claims             ${report.summary.unapprovedClaims}`)
-console.log(`Outcome claims                ${report.summary.outcomeClaims}`)
-for (const [tier, count] of Object.entries(tierCounts).sort((a, b) => b[1] - a[1])) {
-  console.log(`${tier.padEnd(29)} ${count}`)
+console.log(`Structured claims                  ${report.summary.structuredClaims}`)
+console.log(`Approved claims                    ${report.summary.approvedClaims}`)
+console.log(`Unapproved claims                  ${report.summary.unapprovedClaims}`)
+console.log(`Outcome claims                     ${report.summary.outcomeClaims}`)
+console.log(`Weak approved structured claims    ${report.summary.weakApprovedStructuredClaims}`)
+console.log(`High-confidence weak structured    ${report.summary.highConfidenceWeakStructuredClaims}`)
+console.log(`High-confidence weak outcomes      ${report.summary.highConfidenceWeakOutcome}`)
+console.log(`Unapproved unsupported claims      ${report.summary.unapprovedUnsupportedStructuredClaims}`)
+console.log(`Unapproved weak structured claims  ${report.summary.unapprovedWeakStructuredClaims}`)
+console.log('\nStructured support tiers:')
+for (const [tier, count] of Object.entries(structuredTierCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${tier.padEnd(26)} ${count}`)
 }
-console.log(`High-confidence weak outcomes ${report.summary.highConfidenceWeakOutcome}`)
-console.log(`Unapproved unsupported claims ${report.summary.unapprovedUnsupportedStructuredClaims}`)
-console.log(`Unapproved weak outcomes      ${report.summary.unapprovedWeakOutcomeClaims}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)


### PR DESCRIPTION
Closed after the analyzer portion landed independently in #3345. Replacing this with an audit-only PR from current main so no already-merged canonical core is replayed.