### PR TITLE
refactor(research): make citation integrity one-pass

### DIFF
--- a/lib/citation-integrity.mjs
+++ b/lib/citation-integrity.mjs
@@ -1,0 +1,155 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  citationCompleteness,
+  citationIdentifiers,
+  isPlaceholderCitationTitle,
+  isValidDoi,
+  isValidPmid,
+  normalizeDoi,
+} from './citation-identifiers.mjs'
+
+const text = (value) => String(value ?? '').trim()
+
+export function loadCitationProfiles(root = process.cwd()) {
+  const dataDir = path.join(root, 'public', 'data')
+  const profiles = []
+  for (const [dir, kind] of [
+    ['herbs-detail', 'herbs'],
+    ['compounds-detail', 'compounds'],
+  ]) {
+    const full = path.join(dataDir, dir)
+    if (!fs.existsSync(full)) continue
+    for (const file of fs.readdirSync(full)) {
+      if (!file.endsWith('.json')) continue
+      try {
+        const record = JSON.parse(fs.readFileSync(path.join(full, file), 'utf8'))
+        const slug = record.slug ?? file.replace(/\.json$/, '')
+        profiles.push({ kind: kind === 'herbs' ? 'herbs' : 'compounds', url: `/${kind}/${slug}/`, record })
+      } catch {
+        // Malformed profile JSON belongs to the data-format validators.
+      }
+    }
+  }
+  return profiles
+}
+
+function addMapping(map, key, value) {
+  if (!key || !value) return
+  const values = map.get(key) ?? new Set()
+  values.add(value)
+  map.set(key, values)
+}
+
+function mappingConflicts(map, fromKind, toKind) {
+  return [...map.entries()]
+    .filter(([, values]) => values.size > 1)
+    .map(([identifier, values]) => ({
+      kind: `${fromKind}-to-${toKind}`,
+      identifier,
+      values: [...values].sort(),
+    }))
+}
+
+/**
+ * Validate citation identity invariants over an existing profile collection.
+ * Canonical research-quality passes its already-loaded profiles here, avoiding
+ * another full directory traversal. Standalone callers can use loadCitationProfiles().
+ */
+export function analyzeCitationIntegrity(profiles) {
+  const blocking = []
+  const advisory = []
+  const seenByIdentifier = new Map()
+  const duplicateProfileSources = []
+  const pmidToDois = new Map()
+  const doiToPmids = new Map()
+  let sources = 0
+
+  for (const profile of profiles) {
+    const kind = profile.kind === 'herbs' || profile.kind === 'herb' ? 'herbs' : 'compounds'
+    const slug = profile.record?.slug ?? profile.slug ?? ''
+    const url = profile.url ?? `/${kind}/${slug}/`
+    const record = profile.record ?? profile
+    const profileIdentifiers = new Set()
+
+    for (const source of Array.isArray(record.sources) ? record.sources : []) {
+      sources += 1
+      const rawPmid = text(source.pmid ?? source.pubmedId)
+      const rawDoi = normalizeDoi(source.doi)
+      const canonicalDoi = rawDoi.toLowerCase()
+      const rawUrl = text(source.url)
+
+      if (rawPmid && !isValidPmid(rawPmid)) {
+        blocking.push({ url, kind: 'invalid-pmid', value: rawPmid, title: text(source.title).slice(0, 80) })
+      }
+      if (rawDoi && !isValidDoi(rawDoi)) {
+        blocking.push({ url, kind: 'invalid-doi', value: rawDoi, title: text(source.title).slice(0, 80) })
+      }
+      if (rawUrl && !/^https?:\/\/\S+$/.test(rawUrl)) {
+        blocking.push({ url, kind: 'malformed-citation-url', value: rawUrl.slice(0, 120), title: text(source.title).slice(0, 80) })
+      }
+
+      if (isValidPmid(rawPmid) && isValidDoi(rawDoi)) {
+        addMapping(pmidToDois, rawPmid, canonicalDoi)
+        addMapping(doiToPmids, canonicalDoi, rawPmid)
+      }
+
+      const completeness = citationCompleteness(source)
+      if (!completeness.complete) advisory.push({ url, missing: completeness.missing, identifier: completeness.identifier })
+      if (isPlaceholderCitationTitle(source.title)) {
+        advisory.push({ url, missing: ['placeholder-title'], value: text(source.title).slice(0, 90) })
+      }
+
+      const aliases = citationIdentifiers(source)
+      const duplicateAliases = aliases.filter((identifier) => profileIdentifiers.has(identifier))
+      if (duplicateAliases.length) {
+        duplicateProfileSources.push({ url, identifiers: duplicateAliases, title: text(source.title).slice(0, 80) })
+      }
+      for (const identifier of aliases) profileIdentifiers.add(identifier)
+
+      const normalizedTitle = text(source.title).toLowerCase()
+      for (const identifier of aliases) {
+        const titles = seenByIdentifier.get(identifier) ?? new Set()
+        if (normalizedTitle) titles.add(normalizedTitle)
+        seenByIdentifier.set(identifier, titles)
+      }
+    }
+  }
+
+  const conflicts = [...seenByIdentifier.entries()]
+    .filter(([, titles]) => titles.size > 1)
+    .map(([identifier, titles]) => ({ identifier, titles: [...titles].map((title) => title.slice(0, 80)) }))
+    .sort((a, b) => a.identifier.localeCompare(b.identifier))
+
+  const identifierPairConflicts = [
+    ...mappingConflicts(pmidToDois, 'pmid', 'doi'),
+    ...mappingConflicts(doiToPmids, 'doi', 'pmid'),
+  ].sort((a, b) => a.kind.localeCompare(b.kind) || a.identifier.localeCompare(b.identifier))
+
+  const missingCounts = {}
+  for (const item of advisory) {
+    for (const field of item.missing) missingCounts[field] = (missingCounts[field] ?? 0) + 1
+  }
+
+  const blockingCount = blocking.length + duplicateProfileSources.length + identifierPairConflicts.length + conflicts.length
+  return {
+    generatedAt: new Date().toISOString(),
+    sources,
+    blockingCount,
+    blocking,
+    duplicateProfileSources,
+    identifierPairConflicts,
+    missingCounts,
+    conflicts,
+    passed: blockingCount === 0,
+  }
+}
+
+export function writeCitationIntegrityReport(report, root = process.cwd()) {
+  const reportsDir = path.join(root, 'ops', 'reports')
+  const reportPath = path.join(reportsDir, 'citation-identifiers.json')
+  fs.mkdirSync(reportsDir, { recursive: true })
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+  return reportPath
+}

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
+import { analyzeCitationIntegrity, writeCitationIntegrityReport } from '../../lib/citation-integrity.mjs'
 import { analyzeEvidenceGradeConsistency, writeEvidenceGradeConsistencyReport } from '../../lib/evidence-grade-consistency'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from '../../lib/research-evidence-age'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
