### PR TITLE
refactor(research): make source integrity one-pass

### DIFF
--- a/lib/research-source-integrity.ts
+++ b/lib/research-source-integrity.ts
@@ -1,0 +1,135 @@
+import {
+  designFromPublicationTypes,
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  SYNTHESIS_STUDY_CLASSES,
+} from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { StudyClass } from './study-class'
+
+const WITHDRAWN = /retract|expression of concern|withdrawn/i
+
+export type SourceIntegrityStudy = {
+  pmid: string
+  pageCount: number
+  pages: string[]
+  title: string
+  journal: string
+  year: number | null
+  design: StudyClass
+  publicationTypes: string[]
+  hasMetadata: boolean
+}
+
+export type ResearchSourceIntegrity = {
+  currentYear: number
+  summary: {
+    citedStudies: number
+    withMetadata: number
+    citedOnMultipleProfiles: number
+    loadBearing: number
+    oldAndLoadBearing: number
+    withdrawn: number
+    age: Record<'within5' | 'within10' | 'within20' | 'over20', number>
+    designMix: Record<string, number>
+    humanPrimary: number
+    synthesis: number
+    medianYear: number | null
+  }
+  withdrawn: SourceIntegrityStudy[]
+  mostReferenced: SourceIntegrityStudy[]
+  oldAndLoadBearing: SourceIntegrityStudy[]
+  studies: SourceIntegrityStudy[]
+}
+
+function citationGraph(analysis: ResearchQualityAnalysis): Map<string, Set<string>> {
+  const referencedBy = new Map<string, Set<string>>()
+  for (const { url, record } of analysis.profiles) {
+    for (const source of Array.isArray(record.sources) ? record.sources : []) {
+      const pmid = String(source.pmid ?? source.pubmedId ?? '').trim()
+      if (!pmid) continue
+      const pages = referencedBy.get(pmid) ?? new Set<string>()
+      pages.add(url)
+      referencedBy.set(pmid, pages)
+    }
+  }
+  return referencedBy
+}
+
+/**
+ * Source-level integrity facts derived from an already-built canonical research
+ * analysis. This deliberately excludes claim/profile topology; that belongs to
+ * research-quality-analysis and research-quality-policy rather than a second
+ * competing source-integrity report.
+ */
+export function analyzeResearchSourceIntegrity(
+  analysis: ResearchQualityAnalysis,
+  currentYear = Number(process.env.SOURCE_AUDIT_YEAR) || new Date().getFullYear(),
+): ResearchSourceIntegrity {
+  const referencedBy = citationGraph(analysis)
+  const studies: SourceIntegrityStudy[] = [...referencedBy.entries()].map(([pmid, pages]) => {
+    const meta = (analysis.cache[pmid] ?? {}) as {
+      title?: string
+      journal?: string
+      year?: number
+      publicationTypes?: string[]
+    }
+    return {
+      pmid,
+      pageCount: pages.size,
+      pages: [...pages].sort(),
+      title: String(meta.title ?? '').slice(0, 120),
+      journal: String(meta.journal ?? ''),
+      year: Number.isFinite(Number(meta.year)) ? Number(meta.year) : null,
+      design: designFromPublicationTypes(meta.publicationTypes ?? []),
+      publicationTypes: meta.publicationTypes ?? [],
+      hasMetadata: Boolean(meta.title),
+    }
+  })
+
+  studies.sort((a, b) => b.pageCount - a.pageCount || (a.year ?? 0) - (b.year ?? 0) || a.pmid.localeCompare(b.pmid))
+  const withdrawn = studies.filter((study) => study.publicationTypes.some((type) => WITHDRAWN.test(type)))
+  const dated = studies.filter((study): study is SourceIntegrityStudy & { year: number } => typeof study.year === 'number')
+  const age: Record<'within5' | 'within10' | 'within20' | 'over20', number> = {
+    within5: 0,
+    within10: 0,
+    within20: 0,
+    over20: 0,
+  }
+
+  for (const study of dated) {
+    const years = currentYear - study.year
+    if (years <= 5) age.within5 += 1
+    else if (years <= 10) age.within10 += 1
+    else if (years <= 20) age.within20 += 1
+    else age.over20 += 1
+  }
+
+  const designMix: Record<string, number> = {}
+  for (const study of studies) designMix[study.design] = (designMix[study.design] ?? 0) + 1
+  const loadBearing = studies.filter((study) => study.pageCount >= 3)
+  const oldAndLoadBearing = loadBearing.filter((study) => study.year !== null && currentYear - study.year > 15)
+  const humanPrimary = studies.filter((study) => PRIMARY_HUMAN_STUDY_CLASSES.has(study.design)).length
+  const synthesis = studies.filter((study) => SYNTHESIS_STUDY_CLASSES.has(study.design)).length
+  const sortedYears = dated.map((study) => study.year).sort((a, b) => a - b)
+
+  return {
+    currentYear,
+    summary: {
+      citedStudies: studies.length,
+      withMetadata: studies.filter((study) => study.hasMetadata).length,
+      citedOnMultipleProfiles: studies.filter((study) => study.pageCount > 1).length,
+      loadBearing: loadBearing.length,
+      oldAndLoadBearing: oldAndLoadBearing.length,
+      withdrawn: withdrawn.length,
+      age,
+      designMix,
+      humanPrimary,
+      synthesis,
+      medianYear: sortedYears.length ? sortedYears[Math.floor(sortedYears.length / 2)] : null,
+    },
+    withdrawn,
+    mostReferenced: studies.slice(0, 40),
+    oldAndLoadBearing,
+    studies,
+  }
+}

