### PR TITLE
feat(research): detect systemic load-bearing studies

### DIFF
--- a/lib/research-study-load.ts
+++ b/lib/research-study-load.ts
@@ -1,0 +1,72 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type CrossProfileStudyLoad = {
+  studyId: string
+  approvedClaimCount: number
+  profileCount: number
+  outcomeClaimCount: number
+  highConfidenceClaimCount: number
+  profiles: string[]
+  claims: Array<{ url: string; claimId: string; predicate: string; confidence: number }>
+  systemicLoadBearing: boolean
+}
+
+/**
+ * Measure how many approved claims and profiles depend on each canonical study.
+ * This complements per-profile concentration: a study may look harmless on every
+ * individual page while still underwriting a large portion of the site globally.
+ */
+export function analyzeCrossProfileStudyLoad(analysis: ResearchQualityAnalysis): CrossProfileStudyLoad[] {
+  const byStudy = new Map<string, {
+    profiles: Set<string>
+    claims: Map<string, { url: string; claimId: string; predicate: string; confidence: number }>
+    outcomeClaimCount: number
+    highConfidenceClaimCount: number
+  }>()
+
+  for (const claim of analysis.claimAnalyses) {
+    for (const studyId of claim.studyIds) {
+      const item = byStudy.get(studyId) ?? {
+        profiles: new Set<string>(),
+        claims: new Map<string, { url: string; claimId: string; predicate: string; confidence: number }>(),
+        outcomeClaimCount: 0,
+        highConfidenceClaimCount: 0,
+      }
+      const claimKey = `${claim.url}#${claim.claimId}`
+      if (!item.claims.has(claimKey)) {
+        item.claims.set(claimKey, {
+          url: claim.url,
+          claimId: claim.claimId,
+          predicate: claim.predicate,
+          confidence: claim.confidence,
+        })
+        if (claim.outcomeClaim) item.outcomeClaimCount += 1
+        if (claim.confidence >= 0.75) item.highConfidenceClaimCount += 1
+      }
+      item.profiles.add(claim.url)
+      byStudy.set(studyId, item)
+    }
+  }
+
+  return [...byStudy.entries()]
+    .map(([studyId, item]) => {
+      const approvedClaimCount = item.claims.size
+      const profileCount = item.profiles.size
+      return {
+        studyId,
+        approvedClaimCount,
+        profileCount,
+        outcomeClaimCount: item.outcomeClaimCount,
+        highConfidenceClaimCount: item.highConfidenceClaimCount,
+        profiles: [...item.profiles].sort(),
+        claims: [...item.claims.values()].sort((a, b) => a.url.localeCompare(b.url) || a.claimId.localeCompare(b.claimId)),
+        systemicLoadBearing: approvedClaimCount >= 5 && profileCount >= 3,
+      }
+    })
+    .sort((a, b) =>
+      Number(b.systemicLoadBearing) - Number(a.systemicLoadBearing)
+      || b.approvedClaimCount - a.approvedClaimCount
+      || b.profileCount - a.profileCount
+      || a.studyId.localeCompare(b.studyId),
+    )
+}

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchGapQueue, structuralCoverageFailures } from '../../lib/research-quality-policy'
+import { analyzeCrossProfileStudyLoad } from '../../lib/research-study-load'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
@@ -46,6 +47,8 @@ const coreStarted = Date.now()
 const analysis = analyzeResearchQuality(ROOT)
 const structuralFailures = structuralCoverageFailures(analysis)
 const researchGapQueue = buildResearchGapQueue(analysis)
+const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
+const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
 const weakApprovedOutcomes = analysis.claimAnalyses.filter((claim) =>
   claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
 )
@@ -67,7 +70,7 @@ results.push({
   passed: corePassed,
   exitCode: corePassed ? 0 : 1,
   durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; structuredClaims=${analysis.structuredClaimAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; gaps=${researchGapQueue.length}`,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; structuredClaims=${analysis.structuredClaimAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}`,
   stderrTail: structuralFailures.length ? `${structuralFailures.length} structurally invalid approved-claim evidence edge(s)` : '',
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile research-quality analysis  (${coreDurationMs}ms)`)
@@ -104,19 +107,24 @@ const coreSummary = {
   narrativeDominatedProfiles: narrativeDominatedProfiles.length,
   profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
   profilesWithResearchGaps: researchGapQueue.length,
+  canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
+  systemicLoadBearingStudies: systemicLoadBearingStudies.length,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 2,
+  schemaVersion: 3,
   generatedAt: new Date().toISOString(),
   passed: !failed,
   source: {
     analysis: 'lib/research-quality-analysis.ts',
     policy: 'lib/research-quality-policy.ts',
+    crossProfileStudyLoad: 'lib/research-study-load.ts',
   },
   coreSummary,
   structuralFailures,
+  systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
+  topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100),
   topResearchGaps: researchGapQueue.slice(0, 50),
   checks: results,
   sourceIntegritySummary: readSummary('source-integrity.json'),
@@ -126,6 +134,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
 
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
 console.log(`Structural failures ${coreSummary.structuralFailures} · weak approved outcomes ${coreSummary.weakApprovedOutcomeClaims} · research-gap profiles ${coreSummary.profilesWithResearchGaps}`)
+console.log(`Systemic load-bearing studies ${coreSummary.systemicLoadBearingStudies} of ${coreSummary.canonicalStudiesSupportingApprovedClaims} canonical studies supporting approved claims`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
 if (failed) {
   console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.')


### PR DESCRIPTION
Adds cross-profile canonical-study load analysis over approved claim-study edges. The canonical research-quality report now surfaces papers that support at least five approved claims across at least three profiles, plus ranked global study load, closing the gap where a paper could be modestly used per page but systemically over-relied upon across the site.