### PR TITLE
refactor(research): make evidence grades one-pass

### DIFF
--- a/lib/evidence-grade-consistency.ts
+++ b/lib/evidence-grade-consistency.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import {
+  CANONICAL_EVIDENCE_GRADES,
+  bandFromEvidenceTier,
+  gradeTierDistance,
+  isCanonicalEvidenceGrade,
+  normalizeEvidenceGrade,
+  type CanonicalEvidenceGrade,
+  type EvidenceBand,
+} from './evidence-grade'
+
+export type EvidenceGradeProfileRecord = {
+  slug?: string
+  evidence_grade?: unknown
+  evidence_grade_reason?: unknown
+  evidence_tier?: unknown
+  indexability_status?: unknown
+  evidence_design_match?: unknown
+  evidence_risk_of_bias?: unknown
+  evidence_consistency?: unknown
+}
+
+export type EvidenceGradeFinding = {
+  kind: 'herb' | 'compound'
+  slug: string
+  url: string
+  indexable: boolean
+  rawGrade: string
+  rawTier: string
+  canonicalGrade: CanonicalEvidenceGrade | null
+  gradeLetter: string | null
+  gradeBand: EvidenceBand | null
+  tierBand: EvidenceBand | null
+  distance: number | null
+  issues: string[]
+}
+
+export type EvidenceGradeConsistencyReport = {
+  generatedAt: string
+  canonicalEnum: typeof CANONICAL_EVIDENCE_GRADES
+  totals: {
+    profiles: number
+    indexable: number
+    flagged: number
+    flaggedIndexable: number
+    contradictionsIndexable: number
+    gradeCardRenderable: number
+    invalidPublishedGrades: number
+  }
+  issueCounts: Record<string, number>
+  contradictions: EvidenceGradeFinding[]
+  invalid: EvidenceGradeFinding[]
+  findings: EvidenceGradeFinding[]
+}
+
+function readJson(dataDir: string, file: string): EvidenceGradeProfileRecord[] {
+  try {
+    const parsed = JSON.parse(readFileSync(path.join(dataDir, file), 'utf8'))
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+/** Analyze published profile evidence grades without owning CLI/report behavior. */
+export function analyzeEvidenceGradeConsistency(root = process.cwd()): EvidenceGradeConsistencyReport {
+  const dataDir = path.join(root, 'public', 'data')
+  const records: [('herb' | 'compound'), EvidenceGradeProfileRecord[]][] = [
+    ['herb', readJson(dataDir, 'herbs.json')],
+    ['compound', readJson(dataDir, 'compounds.json')],
+  ]
+  const findings: EvidenceGradeFinding[] = []
+
+  for (const [kind, rows] of records) {
+    for (const record of rows) {
+      const slug = String(record.slug ?? '')
+      if (!slug) continue
+
+      const published = record.evidence_grade
+      const normalized = normalizeEvidenceGrade(published)
+      const tierBand = bandFromEvidenceTier(record.evidence_tier)
+      const distance = gradeTierDistance(normalized.band, tierBand)
+      const indexable = String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'
+      const issues: string[] = []
+
+      const publishedIsValid = published === null || published === undefined || isCanonicalEvidenceGrade(published)
+      if (!publishedIsValid) issues.push('invalid-published-grade')
+      if (distance !== null && distance >= 2) issues.push('contradicts-evidence-tier')
+      else if (distance === 1) issues.push('minor-disagreement')
+      if (normalized.outcomeDependent) issues.push('outcome-dependent-grade')
+      if (published === null && String(record.evidence_grade_reason ?? '') === 'unresolved') issues.push('missing-grade')
+      if (!issues.length) continue
+
+      findings.push({
+        kind,
+        slug,
+        url: `/${kind === 'herb' ? 'herbs' : 'compounds'}/${slug}/`,
+        indexable,
+        rawGrade: normalized.raw,
+        rawTier: String(record.evidence_tier ?? ''),
+        canonicalGrade: normalized.grade,
+        gradeLetter: normalized.letter,
+        gradeBand: normalized.band,
+        tierBand,
+        distance,
+        issues,
+      })
+    }
+  }
+
+  const indexableFindings = findings.filter((finding) => finding.indexable)
+  const contradictions = indexableFindings
+    .filter((finding) => finding.issues.includes('contradicts-evidence-tier'))
+    .sort((a, b) => (b.distance ?? 0) - (a.distance ?? 0) || a.url.localeCompare(b.url))
+  const invalid = findings.filter((finding) => finding.issues.includes('invalid-published-grade'))
+  const issueCounts: Record<string, number> = {}
+  for (const finding of indexableFindings) {
+    for (const issue of finding.issues) issueCounts[issue] = (issueCounts[issue] ?? 0) + 1
+  }
+
+  const indexableRecords = records.flatMap(([, rows]) =>
+    rows.filter((record) => String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'),
+  )
+  const gradeCardRenderable = indexableRecords.filter(
+    (record) => record.evidence_design_match && record.evidence_risk_of_bias && record.evidence_consistency,
+  ).length
+
+  return {
+    generatedAt: new Date().toISOString(),
+    canonicalEnum: CANONICAL_EVIDENCE_GRADES,
+    totals: {
+      profiles: records.reduce((sum, [, rows]) => sum + rows.length, 0),
+      indexable: indexableRecords.length,
+      flagged: findings.length,
+      flaggedIndexable: indexableFindings.length,
+      contradictionsIndexable: contradictions.length,
+      gradeCardRenderable,
+      invalidPublishedGrades: invalid.length,
+    },
+    issueCounts,
+    contradictions,
+    invalid,
+    findings,
+  }
+}
+
+export function writeEvidenceGradeConsistencyReport(
+  report: EvidenceGradeConsistencyReport,
+  root = process.cwd(),
+): string {
+  const reportsDir = path.join(root, 'ops', 'reports')
+  const reportPath = path.join(reportsDir, 'evidence-grade-consistency.json')
+  mkdirSync(reportsDir, { recursive: true })
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+  return reportPath
+}

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
+import { analyzeEvidenceGradeConsistency, writeEvidenceGradeConsistencyReport } from '../../lib/evidence-grade-consistency'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from '../../lib/research-evidence-age'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchGapQueue, structuralCoverageFailures } from '../../lib/research-quality-policy'
@@ -15,11 +16,9 @@ import { analyzeClaimEvidenceOverlap, analyzeCrossProfileStudyLoad, analyzeEvide
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const REPORT_PATH = path.join(REPORT_DIR, 'research-quality.json')
-const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx'
 
 const externalChecks = [
   { id: 'citation-identities', label: 'Citation identity integrity', command: process.execPath, args: ['scripts/ci/validate-citation-identifiers.mjs'] },
-  { id: 'evidence-grades', label: 'Evidence grade consistency', command: NPX, args: ['tsx', 'scripts/ci/validate-evidence-grade-consistency.ts'] },
   { id: 'content-integrity', label: 'Structured content integrity', command: process.execPath, args: ['scripts/ci/audit-content-integrity.mjs'] },
 ] as const
 
@@ -41,6 +40,8 @@ const analysis = analyzeResearchQuality(ROOT)
 const structuralFailures = structuralCoverageFailures(analysis)
 const researchGapQueue = buildResearchGapQueue(analysis)
 const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
+const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(ROOT)
+const evidenceGradeReportPath = writeEvidenceGradeConsistencyReport(evidenceGradeConsistency, ROOT)
 const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
 const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
 const evidenceBundleReuse = analyzeEvidenceBundleReuse(analysis)
@@ -71,6 +72,19 @@ results.push({
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
 if (!corePassed) failed = true
 
+const gradesPassed = evidenceGradeConsistency.invalid.length === 0
+results.push({
+  id: 'evidence-grades',
+  label: 'Evidence grade consistency',
+  passed: gradesPassed,
+  exitCode: gradesPassed ? 0 : 1,
+  durationMs: 0,
+  stdoutTail: `profiles=${evidenceGradeConsistency.totals.profiles}; flaggedIndexable=${evidenceGradeConsistency.totals.flaggedIndexable}; contradictions=${evidenceGradeConsistency.totals.contradictionsIndexable}`,
+  stderrTail: gradesPassed ? '' : `${evidenceGradeConsistency.invalid.length} non-canonical published grade(s)`,
+})
+console.log(`${gradesPassed ? 'PASS' : 'FAIL'}  Evidence grade consistency  (in-process)`)
+if (!gradesPassed) failed = true
+
 for (const check of externalChecks) {
   const started = Date.now(); const run = spawnSync(check.command, check.args, { cwd: ROOT, encoding: 'utf8', env: process.env })
   const exitCode = run.status ?? 1; const passed = exitCode === 0; const durationMs = Date.now() - started
@@ -90,26 +104,29 @@ const coreSummary = {
   systemicLoadBearingStudies: systemicLoadBearingStudies.length, repeatedEvidenceBundles: evidenceBundleReuse.length,
   narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length, nearDuplicateEvidencePairs: claimEvidenceOverlap.length,
   crossPredicateNearDuplicateEvidencePairs: crossPredicateEvidenceOverlap.length, sourceIntegrity: sourceIntegrity.summary,
-  evidenceAge: evidenceAgeSummary, aiCitationReadiness: aiCitationReadiness.summary,
+  evidenceGradeConsistency: evidenceGradeConsistency.totals, evidenceAge: evidenceAgeSummary, aiCitationReadiness: aiCitationReadiness.summary,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 8, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', policy: 'lib/research-quality-policy.ts', sourceIntegrity: 'lib/research-source-integrity.ts', crossProfileStudyLoad: 'lib/research-study-load.ts', evidenceBundleReuse: 'lib/research-study-load.ts', claimEvidenceOverlap: 'lib/research-study-load.ts', evidenceAge: 'lib/research-evidence-age.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  schemaVersion: 9, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', policy: 'lib/research-quality-policy.ts', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', crossProfileStudyLoad: 'lib/research-study-load.ts', evidenceBundleReuse: 'lib/research-study-load.ts', claimEvidenceOverlap: 'lib/research-study-load.ts', evidenceAge: 'lib/research-evidence-age.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
   coreSummary, structuralFailures, withdrawnCitedStudies: sourceIntegrity.withdrawn,
+  evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
   oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
   topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100), topClaimEvidenceOverlap: claimEvidenceOverlap.slice(0, 150),
   highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100), topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100),
   topResearchGaps: researchGapQueue.slice(0, 50), topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
-  checks: results, evidenceGradeSummary: readSummary('evidence-grade-consistency.json'), contentIntegritySummary: readSummary('content-integrity.json'),
+  checks: results, contentIntegritySummary: readSummary('content-integrity.json'),
 }, null, 2)}\n`)
 
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
 console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
+console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
 console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
+console.log(`Evidence-grade report: ${path.relative(ROOT, evidenceGradeReportPath)}`)
 console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
 if (failed) { console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.'); process.exit(1) }

--- a/scripts/ci/validate-evidence-grade-consistency.ts
+++ b/scripts/ci/validate-evidence-grade-consistency.ts
@@ -1,170 +1,37 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 import {
-  CANONICAL_EVIDENCE_GRADES,
-  bandFromEvidenceTier,
-  gradeTierDistance,
-  isCanonicalEvidenceGrade,
-  normalizeEvidenceGrade,
-  type CanonicalEvidenceGrade,
-  type EvidenceBand,
-} from '../../lib/evidence-grade'
+  analyzeEvidenceGradeConsistency,
+  writeEvidenceGradeConsistencyReport,
+} from '../../lib/evidence-grade-consistency'
 
 const ROOT = process.cwd()
-const DATA_DIR = path.join(ROOT, 'public', 'data')
-const REPORTS_DIR = path.join(ROOT, 'ops', 'reports')
-const REPORT_PATH = path.join(REPORTS_DIR, 'evidence-grade-consistency.json')
 const STRICT = process.argv.slice(2).includes('--strict')
 
-type ProfileRecord = {
-  slug?: string
-  evidence_grade?: unknown
-  evidence_tier?: unknown
-  indexability_status?: unknown
-  evidence_design_match?: unknown
-  evidence_risk_of_bias?: unknown
-  evidence_consistency?: unknown
+const report = analyzeEvidenceGradeConsistency(ROOT)
+const reportPath = writeEvidenceGradeConsistencyReport(report, ROOT)
+
+console.log('\nEvidence grade consistency')
+console.log('='.repeat(66))
+console.log(`Profiles scanned            ${report.totals.profiles}`)
+console.log(`Indexable                   ${report.totals.indexable}`)
+console.log(`Flagged (indexable)         ${report.totals.flaggedIndexable}`)
+console.log(`Rationale cards renderable  ${report.totals.gradeCardRenderable}`)
+for (const [issue, count] of Object.entries(report.issueCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${String(count).padStart(5)}  ${issue}`)
+}
+console.log(`\nReport: ${path.relative(ROOT, reportPath)}`)
+
+if (report.invalid.length > 0) {
+  console.error(`\n[evidence-grade] FAILED — ${report.invalid.length} record(s) publish a non-canonical grade.`)
+  for (const finding of report.invalid.slice(0, 20)) {
+    console.error(`  ${finding.url}  evidence_grade=${JSON.stringify(finding.rawGrade)}`)
+  }
+  console.error('\nRun `npm run data:normalize-evidence` to migrate, or fix the workbook value.')
+  process.exit(1)
 }
 
