### PR TITLE
refactor(research): reuse one derived topology snapshot

### DIFF
--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -1,6 +1,5 @@
-import { analyzeClaimEvidenceAge } from './research-evidence-age'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
-import { analyzeClaimEvidenceOverlap, analyzeCrossProfileStudyLoad, analyzeEvidenceBundleReuse } from './research-study-load'
+import { buildResearchQualityTopology, type ResearchQualityTopology } from './research-quality-topology'
 
 export type ResearchGapReason = {
   kind: string
@@ -62,7 +61,10 @@ export function structuralCoverageFailures(analysis: ResearchQualityAnalysis): S
   return failures
 }
 
-export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): ResearchGapItem[] {
+export function buildResearchGapQueue(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology = buildResearchQualityTopology(analysis),
+): ResearchGapItem[] {
   const queue = new Map<string, { url: string; score: number; reasons: ResearchGapReason[] }>()
 
   const add = (url: string, kind: string, weight: number, detail?: string) => {
@@ -213,8 +215,7 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): Resear
     }
   }
 
-  for (const bundle of analyzeEvidenceBundleReuse(analysis)) {
-    if (!bundle.narrowRepeatedEvidenceBundle) continue
+  for (const bundle of topology.narrowRepeatedEvidenceBundles) {
     const reuseBonus = Math.min(10, Math.max(0, bundle.approvedClaimCount - 3) * 2)
     add(
       bundle.url,
@@ -224,8 +225,8 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): Resear
     )
   }
 
-  const overlapByProfile = new Map<string, ReturnType<typeof analyzeClaimEvidenceOverlap>>()
-  for (const overlap of analyzeClaimEvidenceOverlap(analysis)) {
+  const overlapByProfile = new Map<string, typeof topology.claimEvidenceOverlap>()
+  for (const overlap of topology.claimEvidenceOverlap) {
     const items = overlapByProfile.get(overlap.url) ?? []
     items.push(overlap)
     overlapByProfile.set(overlap.url, items)
@@ -243,8 +244,7 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): Resear
   }
 
   const systemicByProfile = new Map<string, { studies: number; claims: number }>()
-  for (const study of analyzeCrossProfileStudyLoad(analysis)) {
-    if (!study.systemicLoadBearing) continue
+  for (const study of topology.systemicLoadBearingStudies) {
     for (const url of study.profiles) {
       const item = systemicByProfile.get(url) ?? { studies: 0, claims: 0 }
       item.studies += 1
@@ -262,7 +262,7 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis): Resear
     )
   }
 
-  for (const freshness of analyzeClaimEvidenceAge(analysis)) {
+  for (const freshness of topology.claimEvidenceAge) {
     if (freshness.studyCount > 0 && freshness.knownYearCount === 0) {
       add(
         freshness.url,

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,0 +1,40 @@
+import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import {
+  analyzeClaimEvidenceOverlap,
+  analyzeCrossProfileStudyLoad,
+  analyzeEvidenceBundleReuse,
+} from './research-study-load'
+
+export type ResearchQualityTopology = ReturnType<typeof buildResearchQualityTopology>
+
+/**
+ * Build all derived evidence-topology products once from the canonical analysis.
+ * Policy and reporting should consume this snapshot rather than independently
+ * walking the same claim/study graph again.
+ */
+export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) {
+  const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
+  const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
+  const evidenceBundleReuse = analyzeEvidenceBundleReuse(analysis)
+  const narrowRepeatedEvidenceBundles = evidenceBundleReuse.filter((bundle) => bundle.narrowRepeatedEvidenceBundle)
+  const claimEvidenceOverlap = analyzeClaimEvidenceOverlap(analysis)
+  const crossPredicateEvidenceOverlap = claimEvidenceOverlap.filter((item) => item.differentPredicates)
+  const claimEvidenceAge = analyzeClaimEvidenceAge(analysis)
+  const evidenceAgeSummary = summarizeEvidenceAge(claimEvidenceAge)
+  const legacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.allKnownEvidenceOlderThan10Years)
+  const highConfidenceLegacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.highConfidenceLegacyOnlyClaim)
+
+  return {
+    crossProfileStudyLoad,
+    systemicLoadBearingStudies,
+    evidenceBundleReuse,
+    narrowRepeatedEvidenceBundles,
+    claimEvidenceOverlap,
+    crossPredicateEvidenceOverlap,
+    claimEvidenceAge,
+    evidenceAgeSummary,
+    legacyOnlyClaims,
+    highConfidenceLegacyOnlyClaims,
+  }
+}

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -8,11 +8,10 @@ import path from 'node:path'
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
 import { analyzeCitationIntegrity, writeCitationIntegrityReport } from '../../lib/citation-integrity.mjs'
 import { analyzeEvidenceGradeConsistency, writeEvidenceGradeConsistencyReport } from '../../lib/evidence-grade-consistency'
-import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from '../../lib/research-evidence-age'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchGapQueue, structuralCoverageFailures } from '../../lib/research-quality-policy'
+import { buildResearchQualityTopology } from '../../lib/research-quality-topology'
 import { analyzeResearchSourceIntegrity } from '../../lib/research-source-integrity'
