### PR TITLE
fix(research): use claim-linked evidence for design topology

### DIFF
--- a/lib/__tests__/research-quality-topology.test.ts
+++ b/lib/__tests__/research-quality-topology.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
-import type { ClaimQualityAnalysis, ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import { analyzeResearchQuality, type ClaimQualityAnalysis, type ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
 import { buildResearchGapQueue } from '@/lib/research-quality-policy'
 import {
   analyzeClaimEvidenceOverlap,
@@ -50,14 +54,22 @@ function analysis(claims: ClaimQualityAnalysis[]): ResearchQualityAnalysis {
       url,
       sourceCount: 0,
       canonicalStudyCount: 0,
+      claimLinkedCanonicalStudyCount: 0,
+      orphanedCanonicalStudyCount: 0,
       claimCount: claims.filter((item) => item.url === url).length,
       approvedClaimCount: claims.filter((item) => item.url === url).length,
       supportedApprovedClaimCount: claims.filter((item) => item.url === url && item.studyCount > 0).length,
       weakStructuredClaimCount: claims.filter((item) => item.url === url && item.weakStructuredClaim).length,
       designMix: {},
+      claimLinkedDesignMix: {},
       primaryHuman: 1,
       synthesis: 0,
       narrativeReview: 0,
+      claimLinkedPrimaryHuman: 1,
+      claimLinkedSynthesis: 0,
+      claimLinkedNarrativeReview: 0,
+      orphanedPrimaryHuman: 0,
+      inventoryNarrativeToPrimaryHumanRatio: 0,
       narrativeToPrimaryHumanRatio: 0,
       narrativeDominatedVsPrimaryHuman: false,
       unsupportedApprovedClaims: [],
@@ -140,5 +152,40 @@ describe('research evidence topology contracts', () => {
     expect(ordinary?.reasonCounts['single-study-approved-claim']).toBe(1)
     expect(high?.reasonCounts['single-study-approved-claim']).toBe(1)
     expect(high?.score ?? 0).toBeGreaterThan(ordinary?.score ?? 0)
+  })
+
+  it('does not let an uncited RCT hide review-dominated approved claims', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'research-quality-'))
+    try {
+      const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+      mkdirSync(detailDir, { recursive: true })
+      writeFileSync(path.join(detailDir, 'example.json'), JSON.stringify({
+        slug: 'example',
+        sources: [
+          { id: 'orphan-rct', pmid: '11111111', studyClass: 'rct' },
+          { id: 'review-1', pmid: '22222222', studyClass: 'narrative-review' },
+          { id: 'review-2', pmid: '33333333', studyClass: 'narrative-review' },
+        ],
+        claimMap: [
+          {
+            id: 'outcome',
+            predicate: 'supports_outcome',
+            confidence: 0.7,
+            reviewStatus: 'approved',
+            sourceRefIds: ['review-1', 'review-2'],
+          },
+        ],
+      }))
+
+      const profile = analyzeResearchQuality(root).profileAnalyses[0]
+      expect(profile.primaryHuman).toBe(1)
+      expect(profile.claimLinkedPrimaryHuman).toBe(0)
+      expect(profile.claimLinkedNarrativeReview).toBe(2)
+      expect(profile.orphanedPrimaryHuman).toBe(1)
+      expect(profile.noPrimaryHuman).toBe(true)
+      expect(profile.narrativeDominatedVsPrimaryHuman).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -64,14 +64,22 @@ export type ProfileQualityAnalysis = {
   url: string
   sourceCount: number
   canonicalStudyCount: number
+  claimLinkedCanonicalStudyCount: number
+  orphanedCanonicalStudyCount: number
   claimCount: number
   approvedClaimCount: number
   supportedApprovedClaimCount: number
   weakStructuredClaimCount: number
   designMix: Record<string, number>
+  claimLinkedDesignMix: Record<string, number>
   primaryHuman: number
   synthesis: number
   narrativeReview: number
+  claimLinkedPrimaryHuman: number
+  claimLinkedSynthesis: number
+  claimLinkedNarrativeReview: number
+  orphanedPrimaryHuman: number
+  inventoryNarrativeToPrimaryHumanRatio: number | null
   narrativeToPrimaryHumanRatio: number | null
   narrativeDominatedVsPrimaryHuman: boolean
   unsupportedApprovedClaims: string[]
@@ -242,6 +250,21 @@ function analyzeProfile(
     }
   }
 
+  const claimLinkedDesignMix: Record<string, number> = {}
+  let claimLinkedPrimaryHuman = 0
+  let claimLinkedSynthesis = 0
+  let claimLinkedNarrativeReview = 0
+  for (const studyId of studyUse.keys()) {
+    const design = context.studyDesigns.get(studyId) ?? 'unclassified'
+    claimLinkedDesignMix[design] = (claimLinkedDesignMix[design] ?? 0) + 1
+    if (PRIMARY_HUMAN_STUDY_CLASSES.has(design)) claimLinkedPrimaryHuman += 1
+    if (SYNTHESIS_STUDY_CLASSES.has(design)) claimLinkedSynthesis += 1
+    if (NARRATIVE_STUDY_CLASSES.has(design)) claimLinkedNarrativeReview += 1
+  }
+
+  const claimLinkedCanonicalStudyCount = studyUse.size
+  const orphanedCanonicalStudyCount = Math.max(0, context.studyGroups.size - claimLinkedCanonicalStudyCount)
+  const orphanedPrimaryHuman = Math.max(0, primaryHuman - claimLinkedPrimaryHuman)
   const rankedStudyUse = [...studyUse.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
   const mostUsed = rankedStudyUse[0] ?? null
   const mostUsedStudyClaimCount = mostUsed?.[1] ?? 0
@@ -252,9 +275,15 @@ function analyzeProfile(
   const edgeShares = claimStudyEdges ? rankedStudyUse.map(([, count]) => count / claimStudyEdges) : []
   const studyConcentrationIndex = edgeShares.reduce((sum, share) => sum + share * share, 0)
   const effectiveStudyCount = studyConcentrationIndex > 0 ? 1 / studyConcentrationIndex : 0
-  const narrativeToPrimaryHumanRatio = primaryHuman > 0 ? narrativeReview / primaryHuman : narrativeReview > 0 ? null : 0
+  const inventoryNarrativeToPrimaryHumanRatio = primaryHuman > 0 ? narrativeReview / primaryHuman : narrativeReview > 0 ? null : 0
+  const narrativeToPrimaryHumanRatio = claimLinkedPrimaryHuman > 0
+    ? claimLinkedNarrativeReview / claimLinkedPrimaryHuman
+    : claimLinkedNarrativeReview > 0
+      ? null
+      : 0
   const narrativeDominatedVsPrimaryHuman =
-    narrativeReview >= 2 && (primaryHuman === 0 || narrativeReview >= primaryHuman * 2)
+    claimLinkedNarrativeReview >= 2 &&
+    (claimLinkedPrimaryHuman === 0 || claimLinkedNarrativeReview >= claimLinkedPrimaryHuman * 2)
   const overDependentOnSingleStudy =
     supportedApprovedClaimCount >= 3 &&
     dominantStudySupportedClaimShare >= 0.5 &&
@@ -264,14 +293,23 @@ function analyzeProfile(
     url,
     sourceCount: context.sources.length,
     canonicalStudyCount: context.studyGroups.size,
+    claimLinkedCanonicalStudyCount,
+    orphanedCanonicalStudyCount,
     claimCount: allClaims.length,
     approvedClaimCount: approved.length,
     supportedApprovedClaimCount,
     weakStructuredClaimCount: weakStructuredClaims.length,
     designMix,
+    claimLinkedDesignMix,
     primaryHuman,
     synthesis,
     narrativeReview,
+    claimLinkedPrimaryHuman,
+    claimLinkedSynthesis,
+    claimLinkedNarrativeReview,
+    orphanedPrimaryHuman,
+    inventoryNarrativeToPrimaryHumanRatio:
+      inventoryNarrativeToPrimaryHumanRatio === null ? null : round(inventoryNarrativeToPrimaryHumanRatio),
     narrativeToPrimaryHumanRatio: narrativeToPrimaryHumanRatio === null ? null : round(narrativeToPrimaryHumanRatio),
     narrativeDominatedVsPrimaryHuman,
     unsupportedApprovedClaims,
@@ -288,7 +326,7 @@ function analyzeProfile(
     effectiveStudyCount: round(effectiveStudyCount),
     overDependentOnSingleStudy,
     reviewDominated: narrativeDominatedVsPrimaryHuman,
-    noPrimaryHuman: approved.length > 0 && primaryHuman === 0,
+    noPrimaryHuman: approved.length > 0 && claimLinkedPrimaryHuman === 0,
   }
 }
 


### PR DESCRIPTION
Separates profile source inventory from the evidence actually linked to approved claims. Primary-human, synthesis, and narrative counts are now tracked both for the full source inventory and for claim-linked canonical studies; narrative dominance and no-primary-human flags use the claim-linked graph. Orphaned canonical studies and orphaned primary-human studies are exposed explicitly. Adds a regression test proving an uncited RCT can no longer mask review-only approved claim support.