-type Finding = {
-  kind: 'herb' | 'compound'
-  slug: string
-  url: string
-  indexable: boolean
-  rawGrade: string
-  rawTier: string
-  canonicalGrade: CanonicalEvidenceGrade | null
-  gradeLetter: string | null
-  gradeBand: EvidenceBand | null
-  tierBand: EvidenceBand | null
-  distance: number | null
-  issues: string[]
+if (STRICT && report.contradictions.length > 0) {
+  console.error(`\n[evidence-grade] FAILED — ${report.contradictions.length} indexable contradiction(s).`)
+  process.exit(1)
 }
-
-function readJson(file: string): ProfileRecord[] {
-  try {
-    const parsed = JSON.parse(readFileSync(path.join(DATA_DIR, file), 'utf8'))
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-function main() {
-  const records: [('herb' | 'compound'), ProfileRecord[]][] = [
-    ['herb', readJson('herbs.json')],
-    ['compound', readJson('compounds.json')],
-  ]
-  const findings: Finding[] = []
-
-  for (const [kind, rows] of records) {
-    for (const record of rows) {
-      const slug = String(record.slug ?? '')
-      if (!slug) continue
-
-      const published = record.evidence_grade
-      const normalized = normalizeEvidenceGrade(published)
-      const tierBand = bandFromEvidenceTier(record.evidence_tier)
-      const distance = gradeTierDistance(normalized.band, tierBand)
-      const indexable = String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'
-      const issues: string[] = []
-
-      // Hard invariant (build-blocking): the published field must hold a
-      // canonical enum value or an explicit null. Anything else means an
-      // un-normalized value reached the dataset.
-      const publishedIsValid =
-        published === null || published === undefined || isCanonicalEvidenceGrade(published)
-      if (!publishedIsValid) issues.push('invalid-published-grade')
-
-      // Editorial findings: the two authored columns disagree. The published
-      // grade already resolves this conservatively, so these are review work
-      // rather than build failures.
-      if (distance !== null && distance >= 2) issues.push('contradicts-evidence-tier')
-      else if (distance === 1) issues.push('minor-disagreement')
-      if (normalized.outcomeDependent) issues.push('outcome-dependent-grade')
-      if (published === null && String(record.evidence_grade_reason ?? '') === 'unresolved') {
-        issues.push('missing-grade')
-      }
-      if (!issues.length) continue
-
-      findings.push({
-        kind,
-        slug,
-        url: `/${kind === 'herb' ? 'herbs' : 'compounds'}/${slug}/`,
-        indexable,
-        rawGrade: normalized.raw,
-        rawTier: String(record.evidence_tier ?? ''),
-        canonicalGrade: normalized.grade,
-        gradeLetter: normalized.letter,
-        gradeBand: normalized.band,
-        tierBand,
-        distance,
-        issues,
-      })
-    }
-  }
-
-  const indexableFindings = findings.filter((finding) => finding.indexable)
-  const contradictions = indexableFindings
-    .filter((finding) => finding.issues.includes('contradicts-evidence-tier'))
-    .sort((a, b) => (b.distance ?? 0) - (a.distance ?? 0))
-  const issueCounts: Record<string, number> = {}
-  for (const finding of indexableFindings) {
-    for (const issue of finding.issues) issueCounts[issue] = (issueCounts[issue] ?? 0) + 1
-  }
-
-  const indexableRecords = records.flatMap(([, rows]) =>
-    rows.filter((record) => String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'),
-  )
-  const gradeCardRenderable = indexableRecords.filter(
-    (record) => record.evidence_design_match && record.evidence_risk_of_bias && record.evidence_consistency,
-  ).length
-
-  const report = {
-    generatedAt: new Date().toISOString(),
-    canonicalEnum: CANONICAL_EVIDENCE_GRADES,
-    totals: {
-      profiles: records.reduce((sum, [, rows]) => sum + rows.length, 0),
-      indexable: indexableRecords.length,
-      flagged: findings.length,
-      flaggedIndexable: indexableFindings.length,
-      contradictionsIndexable: contradictions.length,
-      gradeCardRenderable,
-    },
-    issueCounts,
-    contradictions,
-    findings,
-  }
-
-  mkdirSync(REPORTS_DIR, { recursive: true })
-  writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`)
-
-  console.log('\nEvidence grade consistency')
-  console.log('='.repeat(66))
-  console.log(`Profiles scanned            ${report.totals.profiles}`)
-  console.log(`Indexable                   ${report.totals.indexable}`)
-  console.log(`Flagged (indexable)         ${report.totals.flaggedIndexable}`)
-  console.log(`Rationale cards renderable  ${gradeCardRenderable}`)
-  for (const [issue, count] of Object.entries(issueCounts).sort((a, b) => b[1] - a[1])) {
-    console.log(`  ${String(count).padStart(5)}  ${issue}`)
-  }
-  console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)
-
-  const invalid = findings.filter((finding) => finding.issues.includes('invalid-published-grade'))
-  if (invalid.length > 0) {
-    console.error(`\n[evidence-grade] FAILED — ${invalid.length} record(s) publish a non-canonical grade.`)
-    for (const finding of invalid.slice(0, 20)) {
-      console.error(`  ${finding.url}  evidence_grade=${JSON.stringify(finding.rawGrade)}`)
-    }
-    console.error('\nRun `npm run data:normalize-evidence` to migrate, or fix the workbook value.')
-    process.exit(1)
-  }
-
-  if (STRICT && contradictions.length > 0) {
-    console.error(`\n[evidence-grade] FAILED — ${contradictions.length} indexable contradiction(s).`)
-    process.exit(1)
-  }
-}
-
-main()


### PR DESCRIPTION
Extracts evidence-grade consistency into a reusable library analyzer, fixes the local record contract for evidence_grade_reason, turns the CLI validator into a thin compatibility/strict wrapper, and runs non-strict evidence-grade validation directly inside the canonical research-quality process instead of spawning another subprocess.