### PR TITLE
Report predicate-agnostic structured support

### DIFF
--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -15,14 +15,12 @@ const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
   return counts
 }, {})
 const structuredTierCounts = structuredClaimAnalyses.reduce<Record<string, number>>((counts, claim) => {
-  counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
+  counts[claim.structuredSupportTier] = (counts[claim.structuredSupportTier] ?? 0) + 1
   return counts
 }, {})
 const unapproved = structuredClaimAnalyses.filter((claim) => !claim.approved)
-const unapprovedUnsupported = unapproved.filter((claim) => claim.supportTier === 'unsupported')
-const unapprovedWeakOutcome = unapproved.filter((claim) =>
-  claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
-)
+const unapprovedUnsupported = unapproved.filter((claim) => claim.structuredSupportTier === 'unsupported')
+const unapprovedWeakStructured = unapproved.filter((claim) => claim.weakStructuredClaim)
 
 const report = {
   generatedAt: new Date().toISOString(),
@@ -32,15 +30,17 @@ const report = {
     unapprovedClaims: unapproved.length,
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
     supportTiers: tierCounts,
-    allStructuredSupportTiers: structuredTierCounts,
+    structuredSupportTiers: structuredTierCounts,
+    weakApprovedStructuredClaims: claims.filter((claim) => claim.weakStructuredClaim).length,
+    highConfidenceWeakStructuredClaims: structuredClaimAnalyses.filter((claim) => claim.highConfidenceWeakStructured).length,
     highConfidenceWeakOutcome: claims.filter((claim) => claim.highConfidenceWeakOutcome).length,
     unapprovedUnsupportedStructuredClaims: unapprovedUnsupported.length,
-    unapprovedWeakOutcomeClaims: unapprovedWeakOutcome.length,
+    unapprovedWeakStructuredClaims: unapprovedWeakStructured.length,
   },
   claims,
   editorialBacklog: {
     unsupportedStructuredClaims: unapprovedUnsupported,
-    weakOutcomeClaims: unapprovedWeakOutcome,
+    weakStructuredClaims: unapprovedWeakStructured,
   },
 }
 
@@ -49,14 +49,17 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`)
 
 console.log('\nClaim-level evidence strength')
 console.log('='.repeat(72))
-console.log(`Structured claims             ${report.summary.structuredClaims}`)
-console.log(`Approved claims               ${report.summary.approvedClaims}`)
-console.log(`Unapproved claims             ${report.summary.unapprovedClaims}`)
-console.log(`Outcome claims                ${report.summary.outcomeClaims}`)
-for (const [tier, count] of Object.entries(tierCounts).sort((a, b) => b[1] - a[1])) {
-  console.log(`${tier.padEnd(29)} ${count}`)
+console.log(`Structured claims                  ${report.summary.structuredClaims}`)
+console.log(`Approved claims                    ${report.summary.approvedClaims}`)
+console.log(`Unapproved claims                  ${report.summary.unapprovedClaims}`)
+console.log(`Outcome claims                     ${report.summary.outcomeClaims}`)
+console.log(`Weak approved structured claims    ${report.summary.weakApprovedStructuredClaims}`)
+console.log(`High-confidence weak structured    ${report.summary.highConfidenceWeakStructuredClaims}`)
+console.log(`High-confidence weak outcomes      ${report.summary.highConfidenceWeakOutcome}`)
+console.log(`Unapproved unsupported claims      ${report.summary.unapprovedUnsupportedStructuredClaims}`)
+console.log(`Unapproved weak structured claims  ${report.summary.unapprovedWeakStructuredClaims}`)
+console.log('\nStructured support tiers:')
+for (const [tier, count] of Object.entries(structuredTierCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${tier.padEnd(26)} ${count}`)
 }
-console.log(`High-confidence weak outcomes ${report.summary.highConfidenceWeakOutcome}`)
-console.log(`Unapproved unsupported claims ${report.summary.unapprovedUnsupportedStructuredClaims}`)
-console.log(`Unapproved weak outcomes      ${report.summary.unapprovedWeakOutcomeClaims}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)


### PR DESCRIPTION
Updates the claim-strength report to use canonical structured support tiers for all predicates, including weak approved claims and unapproved editorial backlog.