### PR TITLE
Refactor research quality and AI citation remediation into one pass

### DIFF
--- a/docs/ai-citation-readiness-topology.md
+++ b/docs/ai-citation-readiness-topology.md
@@ -6,7 +6,7 @@ Use one profile-level prioritization layer to decide which herb and compound pag
 
 ## Canonical score
 
-`scripts/ci/audit-ai-citation-topology.ts` scores each machine-readable profile from 0–100 using:
+`lib/ai-citation-readiness.ts` builds each machine-readable profile score from 0–100 using:
 
 - canonical claim-to-source citation completeness: 25%
 - canonical primary-human/systematic-review coverage: 20%
@@ -37,6 +37,15 @@ The topology consumes these fields directly from the shared research-quality ana
 
 This prevents AI SEO scoring from silently disagreeing with release research-quality policy.
 
+## One-pass generation
+
+The canonical `scripts/ci/research-quality.ts` pipeline now runs `analyzeResearchQuality()` once, derives research gaps and study-load topology, and passes that same in-memory analysis into `buildAiCitationReadiness()`. It writes both:
+
+- `ops/reports/research-quality.json` — authoritative research-quality roll-up plus the top AI remediation rows.
+- `reports/ai-citation-readiness.json` — the full AI citation-remediation queue.
+
+The standalone CLI remains a thin compatibility/diagnostic wrapper. It no longer owns scientific classification logic.
+
 ## Interpretation
 
 - 85–100: citation-ready structure; still subject to substantive editorial review.
@@ -60,18 +69,22 @@ For low-scoring profiles, fix gaps in this order:
 
 Never improve the score by fabricating citations, duplicating sources, relabeling narrative reviews as primary studies, or adding generic safety/freshness prose that is not supported by the underlying record.
 
-## Output
+## Commands
 
-Run:
+Canonical full research-quality pass:
+
+```bash
+npx tsx scripts/ci/research-quality.ts
+```
+
+Standalone AI view when only that report is needed:
 
 ```bash
 npx tsx scripts/ci/audit-ai-citation-topology.ts
 ```
 
-The audit writes `reports/ai-citation-readiness.json`, sorted from weakest to strongest profile. This is the canonical AI citation-remediation queue.
-
-Use `--strict` only when the entity artifacts have been generated and the existing backlog has been intentionally triaged. Strict mode fails on contradictory profiles or any profile scoring below 50.
+Use `--strict` on the standalone topology only after the current remediation backlog has been intentionally triaged.
 
 ## Relationship to existing audits
 
-`analyzeResearchQuality()` is authoritative for scientific-support topology. Specialized audits remain diagnostics. The AI topology adds retrieval/presentation readiness on top of that canonical graph; it must not create a second research-quality taxonomy, study classifier, concentration model, or remediation queue.
+`analyzeResearchQuality()` is authoritative for scientific-support topology. `buildAiCitationReadiness()` is the only AI citation-prioritization layer. Specialized audits remain diagnostics. Do not create a second research-quality taxonomy, study classifier, concentration model, or competing remediation queue.

