### PR TITLE
cleanup: consolidate runtime slug generation

### DIFF
--- a/lib/ecosystem-authority-pages.ts
+++ b/lib/ecosystem-authority-pages.ts
@@ -1,5 +1,6 @@
 import { list, text, unique } from '@/lib/display-utils'
 import { buildSemanticLinkSuggestions } from '@/lib/semantic-internal-linking'
+import { slugify } from '@/lib/slug-utils'
 import { buildResearchKnowledgeReport } from '../src/lib/research-knowledge-layer'
 import { buildProgrammaticTopicClusters } from '@/lib/programmatic-topic-clusters'
 import type { RuntimeRecord } from '../src/types/content'
@@ -18,13 +19,6 @@ export type EcosystemAuthorityPage = {
     caution: string
   }[]
   internalLinks: ReturnType<typeof buildSemanticLinkSuggestions>
-}
-
-function slugify(value: unknown) {
-  return text(value)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
 }
 
 function title(value: unknown) {

--- a/lib/high-intent-commercial-pages.ts
+++ b/lib/high-intent-commercial-pages.ts
@@ -1,4 +1,5 @@
 import { text, unique } from '@/lib/display-utils'
+import { slugify } from '@/lib/slug-utils'
 import { buildProductRecommendationContext } from '@/lib/semantic-product-recommendations'
 
 export type CommercialPageBlueprint = {
@@ -8,10 +9,6 @@ export type CommercialPageBlueprint = {
   description: string
   safetyNote: string
   qualityCriteria: string[]
-}
-
-function slugify(value: unknown) {
-  return text(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 }
 
 function title(value: unknown) {

--- a/lib/programmatic-topic-clusters.ts
+++ b/lib/programmatic-topic-clusters.ts
@@ -1,5 +1,6 @@
 import { list, text, unique } from '@/lib/display-utils'
 import { buildSemanticLinkSuggestions } from '@/lib/semantic-internal-linking'
+import { slugify } from '@/lib/slug-utils'
 
 export type ProgrammaticTopicCluster = {
   slug: string
@@ -8,13 +9,6 @@ export type ProgrammaticTopicCluster = {
   intent: 'best-for' | 'compare' | 'pathway' | 'beginner-guide'
   signals: string[]
   links: ReturnType<typeof buildSemanticLinkSuggestions>
-}
-
-function slugify(value: unknown) {
-  return text(value)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
 }
 
 function title(value: unknown) {


### PR DESCRIPTION
Broad cleanup pass 11.

- removes private slugify implementations from programmatic topic clusters, ecosystem authority pages, and high-intent commercial page generation
- reuses the canonical TypeScript slug utility in lib/slug-utils.ts
- preserves route/output semantics while reducing feature-level normalization drift
- keeps presentation-specific title formatting local because that is not identity normalization

This continues collapsing runtime/page-generation helpers onto one TypeScript slug authority.