### PR TITLE
cleanup: remove obsolete TypeScript slug facade

### DIFF
--- a/src/components/CompoundBadge.tsx
+++ b/src/components/CompoundBadge.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from '../lib/router-compat'
-import { slugify } from '../lib/slug'
+import { slugify } from '../../lib/slug-utils'
 import TagBadge from './TagBadge'
 
 export default function CompoundBadge({ name }: { name: string }) {

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,3 +1,0 @@
-// Compatibility facade for older src/lib callers.
-// Canonical TypeScript slug behavior lives in /lib/slug-utils.ts.
-export { canonicalSlug, slugify } from '../../lib/slug-utils'


### PR DESCRIPTION
Broad cleanup pass 16.

- points the last src/lib/slug consumer directly at lib/slug-utils.ts
- deletes src/lib/slug.ts compatibility facade
- leaves one TypeScript slug authority instead of canonical + compatibility layers

This completes the earlier TypeScript slug consolidation rather than leaving a permanent legacy shim behind.