### PR TITLE
SEO: keep safety semantics qualitative for answer engines

### DIFF
--- a/components/ui/SafetyGaugeMeter.tsx
+++ b/components/ui/SafetyGaugeMeter.tsx
@@ -1,6 +1,7 @@
 type SafetyGaugeMeterProps = {
-  /** 0-100 safety score; higher is safer */
+  /** 0-100 visual safety gauge; higher renders toward lower caution. */
   score: number
+  /** Human-readable qualitative interpretation derived by the profile safety policy. */
   label: string
   className?: string
 }
@@ -25,7 +26,6 @@ export default function SafetyGaugeMeter({ score, label, className = '' }: Safet
   return (
     <div
       data-safety-context="true"
-      data-safety-score={clamped}
       data-safety-label={label}
       className={`flex flex-col items-center ${className}`}
     >
@@ -33,7 +33,7 @@ export default function SafetyGaugeMeter({ score, label, className = '' }: Safet
         viewBox="0 0 100 58"
         className="w-full max-w-[200px]"
         role="img"
-        aria-label={`Safety meter: ${clamped} out of 100 — ${label}`}
+        aria-label={`Safety context: ${label}. Visual gauge position ${clamped} out of 100.`}
       >
         <path d={describeArc(50, 50, 40, 180, 120)} stroke="#dc4c3c" strokeWidth="9" fill="none" strokeLinecap="round" />
         <path d={describeArc(50, 50, 40, 120, 60)} stroke="#e8a13c" strokeWidth="9" fill="none" strokeLinecap="round" />
@@ -49,7 +49,7 @@ export default function SafetyGaugeMeter({ score, label, className = '' }: Safet
         />
         <circle cx="50" cy="50" r="3.5" className="fill-ink dark:fill-white" />
       </svg>
-      <p className="-mt-2 text-2xl font-bold text-ink">{clamped}%</p>
+      <p className="-mt-2 text-2xl font-bold text-ink" aria-hidden="true">{clamped}%</p>
       <p className="max-w-full text-center text-xs font-semibold uppercase leading-5 tracking-wide text-muted">{label}</p>
     </div>
   )

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -115,8 +115,11 @@ function auditProfilePrimitives() {
   ])
   requireSignals(SAFETY_GAUGE, 'profile-semantics', 'SafetyGaugeMeter', [
     ['data-safety-context="true"', 'safety-context marker'],
-    ['data-safety-score={clamped}', 'safety-score value'],
+    ['data-safety-label={label}', 'qualitative safety label'],
   ])
+  if (text(SAFETY_GAUGE).includes('data-safety-score=')) {
+    add('error', 'profile-semantics', 'SafetyGaugeMeter exposes a derived visual gauge as a machine-readable clinical-looking score')
+  }
   requireSignals(LAST_UPDATED, 'profile-semantics', 'LastUpdatedBadge', [
     ['data-editorial-provenance="true"', 'editorial-provenance marker'],
     ['data-last-reviewed=', 'last-reviewed value'],


### PR DESCRIPTION
## Summary
- keeps the existing visual 0–100 safety gauge unchanged for users
- removes the derived numeric gauge from machine-readable `data-*` semantics
- exposes only the qualitative governed safety label as answer-engine context
- updates the canonical answer-engine audit to require the qualitative label and fail if a machine-readable pseudo-precise safety score returns

## Why
The profile gauge maps coarse safety categories into display positions. Publishing that UI coordinate as machine-readable data risks making a visual aid look like a validated clinical safety metric.

## Guardrails
No visible safety language or underlying safety policy is changed. This only narrows machine-readable semantics to what the data actually supports.