### PR TITLE
Refactor AI search docs and CI around canonical pipeline

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -1,14 +1,26 @@
-name: AI entity enrichment check
+name: AI search quality check
 
 on:
   pull_request:
     paths:
-      - 'components/seo/SchemaGraphScript.tsx'
-      - 'components/seo/__tests__/SchemaGraphScript.test.ts'
+      - 'components/seo/**'
+      - 'components/editorial/ProfileDecisionPanel.tsx'
+      - 'components/editorial/ScientificVerdictCard.tsx'
+      - 'components/ui/EvidenceScoreBadge.tsx'
+      - 'components/ui/SafetyGaugeMeter.tsx'
+      - 'src/components/editorial/LastUpdatedBadge.tsx'
+      - 'app/info/content-licensing/**'
+      - 'public/llms.txt'
+      - 'app/robots.ts'
+      - 'lib/ai-citation-readiness.ts'
+      - 'lib/research-quality-analysis.ts'
+      - 'scripts/ci/audit-ai-*.mjs'
+      - 'scripts/ci/audit-ai-*.ts'
       - 'scripts/data/ai-entity-enrichment-lib.mjs'
       - 'scripts/data/ai-entity-enrichment-smoke.mjs'
       - 'scripts/data/build-runtime-summary-indexes.mjs'
-      - 'scripts/ci/audit-ai-entity-completeness.mjs'
+      - 'docs/ai-search-*.md'
+      - 'docs/ai-citation-readiness-topology.md'
       - '.github/workflows/ai-entity-enrichment-check.yml'
   workflow_dispatch:
 
@@ -22,7 +34,7 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -57,11 +69,34 @@ jobs:
       - name: Install dependencies
         run: npm ci --silent
 
-      - name: Run schema discovery unit test
-        run: npx vitest run components/seo/__tests__/SchemaGraphScript.test.ts
+      - name: Run schema discovery and provenance tests
+        run: npx vitest run components/seo/__tests__/SchemaGraphScript.test.ts components/seo/__tests__/SchemaGraphScript.provenance.test.ts
 
-      - name: Lint changed implementation files
-        run: npx eslint components/seo/SchemaGraphScript.tsx components/seo/__tests__/SchemaGraphScript.test.ts scripts/data/ai-entity-enrichment-lib.mjs scripts/data/ai-entity-enrichment-smoke.mjs scripts/data/build-runtime-summary-indexes.mjs scripts/ci/audit-ai-entity-completeness.mjs scripts/ci/audit-ai-citation-readiness.mjs --max-warnings=0
+      - name: Run canonical AI-search quality audit
+        run: npm run audit:ai-citations
+
+      - name: Lint AI-search implementation files
+        run: >-
+          npx eslint
+          components/seo/SchemaGraphScript.tsx
+          components/seo/CitationReadySummary.tsx
+          components/seo/AnswerEngineTable.tsx
+          components/seo/__tests__/SchemaGraphScript.test.ts
+          components/seo/__tests__/SchemaGraphScript.provenance.test.ts
+          components/editorial/ProfileDecisionPanel.tsx
+          components/editorial/ScientificVerdictCard.tsx
+          components/ui/EvidenceScoreBadge.tsx
+          components/ui/SafetyGaugeMeter.tsx
+          src/components/editorial/LastUpdatedBadge.tsx
+          scripts/data/ai-entity-enrichment-lib.mjs
+          scripts/data/ai-entity-enrichment-smoke.mjs
+          scripts/data/build-runtime-summary-indexes.mjs
+          scripts/ci/audit-ai-entity-completeness.mjs
+          scripts/ci/audit-ai-citation-readiness.mjs
+          scripts/ci/audit-ai-answer-engine-readiness.mjs
+          scripts/ci/audit-ai-claim-integrity.mjs
+          scripts/ci/audit-ai-citation-topology.ts
+          --max-warnings=0
 
       - name: Typecheck
         run: npm run typecheck