@@ -18,7 +19,6 @@ const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const REPORT_PATH = path.join(REPORT_DIR, 'research-quality.json')
 
 const externalChecks = [
-  { id: 'citation-identities', label: 'Citation identity integrity', command: process.execPath, args: ['scripts/ci/validate-citation-identifiers.mjs'] },
   { id: 'content-integrity', label: 'Structured content integrity', command: process.execPath, args: ['scripts/ci/audit-content-integrity.mjs'] },
 ] as const
 
@@ -40,6 +40,8 @@ const analysis = analyzeResearchQuality(ROOT)
 const structuralFailures = structuralCoverageFailures(analysis)
 const researchGapQueue = buildResearchGapQueue(analysis)
 const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
+const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
+const citationReportPath = writeCitationIntegrityReport(citationIntegrity, ROOT)
 const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(ROOT)
 const evidenceGradeReportPath = writeEvidenceGradeConsistencyReport(evidenceGradeConsistency, ROOT)
 const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
@@ -72,6 +74,18 @@ results.push({
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
 if (!corePassed) failed = true
 
+results.push({
+  id: 'citation-identities',
+  label: 'Citation identity integrity',
+  passed: citationIntegrity.passed,
+  exitCode: citationIntegrity.passed ? 0 : 1,
+  durationMs: 0,
+  stdoutTail: `sources=${citationIntegrity.sources}; blocking=${citationIntegrity.blocking.length}; duplicateProfileRefs=${citationIntegrity.duplicateProfileSources.length}; pairConflicts=${citationIntegrity.identifierPairConflicts.length}; titleConflicts=${citationIntegrity.conflicts.length}`,
+  stderrTail: citationIntegrity.passed ? '' : `${citationIntegrity.blockingCount} citation identity problem(s)`,
+})
+console.log(`${citationIntegrity.passed ? 'PASS' : 'FAIL'}  Citation identity integrity  (in-process)`)
+if (!citationIntegrity.passed) failed = true
+
 const gradesPassed = evidenceGradeConsistency.invalid.length === 0
 results.push({
   id: 'evidence-grades',
@@ -97,6 +111,7 @@ for (const check of externalChecks) {
 const coreSummary = {
   profiles: analysis.profileAnalyses.length, structuredClaims: analysis.structuredClaimAnalyses.length, approvedClaims: analysis.claimAnalyses.length,
   structuralFailures: structuralFailures.length, withdrawnCitedStudies: sourceIntegrity.summary.withdrawn,
+  citationIntegrityProblems: citationIntegrity.blockingCount,
   weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
   weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
   narrativeDominatedProfiles: narrativeDominatedProfiles.length, profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
@@ -109,10 +124,10 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 9, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', policy: 'lib/research-quality-policy.ts', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', crossProfileStudyLoad: 'lib/research-study-load.ts', evidenceBundleReuse: 'lib/research-study-load.ts', claimEvidenceOverlap: 'lib/research-study-load.ts', evidenceAge: 'lib/research-evidence-age.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
-  coreSummary, structuralFailures, withdrawnCitedStudies: sourceIntegrity.withdrawn,
-  evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
+  schemaVersion: 10, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', policy: 'lib/research-quality-policy.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', crossProfileStudyLoad: 'lib/research-study-load.ts', evidenceBundleReuse: 'lib/research-study-load.ts', claimEvidenceOverlap: 'lib/research-study-load.ts', evidenceAge: 'lib/research-evidence-age.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  coreSummary, structuralFailures, citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
+  withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
   oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
   topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100), topClaimEvidenceOverlap: claimEvidenceOverlap.slice(0, 150),
@@ -122,12 +137,14 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
 }, null, 2)}\n`)
 
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
+console.log(`Citation integrity: ${citationIntegrity.sources} sources · ${citationIntegrity.blockingCount} blocking identity problems`)
 console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
 console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
 console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
+console.log(`Citation report: ${path.relative(ROOT, citationReportPath)}`)
 console.log(`Evidence-grade report: ${path.relative(ROOT, evidenceGradeReportPath)}`)
 console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
 if (failed) { console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.'); process.exit(1) }
-console.log('\n[research-quality] PASS — one-pass canonical research analysis, source integrity, evidence grades, and structured integrity agree.')
+console.log('\n[research-quality] PASS — one-pass canonical research analysis, citation/source integrity, evidence grades, and structured integrity agree.')

--- a/scripts/ci/validate-citation-identifiers.mjs
+++ b/scripts/ci/validate-citation-identifiers.mjs
@@ -1,209 +1,54 @@
 #!/usr/bin/env node
-/**
- * Validate every citation identifier before it can ship.
- *
- * A citation is the mechanism by which a reader checks a claim, so a malformed
- * identifier is worse than an absent one: the page still presents itself as
- * sourced. Two compounds shipped a packed cell — `pmid: "15070181; 22167571"` —
- * which the exporter turned into one href containing two URLs, resolving
- * nowhere.
- *
- * Blocking (exit 1):
- *   - a PMID or DOI that cannot be a real identifier
- *   - a citation URL that is not a single well-formed link
- *   - one identifier recorded under conflicting study titles
- *   - the same identified study listed more than once on one profile
- *   - one PMID paired with multiple DOIs, or one DOI paired with multiple PMIDs
- *
- * Reported only: missing year/authors/journal and placeholder titles. Those are
- * enrichment gaps across most of the corpus; failing on them would block every
- * build without telling anyone something new.
- *
- * Usage: node scripts/ci/validate-citation-identifiers.mjs
- */
+/** Standalone compatibility wrapper for canonical citation-integrity analysis. */
 
-import fs from 'node:fs'
 import path from 'node:path'
 
 import {
-  citationCompleteness,
-  citationIdentifiers,
-  isPlaceholderCitationTitle,
-  isValidDoi,
-  isValidPmid,
-  normalizeDoi,
-} from '../../lib/citation-identifiers.mjs'
+  analyzeCitationIntegrity,
+  loadCitationProfiles,
+  writeCitationIntegrityReport,
+} from '../../lib/citation-integrity.mjs'
 
 const ROOT = process.cwd()
-const DATA_DIR = path.join(ROOT, 'public', 'data')
-const REPORTS_DIR = path.join(ROOT, 'ops', 'reports')
-const REPORT_PATH = path.join(REPORTS_DIR, 'citation-identifiers.json')
+const report = analyzeCitationIntegrity(loadCitationProfiles(ROOT))
+const reportPath = writeCitationIntegrityReport(report, ROOT)
 
-const text = (value) => String(value ?? '').trim()
+console.log('\nCitation identifiers')
+console.log('='.repeat(66))
+console.log(`Sources scanned        ${report.sources}`)
+console.log(`Blocking problems      ${report.blocking.length}`)
+console.log(`Duplicate profile refs ${report.duplicateProfileSources.length}`)
+console.log(`Identifier pair issues ${report.identifierPairConflicts.length}`)
+console.log(`Same id, two titles    ${report.conflicts.length}`)
+for (const [field, count] of Object.entries(report.missingCounts).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${String(count).padStart(5)}  missing ${field}`)
+}
+console.log(`\nReport: ${path.relative(ROOT, reportPath)}`)
 
