### PR TITLE
cleanup: consolidate TypeScript slug utilities

### DIFF
--- a/lib/slug-utils.ts
+++ b/lib/slug-utils.ts
@@ -1,9 +1,24 @@
 export function normalizeSlug(value: unknown): string {
-  return String(value || '')
+  return String(value ?? '')
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
+}
+
+/** Backward-compatible semantic alias for callers that create a slug. */
+export function slugify(value: unknown): string {
+  return normalizeSlug(value)
+}
+
+/** Select the first non-empty candidate and normalize it once. */
+export function canonicalSlug(...inputs: Array<string | null | undefined>): string {
+  for (const input of inputs) {
+    if (typeof input !== 'string' || !input.trim()) continue
+    const slug = normalizeSlug(input)
+    if (slug) return slug
+  }
+  return ''
 }
 
 export function isCanonicalSlug(input: string, canonical: string): boolean {

--- a/src/lib/__tests__/slug-utils.test.ts
+++ b/src/lib/__tests__/slug-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeSlug, isCanonicalSlug } from '../../../lib/slug-utils'
+import { canonicalSlug, isCanonicalSlug, normalizeSlug, slugify } from '../../../lib/slug-utils'
 
 describe('normalizeSlug', () => {
   it('lowercases and hyphenates spaces/punctuation', () => {
@@ -21,6 +21,17 @@ describe('normalizeSlug', () => {
 
   it('coerces non-string input to a string first', () => {
     expect(normalizeSlug(12345)).toBe('12345')
+  })
+})
+
+describe('slugify / canonicalSlug', () => {
+  it('keeps slug creation on the same canonical normalization path', () => {
+    expect(slugify('St. John’s Wort')).toBe('st-john-s-wort')
+    expect(canonicalSlug('', null, '  Lion’s Mane  ')).toBe('lion-s-mane')
+  })
+
+  it('returns empty when no canonical candidate exists', () => {
+    expect(canonicalSlug('', '   ', undefined)).toBe('')
   })
 })
 

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,16 +1,3 @@
-export function slugify(s: string) {
-  return s
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-export function canonicalSlug(...inputs: Array<string | null | undefined>) {
-  for (const input of inputs) {
-    if (typeof input === 'string' && input.trim()) {
-      const slug = slugify(input.trim())
-      if (slug) return slug
-    }
-  }
-  return ''
-}
+// Compatibility facade for older src/lib callers.
+// Canonical TypeScript slug behavior lives in /lib/slug-utils.ts.
+export { canonicalSlug, slugify } from '../../lib/slug-utils'


### PR DESCRIPTION
Broad cleanup pass 10.

- makes lib/slug-utils.ts the canonical TypeScript slug implementation
- folds slugify and canonicalSlug into that module
- reduces src/lib/slug.ts to a compatibility re-export instead of a second implementation
- expands regression coverage for slug creation and canonical candidate selection

This removes one of the three competing slug implementations without forcing a risky cross-runtime migration for Node .mjs callers.