--- a/docs/ai-search-citation-share.md
+++ b/docs/ai-search-citation-share.md
@@ -1,264 +1,141 @@
-# AI Searchability & Citation-Share Roadmap
+# AI Citation-Share & Feedback Playbook
 
-Purpose: make The Hippie Scientist easier for AI search engines, answer engines, and citation systems to understand, quote, and cite without weakening editorial quality or creating fake authority signals.
+This document covers **measurement and iteration**. The implementation standard lives in `docs/ai-search-optimization.md`; scientific support policy lives in the canonical research-quality pipeline. Do not use this file to create a second readiness model.
 
-## Current baseline
+## Goal
 
-- Canonical host is `https://thehippiescientist.net`, not the `www` host.
-- `app/robots.ts` allows public crawling and blocks internal/API/draft/temp routes.
-- `app/sitemap.ts` emits canonical, indexable routes and avoids generated compare pages that are not actually built.
-- `components/References.tsx` renders visible reference lists with stable `#ref-N` anchors.
-- `components/seo/AuthorityJsonLd.tsx` and `src/lib/schema-graph.ts` already provide JSON-LD patterns for WebPage, Article, MedicalWebPage, FAQPage, BreadcrumbList, ItemList, author, publisher, reviewedBy, dateReviewed, and dateModified signals where used.
+Increase the share and breadth of canonical Hippie Scientist pages cited by answer engines while preserving scientific nuance, source provenance, safety context, and canonical URL discipline.
 
-## Bing AI Performance model
+## Metrics
 
-Bing Webmaster Tools' AI Performance reporting changes the optimization target from only ranking/clicks to citation participation. Treat the report as a feedback loop for:
+Use observed data when available:
 
-- `Total citations`: how often site content is cited in Microsoft AI experiences.
-- `Average cited pages`: whether AI systems are using one isolated URL or multiple supporting pages from the site.
-- `Citation timeline`: whether citation activity improves after content refreshes and URL submissions.
-- `Grounding queries`: the phrases that caused Bing/Copilot-style systems to retrieve and cite site content.
-- `Page-level citation activity`: which exact URLs earn citations and which important pages are missing.
+- citation frequency — how often canonical THS URLs are cited;
+- cited-page breadth — how many distinct canonical pages participate;
+- grounding-query coverage — whether important questions map to a strong existing source;
+- citation momentum — whether page/topic citations are rising or falling between retained snapshots;
+- competitor-source pressure — where other domains repeatedly win citations;
+- source-gap structure — facts/qualifiers competitors make easier to verify, after independent verification;
+- organic demand — Search Console impressions/clicks/opportunity for the same canonical page;
+- citation readiness — structural ability of the page to expose governed claims, evidence, limitations, safety, sources, freshness, and identity.
 
-Optimization implication: every important page should be answerable at the passage level, canonical at the URL level, supported at the cluster level, and safe to cite at the claim level.
+None of these metrics upgrades or downgrades scientific evidence.
 
-## Bing-informed KPI definitions
+## Canonical reports
 
-Track these internally when reviewing Bing AI Performance data:
+### First-party AI citation performance
 
