### PR TITLE
cleanup: consolidate enrichment and goal slugging

### DIFF
--- a/scripts/verify-enrichment-discovery.ts
+++ b/scripts/verify-enrichment-discovery.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import assert from 'node:assert/strict'
+import { slugify } from '../lib/slug-utils'
 
 type GovernedRow = {
   entityType: 'herb' | 'compound'
@@ -40,13 +41,6 @@ const EVIDENCE_LABEL_TITLES: Record<string, string> = {
 
 function readJson<T>(relativePath: string): T {
   return JSON.parse(fs.readFileSync(path.join(ROOT, relativePath), 'utf8')) as T
-}
-
-function slugify(value: string) {
-  return String(value || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
 }
 
 function isPublishableEnrichment(enrichment: Record<string, any>) {

--- a/src/lib/goal-adjacency.ts
+++ b/src/lib/goal-adjacency.ts
@@ -1,3 +1,4 @@
+import { slugify } from '../../lib/slug-utils'
 import {
   getGoalOverlap,
   getMechanismOverlap,
@@ -29,13 +30,6 @@ function clean(value: unknown): string {
   if (typeof value === 'string') return value.trim()
   if (typeof value === 'number' || typeof value === 'boolean') return String(value).trim()
   return ''
-}
-
-function slugify(value: unknown): string {
-  return clean(value)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
 }
 
 export function scoreGoalAdjacency<T extends GoalProfile>(base: GoalProfile, candidate: T): RelatedGoal<T> {


### PR DESCRIPTION
Broad cleanup pass 12.

- removes the enrichment-discovery verifier's private slugify implementation
- removes goal-adjacency's private slugify implementation
- routes both TypeScript callers through lib/slug-utils.ts
- preserves their domain-specific validation/scoring logic and only consolidates identity normalization

This extends the canonical TypeScript slug boundary into verification and relationship-ranking code.