### PR TITLE
feat(research): surface directness and metadata gaps

### DIFF
--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -28,6 +28,8 @@ export const RESEARCH_GAP_WEIGHTS = {
   highConfidenceWeakClaimBonus: 15,
   noPrimaryHumanStudy: 20,
   narrativeReviewDominatedProfile: 20,
+  synthesisOnlyApprovedOutcome: 8,
+  poorStudyMetadataCoverage: 12,
   singleStudyApprovedClaim: 5,
   unsupportedUnapprovedStructuredClaim: 4,
   weakUnapprovedOutcomeClaim: 3,
@@ -71,6 +73,14 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): Resear
     }
     if (claim.singleStudy) {
       add(claim.url, 'single-study-approved-claim', RESEARCH_GAP_WEIGHTS.singleStudyApprovedClaim, claim.claimId)
+    }
+    if (claim.outcomeClaim && claim.primaryHuman === 0 && claim.synthesis > 0) {
+      add(
+        claim.url,
+        'synthesis-only-approved-outcome',
+        RESEARCH_GAP_WEIGHTS.synthesisOnlyApprovedOutcome,
+        `${claim.claimId} · synthesis evidence present but no direct primary-human study`,
+      )
     }
 
     const tier = claim.supportTier
@@ -134,6 +144,18 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): Resear
         profile.url,
         'approved-claims-without-primary-human-study',
         RESEARCH_GAP_WEIGHTS.noPrimaryHumanStudy,
+      )
+    }
+
+    const unclassifiedStudies = Number(profile.designMix.unclassified ?? 0)
+    const classifiedStudies = Math.max(0, profile.canonicalStudyCount - unclassifiedStudies)
+    const metadataCoverage = profile.canonicalStudyCount ? classifiedStudies / profile.canonicalStudyCount : 1
+    if (profile.canonicalStudyCount >= 3 && metadataCoverage < 0.7) {
+      add(
+        profile.url,
+        'poor-study-metadata-coverage',
+        RESEARCH_GAP_WEIGHTS.poorStudyMetadataCoverage,
+        `${Math.round(metadataCoverage * 100)}% of canonical studies have classified study designs`,
       )
     }
   }


### PR DESCRIPTION
Adds two research-quality gap signals without disturbing the newer structured-support-tier model: synthesis-only approved outcome claims (human synthesis exists but no direct primary-human study) and poor study-design metadata coverage (<70% classified across profiles with at least 3 canonical studies). These remain editorial/coverage gaps, not evidence downgrades.