-| KPI | What it means | How to improve it |
-| --- | --- | --- |
-| Citation frequency | How often the site is cited in AI answers | Strengthen exact-answer passages, schema, references, and topical authority |
-| Cited-page breadth | How many different canonical pages receive citations | Build clusters around goals, comparisons, safety, and product quality |
-| Grounding-query coverage | Whether reported grounding queries have a strong matching page | Map each query to a canonical page and add a visible answer block if weak |
-| Citation share by page | Which URLs are carrying AI visibility | Upgrade pages already earning citations first, then close gaps |
-| Citation freshness | Whether citation activity responds to updates | Add dateModified/dateReviewed where accurate and submit updated URLs through Bing/IndexNow |
-
-## Priority 1: Make the site easy for AI crawlers to understand
-
-- Add and maintain `/llms.txt` as a human-readable AI discovery file.
-- Keep `/llms.txt` focused on canonical URLs, preferred citation targets, and safety/medical-advice boundaries.
-- Do not expose internal JSON endpoints, dashboards, draft routes, preview routes, or temporary tooling.
-- Keep canonical URLs consistent with sitemap output and redirects.
-- Keep compare URLs canonical under `/guides/compare/*`; do not recreate duplicate `/compare/*` indexable pages.
-
-Acceptance checks:
-
-- `/llms.txt` exists in the static export.
-- `/llms.txt` points to canonical, live URLs only.
-- No noncanonical `/compare/*` URL is listed when the canonical page lives at `/guides/compare/*`.
-- The file includes guidance for query-to-page citation matching.
-
-## Priority 2: Make pages quoteable and citation-ready
-
-For flagship pages and pages with search traction, add a consistent citation-ready block near the top:
-
-- `Quick answer`
-- `Best fit`
-- `Evidence level`
-- `Safety note`
-- `What this page is not claiming`
-- `References` link jump
-
-The goal is not more words. The goal is making the answer extractable without losing nuance.
-
-Recommended component name:
-
-- `components/seo/CitationReadySummary.tsx`
-
-Suggested props:
-
-```ts
-type CitationReadySummaryProps = {
-  answer: string
-  bestFor?: string[]
-  evidenceLevel?: string
-  safetyNote?: string
-  notClaiming?: string
-  referencesHref?: string
-}
+```bash
+node scripts/seo/ai-citation-tracker.mjs --label=YYYY-MM-DD
 ```
 
-## Priority 3: Upgrade references from visible list to structured citation signals
+Primary output:
 
-Current `References` output is useful, but it can become more machine-readable.
+- `ops/reports/ai-citations.json`
+- retained history under `ops/ai-citations/`
 
-Improve `components/References.tsx` carefully:
+### Competitor/source-gap observations
 
-- Keep the visible ordered list.
-- Keep stable `id="ref-N"` anchors.
-- Add `aria-label="References"` to the section.
-- Add `itemScope` / `itemType="https://schema.org/CreativeWork"` where safe.
-- Add `rel="noopener noreferrer nofollow"` only if the editorial policy wants nofollow; otherwise keep current outbound citation links clean.
-- Support optional fields in refs later:
-  - `title`
-  - `authors`
-  - `journal`
-  - `year`
-  - `pmid`
-  - `doi`
+Store generic, non-sensitive question→cited-source observations under:
 
-Do not invent citation metadata. Only use fields already known from source content or workbook data.
+- `data-sources/ai-source-audits/*.csv`
 
-## Priority 4: Improve article JSON-LD for cite-worthy pages
+Then run:
 
-For high-value guide and compare pages, prefer schema that includes:
-
-- `@type`: `Article` or `MedicalWebPage` + `WebPage` where medically adjacent
-- `headline`
-- `description`
-- `url`
-- `mainEntityOfPage`
-- `author`
-- `publisher`
-- `dateModified`
-- `dateReviewed` when true
-- `about`
-- `citation` only when citation URLs/metadata are real
-- `breadcrumb`
-- FAQ schema only when the FAQ is visible on the page
-
-Do not add fake Review or AggregateRating schema.
-
-## Priority 5: Build a citation-share audit script
-
-Add a script that reports whether indexable pages have the minimum citation-readiness features.
-
-Suggested script:
-
-- `scripts/ci/audit-ai-citation-readiness.mjs`
-
-Checks:
-
-- Page has indexable metadata/canonical.
-- Page is in sitemap if indexable.
-- Page has an H1.
-- Page has a quick-answer or summary block.
-- Page has visible references when making evidence claims.
-- Page links to methodology/disclaimer/safety context where appropriate.
-- Page has JSON-LD.
-- Page avoids fake ratings/reviews.
-- Page has canonical internal links to relevant hubs.
-- Page includes Bing-relevant answer structure: direct answer, comparison, safety, evidence, and next-step context.
-
-Suggested npm script:
-
-```json
-"audit:ai-citations": "node scripts/ci/audit-ai-citation-readiness.mjs"
+```bash
+node scripts/seo/ai-source-gap-audit.mjs --label=YYYY-MM-DD
 ```
 
-## Priority 6: Add a Bing AI Performance workflow
+Primary output:
 
-When Bing Webmaster Tools shows AI Performance data, use this loop:
+- `ops/reports/ai-source-gaps.json`
+- `ops/reports/ai-source-gaps.md`
+- dated source-gap history
 
-1. Export or record the top grounding queries.
-2. Group queries by intent: comparison, goal, safety, dosing, product quality, specific herb/compound.
-3. Map every query to one canonical URL.
-4. For each high-value query with no clear target page, create or upgrade one page — do not scatter answers across many weak pages.
-5. For each cited page, inspect whether the cited passage is safe, nuanced, and directly quotable.
-6. Add internal links from the cited page to its support cluster so AI systems can cite multiple pages when useful.
-7. Refresh `dateModified` only when meaningful editorial changes were made.
-8. Submit changed canonical URLs through Bing URL Submission/IndexNow.
-9. Recheck total citations, average cited pages, grounding queries, and page-level citation activity after Bing refreshes.
+A `missing_fact` field is a **verification task**, not permission to copy a competitor. Check the underlying fact against primary or otherwise authoritative sources before editing THS.
 
-## Priority 7: Roll out by page type, not randomly
+### Structural citation readiness
 
-Order of operations:
-
-1. Compare pages with Semrush/GSC/Bing grounding-query traction.
-2. Goal hubs: sleep, stress, anxiety, focus.
-3. Money guides and best-supplement pages.
-4. Herb/compound profiles that already pass indexability gates.
-5. Lower-priority long-tail pages only after the system is stable.
-
-## Flagship implementation target
-
-Start with:
-
-- `/guides/compare/melatonin-vs-magnesium/`
-
-Why:
-
-- It has clear search intent.
-- It has visible references.
-- It has comparison structure.
-- Semrush already flagged content/semantic improvements.
-- Bing AI Performance can evaluate whether the page earns citations for grounding queries like `melatonin vs magnesium`, `magnesium glycinate vs melatonin`, `can you take magnesium and melatonin together`, and `melatonin side effects vs magnesium side effects`.
-- It can become the template for future compare pages.
-
-## Codex implementation prompt
-
-```text
-You are working in Razzleberrytt/hippie-scientist-site.
-
-Goal: optimize AI searchability and citation share using Bing Webmaster Tools AI Performance concepts: total citations, average cited pages, grounding queries, citation timeline, and page-level citation activity.
-
-Implement an AI-citation-readiness pass with these constraints:
-
-1. Preserve canonical route policy.
-   - Do not create duplicate indexable /compare/* pages.
-   - Use /guides/compare/* as canonical for built compare pages.
-   - Add redirects only when needed; do not split citation signals.
-
-2. Keep /public/llms.txt accurate.
-   - Ensure it is included in static export.
-   - Ensure all listed URLs are canonical and public.
-   - Do not list internal JSON/data/dashboard/preview routes.
-   - Keep the AI citation and Bing grounding-query guidance aligned with real canonical pages.
-
-3. Create a reusable CitationReadySummary component.
-   - Location: components/seo/CitationReadySummary.tsx
-   - Props: answer, bestFor, evidenceLevel, safetyNote, notClaiming, referencesHref.
-   - Render readable, scannable text for humans.
-   - Do not use hidden text.
-   - The block should be extractable as a safe AI answer passage.
-
-4. Upgrade the melatonin vs magnesium page first.
-   - File: app/guides/compare/melatonin-vs-magnesium/page.tsx
-   - Add the CitationReadySummary near the top after the intro.
-   - Include a concise answer, best-fit bullets, evidence level, safety note, and references jump.
-   - Add direct subheadings that match likely Bing grounding queries:
-     - Melatonin vs magnesium: quick answer
-     - Magnesium glycinate vs melatonin: the core difference
-     - Can you take magnesium and melatonin together?
-     - Side effects: melatonin vs magnesium
-     - Which is better for staying asleep?
-   - Keep the content natural; do not keyword-stuff.
-   - Keep existing references visible.
-   - Add links to /guides/sleep/, /safety-checker/, /info/dosing/, and relevant compound pages.
-
-5. Improve References component accessibility and citation readiness.
-   - File: components/References.tsx
-   - Keep existing visual behavior.
-   - Add aria-label and stable anchor behavior.
-   - Add machine-readable structure only for fields that already exist.
-   - Do not invent citation metadata.
-
-6. Improve structured data for cite-worthy pages.
-   - For compare detail pages, support real citation URLs in JSON-LD when refs are passed.
-   - Do not add fake AggregateRating, Review, or medical claims.
-   - FAQ schema only if the questions and answers are visibly rendered on the page.
-
-7. Add a lightweight audit script.
-   - File: scripts/ci/audit-ai-citation-readiness.mjs
-   - It should scan built app guide/compare pages and report missing quick answer/citation summary/references/schema/internal-link signals.
-   - Add Bing-specific checks: likely grounding-query headings, citation target links, and no noncanonical /compare/* links.
-   - Make it advisory first; do not fail CI yet.
-   - Add npm script: audit:ai-citations.
-
-8. Validation:
-   npm run typecheck
-   npm run lint
-   npm run build
-
-Report files changed, exact URLs improved, Bing AI Performance metrics targeted, and any skipped SEO suggestions such as fake AggregateRating schema.
+```bash
+npx tsx scripts/ci/audit-ai-citation-topology.ts
 ```
 
-## Do not do
+Output:
 
-- Do not add fake aggregate ratings.
-- Do not add hidden keyword text.
-- Do not cite studies that are not actually referenced.
-- Do not list noncanonical redirected URLs in `/llms.txt`.
-- Do not expose private/internal/generated data routes as citation targets.
-- Do not chase every grounding query with a new thin page; strengthen canonical pages and clusters first.
+- `reports/ai-citation-readiness.json`
+
+This report consumes canonical research-quality analysis for study identity, support tiers, source concentration, primary-human/synthesis/narrative coverage, and related scientific signals.
+
+### Final action priority
+
+```bash
+node scripts/seo/ai-opportunity-priority.mjs
+```
+
+Output:
+
+- `ops/reports/ai-opportunity-priority.json`
+- `ops/reports/ai-opportunity-priority.md`
+
+This is the operating queue. It joins readiness deficit, observed AI citations/momentum, competitor citation pressure, and Search Console demand by canonical page.
+
+## Weekly loop
+
+The existing maintenance workflow runs the measurement chain and retains history across ephemeral GitHub runners.
+
+Review the resulting queue in this order:
+
+1. **Correctness first.** Fix contradictions, unsupported approved claims, dangling refs, and misleading safety/evidence wording regardless of traffic upside.
+2. **Then demand-weighted repair.** Among scientifically valid pages, prioritize high competitor pressure, meaningful AI citation activity, falling citation momentum, and/or organic impressions.
+3. **Improve the existing canonical source.** Add or clarify answer-first passages, qualifiers, source proximity, semantic tables, anchors, provenance, or internal routing only where the information already belongs.
+4. **Verify missing facts independently.** Do not copy competitor wording or treat competitor publication as proof.
+5. **Create a new page only for genuinely distinct intent.** Do not generate AI-only doorway pages or one thin page per grounding query.
+6. **Retain history and compare again.** Look for citation-rate, breadth, and page-level changes rather than assuming a structural edit worked.
+
+## Query mapping rules
+
+Map common intents to the smallest authoritative canonical source:
+
+- `Does X work for Y?` → specific herb/compound profile plus the closest outcome guide when needed.
+- `X vs Y` → the matching comparison page.
+- `Is X safe?` → the specific profile plus interaction/safety context.
+- `Can I combine X and Y?` → interaction/safety context first; absence of a listed warning is not proof of no interaction.
+- `How much X?` → dosing principles plus visible studied-dose context; do not turn a research dose into personalized medical instruction.
+- `How does X work?` → mechanism section, explicitly separate from efficacy.
+- `What is the evidence?` → evidence summary, human studies, limitations, methodology.
+- `Best supplement for Y?` → goal/comparison guide; evidence and safety outrank popularity or monetization.
+
+## What to improve on a cited or near-cited page
+
+Only when supported by the page data:
+
+- concise direct answer or verdict;
+- stable answer/decision anchor;
+- canonical evidence grade and plain-language meaning;
+- population, formulation, dose, duration, and outcome qualifiers;
+- direct study/reference links near the conclusion;
+- explicit limitations and disagreement;
+- visible safety/interaction context;
+- meaningful last-reviewed/date-modified provenance;
+- semantic research/comparison tables;
+- canonical internal links to methodology and supporting cluster pages.
+
+## What not to do
+
+- Do not add fake `AggregateRating` or `Review` schema.
+- Do not add hidden citation text or keyword dumps.
+- Do not fabricate citations, author/reviewer credentials, dates, or research metadata.
+- Do not expose private/internal data as citation targets.
+- Do not create duplicate `/compare/*` or other alternate indexable copies of canonical pages.
+- Do not use a visual safety percentage as if it were a validated machine-readable clinical risk score.
+- Do not let AI citation or Search Console demand alter the scientific evidence grade.
+
+## Canonical quality command
+
+For implementation/release readiness, use the orchestrator rather than independently running overlapping legacy checks:
+
+```bash
+npm run audit:ai-citations
+```
+
+Use `docs/ai-search-optimization.md` for architecture and policy details.

--- a/docs/ai-search-optimization.md
+++ b/docs/ai-search-optimization.md
@@ -2,71 +2,116 @@
 
 ## Objective
 
-Optimize The Hippie Scientist for retrieval, grounding, entity resolution, and citation by AI answer systems without creating doorway pages, hidden keyword text, fake authority, or schema that is not supported by visible content.
+Optimize The Hippie Scientist for retrieval, grounding, entity resolution, and citation by AI answer systems without creating doorway pages, hidden keyword text, fake authority, unsupported schema, or a second scientific evidence model.
 
 ## Canonical architecture
 
-The site uses one public answer surface and one supporting machine-readable surface:
+The site has one scientific-support graph and one public answer architecture:
 
-1. Canonical HTML pages are the user-facing source and citation target.
-2. JSON-LD entity shards under `/data/ai-entities/` support entity resolution, atomic claims, relationships, provenance, safety, and freshness.
-3. `llms.txt` explains retrieval, citation, evidence, entity, and temporal semantics.
-4. `robots.txt` keeps canonical public pages and AI entity artifacts crawlable while excluding internal/runtime surfaces.
-5. `sitemap.xml` remains the canonical discovery inventory.
+1. `lib/research-quality-analysis.ts` is authoritative for scientific support topology: canonical studies, study classes, claim/source links, weak support, study dependence, and narrative-vs-primary-human coverage.
+2. Canonical HTML pages are the user-facing source and public citation target.
+3. JSON-LD entity shards under `/data/ai-entities/` support entity resolution, atomic claims, relationships, provenance, safety context, and review freshness.
+4. `lib/ai-citation-readiness.ts` adds retrieval/presentation readiness on top of the canonical research graph. It is not an evidence grader.
+5. `public/llms.txt` documents source routing, evidence semantics, entity resolution, citation, safety, and attribution conventions.
+6. `robots.txt` and `sitemap.xml` remain the public crawl/discovery controls.
+7. Observed AI citations/source gaps and Search Console demand feed one operational priority queue. They do not change scientific evidence grades.
 
-Do not create separate “AI versions” of editorial pages.
+Do not create separate “AI versions” of editorial pages or a competing research-quality taxonomy.
 
 ## Page-level answer contract
 
 High-value pages should expose, when supported by source data:
 
 - One unambiguous H1 naming the entity/question.
-- A concise answer-first summary near the top.
+- A concise answer-first summary or scientific verdict near the top.
+- Stable deep-link anchors for important answer/decision sections.
 - Evidence grade with plain-language interpretation.
 - Human-study count and study types where known.
 - Material population, formulation, dose, duration, and outcome qualifiers.
 - Safety/interaction context before a recommendation-like conclusion.
-- Visible references close enough to claims to verify them.
+- Visible references or source links close enough to claims to verify them.
 - Explicit limitations, conflicts, and research gaps.
 - Last-reviewed/date-modified signals that distinguish editorial freshness from study publication dates.
+- Semantic comparison/research tables where tabular facts are genuinely useful.
 - Canonical internal links to methodology, safety, dosing, related entities, and comparisons.
 
 ## Claim extraction contract
 
-Atomic claims should answer: subject, predicate, object/outcome, population, formulation, dose when material, duration when material, evidence class, evidence grade, source IDs, review state, and uncertainty.
+Atomic claims should preserve subject, predicate, object/outcome, population, formulation, dose when material, duration when material, evidence class, evidence grade, source IDs, review state, and uncertainty.
 
-Do not allow mechanism-only evidence to masquerade as human efficacy. Do not allow a narrative review to become the sole evidence for a strong clinical claim when primary human evidence should exist. Flag claims dominated by one study or one research group.
+Do not allow mechanism-only evidence to masquerade as human efficacy. Do not allow a narrative review to substitute for direct primary human evidence where that distinction changes the claim. Claims dominated by one study or one research group must remain identifiable as concentration risk.
 
-## Entity resolution contract
+## Entity and dataset contract
 
 Entity artifacts should prefer stable identifiers and explicit aliases. Whole herbs, extracts, isolated constituents, salts, formulations, and branded preparations must not be silently collapsed when the distinction changes the evidence.
 
+Each public entity Dataset resolves back to the canonical HTML profile, identifies The Hippie Scientist as the synthesis creator/publisher, exposes the JSON-LD shard as a data download, and points to the public attribution/reuse policy. Do not claim an open license that has not actually been granted.
+
 ## Citation-worthiness
 
-AI systems are more likely to reuse passages that are direct, bounded, attributable, and easy to verify. Prefer short factual sections with visible qualifiers over generic SEO prose. Every high-value conclusion should make it obvious what evidence supports it and what would change the conclusion.
+Prefer direct, bounded, attributable passages over generic SEO prose. High-value conclusions should make it obvious:
 
-## Anti-patterns
+- what the conclusion is;
+- what evidence supports it;
+- what population/formulation/outcome it applies to;
+- what safety or uncertainty materially qualifies it;
+- what source or reference lets a reader verify it;
+- what would change the conclusion.
 
-Never optimize for AI search by adding hidden text, keyword dumps, generated doorway pages, fake FAQ questions, fake author credentials, unsupported medical claims, fake ratings/reviews, fabricated citations, or duplicate pages targeting model names such as “ChatGPT” or “Perplexity.”
+A visual display coordinate such as a coarse safety gauge must not be promoted into a machine-readable clinical-looking metric. Expose the governed qualitative interpretation instead.
 
-## Release audit
+## Canonical quality commands
 
-Run:
+The compatibility entrypoint is also the canonical AI-search orchestrator:
 
 ```bash
-node scripts/ci/audit-ai-answer-engine-readiness.mjs
-node scripts/ci/audit-ai-citation-readiness.mjs
-node scripts/ci/audit-ai-entity-completeness.mjs
+npm run audit:ai-citations
 ```
 
-Use `--strict` on the answer-engine audit only after advisory warnings have been intentionally triaged. The entity completeness audit can use its explicit average-score threshold when the dataset is mature enough to gate releases.
+It keeps only comparison-page-specific grounding checks locally and delegates to the authoritative modules for:
+
+- answer-engine discovery/extractability/profile semantics;
+- canonical research + AI citation-readiness topology;
+- claim/evidence consistency;
+- entity completeness when built runtime data is available.
+
+Use strict mode only when the advisory backlog has been intentionally triaged:
+
+```bash
+node scripts/ci/audit-ai-citation-readiness.mjs --strict
+```
+
+Canonical research-quality pass:
+
+```bash
+npx tsx scripts/ci/research-quality.ts
+```
+
+That pass computes the scientific support graph once and reuses it for research gaps, study-load topology, and AI citation readiness.
+
+## Measurement loop
+
+Weekly maintenance produces complementary evidence about what deserves work next:
+
+- `ops/reports/ai-citations.json` — observed first-party AI citation performance when exports are available.
+- `ops/reports/ai-source-gaps.json` — externally observed question→source gaps and competitor citation pressure.
+- `reports/ai-citation-readiness.json` — structural citation/readiness queue over the canonical research graph.
+- `ops/reports/ai-opportunity-priority.json` — ROI/action queue joining readiness, AI citation demand/momentum, competitor pressure, and Search Console demand.
+
+The priority score is operational triage only. It must never override the scientific evidence model.
 
 ## Priority order
 
 1. Correct contradictory evidence/safety claims.
-2. Strengthen claim-to-source provenance.
-3. Improve answer-first extractability on pages already earning impressions.
-4. Improve entity completeness and stable identifiers.
-5. Improve freshness and conflict signals.
-6. Expand comparison and goal-query coverage only when it adds genuinely new decision value.
-7. Measure citations/referrals and iterate from observed query demand rather than generating pages speculatively.
+2. Repair unsupported approved claims and dangling source references.
+3. Reduce inappropriate single-study dependence and narrative-review dominance.
+4. Strengthen claim-to-source provenance and direct human-evidence coverage.
+5. Improve answer-first extractability on pages with observed demand.
+6. Improve entity identity/provenance, safety context, and freshness signals.
+7. Improve semantic tables/anchors/source proximity when they clarify existing information.
+8. Expand comparison or goal-query coverage only when it adds genuinely new decision value.
+9. Measure citations/referrals and iterate from observed demand rather than generating pages speculatively.
+
+## Anti-patterns
+
+Never optimize for AI search by adding hidden text, keyword dumps, generated doorway pages, fake FAQ questions, fake author credentials, unsupported medical claims, fake ratings/reviews, fabricated citations, invented review dates, duplicate model-name pages, or pseudo-precise machine-readable health scores derived only for visual presentation.


### PR DESCRIPTION
## Summary
- rewrites the AI-search implementation standard around the now-canonical research graph, AI citation-readiness builder, public answer/entity surfaces, and demand-weighted telemetry loop
- replaces the stale implementation roadmap with a concise citation-share/feedback playbook that references already-implemented commands and reports
- removes duplicated future component/script instructions that no longer reflect the repository
- broadens the AI quality workflow to watch the actual shared AI-search surfaces
- runs schema discovery + provenance tests and the canonical `npm run audit:ai-citations` orchestrator in CI
- lints the shared answer/evidence/safety/provenance components and canonical AI audit modules

## Consolidation impact
Documentation now separates architecture/policy from measurement/iteration, and CI exercises one canonical AI-search command instead of preserving an entity-only validation island.