### PR TITLE
SEO: expose profile-wide answer-engine semantics

### DIFF
--- a/components/editorial/ProfileDecisionPanel.tsx
+++ b/components/editorial/ProfileDecisionPanel.tsx
@@ -3,19 +3,7 @@ import type { ProfileDecision } from '@/lib/profile-decision'
 import ScientificVerdictCard from '@/components/editorial/ScientificVerdictCard'
 import EvidenceConfidence from '@/components/editorial/EvidenceConfidence'
 
-/**
- * ProfileDecisionPanel — the shared decision surface for every herb and
- * compound profile. Rendered once by each profile template, so improving it
- * improves hundreds of pages at once.
- *
- * - When the slug has a curated verdict (config/profile-verdicts.ts), it opens
- *   with a full ScientificVerdictCard.
- * - Always shows an intent-based "Continue reading" nav derived from the
- *   record's own data — replacing generic related-link dumps with routing.
- *
- * Static-safe server component; theme-aware. Data comes from
- * `buildProfileDecision(record, kind)`.
- */
+/** Shared decision surface for every herb and compound profile. */
 export function ProfileDecisionPanel({
   decision,
   name,
@@ -30,6 +18,7 @@ export function ProfileDecisionPanel({
     <div className="space-y-4">
       {verdict ? (
         <ScientificVerdictCard
+          id="decision-summary"
           title={`Verdict: ${name}`}
           recommendation={verdict.recommendation}
           confidence={verdict.confidence}
@@ -76,31 +65,20 @@ export function ProfileDecisionPanel({
                   <p className="text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--hs-gold)]">Start here</p>
                   <p className="text-sm leading-6 text-[color:var(--hs-body)]">
                     New to this? Begin with{' '}
-                    <Link
-                      href={verdict.primaryGuide.href}
-                      className="font-bold text-[color:var(--tone-ink)] underline-offset-4 hover:underline"
-                    >
+                    <Link href={verdict.primaryGuide.href} className="font-bold text-[color:var(--tone-ink)] underline-offset-4 hover:underline">
                       {verdict.primaryGuide.label}
-                    </Link>
-                    .
+                    </Link>.
                   </p>
                 </div>
               ) : null}
 
               {verdict?.comparisons && verdict.comparisons.length > 0 ? (
                 <div className="border-t border-[color:var(--hs-hairline)] py-4 sm:grid sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-4">
-                  <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">
-                    Compare first
-                  </p>
+                  <p className="text-xs font-bold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-300">Compare first</p>
                   <ul className="mt-2 space-y-2 sm:mt-0">
                     {verdict.comparisons.map((comparison) => (
                       <li key={comparison.href} className="text-sm leading-6 text-[color:var(--hs-body)]">
-                        <Link
-                          href={comparison.href}
-                          className="font-bold text-[color:var(--tone-ink)] underline-offset-4 hover:underline"
-                        >
-                          {comparison.label}
-                        </Link>
+                        <Link href={comparison.href} className="font-bold text-[color:var(--tone-ink)] underline-offset-4 hover:underline">{comparison.label}</Link>
                         <span> — if {comparison.when}</span>
                       </li>
                     ))}
@@ -115,12 +93,7 @@ export function ProfileDecisionPanel({
                     {continueReading.map((path) => (
                       <li key={path.href} className="text-sm leading-6 text-[color:var(--hs-body)]">
                         <span>If you want {path.ifYouWant} → </span>
-                        <Link
-                          href={path.href}
-                          className="font-bold text-[color:var(--tone-ink)] underline-offset-4 hover:underline"
-                        >
-                          {path.goTo}
-                        </Link>
+                        <Link href={path.href} className="font-bold text-[color:var(--tone-ink)] underline-offset-4 hover:underline">{path.goTo}</Link>
                       </li>
                     ))}
                   </ul>

--- a/components/editorial/ScientificVerdictCard.tsx
+++ b/components/editorial/ScientificVerdictCard.tsx
@@ -10,6 +10,7 @@ type BetterAlternative = {
 }
 
 type ScientificVerdictCardProps = {
+  id?: string
   /** Heading label. Defaults to "Scientific Verdict". */
   title?: string
   /** Overall call: Yes | Maybe | No | Situation-dependent. */
@@ -44,45 +45,19 @@ type ScientificVerdictCardProps = {
 const toList = (value?: string | string[]): string[] => {
   if (!value) return []
   if (Array.isArray(value)) return value.map((v) => String(v).trim()).filter(Boolean)
-  return String(value)
-    .split('|')
-    .map((v) => v.trim())
-    .filter(Boolean)
+  return String(value).split('|').map((v) => v.trim()).filter(Boolean)
 }
 
 const RECOMMENDATION_STYLES: Record<string, string> = {
   yes: 'border-emerald-500/40 bg-emerald-100 text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-900/40 dark:text-emerald-100',
   maybe: 'border-amber-500/40 bg-amber-100 text-amber-900 dark:border-amber-400/30 dark:bg-amber-900/40 dark:text-amber-100',
   no: 'border-rose-500/40 bg-rose-100 text-rose-900 dark:border-rose-400/30 dark:bg-rose-900/40 dark:text-rose-100',
-  'situation-dependent':
-    'border-sky-500/40 bg-sky-100 text-sky-900 dark:border-sky-400/30 dark:bg-sky-900/40 dark:text-sky-100',
+  'situation-dependent': 'border-sky-500/40 bg-sky-100 text-sky-900 dark:border-sky-400/30 dark:bg-sky-900/40 dark:text-sky-100',
 }
 
-/**
- * ScientificVerdictCard — the signature decision module for The Hippie Scientist.
- *
- * Every major article/herb/compound/comparison page should OPEN with one of
- * these. It answers, before any biochemistry: would we recommend this, for
- * whom, for what use, how confident, how fast, and when to choose something
- * else. Registered as an MDX component (also under the alias `ScientificVerdict`
- * for Pass-1 compatibility) so any article can drop it at the top of the body.
- *
- *   <ScientificVerdictCard
- *     recommendation="Yes"
- *     bestFor="Racing thoughts|Caffeine jitters|Mild situational anxiety"
- *     notIdealFor="Severe insomnia|Panic attacks|Chronic stress alone"
- *     confidence="Moderate" onset="30–40 minutes" evaluationWindow="Same day to 2 weeks"
- *     betterAlternative={{ label: 'Ashwagandha', href: '/articles/ashwagandha/',
- *       reason: 'for chronic baseline stress' }}
- *   >
- *   L-theanine is a strong first choice for calm focus, not for chronic stress.
- *   </ScientificVerdictCard>
- *
- * Lists accept a pipe-delimited string (MDX-friendly) or a real array (.tsx).
- * Keep it honest: use "No" / "Situation-dependent" and a real "Not ideal for"
- * list when the evidence warrants.
- */
+/** Shared scientific decision surface for articles and profiles. */
 export function ScientificVerdictCard({
+  id,
   title = 'Scientific Verdict',
   recommendation,
   confidence,
@@ -100,28 +75,24 @@ export function ScientificVerdictCard({
 }: ScientificVerdictCardProps) {
   const best = toList(bestFor)
   const not = toList(notIdealFor ?? notFor)
-  const badgeStyle =
-    RECOMMENDATION_STYLES[String(recommendation).toLowerCase()] ?? RECOMMENDATION_STYLES.maybe
+  const badgeStyle = RECOMMENDATION_STYLES[String(recommendation).toLowerCase()] ?? RECOMMENDATION_STYLES.maybe
   const stats = [
-    confidence ? { label: 'Evidence confidence', value: confidence } : null,
-    onset ? { label: 'Expected onset', value: onset } : null,
-    evaluationWindow ? { label: 'Give it', value: evaluationWindow } : null,
-  ].filter((s): s is { label: string; value: string } => Boolean(s))
+    confidence ? { label: 'Evidence confidence', value: confidence, evidence: true } : null,
+    onset ? { label: 'Expected onset', value: onset, evidence: false } : null,
+    evaluationWindow ? { label: 'Give it', value: evaluationWindow, evidence: false } : null,
+  ].filter((s): s is { label: string; value: string; evidence: boolean } => Boolean(s))
 
   return (
-    // Root is a <section> (not <aside>) on purpose: the article body is
-    // post-processed by ContentCards, which wraps any pre-section "intro"
-    // content in its own card. Being a section makes ContentCards treat this
-    // as the first section and leave it standalone instead of double-wrapping.
     <section
+      id={id}
+      data-answer-engine-decision="true"
+      data-recommendation={String(recommendation)}
       aria-label="Scientific verdict"
-      className="not-prose my-6 overflow-hidden rounded-2xl border-2 border-brand-900/15 bg-white shadow-md ring-1 ring-brand-900/5 dark:border-white/12 dark:bg-[var(--surface-card)]"
+      className="not-prose my-6 scroll-mt-24 overflow-hidden rounded-2xl border-2 border-brand-900/15 bg-white shadow-md ring-1 ring-brand-900/5 dark:border-white/12 dark:bg-[var(--surface-card)]"
     >
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-brand-900/10 bg-brand-50/60 px-5 py-3 dark:border-white/10 dark:bg-[var(--surface-subtle)]">
         <span className="text-xs font-bold uppercase tracking-[0.16em] text-brand-700">{title}</span>
-        <span className={`rounded-full border px-3 py-1 text-sm font-bold ${badgeStyle}`}>
-          {badgeLabel ?? recommendation}
-        </span>
+        <span className={`rounded-full border px-3 py-1 text-sm font-bold ${badgeStyle}`}>{badgeLabel ?? recommendation}</span>
       </div>
 
       <div className="px-5 py-4">
@@ -129,15 +100,11 @@ export function ScientificVerdictCard({
           <div className="grid gap-4 sm:grid-cols-2">
             {best.length > 0 && (
               <div>
-                <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
-                  Best for
-                </p>
+                <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">Best for</p>
                 <ul className="mt-2 space-y-1.5">
                   {best.map((item) => (
                     <li key={item} className="flex gap-2 text-sm leading-6 text-ink">
-                      <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">
-                        ✓
-                      </span>
+                      <span aria-hidden="true" className="mt-0.5 font-bold text-emerald-600 dark:text-emerald-400">✓</span>
                       <span>{item}</span>
                     </li>
                   ))}
@@ -145,16 +112,12 @@ export function ScientificVerdictCard({
               </div>
             )}
             {not.length > 0 && (
-              <div>
-                <p className="text-xs font-bold uppercase tracking-wider text-rose-700 dark:text-rose-300">
-                  Not ideal for
-                </p>
+              <div data-limitation="true">
+                <p className="text-xs font-bold uppercase tracking-wider text-rose-700 dark:text-rose-300">Not ideal for</p>
                 <ul className="mt-2 space-y-1.5">
                   {not.map((item) => (
                     <li key={item} className="flex gap-2 text-sm leading-6 text-muted">
-                      <span aria-hidden="true" className="mt-0.5 font-bold text-rose-500 dark:text-rose-400">
-                        ✕
-                      </span>
+                      <span aria-hidden="true" className="mt-0.5 font-bold text-rose-500 dark:text-rose-400">✕</span>
                       <span>{item}</span>
                     </li>
                   ))}
@@ -167,7 +130,7 @@ export function ScientificVerdictCard({
         {stats.length > 0 && (
           <dl className="mt-4 grid gap-3 border-t border-brand-900/10 pt-4 sm:grid-cols-3 dark:border-white/10">
             {stats.map((stat) => (
-              <div key={stat.label}>
+              <div key={stat.label} data-evidence={stat.evidence ? 'true' : undefined}>
                 <dt className="text-[0.7rem] font-bold uppercase tracking-wider text-muted">{stat.label}</dt>
                 <dd className="mt-0.5 text-sm font-semibold text-ink">{stat.value}</dd>
               </div>
@@ -176,41 +139,35 @@ export function ScientificVerdictCard({
         )}
 
         {(bottomLine || children) && (
-          <div className="mt-4 border-t border-brand-900/10 pt-4 text-sm leading-7 text-ink dark:border-white/10">
-            <span className="font-bold">Bottom line: </span>
-            {bottomLine ?? children}
+          <div data-claim="true" className="mt-4 border-t border-brand-900/10 pt-4 text-sm leading-7 text-ink dark:border-white/10">
+            <span className="font-bold">Bottom line: </span>{bottomLine ?? children}
           </div>
         )}
 
         {safetyNote ? (
-          <p className="mt-3 rounded-lg border border-amber-500/30 bg-amber-50/70 px-3 py-2 text-sm leading-6 text-amber-900 dark:border-amber-400/25 dark:bg-amber-900/25 dark:text-amber-100">
-            <span className="font-bold">Safety: </span>
-            {safetyNote}
+          <p data-safety-context="true" className="mt-3 rounded-lg border border-amber-500/30 bg-amber-50/70 px-3 py-2 text-sm leading-6 text-amber-900 dark:border-amber-400/25 dark:bg-amber-900/25 dark:text-amber-100">
+            <span className="font-bold">Safety: </span>{safetyNote}
           </p>
         ) : null}
 
         {evidenceNote ? (
-          <p className="mt-3 text-sm leading-6 text-muted">
-            <span className="font-semibold text-ink">On the evidence: </span>
-            {evidenceNote}
+          <p data-evidence="true" className="mt-3 text-sm leading-6 text-muted">
+            <span className="font-semibold text-ink">On the evidence: </span>{evidenceNote}
           </p>
         ) : null}
 
         {betterAlternative ? (
           <p className="mt-4 border-t border-brand-900/10 pt-4 text-sm leading-6 dark:border-white/10">
             <span className="font-bold text-ink">Consider instead: </span>
-            <Link href={betterAlternative.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]">
-              {betterAlternative.label}
-            </Link>
+            <Link href={betterAlternative.href} className="font-semibold text-brand-800 hover:underline dark:text-[var(--text-primary)]">{betterAlternative.label}</Link>
             {betterAlternative.reason ? <span className="text-muted"> — {betterAlternative.reason}</span> : null}
           </p>
         ) : null}
       </div>
+      {id ? <a href={`#${id}`} className="sr-only">Permanent link to this scientific verdict</a> : null}
     </section>
   )
 }
 
-/** Pass-1 compatibility alias. Prefer `ScientificVerdictCard` going forward. */
 export const ScientificVerdict = ScientificVerdictCard
-
 export default ScientificVerdictCard

--- a/components/ui/EvidenceScoreBadge.tsx
+++ b/components/ui/EvidenceScoreBadge.tsx
@@ -71,9 +71,6 @@ const GRADE_MEANING_SHORT: Record<EvidenceLetterGrade, string> = {
   'Avoid/Insufficient': 'Avoid / Insufficient',
 }
 
-// Dark-mode-aware text color for the circle variant's label — the static
-// --color-evidence-* tokens don't have dark overrides and read low-contrast
-// against dark surfaces, so this uses adaptive Tailwind utilities instead.
 const GRADE_TEXT_ADAPTIVE: Record<EvidenceLetterGrade, string> = {
   A: 'text-emerald-800 dark:text-emerald-100',
   B: 'text-blue-800 dark:text-blue-100',
@@ -103,6 +100,8 @@ export default function EvidenceScoreBadge({
   if (size === 'circle') {
     return (
       <span
+        data-evidence="true"
+        data-evidence-grade={canonicalGrade}
         className={`inline-flex items-center gap-2 ${className}`}
         title={config.meaning}
       >
@@ -121,23 +120,19 @@ export default function EvidenceScoreBadge({
     )
   }
 
-  const sizeClasses =
-    size === 'sm'
-      ? 'px-2 py-0.5 text-[0.7rem] gap-1'
-      : 'px-3 py-1 text-xs gap-1.5'
+  const sizeClasses = size === 'sm' ? 'px-2 py-0.5 text-[0.7rem] gap-1' : 'px-3 py-1 text-xs gap-1.5'
 
   return (
     <span
+      data-evidence="true"
+      data-evidence-grade={canonicalGrade}
       title={config.meaning}
       aria-label={`Evidence grade ${canonicalGrade}: ${config.meaning}`}
       className={`inline-flex items-center rounded-full border font-bold tracking-wide ${config.bg} ${config.text} ${config.border} ${sizeClasses} ${className}`}
     >
       <span className={size === 'sm' ? 'text-[0.8rem]' : 'text-sm'}>{config.label}</span>
       {showLabel && canonicalGrade !== 'Avoid/Insufficient' && (
-        <span className="font-semibold">
-          {' '}
-          {GRADE_MEANING_SHORT[canonicalGrade]}
-        </span>
+        <span className="font-semibold">{' '}{GRADE_MEANING_SHORT[canonicalGrade]}</span>
       )}
     </span>
   )

--- a/components/ui/SafetyGaugeMeter.tsx
+++ b/components/ui/SafetyGaugeMeter.tsx
@@ -23,7 +23,12 @@ export default function SafetyGaugeMeter({ score, label, className = '' }: Safet
   const needleTip = polarToCartesian(50, 50, 34, needleAngle)
 
   return (
-    <div className={`flex flex-col items-center ${className}`}>
+    <div
+      data-safety-context="true"
+      data-safety-score={clamped}
+      data-safety-label={label}
+      className={`flex flex-col items-center ${className}`}
+    >
       <svg
         viewBox="0 0 100 58"
         className="w-full max-w-[200px]"

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -9,6 +9,11 @@ const MANIFEST = path.join(ROOT, 'public', 'data', 'ai-entities', 'manifest.json
 const SCHEMA = path.join(ROOT, 'components', 'seo', 'SchemaGraphScript.tsx')
 const CITATION_SUMMARY = path.join(ROOT, 'components', 'seo', 'CitationReadySummary.tsx')
 const ANSWER_TABLE = path.join(ROOT, 'components', 'seo', 'AnswerEngineTable.tsx')
+const EVIDENCE_BADGE = path.join(ROOT, 'components', 'ui', 'EvidenceScoreBadge.tsx')
+const SAFETY_GAUGE = path.join(ROOT, 'components', 'ui', 'SafetyGaugeMeter.tsx')
+const VERDICT_CARD = path.join(ROOT, 'components', 'editorial', 'ScientificVerdictCard.tsx')
+const PROFILE_DECISION = path.join(ROOT, 'components', 'editorial', 'ProfileDecisionPanel.tsx')
+const LAST_UPDATED = path.join(ROOT, 'src', 'components', 'editorial', 'LastUpdatedBadge.tsx')
 const LICENSING_PAGE = path.join(ROOT, 'app', 'info', 'content-licensing', 'page.tsx')
 const APP = path.join(ROOT, 'app')
 const strict = process.argv.includes('--strict')
@@ -25,6 +30,17 @@ function walk(dir, out = []) {
     else if (/\.(?:tsx|ts|mdx)$/.test(entry.name)) out.push(full)
   }
   return out
+}
+
+function requireSignals(file, area, component, signals) {
+  const source = text(file)
+  if (!source) {
+    add('error', area, `${component} is missing`)
+    return
+  }
+  for (const [signal, label] of signals) {
+    if (!source.includes(signal)) add('error', area, `${component} missing ${label}`)
+  }
 }
 
 function auditDiscovery() {
@@ -70,37 +86,52 @@ function auditMachineReadable() {
 }
 
 function auditSharedExtractionPrimitives() {
-  const summary = text(CITATION_SUMMARY)
-  if (!summary) {
-    add('error', 'extractability', 'CitationReadySummary.tsx is missing')
-  } else {
-    const required = [
-      ['data-answer-engine-summary', 'answer-engine summary marker'],
-      ['data-claim', 'claim marker'],
-      ['data-evidence', 'evidence marker'],
-      ['data-limitation', 'limitation marker'],
-      ['data-citation-sources', 'claim-adjacent source marker'],
-      ['aria-labelledby', 'accessible stable heading relationship'],
-      ['href={`#${id}`}', 'stable permanent answer link'],
-    ]
-    for (const [signal, label] of required) {
-      if (!summary.includes(signal)) add('error', 'extractability', `CitationReadySummary missing ${label}`)
-    }
-    if (!summary.includes('toCitationReadySummary(answer)')) {
-      add('error', 'extractability', 'CitationReadySummary bypasses the canonical citation-ready text normalizer')
-    }
-  }
+  requireSignals(CITATION_SUMMARY, 'extractability', 'CitationReadySummary', [
+    ['data-answer-engine-summary', 'answer-engine summary marker'],
+    ['data-claim', 'claim marker'],
+    ['data-evidence', 'evidence marker'],
+    ['data-limitation', 'limitation marker'],
+    ['data-citation-sources', 'claim-adjacent source marker'],
+    ['aria-labelledby', 'accessible stable heading relationship'],
+    ['href={`#${id}`}', 'stable permanent answer link'],
+    ['toCitationReadySummary(answer)', 'canonical citation-ready text normalizer'],
+  ])
 
   const table = text(ANSWER_TABLE)
-  if (!table) {
-    add('warn', 'extractability', 'AnswerEngineTable semantic research-table primitive is missing')
-  } else {
+  if (!table) add('warn', 'extractability', 'AnswerEngineTable semantic research-table primitive is missing')
+  else {
     for (const signal of ['data-answer-engine-table', '<caption', 'scope="col"', 'scope="row"', 'id={id}']) {
       if (!table.includes(signal)) add('error', 'extractability', `AnswerEngineTable missing semantic signal: ${signal}`)
     }
   }
 
   if (!existsSync(LICENSING_PAGE)) add('warn', 'attribution', 'public content licensing/attribution policy page is missing')
+}
+
+function auditProfilePrimitives() {
+  requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
+    ['data-evidence="true"', 'evidence marker'],
+    ['data-evidence-grade={canonicalGrade}', 'canonical evidence-grade value'],
+  ])
+  requireSignals(SAFETY_GAUGE, 'profile-semantics', 'SafetyGaugeMeter', [
+    ['data-safety-context="true"', 'safety-context marker'],
+    ['data-safety-score={clamped}', 'safety-score value'],
+  ])
+  requireSignals(LAST_UPDATED, 'profile-semantics', 'LastUpdatedBadge', [
+    ['data-editorial-provenance="true"', 'editorial-provenance marker'],
+    ['data-last-reviewed=', 'last-reviewed value'],
+    ['itemProp="dateModified"', 'dateModified semantic'],
+  ])
+  requireSignals(VERDICT_CARD, 'profile-semantics', 'ScientificVerdictCard', [
+    ['data-answer-engine-decision="true"', 'decision marker'],
+    ['data-recommendation=', 'recommendation value'],
+    ['data-claim="true"', 'bottom-line claim marker'],
+    ['data-limitation="true"', 'limitation marker'],
+    ['data-safety-context="true"', 'safety marker'],
+    ['data-evidence="true"', 'evidence marker'],
+  ])
+  const decision = text(PROFILE_DECISION)
+  if (!decision.includes('id="decision-summary"')) add('error', 'profile-semantics', 'ProfileDecisionPanel does not give curated verdicts a stable decision-summary anchor')
 }
 
 function auditExtractability() {
@@ -150,6 +181,7 @@ function auditAntiPatterns() {
 auditDiscovery()
 auditMachineReadable()
 auditSharedExtractionPrimitives()
+auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()
 

--- a/src/components/editorial/LastUpdatedBadge.tsx
+++ b/src/components/editorial/LastUpdatedBadge.tsx
@@ -32,13 +32,16 @@ export default function LastUpdatedBadge({
 
   return (
     <span
+      data-editorial-provenance="true"
+      data-last-reviewed={date || undefined}
+      data-citation-count={citationCount !== undefined ? citationCount : undefined}
       aria-label={`${label}: ${formatted}${citationCount ? `. ${citationCount} ${sourceLabel}.` : ''}${showCorrectionLink ? ' Report a correction.' : ''}`}
       className={`inline-flex flex-wrap items-center gap-2 rounded-full border border-brand-900/10 bg-white/80 px-3 py-1 text-xs font-semibold text-muted ${className}`}
     >
       <span className="inline-flex items-center gap-2">
         <span className='h-1.5 w-1.5 rounded-full bg-[var(--color-evidence-strong)]' aria-hidden='true' />
         <span>
-          {label}: <time dateTime={date || undefined}>{formatted}</time>
+          {label}: <time itemProp="dateModified" dateTime={date || undefined}>{formatted}</time>
           {citationCount !== undefined && citationCount > 0 ? (
             <>
               <span className='mx-1.5 text-muted/30'>•</span>


### PR DESCRIPTION
## Summary
- adds explicit machine-readable evidence-grade markers to the shared evidence badge used across profile surfaces
- exposes reviewed date and citation count as editorial provenance while retaining visible human-readable text
- marks the shared safety gauge as safety context with its normalized score/label
- makes scientific verdict cards extractable decision blocks with recommendation, claim, evidence, safety, limitation, and optional stable-anchor semantics
- gives curated herb/compound profile verdicts the stable `#decision-summary` anchor
- extends the existing answer-engine readiness audit to gate all of these shared profile primitives

## Why
Herb and compound templates already contain strong visible decision/evidence/safety UI. This upgrade annotates those existing shared components rather than adding another redundant AI-only card layer.

## Guardrails
No new evidence, safety score, recommendation, review date, or citation count is generated. The markers only expose values already rendered from governed page data.