-import { analyzeClaimEvidenceOverlap, analyzeCrossProfileStudyLoad, analyzeEvidenceBundleReuse } from '../../lib/research-study-load'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
@@ -37,23 +36,25 @@ console.log('='.repeat(76))
 
 const coreStarted = Date.now()
 const analysis = analyzeResearchQuality(ROOT)
+const topology = buildResearchQualityTopology(analysis)
 const structuralFailures = structuralCoverageFailures(analysis)
-const researchGapQueue = buildResearchGapQueue(analysis)
+const researchGapQueue = buildResearchGapQueue(analysis, topology)
 const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
 const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
 const citationReportPath = writeCitationIntegrityReport(citationIntegrity, ROOT)
 const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(ROOT)
 const evidenceGradeReportPath = writeEvidenceGradeConsistencyReport(evidenceGradeConsistency, ROOT)
-const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
-const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
-const evidenceBundleReuse = analyzeEvidenceBundleReuse(analysis)
-const narrowRepeatedEvidenceBundles = evidenceBundleReuse.filter((bundle) => bundle.narrowRepeatedEvidenceBundle)
-const claimEvidenceOverlap = analyzeClaimEvidenceOverlap(analysis)
-const crossPredicateEvidenceOverlap = claimEvidenceOverlap.filter((item) => item.differentPredicates)
-const claimEvidenceAge = analyzeClaimEvidenceAge(analysis)
-const evidenceAgeSummary = summarizeEvidenceAge(claimEvidenceAge)
-const legacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.allKnownEvidenceOlderThan10Years)
-const highConfidenceLegacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.highConfidenceLegacyOnlyClaim)
+const {
+  crossProfileStudyLoad,
+  systemicLoadBearingStudies,
+  evidenceBundleReuse,
+  narrowRepeatedEvidenceBundles,
+  claimEvidenceOverlap,
+  crossPredicateEvidenceOverlap,
+  evidenceAgeSummary,
+  legacyOnlyClaims,
+  highConfidenceLegacyOnlyClaims,
+} = topology
 const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
 const weakApprovedOutcomes = analysis.claimAnalyses.filter((claim) => claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier))
@@ -62,6 +63,7 @@ const weakUnapprovedOutcomes = analysis.structuredClaimAnalyses.filter((claim) =
 const overDependentProfiles = analysis.profileAnalyses.filter((profile) => profile.overDependentOnSingleStudy)
 const narrativeDominatedProfiles = analysis.profileAnalyses.filter((profile) => profile.narrativeDominatedVsPrimaryHuman)
 const noPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.noPrimaryHuman)
+const orphanedPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.orphanedPrimaryHuman > 0)
 const corePassed = structuralFailures.length === 0 && sourceIntegrity.summary.withdrawn === 0
 const coreDurationMs = Date.now() - coreStarted
 
@@ -115,6 +117,7 @@ const coreSummary = {
   weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
   weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
   narrativeDominatedProfiles: narrativeDominatedProfiles.length, profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
+  profilesWithOrphanedPrimaryHumanEvidence: orphanedPrimaryHumanProfiles.length,
   profilesWithResearchGaps: researchGapQueue.length, canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
   systemicLoadBearingStudies: systemicLoadBearingStudies.length, repeatedEvidenceBundles: evidenceBundleReuse.length,
   narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length, nearDuplicateEvidencePairs: claimEvidenceOverlap.length,
@@ -124,8 +127,8 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 10, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', policy: 'lib/research-quality-policy.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', crossProfileStudyLoad: 'lib/research-study-load.ts', evidenceBundleReuse: 'lib/research-study-load.ts', claimEvidenceOverlap: 'lib/research-study-load.ts', evidenceAge: 'lib/research-evidence-age.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  schemaVersion: 11, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
   coreSummary, structuralFailures, citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
   withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
   oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
@@ -141,10 +144,11 @@ console.log(`Citation integrity: ${citationIntegrity.sources} sources · ${citat
 console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
 console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
 console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
+console.log(`Mapping gaps: ${coreSummary.profilesWithOrphanedPrimaryHumanEvidence} profile(s) contain orphaned primary-human evidence`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
 console.log(`Citation report: ${path.relative(ROOT, citationReportPath)}`)
 console.log(`Evidence-grade report: ${path.relative(ROOT, evidenceGradeReportPath)}`)
 console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
 if (failed) { console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.'); process.exit(1) }
-console.log('\n[research-quality] PASS — one-pass canonical research analysis, citation/source integrity, evidence grades, and structured integrity agree.')
+console.log('\n[research-quality] PASS — one canonical analysis/topology/policy snapshot plus citation/source integrity, evidence grades, and structured integrity agree.')


### PR DESCRIPTION
Adds `lib/research-quality-topology.ts` as the canonical derived-topology snapshot. Cross-profile study load, exact evidence-bundle reuse, near-duplicate claim overlap, and evidence-age analysis are now computed once and shared by both research-gap policy and roll-up reporting. Standalone policy callers retain a default snapshot builder for compatibility. This removes duplicate graph walks inside the canonical one-pass process.