-function* detailRecords() {
-  for (const [dir, kind] of [
-    ['herbs-detail', 'herbs'],
-    ['compounds-detail', 'compounds'],
-  ]) {
-    const full = path.join(DATA_DIR, dir)
-    if (!fs.existsSync(full)) continue
-    for (const file of fs.readdirSync(full)) {
-      if (!file.endsWith('.json')) continue
-      try {
-        const record = JSON.parse(fs.readFileSync(path.join(full, file), 'utf8'))
-        yield { kind, slug: record.slug ?? file.replace(/\.json$/, ''), record }
-      } catch {
-        // A file that will not parse is another validator's finding.
-      }
-    }
+if (report.passed) process.exit(0)
+
+if (report.blocking.length) {
+  console.error(`\n[citation-identifiers] FAILED — ${report.blocking.length} unusable identifier(s).\n`)
+  for (const problem of report.blocking.slice(0, 20)) {
+    console.error(`  ${problem.url} · ${problem.kind} · ${problem.value}`)
   }
 }
-
-function addMapping(map, key, value) {
-  if (!key || !value) return
-  const values = map.get(key) ?? new Set()
-  values.add(value)
-  map.set(key, values)
-}
-
-function mappingConflicts(map, fromKind, toKind) {
-  return [...map.entries()]
-    .filter(([, values]) => values.size > 1)
-    .map(([identifier, values]) => ({
-      kind: `${fromKind}-to-${toKind}`,
-      identifier,
-      values: [...values].sort(),
-    }))
-}
-
-function main() {
-  const blocking = []
-  const advisory = []
-  const seenByIdentifier = new Map()
-  const duplicateProfileSources = []
-  const pmidToDois = new Map()
-  const doiToPmids = new Map()
-  let sources = 0
-
-  for (const { kind, slug, record } of detailRecords()) {
-    const url = `/${kind}/${slug}/`
-    const profileIdentifiers = new Set()
-
-    for (const source of Array.isArray(record.sources) ? record.sources : []) {
-      sources += 1
-
-      const rawPmid = text(source.pmid ?? source.pubmedId)
-      const rawDoi = normalizeDoi(source.doi)
-      const canonicalDoi = rawDoi.toLowerCase()
-      const rawUrl = text(source.url)
-
-      if (rawPmid && !isValidPmid(rawPmid)) {
-        blocking.push({ url, kind: 'invalid-pmid', value: rawPmid, title: text(source.title).slice(0, 80) })
-      }
-      if (rawDoi && !isValidDoi(rawDoi)) {
-        blocking.push({ url, kind: 'invalid-doi', value: rawDoi, title: text(source.title).slice(0, 80) })
-      }
-      if (rawUrl && !/^https?:\/\/\S+$/.test(rawUrl)) {
-        blocking.push({ url, kind: 'malformed-citation-url', value: rawUrl.slice(0, 120), title: text(source.title).slice(0, 80) })
-      }
-
-      if (isValidPmid(rawPmid) && isValidDoi(rawDoi)) {
-        addMapping(pmidToDois, rawPmid, canonicalDoi)
-        addMapping(doiToPmids, canonicalDoi, rawPmid)
-      }
-
-      const completeness = citationCompleteness(source)
-      if (!completeness.complete) {
-        advisory.push({ url, missing: completeness.missing, identifier: completeness.identifier })
-      }
-      if (isPlaceholderCitationTitle(source.title)) {
-        advisory.push({ url, missing: ['placeholder-title'], value: text(source.title).slice(0, 90) })
-      }
-
-      const aliases = citationIdentifiers(source)
-      const duplicateAliases = aliases.filter((identifier) => profileIdentifiers.has(identifier))
-      if (duplicateAliases.length) {
-        duplicateProfileSources.push({
-          url,
-          identifiers: duplicateAliases,
-          title: text(source.title).slice(0, 80),
-        })
-      }
-      for (const identifier of aliases) profileIdentifiers.add(identifier)
-
-      const normalizedTitle = text(source.title).toLowerCase()
-      for (const identifier of aliases) {
-        const titles = seenByIdentifier.get(identifier) ?? new Set()
-        if (normalizedTitle) titles.add(normalizedTitle)
-        seenByIdentifier.set(identifier, titles)
-      }
-    }
-  }
-
-  const conflicts = [...seenByIdentifier.entries()]
-    .filter(([, titles]) => titles.size > 1)
-    .map(([identifier, titles]) => ({ identifier, titles: [...titles].map((t) => t.slice(0, 80)) }))
-
-  const identifierPairConflicts = [
-    ...mappingConflicts(pmidToDois, 'pmid', 'doi'),
-    ...mappingConflicts(doiToPmids, 'doi', 'pmid'),
-  ]
-
-  const missingCounts = {}
-  for (const item of advisory) {
-    for (const field of item.missing) missingCounts[field] = (missingCounts[field] ?? 0) + 1
-  }
-
-  fs.mkdirSync(REPORTS_DIR, { recursive: true })
-  fs.writeFileSync(
-    REPORT_PATH,
-    `${JSON.stringify({ generatedAt: new Date().toISOString(), sources, blocking, duplicateProfileSources, identifierPairConflicts, missingCounts, conflicts }, null, 2)}\n`,
-  )
-
-  console.log('\nCitation identifiers')
-  console.log('='.repeat(66))
-  console.log(`Sources scanned        ${sources}`)
-  console.log(`Blocking problems      ${blocking.length}`)
-  console.log(`Duplicate profile refs ${duplicateProfileSources.length}`)
-  console.log(`Identifier pair issues ${identifierPairConflicts.length}`)
-  console.log(`Same id, two titles    ${conflicts.length}`)
-  for (const [field, count] of Object.entries(missingCounts).sort((a, b) => b[1] - a[1])) {
-    console.log(`  ${String(count).padStart(5)}  missing ${field}`)
-  }
-  console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)
-
-  if (blocking.length) {
-    console.error(`\n[citation-identifiers] FAILED — ${blocking.length} unusable identifier(s).\n`)
-    for (const problem of blocking.slice(0, 20)) {
-      console.error(`  ${problem.url} · ${problem.kind} · ${problem.value}`)
-    }
-    process.exit(1)
-  }
-
-  if (duplicateProfileSources.length) {
-    console.error(`\n[citation-identifiers] FAILED — ${duplicateProfileSources.length} duplicate source reference(s) within profiles.`)
-    for (const duplicate of duplicateProfileSources.slice(0, 20)) {
-      console.error(`  ${duplicate.url} · ${duplicate.identifiers.join(', ')} · ${duplicate.title}`)
-    }
-    process.exit(1)
-  }
-
-  if (identifierPairConflicts.length) {
-    console.error(`\n[citation-identifiers] FAILED — ${identifierPairConflicts.length} inconsistent PMID/DOI mapping(s).`)
-    for (const conflict of identifierPairConflicts.slice(0, 20)) {
-      console.error(`  ${conflict.kind} · ${conflict.identifier} · ${conflict.values.join(' <> ')}`)
-    }
-    process.exit(1)
-  }
-
-  if (conflicts.length) {
-    console.error(`\n[citation-identifiers] FAILED — ${conflicts.length} identifier(s) recorded under conflicting titles.`)
-    for (const conflict of conflicts.slice(0, 20)) {
-      console.error(`  ${conflict.identifier} · ${conflict.titles.join(' <> ')}`)
-    }
-    process.exit(1)
+if (report.duplicateProfileSources.length) {
+  console.error(`\n[citation-identifiers] FAILED — ${report.duplicateProfileSources.length} duplicate source reference(s) within profiles.`)
+  for (const duplicate of report.duplicateProfileSources.slice(0, 20)) {
+    console.error(`  ${duplicate.url} · ${duplicate.identifiers.join(', ')} · ${duplicate.title}`)
   }
 }
-
-main()
+if (report.identifierPairConflicts.length) {
+  console.error(`\n[citation-identifiers] FAILED — ${report.identifierPairConflicts.length} inconsistent PMID/DOI mapping(s).`)
+  for (const conflict of report.identifierPairConflicts.slice(0, 20)) {
+    console.error(`  ${conflict.kind} · ${conflict.identifier} · ${conflict.values.join(' <> ')}`)
+  }
+}
+if (report.conflicts.length) {
+  console.error(`\n[citation-identifiers] FAILED — ${report.conflicts.length} identifier(s) recorded under conflicting titles.`)
+  for (const conflict of report.conflicts.slice(0, 20)) {
+    console.error(`  ${conflict.identifier} · ${conflict.titles.join(' <> ')}`)
+  }
+}
+process.exit(1)


### PR DESCRIPTION
Extracts citation identity validation into a reusable analyzer over the canonical loaded profile set. The standalone validator remains as a compatibility wrapper, while the canonical research-quality runner now checks malformed identifiers, duplicate profile sources, PMID/DOI mapping conflicts, and conflicting titles in-process without re-traversing the detail JSON directories.