### PR TITLE
feat(research): surface orphaned primary-human evidence

### DIFF
--- a/lib/__tests__/research-orphaned-evidence.test.ts
+++ b/lib/__tests__/research-orphaned-evidence.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+import { buildResearchGapQueue } from '@/lib/research-quality-policy'
+
+describe('orphaned primary-human evidence', () => {
+  it('distinguishes an evidence-mapping gap from true absence of human research', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'orphaned-human-'))
+    try {
+      const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+      mkdirSync(detailDir, { recursive: true })
+      writeFileSync(path.join(detailDir, 'example.json'), JSON.stringify({
+        slug: 'example',
+        sources: [
+          { id: 'orphan-rct', pmid: '11111111', studyClass: 'rct' },
+          { id: 'review-1', pmid: '22222222', studyClass: 'narrative-review' },
+          { id: 'review-2', pmid: '33333333', studyClass: 'narrative-review' },
+        ],
+        claimMap: [
+          {
+            id: 'outcome',
+            predicate: 'supports_outcome',
+            confidence: 0.7,
+            reviewStatus: 'approved',
+            sourceRefIds: ['review-1', 'review-2'],
+          },
+        ],
+      }))
+
+      const analysis = analyzeResearchQuality(root)
+      const profile = analysis.profileAnalyses[0]
+      const gap = buildResearchGapQueue(analysis).find((item) => item.url === '/herbs/example/')
+
+      expect(profile).toMatchObject({
+        primaryHuman: 1,
+        claimLinkedPrimaryHuman: 0,
+        orphanedPrimaryHuman: 1,
+        noPrimaryHuman: true,
+      })
+      expect(gap?.reasonCounts['orphaned-primary-human-evidence']).toBe(1)
+      expect(gap?.reasonCounts['approved-claims-without-primary-human-study']).toBe(1)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -31,6 +31,8 @@ export const RESEARCH_GAP_WEIGHTS = {
   unclassifiedStructuredSupport: 20,
   highConfidenceWeakClaimBonus: 15,
   noPrimaryHumanStudy: 20,
+  orphanedPrimaryHumanEvidence: 12,
+  orphanedHumanWhileClaimsNoPrimaryBonus: 8,
   narrativeReviewDominatedProfile: 20,
   synthesisOnlyApprovedOutcome: 8,
   poorStudyMetadataCoverage: 12,
@@ -186,6 +188,15 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): Resear
         profile.url,
         'approved-claims-without-primary-human-study',
         RESEARCH_GAP_WEIGHTS.noPrimaryHumanStudy,
+      )
+    }
+    if (profile.orphanedPrimaryHuman > 0) {
+      const mappingBonus = profile.noPrimaryHuman ? RESEARCH_GAP_WEIGHTS.orphanedHumanWhileClaimsNoPrimaryBonus : 0
+      add(
+        profile.url,
+        'orphaned-primary-human-evidence',
+        RESEARCH_GAP_WEIGHTS.orphanedPrimaryHumanEvidence + mappingBonus,
+        `${profile.orphanedPrimaryHuman} primary-human stud${profile.orphanedPrimaryHuman === 1 ? 'y is' : 'ies are'} present in the profile but not linked to any approved claim${mappingBonus ? '; approved claims otherwise have no linked primary-human study' : ''}`,
       )
     }
 


### PR DESCRIPTION
Adds a distinct research-gap class for primary-human studies that exist in a profile's source inventory but are not linked to any approved claim. The signal receives an extra mapping-gap bonus when approved claims otherwise have no linked primary-human evidence, distinguishing 'find human evidence' from 'review/connect human evidence already present.' Includes a focused regression test.