--- a/lib/ai-citation-readiness.ts
+++ b/lib/ai-citation-readiness.ts
@@ -1,0 +1,225 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type {
+  ClaimQualityAnalysis,
+  ProfileQualityAnalysis,
+  ResearchQualityAnalysis,
+} from './research-quality-analysis'
+
+const WEAK = /preliminary|mixed evidence|limited evidence|insufficient|unclear|weak evidence|theoretical|animal evidence|in[- ]vitro|mechanistic only|research pending/i
+const STRONG = /\b(?:grade\s*)?a\b|strong human evidence|high confidence|well[- ]established|robust evidence/i
+const POSITIVE = /effective|efficacious|clinically proven|proven to|shown to improve|strong evidence for|supports the use/i
+const NEGATIVE = /not supported|unsupported|no good evidence|insufficient evidence|does not support|failed to show|no clear benefit/i
+
+type EntitySurface = {
+  slug: string
+  kind: 'herb' | 'compound' | 'unknown'
+  freshnessSignal: boolean
+  safetySignal: boolean
+  answerSignal: boolean
+  contradiction: boolean
+}
+
+export type AiCitationReadinessRow = {
+  slug: string
+  kind: EntitySurface['kind']
+  score: number
+  researchUrl: string | null
+  approvedClaims: number
+  canonicalStudies: number
+  citationCompleteness: number
+  primaryHuman: number
+  systematicReviews: number
+  narrativeReviews: number
+  dominantStudySupportedClaimShare: number
+  effectiveStudyCount: number
+  contradiction: boolean
+  gaps: string[]
+}
+
+export type AiCitationReadinessReport = {
+  summary: {
+    generatedAt: string
+    researchQualitySource: string
+    profiles: number
+    matchedResearchProfiles: number
+    averageScore: number
+    below50: number
+    below70: number
+    contradictions: number
+    overDependentOnSingleStudy: number
+    narrativeDominated: number
+  }
+  profiles: AiCitationReadinessRow[]
+}
+
+function filesUnder(dir: string, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) filesUnder(full, out)
+    else if (entry.name.endsWith('.json') && entry.name !== 'manifest.json') out.push(full)
+  }
+  return out
+}
+
+function strings(value: unknown, out: string[] = []): string[] {
+  if (value == null) return out
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    out.push(String(value))
+    return out
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) strings(item, out)
+    return out
+  }
+  if (typeof value === 'object') {
+    for (const item of Object.values(value as Record<string, unknown>)) strings(item, out)
+  }
+  return out
+}
+
+function readEntitySurface(file: string, entityRoot: string): EntitySurface | null {
+  try {
+    const doc = JSON.parse(fs.readFileSync(file, 'utf8')) as unknown
+    const allText = strings(doc).join(' | ')
+    const relative = path.relative(entityRoot, file).replaceAll('\\', '/')
+    return {
+      slug: path.basename(file, '.json'),
+      kind: relative.startsWith('herb/') ? 'herb' : relative.startsWith('compound/') ? 'compound' : 'unknown',
+      freshnessSignal: /dateModified|datePublished|lastReviewed|reviewedAt|modifiedAt|review date/i.test(allText),
+      safetySignal: /safety|contraindication|interaction|adverse|pregnan|warning|caution/i.test(allText),
+      answerSignal: /summary|description|bottom line|quick answer|verdict|evidence summary/i.test(allText),
+      contradiction: (STRONG.test(allText) && WEAK.test(allText)) || (POSITIVE.test(allText) && NEGATIVE.test(allText)),
+    }
+  } catch {
+    return null
+  }
+}
+
+function slugFromUrl(url: string): string {
+  try {
+    const parsed = url.startsWith('http') ? new URL(url) : new URL(url, 'https://thehippiescientist.net')
+    return parsed.pathname.split('/').filter(Boolean).at(-1) ?? ''
+  } catch {
+    return url.split('/').filter(Boolean).at(-1) ?? ''
+  }
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function claimsByUrl(claims: ClaimQualityAnalysis[]): Map<string, ClaimQualityAnalysis[]> {
+  const map = new Map<string, ClaimQualityAnalysis[]>()
+  for (const claim of claims) {
+    const items = map.get(claim.url) ?? []
+    items.push(claim)
+    map.set(claim.url, items)
+  }
+  return map
+}
+
+export function buildAiCitationReadiness(
+  analysis: ResearchQualityAnalysis,
+  root = process.cwd(),
+): AiCitationReadinessReport {
+  const entityRoot = path.join(root, 'public', 'data', 'ai-entities')
+  const approvedClaimsByUrl = claimsByUrl(analysis.claimAnalyses)
+  const profileBySlug = new Map<string, ProfileQualityAnalysis>()
+  for (const profile of analysis.profileAnalyses) profileBySlug.set(slugFromUrl(profile.url), profile)
+
+  const surfaces = filesUnder(entityRoot)
+    .map((file) => readEntitySurface(file, entityRoot))
+    .filter((surface): surface is EntitySurface => Boolean(surface))
+
+  const rows: AiCitationReadinessRow[] = []
+  for (const surface of surfaces) {
+    const research = profileBySlug.get(surface.slug)
+    const approvedClaims = research ? (approvedClaimsByUrl.get(research.url) ?? []) : []
+    const citationCompleteness = approvedClaims.length
+      ? approvedClaims.filter((claim) => claim.validSourceRefCount > 0 && claim.danglingSourceRefs.length === 0).length / approvedClaims.length
+      : research?.sourceCount
+        ? 0.6
+        : 0
+    const humanRelevant = research ? research.primaryHuman + research.synthesis + research.narrativeReview : 0
+    const primaryCoverage = humanRelevant && research ? (research.primaryHuman + research.synthesis) / humanRelevant : 0
+    const independence = research ? 1 - Math.min(1, research.dominantStudySupportedClaimShare) : 0
+    const sourceDepth = research ? Math.min(1, research.canonicalStudyCount / 5) : 0
+
+    const score = clamp(
+      citationCompleteness * 25 +
+      primaryCoverage * 20 +
+      independence * 15 +
+      sourceDepth * 10 +
+      Number(surface.freshnessSignal) * 10 +
+      Number(surface.safetySignal) * 10 +
+      Number(surface.answerSignal) * 10 -
+      (surface.contradiction ? 35 : 0),
+    )
+
+    const gaps: string[] = []
+    if (surface.contradiction) gaps.push('contradictory extractable claims')
+    if (!research) gaps.push('no canonical research-quality profile match')
+    if (research?.unsupportedApprovedClaims.length) gaps.push(`${research.unsupportedApprovedClaims.length} unsupported approved claim(s)`)
+    if (research?.danglingSourceRefs.length) gaps.push(`${research.danglingSourceRefs.length} dangling source reference(s)`)
+    if (research?.weakStructuredClaimCount) gaps.push(`${research.weakStructuredClaimCount} weak approved structured claim(s)`)
+    if (research?.singleStudyApprovedClaims.length) gaps.push(`${research.singleStudyApprovedClaims.length} approved claim(s) supported by one study`)
+    if (research?.overDependentOnSingleStudy) gaps.push('canonical research graph is over-dependent on one study')
+    if (research?.narrativeDominatedVsPrimaryHuman) gaps.push('narrative-review dominated versus primary human research')
+    if (research?.noPrimaryHuman) gaps.push('approved claims exist without primary human studies')
+    if (research && research.canonicalStudyCount >= 3) {
+      const classified = research.canonicalStudyCount - (research.designMix.unclassified ?? 0)
+      if (classified / research.canonicalStudyCount < 0.7) gaps.push('study-design metadata coverage below 70%')
+    }
+    if (research && humanRelevant && primaryCoverage < 0.5) gaps.push('low primary/systematic human coverage')
+    if (!surface.freshnessSignal) gaps.push('no explicit freshness signal')
+    if (!surface.safetySignal) gaps.push('no obvious safety signal')
+    if (!surface.answerSignal) gaps.push('no obvious answer-first extractability signal')
+
+    rows.push({
+      slug: surface.slug,
+      kind: surface.kind,
+      score,
+      researchUrl: research?.url ?? null,
+      approvedClaims: research?.approvedClaimCount ?? 0,
+      canonicalStudies: research?.canonicalStudyCount ?? 0,
+      citationCompleteness: Number(citationCompleteness.toFixed(3)),
+      primaryHuman: research?.primaryHuman ?? 0,
+      systematicReviews: research?.synthesis ?? 0,
+      narrativeReviews: research?.narrativeReview ?? 0,
+      dominantStudySupportedClaimShare: research?.dominantStudySupportedClaimShare ?? 0,
+      effectiveStudyCount: research?.effectiveStudyCount ?? 0,
+      contradiction: surface.contradiction,
+      gaps,
+    })
+  }
+
+  rows.sort((a, b) => a.score - b.score || b.gaps.length - a.gaps.length || a.slug.localeCompare(b.slug))
+  return {
+    summary: {
+      generatedAt: new Date().toISOString(),
+      researchQualitySource: 'lib/research-quality-analysis.ts',
+      profiles: rows.length,
+      matchedResearchProfiles: rows.filter((row) => row.researchUrl).length,
+      averageScore: rows.length ? Math.round(rows.reduce((sum, row) => sum + row.score, 0) / rows.length) : 0,
+      below50: rows.filter((row) => row.score < 50).length,
+      below70: rows.filter((row) => row.score < 70).length,
+      contradictions: rows.filter((row) => row.contradiction).length,
+      overDependentOnSingleStudy: rows.filter((row) => row.gaps.includes('canonical research graph is over-dependent on one study')).length,
+      narrativeDominated: rows.filter((row) => row.gaps.includes('narrative-review dominated versus primary human research')).length,
+    },
+    profiles: rows,
+  }
+}
+
+export function writeAiCitationReadinessReport(
+  report: AiCitationReadinessReport,
+  root = process.cwd(),
+): string {
+  const output = path.join(root, 'reports', 'ai-citation-readiness.json')
+  fs.mkdirSync(path.dirname(output), { recursive: true })
+  fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`)
+  return output
+}

--- a/scripts/ci/audit-ai-citation-topology.ts
+++ b/scripts/ci/audit-ai-citation-topology.ts
@@ -1,194 +1,24 @@
 #!/usr/bin/env npx tsx
-import { existsSync, readFileSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs'
+import fs from 'node:fs'
 import path from 'node:path'
 
-import { analyzeResearchQuality, type ClaimQualityAnalysis, type ProfileQualityAnalysis } from '../../lib/research-quality-analysis'
+import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
+import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 
 const ROOT = process.cwd()
-const ENTITY_ROOT = path.join(ROOT, 'public', 'data', 'ai-entities')
-const OUTPUT = path.join(ROOT, 'reports', 'ai-citation-readiness.json')
 const strict = process.argv.includes('--strict')
-
-const WEAK = /preliminary|mixed evidence|limited evidence|insufficient|unclear|weak evidence|theoretical|animal evidence|in[- ]vitro|mechanistic only|research pending/i
-const STRONG = /\b(?:grade\s*)?a\b|strong human evidence|high confidence|well[- ]established|robust evidence/i
-const POSITIVE = /effective|efficacious|clinically proven|proven to|shown to improve|strong evidence for|supports the use/i
-const NEGATIVE = /not supported|unsupported|no good evidence|insufficient evidence|does not support|failed to show|no clear benefit/i
-
-type EntitySurface = {
-  slug: string
-  kind: 'herb' | 'compound' | 'unknown'
-  allText: string
-  freshnessSignal: boolean
-  safetySignal: boolean
-  answerSignal: boolean
-  contradiction: boolean
-}
-
-function filesUnder(dir: string, out: string[] = []): string[] {
-  if (!existsSync(dir)) return out
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name)
-    if (entry.isDirectory()) filesUnder(full, out)
-    else if (entry.name.endsWith('.json') && entry.name !== 'manifest.json') out.push(full)
-  }
-  return out
-}
-
-function strings(value: unknown, out: string[] = []): string[] {
-  if (value == null) return out
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-    out.push(String(value))
-    return out
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) strings(item, out)
-    return out
-  }
-  if (typeof value === 'object') {
-    for (const item of Object.values(value as Record<string, unknown>)) strings(item, out)
-  }
-  return out
-}
-
-function readEntitySurface(file: string): EntitySurface | null {
-  try {
-    const doc = JSON.parse(readFileSync(file, 'utf8')) as unknown
-    const allText = strings(doc).join(' | ')
-    const relative = path.relative(ENTITY_ROOT, file).replaceAll('\\', '/')
-    const kind = relative.startsWith('herb/') ? 'herb' : relative.startsWith('compound/') ? 'compound' : 'unknown'
-    return {
-      slug: path.basename(file, '.json'),
-      kind,
-      allText,
-      freshnessSignal: /dateModified|datePublished|lastReviewed|reviewedAt|modifiedAt|review date/i.test(allText),
-      safetySignal: /safety|contraindication|interaction|adverse|pregnan|warning|caution/i.test(allText),
-      answerSignal: /summary|description|bottom line|quick answer|verdict|evidence summary/i.test(allText),
-      contradiction: (STRONG.test(allText) && WEAK.test(allText)) || (POSITIVE.test(allText) && NEGATIVE.test(allText)),
-    }
-  } catch {
-    return null
-  }
-}
-
-function slugFromUrl(url: string): string {
-  try {
-    const parsed = url.startsWith('http') ? new URL(url) : new URL(url, 'https://thehippiescientist.net')
-    const parts = parsed.pathname.split('/').filter(Boolean)
-    return parts.at(-1) ?? ''
-  } catch {
-    return url.split('/').filter(Boolean).at(-1) ?? ''
-  }
-}
-
-function clamp(value: number): number {
-  return Math.max(0, Math.min(100, Math.round(value)))
-}
-
-function claimsByUrl(claims: ClaimQualityAnalysis[]): Map<string, ClaimQualityAnalysis[]> {
-  const map = new Map<string, ClaimQualityAnalysis[]>()
-  for (const claim of claims) {
-    const list = map.get(claim.url) ?? []
-    list.push(claim)
-    map.set(claim.url, list)
-  }
-  return map
-}
+const entityRoot = path.join(ROOT, 'public', 'data', 'ai-entities')
 
 const analysis = analyzeResearchQuality(ROOT)
-const approvedClaimsByUrl = claimsByUrl(analysis.claimAnalyses)
-const profileBySlug = new Map<string, ProfileQualityAnalysis>()
-for (const profile of analysis.profileAnalyses) profileBySlug.set(slugFromUrl(profile.url), profile)
+const report = buildAiCitationReadiness(analysis, ROOT)
+const output = writeAiCitationReadinessReport(report, ROOT)
+const { summary } = report
 
-const surfaces = filesUnder(ENTITY_ROOT).map(readEntitySurface).filter((value): value is EntitySurface => Boolean(value))
-const rows = []
-
-for (const surface of surfaces) {
-  const research = profileBySlug.get(surface.slug)
-  const approvedClaims = research ? (approvedClaimsByUrl.get(research.url) ?? []) : []
-
-  const citationCompleteness = approvedClaims.length
-    ? approvedClaims.filter((claim) => claim.validSourceRefCount > 0 && claim.danglingSourceRefs.length === 0).length / approvedClaims.length
-    : research?.sourceCount
-      ? 0.6
-      : 0
-
-  const humanRelevant = research ? research.primaryHuman + research.synthesis + research.narrativeReview : 0
-  const primaryCoverage = humanRelevant && research
-    ? (research.primaryHuman + research.synthesis) / humanRelevant
-    : 0
-
-  // These two are canonical research-quality outputs. Do not re-derive study identity,
-  // source aliases, or concentration from the public JSON-LD graph here.
-  const independence = research ? 1 - Math.min(1, research.dominantStudySupportedClaimShare) : 0
-  const sourceDepth = research ? Math.min(1, research.canonicalStudyCount / 5) : 0
-
-  const score = clamp(
-    citationCompleteness * 25 +
-    primaryCoverage * 20 +
-    independence * 15 +
-    sourceDepth * 10 +
-    Number(surface.freshnessSignal) * 10 +
-    Number(surface.safetySignal) * 10 +
-    Number(surface.answerSignal) * 10 -
-    (surface.contradiction ? 35 : 0)
-  )
-
-  const gaps: string[] = []
-  if (surface.contradiction) gaps.push('contradictory extractable claims')
-  if (!research) gaps.push('no canonical research-quality profile match')
-  if (research?.unsupportedApprovedClaims.length) gaps.push(`${research.unsupportedApprovedClaims.length} unsupported approved claim(s)`)
-  if (research?.danglingSourceRefs.length) gaps.push(`${research.danglingSourceRefs.length} dangling source reference(s)`)
-  if (research?.weakStructuredClaimCount) gaps.push(`${research.weakStructuredClaimCount} weak approved structured claim(s)`)
-  if (research?.singleStudyApprovedClaims.length) gaps.push(`${research.singleStudyApprovedClaims.length} approved claim(s) supported by one study`)
-  if (research?.overDependentOnSingleStudy) gaps.push('canonical research graph is over-dependent on one study')
-  if (research?.narrativeDominatedVsPrimaryHuman) gaps.push('narrative-review dominated versus primary human research')
-  if (research?.noPrimaryHuman) gaps.push('approved claims exist without primary human studies')
-  if (research && research.canonicalStudyCount >= 3) {
-    const classified = research.canonicalStudyCount - (research.designMix.unclassified ?? 0)
-    if (classified / research.canonicalStudyCount < 0.7) gaps.push('study-design metadata coverage below 70%')
-  }
-  if (research && humanRelevant && primaryCoverage < 0.5) gaps.push('low primary/systematic human coverage')
-  if (!surface.freshnessSignal) gaps.push('no explicit freshness signal')
-  if (!surface.safetySignal) gaps.push('no obvious safety signal')
-  if (!surface.answerSignal) gaps.push('no obvious answer-first extractability signal')
-
-  rows.push({
-    slug: surface.slug,
-    kind: surface.kind,
-    score,
-    researchUrl: research?.url ?? null,
-    approvedClaims: research?.approvedClaimCount ?? 0,
-    canonicalStudies: research?.canonicalStudyCount ?? 0,
-    citationCompleteness: Number(citationCompleteness.toFixed(3)),
-    primaryHuman: research?.primaryHuman ?? 0,
-    systematicReviews: research?.synthesis ?? 0,
-    narrativeReviews: research?.narrativeReview ?? 0,
-    dominantStudySupportedClaimShare: research?.dominantStudySupportedClaimShare ?? 0,
-    effectiveStudyCount: research?.effectiveStudyCount ?? 0,
-    contradiction: surface.contradiction,
-    gaps,
-  })
-}
-
-rows.sort((a, b) => a.score - b.score || b.gaps.length - a.gaps.length || a.slug.localeCompare(b.slug))
-const summary = {
-  generatedAt: new Date().toISOString(),
-  researchQualitySource: 'lib/research-quality-analysis.ts',
-  profiles: rows.length,
-  matchedResearchProfiles: rows.filter((row) => row.researchUrl).length,
-  averageScore: rows.length ? Math.round(rows.reduce((sum, row) => sum + row.score, 0) / rows.length) : 0,
-  below50: rows.filter((row) => row.score < 50).length,
-  below70: rows.filter((row) => row.score < 70).length,
-  contradictions: rows.filter((row) => row.contradiction).length,
-  overDependentOnSingleStudy: rows.filter((row) => row.gaps.includes('canonical research graph is over-dependent on one study')).length,
-  narrativeDominated: rows.filter((row) => row.gaps.includes('narrative-review dominated versus primary human research')).length,
-}
-
-mkdirSync(path.dirname(OUTPUT), { recursive: true })
-writeFileSync(OUTPUT, `${JSON.stringify({ summary, profiles: rows }, null, 2)}\n`)
 console.log(`[audit-ai-citation-topology] profiles=${summary.profiles} matched=${summary.matchedResearchProfiles} average=${summary.averageScore} below50=${summary.below50} below70=${summary.below70} contradictions=${summary.contradictions}`)
 console.log(`[audit-ai-citation-topology] single-study-overdependence=${summary.overDependentOnSingleStudy} narrative-dominated=${summary.narrativeDominated}`)
-for (const row of rows.slice(0, 50)) console.log(`${String(row.score).padStart(3)} ${row.kind}/${row.slug}: ${row.gaps.join('; ') || 'no major gaps detected'}`)
-console.log(`[audit-ai-citation-topology] report: ${path.relative(ROOT, OUTPUT)}`)
-if (!existsSync(ENTITY_ROOT)) console.log('[audit-ai-citation-topology] entity artifacts missing; run the runtime/entity build first')
+for (const row of report.profiles.slice(0, 50)) {
+  console.log(`${String(row.score).padStart(3)} ${row.kind}/${row.slug}: ${row.gaps.join('; ') || 'no major gaps detected'}`)
+}
+console.log(`[audit-ai-citation-topology] report: ${path.relative(ROOT, output)}`)
+if (!fs.existsSync(entityRoot)) console.log('[audit-ai-citation-topology] entity artifacts missing; run the runtime/entity build first')
 if (strict && (summary.contradictions > 0 || summary.below50 > 0)) process.exit(1)

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchGapQueue, structuralCoverageFailures } from '../../lib/research-quality-policy'
 import { analyzeCrossProfileStudyLoad } from '../../lib/research-study-load'
@@ -49,6 +50,8 @@ const structuralFailures = structuralCoverageFailures(analysis)
 const researchGapQueue = buildResearchGapQueue(analysis)
 const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
 const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
+const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
+const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
 const weakApprovedOutcomes = analysis.claimAnalyses.filter((claim) =>
   claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
 )
@@ -70,10 +73,11 @@ results.push({
   passed: corePassed,
   exitCode: corePassed ? 0 : 1,
   durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; structuredClaims=${analysis.structuredClaimAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}`,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; structuredClaims=${analysis.structuredClaimAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
   stderrTail: structuralFailures.length ? `${structuralFailures.length} structurally invalid approved-claim evidence edge(s)` : '',
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile research-quality analysis  (${coreDurationMs}ms)`)
+console.log(`INFO  AI citation readiness generated from same analysis pass: average=${aiCitationReadiness.summary.averageScore}; below70=${aiCitationReadiness.summary.below70}; contradictions=${aiCitationReadiness.summary.contradictions}`)
 if (!corePassed) failed = true
 
 for (const check of externalChecks) {
@@ -109,23 +113,26 @@ const coreSummary = {
   profilesWithResearchGaps: researchGapQueue.length,
   canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
   systemicLoadBearingStudies: systemicLoadBearingStudies.length,
+  aiCitationReadiness: aiCitationReadiness.summary,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 3,
+  schemaVersion: 4,
   generatedAt: new Date().toISOString(),
   passed: !failed,
   source: {
     analysis: 'lib/research-quality-analysis.ts',
     policy: 'lib/research-quality-policy.ts',
     crossProfileStudyLoad: 'lib/research-study-load.ts',
+    aiCitationReadiness: 'lib/ai-citation-readiness.ts',
   },
   coreSummary,
   structuralFailures,
   systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100),
   topResearchGaps: researchGapQueue.slice(0, 50),
+  topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
   checks: results,
   sourceIntegritySummary: readSummary('source-integrity.json'),
   evidenceGradeSummary: readSummary('evidence-grade-consistency.json'),
@@ -135,9 +142,11 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
 console.log(`Structural failures ${coreSummary.structuralFailures} · weak approved outcomes ${coreSummary.weakApprovedOutcomeClaims} · research-gap profiles ${coreSummary.profilesWithResearchGaps}`)
 console.log(`Systemic load-bearing studies ${coreSummary.systemicLoadBearingStudies} of ${coreSummary.canonicalStudiesSupportingApprovedClaims} canonical studies supporting approved claims`)
+console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
+console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
 if (failed) {
   console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.')
   process.exit(1)
 }
-console.log('\n[research-quality] PASS — canonical analysis/policy, source integrity, evidence grades, and structured integrity agree.')
+console.log('\n[research-quality] PASS — canonical analysis/policy, AI citation topology, source integrity, evidence grades, and structured integrity agree.')


### PR DESCRIPTION
## Summary
- extracts `lib/ai-citation-readiness.ts` as the single AI citation-prioritization builder
- makes the standalone AI audit a thin wrapper instead of a second analysis pipeline
- makes `scripts/ci/research-quality.ts` reuse its existing in-memory `analyzeResearchQuality()` result to emit the AI citation queue in the same pass
- embeds the top AI remediation rows and summary into the canonical research-quality roll-up
- bumps the research-quality report schema and documents the single-pass architecture

## Consolidation impact
This removes a second full research-analysis traversal when the canonical quality pipeline runs and makes the AI remediation queue a view over the authoritative research graph rather than a sibling subsystem.

## Policy
AI readiness remains advisory in the canonical research pass; structural research failures remain the release-critical gate. The standalone topology keeps `--strict` for intentional AI-remediation gating.