### PR TITLE
cleanup: separate route and entity slug semantics

### DIFF
--- a/lib/__tests__/entity-identity.test.ts
+++ b/lib/__tests__/entity-identity.test.ts
@@ -5,13 +5,15 @@ import {
   extractParentheticalNames,
   levenshteinDistance,
   normalizeEntityName,
+  normalizeRouteSlug,
   slugifyEntityName,
   stripBracketedIdentityNotes,
   stripParentheticalName,
 } from '@/lib/entity-identity.mjs'
 
 describe('entity identity primitives', () => {
-  it('normalizes names and slugs consistently', () => {
+  it('keeps route and entity slug semantics explicit', () => {
+    expect(normalizeRouteSlug('St. John’s Wort')).toBe('st-john-s-wort')
     expect(slugifyEntityName('St. John’s Wort')).toBe('st-johns-wort')
     expect(normalizeEntityName('  Lion’s   Mane ')).toBe('lions mane')
   })

--- a/lib/entity-identity.mjs
+++ b/lib/entity-identity.mjs
@@ -2,6 +2,22 @@
 
 const QUOTES = /[’'"“”`]/g
 
+/**
+ * Normalize an arbitrary route token without changing legacy punctuation
+ * semantics: punctuation separates words rather than disappearing.
+ */
+export function normalizeRouteSlug(value) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Normalize an entity name for identity matching. Quotes are removed before
+ * tokenization so names such as St. John’s Wort resolve to st-johns-wort.
+ */
 export function slugifyEntityName(value) {
   return String(value ?? '')
     .toLowerCase()

--- a/scripts/ai-generate-post.mjs
+++ b/scripts/ai-generate-post.mjs
@@ -1,6 +1,7 @@
 // Generates one MDX blog post and saves to src/content/blog/YYYY-MM-DD-slug.mdx
 import fs from "fs";
 import path from "path";
+import { normalizeRouteSlug } from "../lib/entity-identity.mjs";
 import { haveAiSecrets, promptLLM } from "./ai-client.mjs";
 
 if (process.env.SKIP_AI_GENERATE === "true") {
@@ -18,7 +19,6 @@ const OUT_DIR = "src/content/blog";
 
 fs.mkdirSync(OUT_DIR, { recursive: true });
 
-function slugify(s){ return String(s).toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/(^-|-$)/g,""); }
 function today(){ return new Date().toISOString().slice(0,10); }
 
 function pickTopic(){
@@ -43,7 +43,7 @@ if (picked.postQueue) {
 
 const topic = picked.topic;
 const date  = today();
-const baseSlug = slugify(topic);
+const baseSlug = normalizeRouteSlug(topic);
 const slug  = `${date}-${baseSlug}`;
 const outPath = path.join(OUT_DIR, `${slug}.mdx`);
 

--- a/scripts/prerender-entities.mjs
+++ b/scripts/prerender-entities.mjs
@@ -2,16 +2,11 @@
 // Generated entity pages now render prerendered SEO content as sr-only to avoid duplicate visible content.
 import fs from 'node:fs'
 import path from 'node:path'
+import { normalizeRouteSlug } from '../lib/entity-identity.mjs'
 
 const ROOT = process.cwd()
 const herbs = JSON.parse(fs.readFileSync(path.join(ROOT, 'public/data/herbs.json'), 'utf8'))
 const compounds = JSON.parse(fs.readFileSync(path.join(ROOT, 'public/data/compounds.json'), 'utf8'))
-
-const slugify = value =>
-  String(value || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
 
 const ensure = dir => fs.mkdirSync(dir, { recursive: true })
 const fmtDate = value => {
@@ -62,7 +57,7 @@ function renderPage(kind, item) {
 function writeKind(kind, items) {
   for (const item of items) {
     const slug =
-      item.slug || slugify(item.commonName || item.common || item.name || item.latinName || item.id)
+      item.slug || normalizeRouteSlug(item.commonName || item.common || item.name || item.latinName || item.id)
     if (!slug) continue
     const outDir = path.join(ROOT, 'public', kind, slug)
     ensure(outDir)


### PR DESCRIPTION
Broad cleanup pass 15.

- adds an explicit route-preserving slug primitive beside entity-name slugging
- documents and regression-tests the difference between punctuation-as-separator route slugs and quote-collapsing entity identity slugs
- migrates prerendered entity fallback routes and AI blog generation off private slugify implementations
- preserves legacy route output instead of silently changing apostrophe/punctuation behavior

This consolidates Node-side slugging without conflating two legitimately different normalization policies.