### PR TITLE
SEO: strengthen AI entity dataset provenance

### DIFF
--- a/components/seo/SchemaGraphScript.tsx
+++ b/components/seo/SchemaGraphScript.tsx
@@ -5,6 +5,9 @@ type SchemaGraphScriptProps = {
 }
 
 const LEGACY_PLACEHOLDER_PUBLICATION_DATE = '2026-01-01'
+const SITE_URL = 'https://thehippiescientist.net'
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+const USAGE_POLICY_URL = `${SITE_URL}/info/content-licensing/`
 
 export type EntityArtifact = {
   href: string
@@ -58,28 +61,20 @@ export function normalizeProfileEntitySemantics(
     const record = node as Record<string, unknown>
 
     if (record['@id'] === artifact.entityId) {
-      return {
-        ...record,
-        '@type': 'Substance',
-      }
+      return { ...record, '@type': 'Substance' }
     }
 
     const mainEntity = record.mainEntity
-    const mainEntityId =
-      mainEntity && typeof mainEntity === 'object'
-        ? (mainEntity as Record<string, unknown>)['@id']
-        : null
+    const mainEntityId = mainEntity && typeof mainEntity === 'object'
+      ? (mainEntity as Record<string, unknown>)['@id']
+      : null
     const about = record.about
-    const aboutType =
-      about && typeof about === 'object'
-        ? (about as Record<string, unknown>)['@type']
-        : null
+    const aboutType = about && typeof about === 'object'
+      ? (about as Record<string, unknown>)['@type']
+      : null
 
     if (mainEntityId === artifact.entityId && aboutType === 'MedicalTherapy') {
-      return {
-        ...record,
-        about: { '@id': artifact.entityId },
-      }
+      return { ...record, about: { '@id': artifact.entityId } }
     }
 
     return node
@@ -144,19 +139,25 @@ export function attachEntityDataset(
 ): Record<string, unknown> {
   if (!artifact || !Array.isArray(graph['@graph'])) return graph
 
+  const datasetId = `${artifact.canonicalUrl}#ai-entity-dataset`
   const dataset = {
     '@type': 'Dataset',
-    '@id': `${artifact.canonicalUrl}#ai-entity-dataset`,
+    '@id': datasetId,
     name: `${artifact.name} structured evidence data`,
     description: `Machine-readable identity, evidence claims, citations, relationships, safety, and review provenance for ${artifact.name}.`,
     url: artifact.absoluteUrl,
     encodingFormat: 'application/ld+json',
     about: { '@id': artifact.entityId },
     isBasedOn: artifact.canonicalUrl,
-    creator: {
-      '@type': 'Organization',
-      name: 'The Hippie Scientist',
-      url: 'https://thehippiescientist.net/',
+    creator: { '@id': ORGANIZATION_ID },
+    publisher: { '@id': ORGANIZATION_ID },
+    creditText: 'The Hippie Scientist',
+    usageInfo: USAGE_POLICY_URL,
+    conditionsOfAccess: 'Publicly accessible; reuse remains subject to the site attribution policy and third-party source rights.',
+    distribution: {
+      '@type': 'DataDownload',
+      contentUrl: artifact.absoluteUrl,
+      encodingFormat: 'application/ld+json',
     },
   }
 
@@ -166,16 +167,22 @@ export function attachEntityDataset(
     if (record['@id'] !== artifact.entityId) return node
 
     const existingSubjectOf = record.subjectOf
+    const datasetRef = { '@id': datasetId }
     const subjectOf = existingSubjectOf
       ? Array.isArray(existingSubjectOf)
-        ? [...existingSubjectOf, { '@id': dataset['@id'] }]
-        : [existingSubjectOf, { '@id': dataset['@id'] }]
-      : { '@id': dataset['@id'] }
+        ? existingSubjectOf.some((item) => item && typeof item === 'object' && (item as Record<string, unknown>)['@id'] === datasetId)
+          ? existingSubjectOf
+          : [...existingSubjectOf, datasetRef]
+        : (existingSubjectOf as Record<string, unknown>)['@id'] === datasetId
+          ? existingSubjectOf
+          : [existingSubjectOf, datasetRef]
+      : datasetRef
 
     return { ...record, subjectOf }
   })
 
-  return { ...graph, '@graph': [...nodes, dataset] }
+  const existingDataset = nodes.some((node) => node && typeof node === 'object' && (node as Record<string, unknown>)['@id'] === datasetId)
+  return { ...graph, '@graph': existingDataset ? nodes : [...nodes, dataset] }
 }
 
 export default function SchemaGraphScript({ graph }: SchemaGraphScriptProps) {

--- a/components/seo/__tests__/SchemaGraphScript.provenance.test.ts
+++ b/components/seo/__tests__/SchemaGraphScript.provenance.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { attachEntityDataset, getEntityArtifact } from '../SchemaGraphScript'
+
+describe('SchemaGraphScript dataset provenance', () => {
+  const graph = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': ['ChemicalSubstance', 'Thing'],
+        '@id': 'https://thehippiescientist.net/compounds/magnesium/#entity',
+        name: 'Magnesium',
+        url: 'https://thehippiescientist.net/compounds/magnesium/',
+      },
+    ],
+  }
+
+  it('publishes canonical creator, usage policy, and direct JSON-LD download metadata', () => {
+    const artifact = getEntityArtifact(graph)
+    const enriched = attachEntityDataset(graph, artifact)
+    const nodes = enriched['@graph'] as Record<string, unknown>[]
+    const dataset = nodes.find((node) => node['@id'] === 'https://thehippiescientist.net/compounds/magnesium/#ai-entity-dataset') as Record<string, unknown>
+
+    expect(dataset.creator).toEqual({ '@id': 'https://thehippiescientist.net/#organization' })
+    expect(dataset.publisher).toEqual({ '@id': 'https://thehippiescientist.net/#organization' })
+    expect(dataset.creditText).toBe('The Hippie Scientist')
+    expect(dataset.usageInfo).toBe('https://thehippiescientist.net/info/content-licensing/')
+    expect(dataset.isBasedOn).toBe('https://thehippiescientist.net/compounds/magnesium/')
+    expect(dataset.distribution).toEqual({
+      '@type': 'DataDownload',
+      contentUrl: 'https://thehippiescientist.net/data/ai-entities/compound/magnesium.json',
+      encodingFormat: 'application/ld+json',
+    })
+  })
+
+  it('does not duplicate the entity subjectOf link or Dataset node when enrichment runs twice', () => {
+    const artifact = getEntityArtifact(graph)
+    const once = attachEntityDataset(graph, artifact)
+    const twice = attachEntityDataset(once, artifact)
+    const nodes = twice['@graph'] as Record<string, unknown>[]
+
+    expect(nodes.filter((node) => node['@id'] === 'https://thehippiescientist.net/compounds/magnesium/#ai-entity-dataset')).toHaveLength(1)
+    const entity = nodes.find((node) => node['@id'] === artifact?.entityId)
+    expect(entity?.subjectOf).toEqual({ '@id': 'https://thehippiescientist.net/compounds/magnesium/#ai-entity-dataset' })
+  })
+})


### PR DESCRIPTION
## Summary
- strengthens each herb/compound AI Dataset node with canonical organization creator/publisher IDs
- adds `creditText`, `usageInfo`, and conservative access conditions pointing to the public attribution/reuse policy without claiming a blanket open license
- exposes each JSON-LD shard as an explicit `DataDownload`
- preserves `isBasedOn` back to the canonical human-readable profile
- makes Dataset/`subjectOf` enrichment idempotent so repeated normalization cannot duplicate graph nodes or references
- adds dedicated provenance/idempotence tests

## AI SEO impact
Answer engines can resolve the machine-readable evidence artifact back to the canonical page, identify who created the synthesis, understand where reuse guidance lives, and distinguish the public data download from the underlying third-party research.

## Guardrails
No Creative Commons/open license is asserted. Third-party rights remain explicitly preserved by the public policy.