--- a/scripts/ci/audit-source-integrity.ts
+++ b/scripts/ci/audit-source-integrity.ts
@@ -1,154 +1,44 @@
-/** Canonical research/source integrity and coverage-topology audit. */
+/** Standalone compatibility reporter for canonical source-level research integrity. */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
-import {
-  designFromPublicationTypes,
-  PRIMARY_HUMAN_STUDY_CLASSES,
-  SYNTHESIS_STUDY_CLASSES,
-} from '../../lib/research-coverage'
+import { analyzeResearchSourceIntegrity } from '../../lib/research-source-integrity'
 import { STUDY_CLASS_INFO, type StudyClass } from '../../lib/study-class'
 
 const ROOT = process.cwd()
 const REPORTS_DIR = path.join(ROOT, 'ops', 'reports')
 const REPORT_PATH = path.join(REPORTS_DIR, 'source-integrity.json')
-const WITHDRAWN = /retract|expression of concern|withdrawn/i
-const CURRENT_YEAR = Number(process.env.SOURCE_AUDIT_YEAR) || new Date().getFullYear()
-
-function buildCitationGraph(profiles: ReturnType<typeof analyzeResearchQuality>['profiles']): Map<string, Set<string>> {
-  const referencedBy = new Map<string, Set<string>>()
-  for (const { url, record } of profiles) {
-    for (const source of Array.isArray(record.sources) ? record.sources : []) {
-      const pmid = String(source.pmid ?? source.pubmedId ?? '').trim()
-      if (!pmid) continue
-      if (!referencedBy.has(pmid)) referencedBy.set(pmid, new Set())
-      referencedBy.get(pmid)!.add(url)
-    }
-  }
-  return referencedBy
-}
 
 function main() {
-  const { cache, profiles, profileAnalyses: profileTopology } = analyzeResearchQuality(ROOT)
-  const referencedBy = buildCitationGraph(profiles)
-
-  const studies = [...referencedBy.entries()].map(([pmid, pages]) => {
-    const meta = (cache[pmid] ?? {}) as { title?: string; journal?: string; year?: number; publicationTypes?: string[] }
-    return {
-      pmid,
-      pageCount: pages.size,
-      pages: [...pages].sort(),
-      title: String(meta.title ?? '').slice(0, 120),
-      journal: meta.journal ?? '',
-      year: meta.year ?? null,
-      design: designFromPublicationTypes(meta.publicationTypes ?? []),
-      publicationTypes: meta.publicationTypes ?? [],
-      hasMetadata: Boolean(meta.title),
-    }
-  })
-
-  studies.sort((a, b) => b.pageCount - a.pageCount || (a.year ?? 0) - (b.year ?? 0))
-  const withdrawn = studies.filter((study) => study.publicationTypes.some((type) => WITHDRAWN.test(type)))
-  const dated = studies.filter((study) => study.year)
-  const age: Record<string, number> = { within5: 0, within10: 0, within20: 0, over20: 0 }
-  for (const study of dated) {
-    const years = CURRENT_YEAR - study.year!
-    if (years <= 5) age.within5 += 1
-    else if (years <= 10) age.within10 += 1
-    else if (years <= 20) age.within20 += 1
-    else age.over20 += 1
-  }
-
-  const designMix: Record<string, number> = {}
-  for (const study of studies) designMix[study.design] = (designMix[study.design] ?? 0) + 1
-  const central = studies.filter((study) => study.pageCount >= 3)
-  const oldAndCentral = central.filter((study) => study.year && CURRENT_YEAR - study.year > 15)
-  const humanPrimary = studies.filter((study) => PRIMARY_HUMAN_STUDY_CLASSES.has(study.design)).length
-  const synthesis = studies.filter((study) => SYNTHESIS_STUDY_CLASSES.has(study.design)).length
-
-  const unsupportedClaims = profileTopology.flatMap((p) => p.unsupportedApprovedClaims.map((claimId) => ({ url: p.url, claimId })))
-  const weakStructuredClaims = profileTopology.flatMap((p) => p.weakStructuredClaims.map((claimId) => ({ url: p.url, claimId })))
-  const danglingRefs = profileTopology.flatMap((p) => p.danglingSourceRefs.map((item) => ({ url: p.url, ...item })))
-  const singleStudyClaims = profileTopology.flatMap((p) => p.singleStudyApprovedClaims.map((claimId) => ({ url: p.url, claimId })))
-  const aliasCollapsedClaims = profileTopology.flatMap((p) => p.aliasCollapsedClaims.map((claimId) => ({ url: p.url, claimId })))
-  const concentratedProfiles = profileTopology
-    .filter((p) => p.overDependentOnSingleStudy)
-    .sort((a, b) => b.dominantStudySupportedClaimShare - a.dominantStudySupportedClaimShare || a.effectiveStudyCount - b.effectiveStudyCount)
-  const reviewDominatedProfiles = profileTopology.filter((p) => p.narrativeDominatedVsPrimaryHuman)
-  const noPrimaryHumanProfiles = profileTopology.filter((p) => p.noPrimaryHuman)
-
-  const summary = {
-    citedStudies: studies.length,
-    withMetadata: studies.filter((study) => study.hasMetadata).length,
-    citedOnMultipleProfiles: studies.filter((study) => study.pageCount > 1).length,
-    loadBearing: central.length,
-    oldAndLoadBearing: oldAndCentral.length,
-    withdrawn: withdrawn.length,
-    age,
-    designMix,
-    humanPrimary,
-    synthesis,
-    medianYear: dated.length ? dated.map((study) => study.year!).sort((a, b) => a - b)[Math.floor(dated.length / 2)] : null,
-    profiles: profileTopology.length,
-    approvedClaims: profileTopology.reduce((sum, profile) => sum + profile.approvedClaimCount, 0),
-    unsupportedApprovedClaims: unsupportedClaims.length,
-    weakStructuredClaims: weakStructuredClaims.length,
-    singleStudyApprovedClaims: singleStudyClaims.length,
-    aliasCollapsedClaims: aliasCollapsedClaims.length,
-    danglingClaimSourceRefs: danglingRefs.length,
-    concentratedProfiles: concentratedProfiles.length,
-    reviewDominatedProfiles: reviewDominatedProfiles.length,
-    profilesWithClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
-  }
+  const analysis = analyzeResearchQuality(ROOT)
+  const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
+  const { summary, withdrawn, mostReferenced, oldAndLoadBearing } = sourceIntegrity
 
   fs.mkdirSync(REPORTS_DIR, { recursive: true })
   fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
-    currentYear: CURRENT_YEAR,
+    currentYear: sourceIntegrity.currentYear,
+    source: 'lib/research-source-integrity.ts',
     summary,
-    claimTopology: {
-      unsupportedClaims,
-      weakStructuredClaims,
-      singleStudyClaims,
-      aliasCollapsedClaims,
-      danglingRefs,
-      concentratedProfiles,
-      reviewDominatedProfiles,
-      noPrimaryHumanProfiles,
-      profiles: profileTopology,
-    },
     withdrawn,
-    mostReferenced: studies.slice(0, 40),
-    oldAndLoadBearing: oldAndCentral,
+    mostReferenced,
+    oldAndLoadBearing,
   }, null, 2)}\n`)
 
-  console.log('\nResearch coverage topology')
+  console.log('\nResearch source integrity')
   console.log('='.repeat(72))
-  console.log(`Profiles analyzed           ${summary.profiles}`)
-  console.log(`Approved structured claims  ${summary.approvedClaims}`)
-  console.log(`Unsupported approved claims ${summary.unsupportedApprovedClaims}`)
-  console.log(`Weak structured claims      ${summary.weakStructuredClaims}`)
-  console.log(`Single-study claims         ${summary.singleStudyApprovedClaims}`)
-  console.log(`Alias-collapsed claims      ${summary.aliasCollapsedClaims}`)
-  console.log(`Dangling claim source refs  ${summary.danglingClaimSourceRefs}`)
-  console.log(`Concentrated profiles       ${summary.concentratedProfiles}`)
-  console.log(`Narrative>human profiles    ${summary.reviewDominatedProfiles}`)
-  console.log(`Claims, no primary human    ${summary.profilesWithClaimsButNoPrimaryHumanStudy}`)
-  console.log(`\nCited studies               ${summary.citedStudies} (${summary.withMetadata} with PubMed metadata)`)
+  console.log(`Cited studies               ${summary.citedStudies} (${summary.withMetadata} with PubMed metadata)`)
+  console.log(`Cited on multiple profiles  ${summary.citedOnMultipleProfiles}`)
   console.log(`Load-bearing (>=3 pages)    ${summary.loadBearing}`)
+  console.log(`Old + load-bearing (>15y)   ${summary.oldAndLoadBearing}`)
   console.log(`Retracted / concern         ${summary.withdrawn}`)
-  console.log(`Primary human ${humanPrimary} · synthesis ${synthesis} · other ${summary.citedStudies - humanPrimary - synthesis}`)
+  console.log(`Primary human ${summary.humanPrimary} · synthesis ${summary.synthesis} · other ${summary.citedStudies - summary.humanPrimary - summary.synthesis}`)
   console.log('\nDesign mix:')
-  for (const [design, count] of Object.entries(designMix).sort((a, b) => b[1] - a[1])) {
+  for (const [design, count] of Object.entries(summary.designMix).sort((a, b) => b[1] - a[1])) {
     console.log(`  ${String(count).padStart(4)}  ${STUDY_CLASS_INFO[design as StudyClass]?.label ?? design}`)
-  }
-  if (concentratedProfiles.length) {
-    console.log('\nHighest claim-study concentration:')
-    for (const profile of concentratedProfiles.slice(0, 10)) {
-      console.log(`  ${(profile.dominantStudySupportedClaimShare * 100).toFixed(0).padStart(3)}% · effective ${profile.effectiveStudyCount.toFixed(2)} studies · ${profile.url}`)
-    }
   }
   console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)
 

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -9,6 +9,7 @@ import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from '../../lib/research-evidence-age'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchGapQueue, structuralCoverageFailures } from '../../lib/research-quality-policy'
+import { analyzeResearchSourceIntegrity } from '../../lib/research-source-integrity'
 import { analyzeCrossProfileStudyLoad, analyzeEvidenceBundleReuse } from '../../lib/research-study-load'
 
 const ROOT = process.cwd()
@@ -18,30 +19,20 @@ const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx'
 
 const externalChecks = [
   { id: 'citation-identities', label: 'Citation identity integrity', command: process.execPath, args: ['scripts/ci/validate-citation-identifiers.mjs'] },
-  { id: 'coverage-topology', label: 'Research source integrity / topology metadata', command: NPX, args: ['tsx', 'scripts/ci/audit-source-integrity.ts'] },
   { id: 'evidence-grades', label: 'Evidence grade consistency', command: NPX, args: ['tsx', 'scripts/ci/validate-evidence-grade-consistency.ts'] },
   { id: 'content-integrity', label: 'Structured content integrity', command: process.execPath, args: ['scripts/ci/audit-content-integrity.mjs'] },
 ] as const
 
 type CheckResult = { id: string; label: string; passed: boolean; exitCode: number; durationMs: number; stdoutTail: string; stderrTail: string }
-
-function tail(value: string, maxLines = 24): string {
-  return value.split(/\r?\n/).filter(Boolean).slice(-maxLines).join('\n')
-}
-
+function tail(value: string, maxLines = 24): string { return value.split(/\r?\n/).filter(Boolean).slice(-maxLines).join('\n') }
 function readSummary(fileName: string): unknown {
   const file = path.join(REPORT_DIR, fileName)
   if (!fs.existsSync(file)) return null
-  try {
-    return JSON.parse(fs.readFileSync(file, 'utf8')).summary ?? null
-  } catch {
-    return null
-  }
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')).summary ?? null } catch { return null }
 }
 
 const results: CheckResult[] = []
 let failed = false
-
 console.log('\nCanonical research-quality pipeline')
 console.log('='.repeat(76))
 
@@ -49,6 +40,7 @@ const coreStarted = Date.now()
 const analysis = analyzeResearchQuality(ROOT)
 const structuralFailures = structuralCoverageFailures(analysis)
 const researchGapQueue = buildResearchGapQueue(analysis)
+const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
 const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
 const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
 const evidenceBundleReuse = analyzeEvidenceBundleReuse(analysis)
@@ -59,112 +51,62 @@ const legacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.allKnownEviden
 const highConfidenceLegacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.highConfidenceLegacyOnlyClaim)
 const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
-const weakApprovedOutcomes = analysis.claimAnalyses.filter((claim) =>
-  claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
-)
-const unsupportedUnapprovedClaims = analysis.structuredClaimAnalyses.filter(
-  (claim) => !claim.approved && claim.supportTier === 'unsupported',
-)
-const weakUnapprovedOutcomes = analysis.structuredClaimAnalyses.filter(
-  (claim) => !claim.approved && claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier),
-)
+const weakApprovedOutcomes = analysis.claimAnalyses.filter((claim) => claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier))
+const unsupportedUnapprovedClaims = analysis.structuredClaimAnalyses.filter((claim) => !claim.approved && claim.supportTier === 'unsupported')
+const weakUnapprovedOutcomes = analysis.structuredClaimAnalyses.filter((claim) => !claim.approved && claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier))
 const overDependentProfiles = analysis.profileAnalyses.filter((profile) => profile.overDependentOnSingleStudy)
 const narrativeDominatedProfiles = analysis.profileAnalyses.filter((profile) => profile.narrativeDominatedVsPrimaryHuman)
 const noPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.noPrimaryHuman)
-const corePassed = structuralFailures.length === 0
+const corePassed = structuralFailures.length === 0 && sourceIntegrity.summary.withdrawn === 0
 const coreDurationMs = Date.now() - coreStarted
 
 results.push({
-  id: 'canonical-core',
-  label: 'Canonical claim/profile research-quality analysis',
-  passed: corePassed,
-  exitCode: corePassed ? 0 : 1,
-  durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; structuredClaims=${analysis.structuredClaimAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
-  stderrTail: structuralFailures.length ? `${structuralFailures.length} structurally invalid approved-claim evidence edge(s)` : '',
+  id: 'canonical-core', label: 'Canonical claim/profile/source research-quality analysis', passed: corePassed,
+  exitCode: corePassed ? 0 : 1, durationMs: coreDurationMs,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
+  stderrTail: [structuralFailures.length ? `${structuralFailures.length} invalid evidence edge(s)` : '', sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : ''].filter(Boolean).join('; '),
 })
-console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile research-quality analysis  (${coreDurationMs}ms)`)
-console.log(`INFO  AI citation readiness generated from same analysis pass: average=${aiCitationReadiness.summary.averageScore}; below70=${aiCitationReadiness.summary.below70}; contradictions=${aiCitationReadiness.summary.contradictions}`)
+console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
 if (!corePassed) failed = true
 
 for (const check of externalChecks) {
-  const started = Date.now()
-  const run = spawnSync(check.command, check.args, { cwd: ROOT, encoding: 'utf8', env: process.env })
-  const exitCode = run.status ?? 1
-  const passed = exitCode === 0
-  const durationMs = Date.now() - started
-  const stdout = String(run.stdout ?? '')
-  const stderr = String(run.stderr ?? '')
-
+  const started = Date.now(); const run = spawnSync(check.command, check.args, { cwd: ROOT, encoding: 'utf8', env: process.env })
+  const exitCode = run.status ?? 1; const passed = exitCode === 0; const durationMs = Date.now() - started
+  const stdout = String(run.stdout ?? ''); const stderr = String(run.stderr ?? '')
   results.push({ id: check.id, label: check.label, passed, exitCode, durationMs, stdoutTail: tail(stdout), stderrTail: tail(stderr) })
   console.log(`${passed ? 'PASS' : 'FAIL'}  ${check.label}  (${durationMs}ms)`)
-
-  if (!passed) {
-    failed = true
-    const detail = tail(stderr || stdout, 10)
-    if (detail) console.error(detail)
-  }
+  if (!passed) { failed = true; const detail = tail(stderr || stdout, 10); if (detail) console.error(detail) }
 }
 
 const coreSummary = {
-  profiles: analysis.profileAnalyses.length,
-  structuredClaims: analysis.structuredClaimAnalyses.length,
-  approvedClaims: analysis.claimAnalyses.length,
-  structuralFailures: structuralFailures.length,
-  weakApprovedOutcomeClaims: weakApprovedOutcomes.length,
-  unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
-  weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length,
-  overDependentProfiles: overDependentProfiles.length,
-  narrativeDominatedProfiles: narrativeDominatedProfiles.length,
-  profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
-  profilesWithResearchGaps: researchGapQueue.length,
-  canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
-  systemicLoadBearingStudies: systemicLoadBearingStudies.length,
-  repeatedEvidenceBundles: evidenceBundleReuse.length,
-  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length,
-  evidenceAge: evidenceAgeSummary,
-  aiCitationReadiness: aiCitationReadiness.summary,
+  profiles: analysis.profileAnalyses.length, structuredClaims: analysis.structuredClaimAnalyses.length, approvedClaims: analysis.claimAnalyses.length,
+  structuralFailures: structuralFailures.length, withdrawnCitedStudies: sourceIntegrity.summary.withdrawn,
+  weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
+  weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
+  narrativeDominatedProfiles: narrativeDominatedProfiles.length, profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
+  profilesWithResearchGaps: researchGapQueue.length, canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
+  systemicLoadBearingStudies: systemicLoadBearingStudies.length, repeatedEvidenceBundles: evidenceBundleReuse.length,
+  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length, sourceIntegrity: sourceIntegrity.summary,
+  evidenceAge: evidenceAgeSummary, aiCitationReadiness: aiCitationReadiness.summary,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 6,
-  generatedAt: new Date().toISOString(),
-  passed: !failed,
-  source: {
-    analysis: 'lib/research-quality-analysis.ts',
-    policy: 'lib/research-quality-policy.ts',
-    crossProfileStudyLoad: 'lib/research-study-load.ts',
-    evidenceBundleReuse: 'lib/research-study-load.ts',
-    evidenceAge: 'lib/research-evidence-age.ts',
-    aiCitationReadiness: 'lib/ai-citation-readiness.ts',
-  },
-  coreSummary,
-  structuralFailures,
-  systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
-  topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100),
-  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
-  topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100),
-  highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100),
-  topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100),
-  topResearchGaps: researchGapQueue.slice(0, 50),
-  topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
-  checks: results,
-  sourceIntegritySummary: readSummary('source-integrity.json'),
-  evidenceGradeSummary: readSummary('evidence-grade-consistency.json'),
-  contentIntegritySummary: readSummary('content-integrity.json'),
+  schemaVersion: 7, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', policy: 'lib/research-quality-policy.ts', sourceIntegrity: 'lib/research-source-integrity.ts', crossProfileStudyLoad: 'lib/research-study-load.ts', evidenceBundleReuse: 'lib/research-study-load.ts', evidenceAge: 'lib/research-evidence-age.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  coreSummary, structuralFailures, withdrawnCitedStudies: sourceIntegrity.withdrawn,
+  oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
+  topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
+  topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100), highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100),
+  topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100), topResearchGaps: researchGapQueue.slice(0, 50), topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
+  checks: results, evidenceGradeSummary: readSummary('evidence-grade-consistency.json'), contentIntegritySummary: readSummary('content-integrity.json'),
 }, null, 2)}\n`)
 
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
-console.log(`Structural failures ${coreSummary.structuralFailures} · weak approved outcomes ${coreSummary.weakApprovedOutcomeClaims} · research-gap profiles ${coreSummary.profilesWithResearchGaps}`)
-console.log(`Systemic load-bearing studies ${coreSummary.systemicLoadBearingStudies} of ${coreSummary.canonicalStudiesSupportingApprovedClaims} canonical studies supporting approved claims`)
-console.log(`Repeated evidence bundles ${coreSummary.repeatedEvidenceBundles} · narrow repeated bundles ${coreSummary.narrowRepeatedEvidenceBundles}`)
-console.log(`Evidence age: ${evidenceAgeSummary.legacyOnly10Years} legacy-only >10y · ${evidenceAgeSummary.highConfidenceLegacyOnlyClaims} high-confidence legacy-only · ${evidenceAgeSummary.claimsWithOnlyUnknownStudyYears} claims with only unknown study years`)
+console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
+console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
 console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
-if (failed) {
-  console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.')
-  process.exit(1)
-}
-console.log('\n[research-quality] PASS — canonical analysis/policy, AI citation topology, source integrity, evidence grades, and structured integrity agree.')
+if (failed) { console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.'); process.exit(1) }
+console.log('\n[research-quality] PASS — one-pass canonical research analysis, source integrity, evidence grades, and structured integrity agree.')


### PR DESCRIPTION
Moves source-level research integrity into `lib/research-source-integrity.ts` and feeds it from the already-built canonical research analysis. The canonical pipeline no longer shells out to `audit-source-integrity.ts`, eliminating another full research-data re-analysis. The legacy command is retained as a thin compatibility reporter and no longer emits duplicated claim/profile topology; retraction, source age, design mix, multi-profile citation load, and old load-bearing studies now come from one reusable source-integrity module.