### PR TITLE
SEO: expose editorial trust and attribution policies globally

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -45,6 +45,9 @@ const safetyLinks = [
 const legalLinks = [
   { href: PUBLIC_ROUTES.about, label: 'About' },
   { href: PUBLIC_ROUTES.author, label: 'Author' },
+  { href: '/info/editorial-policy/', label: 'Editorial Policy' },
+  { href: '/info/corrections/', label: 'Corrections' },
+  { href: '/info/content-licensing/', label: 'Content Attribution' },
   { href: PUBLIC_ROUTES.faq, label: 'FAQ' },
   { href: PUBLIC_ROUTES.contact, label: 'Contact' },
   { href: PUBLIC_ROUTES.privacy, label: 'Privacy Policy' },


### PR DESCRIPTION
## Summary
- adds Editorial Policy, Corrections, and Content Attribution links to the global footer trust/legal surface
- aligns human navigation with the provenance, correction, methodology, and reuse URLs already advertised to answer engines and JSON-LD
- keeps existing research/safety/legal organization intact and avoids adding a duplicate info hub

## AI SEO impact
Canonical trust and attribution policies are now discoverable through normal sitewide HTML links, not only `llms.txt`, schema, or direct URLs. This makes human and machine trust paths converge on the same sources.