### PR TITLE
SEO: make references durable claim-level citation targets

### DIFF
--- a/components/References.tsx
+++ b/components/References.tsx
@@ -21,6 +21,7 @@ export default function References({ refs }: { refs: Ref[] }) {
     <section
       id="references"
       aria-label="References"
+      data-reference-ledger="true"
       className="max-w-4xl border-y border-[color:var(--hs-hairline)] py-7 sm:py-9"
     >
       <div className="flex flex-wrap items-end justify-between gap-3">
@@ -36,47 +37,55 @@ export default function References({ refs }: { refs: Ref[] }) {
       </div>
 
       <ol className="mt-5 divide-y divide-[color:var(--hs-hairline)]">
-        {refs.map((ref) => (
-          <li
-            key={ref.n}
-            id={`ref-${ref.n}`}
-            itemScope
-            itemType="https://schema.org/CreativeWork"
-            className="grid gap-2 py-4 first:pt-0 last:pb-0 sm:grid-cols-[2.4rem_minmax(0,1fr)] sm:gap-4"
-          >
-            <span
-              aria-hidden="true"
-              className="font-mono text-[0.66rem] font-bold tracking-[0.12em] text-[color:var(--hs-gold-ink)] sm:pt-0.5"
+        {refs.map((ref) => {
+          const citationId = `ref-${ref.n}`
+          return (
+            <li
+              key={ref.n}
+              id={citationId}
+              data-citation-source="true"
+              data-citation-id={citationId}
+              data-pmid={ref.pmid || undefined}
+              data-doi={ref.doi || undefined}
+              itemScope
+              itemType="https://schema.org/CreativeWork"
+              className="scroll-mt-24 grid gap-2 py-4 first:pt-0 last:pb-0 sm:grid-cols-[2.4rem_minmax(0,1fr)] sm:gap-4"
             >
-              {String(ref.n).padStart(2, '0')}
-            </span>
-            <div className="text-xs leading-5 text-[color:var(--hs-body)]">
-              <span itemProp="name" className="font-semibold text-[color:var(--hs-ink)]">
-                {ref.title || ref.text}
-              </span>
-              {ref.title ? <span> {ref.text}</span> : null}
-              {ref.authors ? <meta itemProp="author" content={ref.authors} /> : null}
-              {ref.journal ? <meta itemProp="isPartOf" content={ref.journal} /> : null}
-              {ref.year ? <meta itemProp="datePublished" content={String(ref.year)} /> : null}
-              {ref.pmid ? <meta itemProp="identifier" content={`PMID:${ref.pmid}`} /> : null}
-              {ref.doi ? <meta itemProp="identifier" content={`DOI:${ref.doi}`} /> : null}
-              {ref.url ? (
-                <>
-                  {' '}
-                  <a
-                    href={ref.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    itemProp="url"
-                    className="font-semibold text-[color:var(--tone-ink)] underline decoration-[color:var(--hs-hairline-strong)] underline-offset-4 transition hover:text-[color:var(--hs-ink)]"
-                  >
-                    {sourceLabel(ref.url)}
-                  </a>
-                </>
-              ) : null}
-            </div>
-          </li>
-        ))}
+              <a
+                href={`#${citationId}`}
+                aria-label={`Permanent link to reference ${ref.n}`}
+                className="font-mono text-[0.66rem] font-bold tracking-[0.12em] text-[color:var(--hs-gold-ink)] underline-offset-4 hover:underline sm:pt-0.5"
+              >
+                {String(ref.n).padStart(2, '0')}
+              </a>
+              <div className="text-xs leading-5 text-[color:var(--hs-body)]">
+                <cite itemProp="name" className="not-italic font-semibold text-[color:var(--hs-ink)]">
+                  {ref.title || ref.text}
+                </cite>
+                {ref.title ? <span> {ref.text}</span> : null}
+                {ref.authors ? <meta itemProp="author" content={ref.authors} /> : null}
+                {ref.journal ? <meta itemProp="isPartOf" content={ref.journal} /> : null}
+                {ref.year ? <meta itemProp="datePublished" content={String(ref.year)} /> : null}
+                {ref.pmid ? <meta itemProp="identifier" content={`PMID:${ref.pmid}`} /> : null}
+                {ref.doi ? <meta itemProp="identifier" content={`DOI:${ref.doi}`} /> : null}
+                {ref.url ? (
+                  <>
+                    {' '}
+                    <a
+                      href={ref.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      itemProp="url"
+                      className="font-semibold text-[color:var(--tone-ink)] underline decoration-[color:var(--hs-hairline-strong)] underline-offset-4 transition hover:text-[color:var(--hs-ink)]"
+                    >
+                      {sourceLabel(ref.url)}
+                    </a>
+                  </>
+                ) : null}
+              </div>
+            </li>
+          )
+        })}
       </ol>
     </section>
   )


### PR DESCRIPTION
## Summary
- keeps the existing visible source ledger and `#ref-N` IDs
- turns each reference number into a visible permanent deep link
- adds explicit citation/source IDs plus PMID/DOI data markers only when those fields already exist
- marks the reference ledger and each source entry for deterministic extraction
- uses semantic `<cite>` markup for source titles while preserving existing Schema.org CreativeWork metadata and outbound source URLs

## AI SEO impact
Answer engines and readers can resolve a page-level claim to a stable individual source anchor instead of only the broad `#references` section.

## Guardrails
No title, author, PMID, DOI, year, journal, or URL is inferred. Existing data is only exposed more clearly.