### PR TITLE
refactor(research): distinguish evidence mapping states

### DIFF
--- a/lib/__tests__/research-orphaned-evidence.test.ts
+++ b/lib/__tests__/research-orphaned-evidence.test.ts
@@ -7,9 +7,9 @@ import { describe, expect, it } from 'vitest'
 import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
 import { buildResearchGapQueue } from '@/lib/research-quality-policy'
 
-describe('orphaned primary-human evidence', () => {
-  it('distinguishes an evidence-mapping gap from true absence of human research', () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'orphaned-human-'))
+describe('primary-human evidence mapping states', () => {
+  it('flags truly unmapped human evidence separately from true absence', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'unmapped-human-'))
     try {
       const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
       mkdirSync(detailDir, { recursive: true })
@@ -38,11 +38,63 @@ describe('orphaned primary-human evidence', () => {
       expect(profile).toMatchObject({
         primaryHuman: 1,
         claimLinkedPrimaryHuman: 0,
-        orphanedPrimaryHuman: 1,
+        structuredClaimLinkedPrimaryHuman: 0,
+        unmappedPrimaryHuman: 1,
+        unapprovedOnlyPrimaryHuman: 0,
         noPrimaryHuman: true,
       })
-      expect(gap?.reasonCounts['orphaned-primary-human-evidence']).toBe(1)
+      expect(gap?.reasonCounts['unmapped-primary-human-evidence']).toBe(1)
+      expect(gap?.reasonCounts['primary-human-evidence-only-on-unapproved-claims']).toBeUndefined()
       expect(gap?.reasonCounts['approved-claims-without-primary-human-study']).toBe(1)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('distinguishes human evidence already mapped to an unapproved claim', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pending-human-'))
+    try {
+      const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+      mkdirSync(detailDir, { recursive: true })
+      writeFileSync(path.join(detailDir, 'example.json'), JSON.stringify({
+        slug: 'example',
+        sources: [
+          { id: 'rct', pmid: '11111111', studyClass: 'rct' },
+          { id: 'review-1', pmid: '22222222', studyClass: 'narrative-review' },
+          { id: 'review-2', pmid: '33333333', studyClass: 'narrative-review' },
+        ],
+        claimMap: [
+          {
+            id: 'approved-outcome',
+            predicate: 'supports_outcome',
+            confidence: 0.7,
+            reviewStatus: 'approved',
+            sourceRefIds: ['review-1', 'review-2'],
+          },
+          {
+            id: 'pending-human',
+            predicate: 'supports_outcome',
+            confidence: 0.7,
+            reviewStatus: 'pending',
+            sourceRefIds: ['rct'],
+          },
+        ],
+      }))
+
+      const analysis = analyzeResearchQuality(root)
+      const profile = analysis.profileAnalyses[0]
+      const gap = buildResearchGapQueue(analysis).find((item) => item.url === '/herbs/example/')
+
+      expect(profile).toMatchObject({
+        primaryHuman: 1,
+        claimLinkedPrimaryHuman: 0,
+        structuredClaimLinkedPrimaryHuman: 1,
+        unmappedPrimaryHuman: 0,
+        unapprovedOnlyPrimaryHuman: 1,
+        noPrimaryHuman: true,
+      })
+      expect(gap?.reasonCounts['unmapped-primary-human-evidence']).toBeUndefined()
+      expect(gap?.reasonCounts['primary-human-evidence-only-on-unapproved-claims']).toBe(1)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/lib/__tests__/research-quality-topology.test.ts
+++ b/lib/__tests__/research-quality-topology.test.ts
@@ -55,7 +55,9 @@ function analysis(claims: ClaimQualityAnalysis[]): ResearchQualityAnalysis {
       sourceCount: 0,
       canonicalStudyCount: 0,
       claimLinkedCanonicalStudyCount: 0,
+      structuredClaimLinkedCanonicalStudyCount: 0,
       orphanedCanonicalStudyCount: 0,
+      unmappedCanonicalStudyCount: 0,
       claimCount: claims.filter((item) => item.url === url).length,
       approvedClaimCount: claims.filter((item) => item.url === url).length,
       supportedApprovedClaimCount: claims.filter((item) => item.url === url && item.studyCount > 0).length,
@@ -66,9 +68,12 @@ function analysis(claims: ClaimQualityAnalysis[]): ResearchQualityAnalysis {
       synthesis: 0,
       narrativeReview: 0,
       claimLinkedPrimaryHuman: 1,
+      structuredClaimLinkedPrimaryHuman: 1,
       claimLinkedSynthesis: 0,
       claimLinkedNarrativeReview: 0,
       orphanedPrimaryHuman: 0,
+      unmappedPrimaryHuman: 0,
+      unapprovedOnlyPrimaryHuman: 0,
       inventoryNarrativeToPrimaryHumanRatio: 0,
       narrativeToPrimaryHumanRatio: 0,
       narrativeDominatedVsPrimaryHuman: false,
@@ -180,8 +185,11 @@ describe('research evidence topology contracts', () => {
       const profile = analyzeResearchQuality(root).profileAnalyses[0]
       expect(profile.primaryHuman).toBe(1)
       expect(profile.claimLinkedPrimaryHuman).toBe(0)
+      expect(profile.structuredClaimLinkedPrimaryHuman).toBe(0)
       expect(profile.claimLinkedNarrativeReview).toBe(2)
       expect(profile.orphanedPrimaryHuman).toBe(1)
+      expect(profile.unmappedPrimaryHuman).toBe(1)
+      expect(profile.unapprovedOnlyPrimaryHuman).toBe(0)
       expect(profile.noPrimaryHuman).toBe(true)
       expect(profile.narrativeDominatedVsPrimaryHuman).toBe(true)
     } finally {

--- a/lib/research-quality-analysis.ts
+++ b/lib/research-quality-analysis.ts
@@ -65,7 +65,9 @@ export type ProfileQualityAnalysis = {
   sourceCount: number
   canonicalStudyCount: number
   claimLinkedCanonicalStudyCount: number
+  structuredClaimLinkedCanonicalStudyCount: number
   orphanedCanonicalStudyCount: number
+  unmappedCanonicalStudyCount: number
   claimCount: number
   approvedClaimCount: number
   supportedApprovedClaimCount: number
@@ -76,9 +78,12 @@ export type ProfileQualityAnalysis = {
   synthesis: number
   narrativeReview: number
   claimLinkedPrimaryHuman: number
+  structuredClaimLinkedPrimaryHuman: number
   claimLinkedSynthesis: number
   claimLinkedNarrativeReview: number
   orphanedPrimaryHuman: number
+  unmappedPrimaryHuman: number
+  unapprovedOnlyPrimaryHuman: number
   inventoryNarrativeToPrimaryHumanRatio: number | null
   narrativeToPrimaryHumanRatio: number | null
   narrativeDominatedVsPrimaryHuman: boolean
@@ -231,6 +236,7 @@ function analyzeProfile(
   const aliasCollapsedClaims: string[] = []
   const danglingSourceRefs: Array<{ claimId: string; sourceRefId: string }> = []
   const studyUse = new Map<string, number>()
+  const structuredStudyIds = new Set(claims.flatMap((claim) => claim.studyIds))
   let claimStudyEdges = 0
   let supportedApprovedClaimCount = 0
 
@@ -262,9 +268,19 @@ function analyzeProfile(
     if (NARRATIVE_STUDY_CLASSES.has(design)) claimLinkedNarrativeReview += 1
   }
 
+  let structuredClaimLinkedPrimaryHuman = 0
+  for (const studyId of structuredStudyIds) {
+    const design = context.studyDesigns.get(studyId) ?? 'unclassified'
+    if (PRIMARY_HUMAN_STUDY_CLASSES.has(design)) structuredClaimLinkedPrimaryHuman += 1
+  }
+
   const claimLinkedCanonicalStudyCount = studyUse.size
+  const structuredClaimLinkedCanonicalStudyCount = structuredStudyIds.size
   const orphanedCanonicalStudyCount = Math.max(0, context.studyGroups.size - claimLinkedCanonicalStudyCount)
+  const unmappedCanonicalStudyCount = Math.max(0, context.studyGroups.size - structuredClaimLinkedCanonicalStudyCount)
   const orphanedPrimaryHuman = Math.max(0, primaryHuman - claimLinkedPrimaryHuman)
+  const unmappedPrimaryHuman = Math.max(0, primaryHuman - structuredClaimLinkedPrimaryHuman)
+  const unapprovedOnlyPrimaryHuman = Math.max(0, structuredClaimLinkedPrimaryHuman - claimLinkedPrimaryHuman)
   const rankedStudyUse = [...studyUse.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
   const mostUsed = rankedStudyUse[0] ?? null
   const mostUsedStudyClaimCount = mostUsed?.[1] ?? 0
@@ -294,7 +310,9 @@ function analyzeProfile(
     sourceCount: context.sources.length,
     canonicalStudyCount: context.studyGroups.size,
     claimLinkedCanonicalStudyCount,
+    structuredClaimLinkedCanonicalStudyCount,
     orphanedCanonicalStudyCount,
+    unmappedCanonicalStudyCount,
     claimCount: allClaims.length,
     approvedClaimCount: approved.length,
     supportedApprovedClaimCount,
@@ -305,9 +323,12 @@ function analyzeProfile(
     synthesis,
     narrativeReview,
     claimLinkedPrimaryHuman,
+    structuredClaimLinkedPrimaryHuman,
     claimLinkedSynthesis,
     claimLinkedNarrativeReview,
     orphanedPrimaryHuman,
+    unmappedPrimaryHuman,
+    unapprovedOnlyPrimaryHuman,
     inventoryNarrativeToPrimaryHumanRatio:
       inventoryNarrativeToPrimaryHumanRatio === null ? null : round(inventoryNarrativeToPrimaryHumanRatio),
     narrativeToPrimaryHumanRatio: narrativeToPrimaryHumanRatio === null ? null : round(narrativeToPrimaryHumanRatio),

--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -30,8 +30,9 @@ export const RESEARCH_GAP_WEIGHTS = {
   unclassifiedStructuredSupport: 20,
   highConfidenceWeakClaimBonus: 15,
   noPrimaryHumanStudy: 20,
-  orphanedPrimaryHumanEvidence: 12,
-  orphanedHumanWhileClaimsNoPrimaryBonus: 8,
+  unmappedPrimaryHumanEvidence: 12,
+  unapprovedOnlyPrimaryHumanEvidence: 8,
+  mappingGapNoApprovedPrimaryBonus: 8,
   narrativeReviewDominatedProfile: 20,
   synthesisOnlyApprovedOutcome: 8,
   poorStudyMetadataCoverage: 12,
@@ -80,12 +81,7 @@ export function buildResearchGapQueue(
       add(claim.url, 'unsupported-approved-claim', RESEARCH_GAP_WEIGHTS.unsupportedApprovedClaim, claim.claimId)
     }
     for (const sourceRefId of claim.danglingSourceRefs) {
-      add(
-        claim.url,
-        'dangling-claim-source-edge',
-        RESEARCH_GAP_WEIGHTS.danglingClaimSourceEdge,
-        `${claim.claimId} -> ${sourceRefId}`,
-      )
+      add(claim.url, 'dangling-claim-source-edge', RESEARCH_GAP_WEIGHTS.danglingClaimSourceEdge, `${claim.claimId} -> ${sourceRefId}`)
     }
     if (claim.singleStudy) {
       const highConfidenceBonus = claim.confidence >= 0.75 ? RESEARCH_GAP_WEIGHTS.highConfidenceSingleStudyBonus : 0
@@ -98,68 +94,31 @@ export function buildResearchGapQueue(
       )
     }
     if (claim.outcomeClaim && claim.primaryHuman === 0 && claim.synthesis > 0) {
-      add(
-        claim.url,
-        'synthesis-only-approved-outcome',
-        RESEARCH_GAP_WEIGHTS.synthesisOnlyApprovedOutcome,
-        `${claim.claimId} · synthesis evidence present but no direct primary-human study`,
-      )
+      add(claim.url, 'synthesis-only-approved-outcome', RESEARCH_GAP_WEIGHTS.synthesisOnlyApprovedOutcome, `${claim.claimId} · synthesis evidence present but no direct primary-human study`)
     }
 
     if (claim.structuredSupportTier === 'unclassified') {
       const confidenceBonus = claim.highConfidenceWeakStructured ? RESEARCH_GAP_WEIGHTS.highConfidenceWeakClaimBonus : 0
-      add(
-        claim.url,
-        'claim-support-unclassified',
-        RESEARCH_GAP_WEIGHTS.unclassifiedStructuredSupport + confidenceBonus,
-        `${claim.claimId} · ${claim.predicate}${confidenceBonus ? ' · high confidence' : ''}`,
-      )
+      add(claim.url, 'claim-support-unclassified', RESEARCH_GAP_WEIGHTS.unclassifiedStructuredSupport + confidenceBonus, `${claim.claimId} · ${claim.predicate}${confidenceBonus ? ' · high confidence' : ''}`)
     } else if (claim.structuredSupportTier === 'narrative-only') {
-      const baseWeight = claim.outcomeClaim
-        ? RESEARCH_GAP_WEIGHTS.narrativeOnlyOutcomeSupport
-        : RESEARCH_GAP_WEIGHTS.narrativeOnlyOtherStructuredSupport
+      const baseWeight = claim.outcomeClaim ? RESEARCH_GAP_WEIGHTS.narrativeOnlyOutcomeSupport : RESEARCH_GAP_WEIGHTS.narrativeOnlyOtherStructuredSupport
       const confidenceBonus = claim.highConfidenceWeakStructured ? RESEARCH_GAP_WEIGHTS.highConfidenceWeakClaimBonus : 0
-      add(
-        claim.url,
-        'claim-support-narrative-only',
-        baseWeight + confidenceBonus,
-        `${claim.claimId} · ${claim.predicate}${confidenceBonus ? ' · high confidence' : ''}`,
-      )
+      add(claim.url, 'claim-support-narrative-only', baseWeight + confidenceBonus, `${claim.claimId} · ${claim.predicate}${confidenceBonus ? ' · high confidence' : ''}`)
     } else if (claim.supportTier === 'indirect-only') {
       const confidenceBonus = claim.highConfidenceWeakOutcome ? RESEARCH_GAP_WEIGHTS.highConfidenceWeakClaimBonus : 0
-      add(
-        claim.url,
-        'claim-support-indirect-only',
-        RESEARCH_GAP_WEIGHTS.indirectOutcomeSupport + confidenceBonus,
-        `${claim.claimId}${confidenceBonus ? ' · high confidence' : ''}`,
-      )
+      add(claim.url, 'claim-support-indirect-only', RESEARCH_GAP_WEIGHTS.indirectOutcomeSupport + confidenceBonus, `${claim.claimId}${confidenceBonus ? ' · high confidence' : ''}`)
     }
   }
 
   for (const claim of analysis.structuredClaimAnalyses.filter((item) => !item.approved)) {
     if (claim.structuredSupportTier === 'unsupported') {
-      add(
-        claim.url,
-        'unsupported-unapproved-structured-claim',
-        RESEARCH_GAP_WEIGHTS.unsupportedUnapprovedStructuredClaim,
-        `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`,
-      )
+      add(claim.url, 'unsupported-unapproved-structured-claim', RESEARCH_GAP_WEIGHTS.unsupportedUnapprovedStructuredClaim, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
       continue
     }
     if (claim.structuredSupportTier === 'unclassified' || claim.structuredSupportTier === 'narrative-only') {
-      add(
-        claim.url,
-        `unapproved-claim-support-${claim.structuredSupportTier}`,
-        RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim,
-        `${claim.claimId} · ${claim.predicate} · ${claim.reviewStatus || 'unreviewed'}`,
-      )
+      add(claim.url, `unapproved-claim-support-${claim.structuredSupportTier}`, RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim, `${claim.claimId} · ${claim.predicate} · ${claim.reviewStatus || 'unreviewed'}`)
     } else if (claim.supportTier === 'indirect-only') {
-      add(
-        claim.url,
-        'unapproved-claim-support-indirect-only',
-        RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim,
-        `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`,
-      )
+      add(claim.url, 'unapproved-claim-support-indirect-only', RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim, `${claim.claimId} · ${claim.reviewStatus || 'unreviewed'}`)
     }
   }
 
@@ -167,38 +126,31 @@ export function buildResearchGapQueue(
     if (profile.overDependentOnSingleStudy) {
       const share = profile.dominantStudySupportedClaimShare
       const concentrationBonus = Math.round(Math.min(15, profile.studyConcentrationIndex * 20))
-      add(
-        profile.url,
-        'high-study-dependency',
-        Math.round(25 + share * 30 + concentrationBonus),
-        `${Math.round(share * 100)}% of supported approved claims depend on one canonical study; effective study count ${profile.effectiveStudyCount}`,
-      )
+      add(profile.url, 'high-study-dependency', Math.round(25 + share * 30 + concentrationBonus), `${Math.round(share * 100)}% of supported approved claims depend on one canonical study; effective study count ${profile.effectiveStudyCount}`)
     }
     if (profile.narrativeDominatedVsPrimaryHuman) {
-      const ratio = profile.narrativeToPrimaryHumanRatio === null
-        ? 'no primary-human studies'
-        : `${profile.narrativeToPrimaryHumanRatio}:1 narrative-to-primary-human ratio`
-      add(
-        profile.url,
-        'narrative-review-dominated-profile',
-        RESEARCH_GAP_WEIGHTS.narrativeReviewDominatedProfile,
-        ratio,
-      )
+      const ratio = profile.narrativeToPrimaryHumanRatio === null ? 'no primary-human studies' : `${profile.narrativeToPrimaryHumanRatio}:1 narrative-to-primary-human ratio`
+      add(profile.url, 'narrative-review-dominated-profile', RESEARCH_GAP_WEIGHTS.narrativeReviewDominatedProfile, ratio)
     }
     if (profile.noPrimaryHuman) {
+      add(profile.url, 'approved-claims-without-primary-human-study', RESEARCH_GAP_WEIGHTS.noPrimaryHumanStudy)
+    }
+    if (profile.unmappedPrimaryHuman > 0) {
+      const bonus = profile.noPrimaryHuman ? RESEARCH_GAP_WEIGHTS.mappingGapNoApprovedPrimaryBonus : 0
       add(
         profile.url,
-        'approved-claims-without-primary-human-study',
-        RESEARCH_GAP_WEIGHTS.noPrimaryHumanStudy,
+        'unmapped-primary-human-evidence',
+        RESEARCH_GAP_WEIGHTS.unmappedPrimaryHumanEvidence + bonus,
+        `${profile.unmappedPrimaryHuman} primary-human stud${profile.unmappedPrimaryHuman === 1 ? 'y is' : 'ies are'} not linked to any structured claim${bonus ? '; approved claims also have no linked primary-human study' : ''}`,
       )
     }
-    if (profile.orphanedPrimaryHuman > 0) {
-      const mappingBonus = profile.noPrimaryHuman ? RESEARCH_GAP_WEIGHTS.orphanedHumanWhileClaimsNoPrimaryBonus : 0
+    if (profile.unapprovedOnlyPrimaryHuman > 0) {
+      const bonus = profile.noPrimaryHuman ? RESEARCH_GAP_WEIGHTS.mappingGapNoApprovedPrimaryBonus : 0
       add(
         profile.url,
-        'orphaned-primary-human-evidence',
-        RESEARCH_GAP_WEIGHTS.orphanedPrimaryHumanEvidence + mappingBonus,
-        `${profile.orphanedPrimaryHuman} primary-human stud${profile.orphanedPrimaryHuman === 1 ? 'y is' : 'ies are'} present in the profile but not linked to any approved claim${mappingBonus ? '; approved claims otherwise have no linked primary-human study' : ''}`,
+        'primary-human-evidence-only-on-unapproved-claims',
+        RESEARCH_GAP_WEIGHTS.unapprovedOnlyPrimaryHumanEvidence + bonus,
+        `${profile.unapprovedOnlyPrimaryHuman} primary-human stud${profile.unapprovedOnlyPrimaryHuman === 1 ? 'y is' : 'ies are'} linked to structured claims but none of those links reach an approved claim`,
       )
     }
 
@@ -206,23 +158,13 @@ export function buildResearchGapQueue(
     const classifiedStudies = Math.max(0, profile.canonicalStudyCount - unclassifiedStudies)
     const metadataCoverage = profile.canonicalStudyCount ? classifiedStudies / profile.canonicalStudyCount : 1
     if (profile.canonicalStudyCount >= 3 && metadataCoverage < 0.7) {
-      add(
-        profile.url,
-        'poor-study-metadata-coverage',
-        RESEARCH_GAP_WEIGHTS.poorStudyMetadataCoverage,
-        `${Math.round(metadataCoverage * 100)}% of canonical studies have classified study designs`,
-      )
+      add(profile.url, 'poor-study-metadata-coverage', RESEARCH_GAP_WEIGHTS.poorStudyMetadataCoverage, `${Math.round(metadataCoverage * 100)}% of canonical studies have classified study designs`)
     }
   }
 
   for (const bundle of topology.narrowRepeatedEvidenceBundles) {
     const reuseBonus = Math.min(10, Math.max(0, bundle.approvedClaimCount - 3) * 2)
-    add(
-      bundle.url,
-      'narrow-repeated-evidence-bundle',
-      RESEARCH_GAP_WEIGHTS.narrowRepeatedEvidenceBundle + reuseBonus,
-      `${bundle.approvedClaimCount} approved claims reuse the same ${bundle.studyCount}-study evidence bundle`,
-    )
+    add(bundle.url, 'narrow-repeated-evidence-bundle', RESEARCH_GAP_WEIGHTS.narrowRepeatedEvidenceBundle + reuseBonus, `${bundle.approvedClaimCount} approved claims reuse the same ${bundle.studyCount}-study evidence bundle`)
   }
 
   const overlapByProfile = new Map<string, typeof topology.claimEvidenceOverlap>()
@@ -235,12 +177,7 @@ export function buildResearchGapQueue(
     const crossPredicateCount = overlaps.filter((item) => item.differentPredicates).length
     const overlapBonus = Math.min(10, Math.max(0, overlaps.length - 1) * 2)
     const maxContainment = Math.max(...overlaps.map((item) => item.containment))
-    add(
-      url,
-      'near-duplicate-claim-evidence-support',
-      RESEARCH_GAP_WEIGHTS.nearDuplicateEvidenceSupport + overlapBonus,
-      `${overlaps.length} claim pair(s) share near-duplicate evidence; ${crossPredicateCount} cross-predicate; max containment ${Math.round(maxContainment * 100)}%`,
-    )
+    add(url, 'near-duplicate-claim-evidence-support', RESEARCH_GAP_WEIGHTS.nearDuplicateEvidenceSupport + overlapBonus, `${overlaps.length} claim pair(s) share near-duplicate evidence; ${crossPredicateCount} cross-predicate; max containment ${Math.round(maxContainment * 100)}%`)
   }
 
   const systemicByProfile = new Map<string, { studies: number; claims: number }>()
@@ -254,34 +191,17 @@ export function buildResearchGapQueue(
   }
   for (const [url, systemic] of systemicByProfile) {
     const studyBonus = Math.min(12, Math.max(0, systemic.studies - 1) * 2)
-    add(
-      url,
-      'systemic-load-bearing-study-dependency',
-      RESEARCH_GAP_WEIGHTS.systemicLoadBearingStudyDependency + studyBonus,
-      `${systemic.studies} site-wide load-bearing stud${systemic.studies === 1 ? 'y' : 'ies'} support ${systemic.claims} approved claim${systemic.claims === 1 ? '' : 's'} on this profile`,
-    )
+    add(url, 'systemic-load-bearing-study-dependency', RESEARCH_GAP_WEIGHTS.systemicLoadBearingStudyDependency + studyBonus, `${systemic.studies} site-wide load-bearing stud${systemic.studies === 1 ? 'y' : 'ies'} support ${systemic.claims} approved claim${systemic.claims === 1 ? '' : 's'} on this profile`)
   }
 
   for (const freshness of topology.claimEvidenceAge) {
     if (freshness.studyCount > 0 && freshness.knownYearCount === 0) {
-      add(
-        freshness.url,
-        'unknown-evidence-year-metadata',
-        RESEARCH_GAP_WEIGHTS.unknownEvidenceYearMetadata,
-        `${freshness.claimId} · publication year unknown for all ${freshness.studyCount} supporting studies`,
-      )
+      add(freshness.url, 'unknown-evidence-year-metadata', RESEARCH_GAP_WEIGHTS.unknownEvidenceYearMetadata, `${freshness.claimId} · publication year unknown for all ${freshness.studyCount} supporting studies`)
       continue
     }
     if (!freshness.legacyOnlyOutcomeClaim) continue
-    const confidenceBonus = freshness.highConfidenceLegacyOnlyClaim
-      ? RESEARCH_GAP_WEIGHTS.highConfidenceLegacyOnlyBonus
-      : 0
-    add(
-      freshness.url,
-      'legacy-only-outcome-evidence',
-      RESEARCH_GAP_WEIGHTS.legacyOnlyOutcomeClaim + confidenceBonus,
-      `${freshness.claimId} · newest known supporting study ${freshness.newestYear ?? 'unknown'}${confidenceBonus ? ' · high confidence' : ''}`,
-    )
+    const confidenceBonus = freshness.highConfidenceLegacyOnlyClaim ? RESEARCH_GAP_WEIGHTS.highConfidenceLegacyOnlyBonus : 0
+    add(freshness.url, 'legacy-only-outcome-evidence', RESEARCH_GAP_WEIGHTS.legacyOnlyOutcomeClaim + confidenceBonus, `${freshness.claimId} · newest known supporting study ${freshness.newestYear ?? 'unknown'}${confidenceBonus ? ' · high confidence' : ''}`)
   }
 
   return [...queue.values()]

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -63,7 +63,8 @@ const weakUnapprovedOutcomes = analysis.structuredClaimAnalyses.filter((claim) =
 const overDependentProfiles = analysis.profileAnalyses.filter((profile) => profile.overDependentOnSingleStudy)
 const narrativeDominatedProfiles = analysis.profileAnalyses.filter((profile) => profile.narrativeDominatedVsPrimaryHuman)
 const noPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.noPrimaryHuman)
-const orphanedPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.orphanedPrimaryHuman > 0)
+const unmappedPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.unmappedPrimaryHuman > 0)
+const unapprovedOnlyPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.unapprovedOnlyPrimaryHuman > 0)
 const corePassed = structuralFailures.length === 0 && sourceIntegrity.summary.withdrawn === 0
 const coreDurationMs = Date.now() - coreStarted
 
@@ -117,7 +118,8 @@ const coreSummary = {
   weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
   weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
   narrativeDominatedProfiles: narrativeDominatedProfiles.length, profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
-  profilesWithOrphanedPrimaryHumanEvidence: orphanedPrimaryHumanProfiles.length,
+  profilesWithUnmappedPrimaryHumanEvidence: unmappedPrimaryHumanProfiles.length,
+  profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims: unapprovedOnlyPrimaryHumanProfiles.length,
   profilesWithResearchGaps: researchGapQueue.length, canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
   systemicLoadBearingStudies: systemicLoadBearingStudies.length, repeatedEvidenceBundles: evidenceBundleReuse.length,
   narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length, nearDuplicateEvidencePairs: claimEvidenceOverlap.length,
@@ -127,7 +129,7 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 11, generatedAt: new Date().toISOString(), passed: !failed,
+  schemaVersion: 12, generatedAt: new Date().toISOString(), passed: !failed,
   source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
   coreSummary, structuralFailures, citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
   withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
@@ -144,7 +146,7 @@ console.log(`Citation integrity: ${citationIntegrity.sources} sources · ${citat
 console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
 console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
 console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
-console.log(`Mapping gaps: ${coreSummary.profilesWithOrphanedPrimaryHumanEvidence} profile(s) contain orphaned primary-human evidence`)
+console.log(`Mapping gaps: ${coreSummary.profilesWithUnmappedPrimaryHumanEvidence} profile(s) with unmapped primary-human evidence · ${coreSummary.profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims} with primary-human evidence only on unapproved claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
 console.log(`Citation report: ${path.relative(ROOT, citationReportPath)}`)
 console.log(`Evidence-grade report: ${path.relative(ROOT, evidenceGradeReportPath)}`)


### PR DESCRIPTION
Refines source-to-claim topology so evidence absent from approved claims is no longer treated as one ambiguous 'orphaned' bucket. The analyzer now distinguishes studies linked to approved claims, linked to any structured claim, completely unmapped studies, and primary-human evidence linked only to unapproved claims. Research-gap policy and the canonical roll-up score/report the two remediation paths separately, with focused tests for both states.