### PR TITLE
feat(research): detect repeated evidence bundles

### DIFF
--- a/lib/research-study-load.ts
+++ b/lib/research-study-load.ts
@@ -11,6 +11,19 @@ export type CrossProfileStudyLoad = {
   systemicLoadBearing: boolean
 }
 
+export type EvidenceBundleReuse = {
+  url: string
+  studyIds: string[]
+  studyCount: number
+  approvedClaimCount: number
+  outcomeClaimCount: number
+  highConfidenceClaimCount: number
+  predicates: string[]
+  claims: Array<{ claimId: string; predicate: string; confidence: number }>
+  repeatedEvidenceBundle: boolean
+  narrowRepeatedEvidenceBundle: boolean
+}
+
 /**
  * Measure how many approved claims and profiles depend on each canonical study.
  * This complements per-profile concentration: a study may look harmless on every
@@ -68,5 +81,63 @@ export function analyzeCrossProfileStudyLoad(analysis: ResearchQualityAnalysis):
       || b.approvedClaimCount - a.approvedClaimCount
       || b.profileCount - a.profileCount
       || a.studyId.localeCompare(b.studyId),
+    )
+}
+
+/**
+ * Detect multiple approved structured claims on the same profile that reuse the
+ * exact same canonical evidence bundle. Reuse is not automatically wrong, but
+ * it is a topology warning when several apparently distinct claims are all
+ * underwritten by the same narrow study set.
+ */
+export function analyzeEvidenceBundleReuse(analysis: ResearchQualityAnalysis): EvidenceBundleReuse[] {
+  const bundles = new Map<string, {
+    url: string
+    studyIds: string[]
+    claims: Array<{ claimId: string; predicate: string; confidence: number; outcomeClaim: boolean }>
+  }>()
+
+  for (const claim of analysis.claimAnalyses) {
+    if (claim.studyIds.length === 0) continue
+    const studyIds = [...claim.studyIds].sort()
+    const key = `${claim.url}::${studyIds.join('|')}`
+    const item = bundles.get(key) ?? { url: claim.url, studyIds, claims: [] }
+    item.claims.push({
+      claimId: claim.claimId,
+      predicate: claim.predicate,
+      confidence: claim.confidence,
+      outcomeClaim: claim.outcomeClaim,
+    })
+    bundles.set(key, item)
+  }
+
+  return [...bundles.values()]
+    .filter((item) => item.claims.length >= 2)
+    .map((item) => {
+      const predicates = [...new Set(item.claims.map((claim) => claim.predicate))].sort()
+      const approvedClaimCount = item.claims.length
+      const outcomeClaimCount = item.claims.filter((claim) => claim.outcomeClaim).length
+      const highConfidenceClaimCount = item.claims.filter((claim) => claim.confidence >= 0.75).length
+      const studyCount = item.studyIds.length
+      return {
+        url: item.url,
+        studyIds: item.studyIds,
+        studyCount,
+        approvedClaimCount,
+        outcomeClaimCount,
+        highConfidenceClaimCount,
+        predicates,
+        claims: item.claims
+          .map(({ claimId, predicate, confidence }) => ({ claimId, predicate, confidence }))
+          .sort((a, b) => a.claimId.localeCompare(b.claimId)),
+        repeatedEvidenceBundle: approvedClaimCount >= 2,
+        narrowRepeatedEvidenceBundle: approvedClaimCount >= 3 && studyCount <= 2,
+      }
+    })
+    .sort((a, b) =>
+      Number(b.narrowRepeatedEvidenceBundle) - Number(a.narrowRepeatedEvidenceBundle)
+      || b.approvedClaimCount - a.approvedClaimCount
+      || a.studyCount - b.studyCount
+      || a.url.localeCompare(b.url),
     )
 }

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -8,7 +8,7 @@ import path from 'node:path'
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchGapQueue, structuralCoverageFailures } from '../../lib/research-quality-policy'
-import { analyzeCrossProfileStudyLoad } from '../../lib/research-study-load'
+import { analyzeCrossProfileStudyLoad, analyzeEvidenceBundleReuse } from '../../lib/research-study-load'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
@@ -50,6 +50,8 @@ const structuralFailures = structuralCoverageFailures(analysis)
 const researchGapQueue = buildResearchGapQueue(analysis)
 const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
 const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
+const evidenceBundleReuse = analyzeEvidenceBundleReuse(analysis)
+const narrowRepeatedEvidenceBundles = evidenceBundleReuse.filter((bundle) => bundle.narrowRepeatedEvidenceBundle)
 const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
 const weakApprovedOutcomes = analysis.claimAnalyses.filter((claim) =>
@@ -73,7 +75,7 @@ results.push({
   passed: corePassed,
   exitCode: corePassed ? 0 : 1,
   durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; structuredClaims=${analysis.structuredClaimAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; structuredClaims=${analysis.structuredClaimAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
   stderrTail: structuralFailures.length ? `${structuralFailures.length} structurally invalid approved-claim evidence edge(s)` : '',
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile research-quality analysis  (${coreDurationMs}ms)`)
@@ -113,24 +115,29 @@ const coreSummary = {
   profilesWithResearchGaps: researchGapQueue.length,
   canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
   systemicLoadBearingStudies: systemicLoadBearingStudies.length,
+  repeatedEvidenceBundles: evidenceBundleReuse.length,
+  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length,
   aiCitationReadiness: aiCitationReadiness.summary,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 4,
+  schemaVersion: 5,
   generatedAt: new Date().toISOString(),
   passed: !failed,
   source: {
     analysis: 'lib/research-quality-analysis.ts',
     policy: 'lib/research-quality-policy.ts',
     crossProfileStudyLoad: 'lib/research-study-load.ts',
+    evidenceBundleReuse: 'lib/research-study-load.ts',
     aiCitationReadiness: 'lib/ai-citation-readiness.ts',
   },
   coreSummary,
   structuralFailures,
   systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100),
+  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
+  topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100),
   topResearchGaps: researchGapQueue.slice(0, 50),
   topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
   checks: results,
@@ -142,6 +149,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
 console.log(`Structural failures ${coreSummary.structuralFailures} · weak approved outcomes ${coreSummary.weakApprovedOutcomeClaims} · research-gap profiles ${coreSummary.profilesWithResearchGaps}`)
 console.log(`Systemic load-bearing studies ${coreSummary.systemicLoadBearingStudies} of ${coreSummary.canonicalStudiesSupportingApprovedClaims} canonical studies supporting approved claims`)
+console.log(`Repeated evidence bundles ${coreSummary.repeatedEvidenceBundles} · narrow repeated bundles ${coreSummary.narrowRepeatedEvidenceBundles}`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
 console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)


### PR DESCRIPTION
Adds profile-level evidence-bundle reuse topology. Approved claims that reuse the exact same canonical study set are now grouped and ranked, with a stronger flag when 3+ approved claims share only 1–2 studies. The canonical research-quality roll-up reports these repeated/narrow bundles alongside per-profile concentration and cross-profile study load, closing the gap where multiple distinct structured claims could appear diversified while actually sharing the same evidence bundle.