### PR TITLE
feat(research): expose study identity coverage

### DIFF
--- a/lib/__tests__/research-study-identity-coverage.test.ts
+++ b/lib/__tests__/research-study-identity-coverage.test.ts
@@ -1,0 +1,59 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+import { buildResearchGapQueue } from '@/lib/research-quality-policy'
+import { buildResearchQualityTopology } from '@/lib/research-quality-topology'
+
+describe('study identity coverage', () => {
+  it('surfaces uncertain independence when multi-study support includes fallback identities', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'study-identity-'))
+    try {
+      const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+      mkdirSync(detailDir, { recursive: true })
+      writeFileSync(path.join(detailDir, 'example.json'), JSON.stringify({
+        slug: 'example',
+        sources: [
+          { id: 'stable', pmid: '11111111', studyClass: 'rct' },
+          { id: 'anonymous', title: 'Anonymous clinical report', studyClass: 'rct' },
+        ],
+        claimMap: [
+          {
+            id: 'outcome',
+            predicate: 'supports_outcome',
+            confidence: 0.9,
+            reviewStatus: 'approved',
+            sourceRefIds: ['stable', 'anonymous'],
+          },
+        ],
+      }))
+
+      const analysis = analyzeResearchQuality(root)
+      const topology = buildResearchQualityTopology(analysis)
+      const claimCoverage = topology.studyIdentityCoverage.claims[0]
+      const profileCoverage = topology.studyIdentityCoverage.profiles[0]
+      const gap = buildResearchGapQueue(analysis, topology).find((item) => item.url === '/herbs/example/')
+
+      expect(claimCoverage).toMatchObject({
+        studyCount: 2,
+        stableIdentityCount: 1,
+        fallbackIdentityCount: 1,
+        stableIdentityCoverage: 0.5,
+        uncertainIndependence: true,
+        highConfidenceUncertainIndependence: true,
+      })
+      expect(profileCoverage).toMatchObject({
+        approvedStudyCount: 2,
+        stableIdentityCoverage: 0.5,
+        uncertainMultiStudyClaimCount: 1,
+        highConfidenceUncertainClaimCount: 1,
+      })
+      expect(gap?.reasonCounts['uncertain-study-identity-independence']).toBe(1)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -39,6 +39,9 @@ export const RESEARCH_GAP_WEIGHTS = {
   narrowRepeatedEvidenceBundle: 15,
   nearDuplicateEvidenceSupport: 10,
   systemicLoadBearingStudyDependency: 8,
+  uncertainStudyIdentityCoverage: 10,
+  highConfidenceIdentityUncertaintyBonus: 8,
+  weakIdentityCoverageBonus: 6,
   legacyOnlyOutcomeClaim: 8,
   highConfidenceLegacyOnlyBonus: 4,
   unknownEvidenceYearMetadata: 4,
@@ -67,7 +70,6 @@ export function buildResearchGapQueue(
   topology: ResearchQualityTopology = buildResearchQualityTopology(analysis),
 ): ResearchGapItem[] {
   const queue = new Map<string, { url: string; score: number; reasons: ResearchGapReason[] }>()
-
   const add = (url: string, kind: string, weight: number, detail?: string) => {
     if (!url) return
     const item = queue.get(url) ?? { url, score: 0, reasons: [] }
@@ -137,21 +139,11 @@ export function buildResearchGapQueue(
     }
     if (profile.unmappedPrimaryHuman > 0) {
       const bonus = profile.noPrimaryHuman ? RESEARCH_GAP_WEIGHTS.mappingGapNoApprovedPrimaryBonus : 0
-      add(
-        profile.url,
-        'unmapped-primary-human-evidence',
-        RESEARCH_GAP_WEIGHTS.unmappedPrimaryHumanEvidence + bonus,
-        `${profile.unmappedPrimaryHuman} primary-human stud${profile.unmappedPrimaryHuman === 1 ? 'y is' : 'ies are'} not linked to any structured claim${bonus ? '; approved claims also have no linked primary-human study' : ''}`,
-      )
+      add(profile.url, 'unmapped-primary-human-evidence', RESEARCH_GAP_WEIGHTS.unmappedPrimaryHumanEvidence + bonus, `${profile.unmappedPrimaryHuman} primary-human stud${profile.unmappedPrimaryHuman === 1 ? 'y is' : 'ies are'} not linked to any structured claim${bonus ? '; approved claims also have no linked primary-human study' : ''}`)
     }
     if (profile.unapprovedOnlyPrimaryHuman > 0) {
       const bonus = profile.noPrimaryHuman ? RESEARCH_GAP_WEIGHTS.mappingGapNoApprovedPrimaryBonus : 0
-      add(
-        profile.url,
-        'primary-human-evidence-only-on-unapproved-claims',
-        RESEARCH_GAP_WEIGHTS.unapprovedOnlyPrimaryHumanEvidence + bonus,
-        `${profile.unapprovedOnlyPrimaryHuman} primary-human stud${profile.unapprovedOnlyPrimaryHuman === 1 ? 'y is' : 'ies are'} linked to structured claims but none of those links reach an approved claim`,
-      )
+      add(profile.url, 'primary-human-evidence-only-on-unapproved-claims', RESEARCH_GAP_WEIGHTS.unapprovedOnlyPrimaryHumanEvidence + bonus, `${profile.unapprovedOnlyPrimaryHuman} primary-human stud${profile.unapprovedOnlyPrimaryHuman === 1 ? 'y is' : 'ies are'} linked to structured claims but none of those links reach an approved claim`)
     }
 
     const unclassifiedStudies = Number(profile.designMix.unclassified ?? 0)
@@ -192,6 +184,18 @@ export function buildResearchGapQueue(
   for (const [url, systemic] of systemicByProfile) {
     const studyBonus = Math.min(12, Math.max(0, systemic.studies - 1) * 2)
     add(url, 'systemic-load-bearing-study-dependency', RESEARCH_GAP_WEIGHTS.systemicLoadBearingStudyDependency + studyBonus, `${systemic.studies} site-wide load-bearing stud${systemic.studies === 1 ? 'y' : 'ies'} support ${systemic.claims} approved claim${systemic.claims === 1 ? '' : 's'} on this profile`)
+  }
+
+  for (const identity of topology.studyIdentityCoverage.profiles) {
+    if (identity.uncertainMultiStudyClaimCount === 0 && !identity.weakIdentityCoverage) continue
+    const highConfidenceBonus = identity.highConfidenceUncertainClaimCount > 0 ? RESEARCH_GAP_WEIGHTS.highConfidenceIdentityUncertaintyBonus : 0
+    const weakCoverageBonus = identity.weakIdentityCoverage ? RESEARCH_GAP_WEIGHTS.weakIdentityCoverageBonus : 0
+    add(
+      identity.url,
+      'uncertain-study-identity-independence',
+      RESEARCH_GAP_WEIGHTS.uncertainStudyIdentityCoverage + highConfidenceBonus + weakCoverageBonus,
+      `${identity.uncertainMultiStudyClaimCount} multi-study approved claim(s) include fallback source identities; ${Math.round(identity.stableIdentityCoverage * 100)}% of approved claim-linked studies have stable DOI/PMID identity${identity.highConfidenceUncertainClaimCount ? `; ${identity.highConfidenceUncertainClaimCount} high-confidence claim(s) affected` : ''}`,
+    )
   }
 
   for (const freshness of topology.claimEvidenceAge) {

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,5 +1,6 @@
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import { analyzeStudyIdentityCoverage } from './research-study-identity-coverage'
 import {
   analyzeClaimEvidenceOverlap,
   analyzeCrossProfileStudyLoad,
@@ -24,6 +25,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const evidenceAgeSummary = summarizeEvidenceAge(claimEvidenceAge)
   const legacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.allKnownEvidenceOlderThan10Years)
   const highConfidenceLegacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.highConfidenceLegacyOnlyClaim)
+  const studyIdentityCoverage = analyzeStudyIdentityCoverage(analysis)
 
   return {
     crossProfileStudyLoad,
@@ -36,5 +38,6 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     evidenceAgeSummary,
     legacyOnlyClaims,
     highConfidenceLegacyOnlyClaims,
+    studyIdentityCoverage,
   }
 }

--- a/lib/research-study-identity-coverage.ts
+++ b/lib/research-study-identity-coverage.ts
@@ -1,0 +1,132 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+const FALLBACK_PREFIX = 'source-ref:'
+
+export type ClaimStudyIdentityCoverage = {
+  url: string
+  claimId: string
+  confidence: number
+  studyCount: number
+  stableIdentityCount: number
+  fallbackIdentityCount: number
+  stableIdentityCoverage: number
+  uncertainIndependence: boolean
+  highConfidenceUncertainIndependence: boolean
+}
+
+export type ProfileStudyIdentityCoverage = {
+  url: string
+  approvedStudyCount: number
+  stableIdentityCount: number
+  fallbackIdentityCount: number
+  stableIdentityCoverage: number
+  uncertainMultiStudyClaimCount: number
+  highConfidenceUncertainClaimCount: number
+  weakIdentityCoverage: boolean
+}
+
+export type ResearchStudyIdentityCoverage = {
+  claims: ClaimStudyIdentityCoverage[]
+  profiles: ProfileStudyIdentityCoverage[]
+  summary: {
+    approvedClaims: number
+    uncertainMultiStudyClaims: number
+    highConfidenceUncertainClaims: number
+    profilesWithWeakIdentityCoverage: number
+  }
+}
+
+function round(value: number, digits = 3): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
+}
+
+function isFallbackIdentity(studyId: string): boolean {
+  return studyId.startsWith(FALLBACK_PREFIX)
+}
+
+/**
+ * Stable PMID/DOI identities let the topology deduplicate aliases confidently.
+ * `source-ref:*` identities preserve usable edges but cannot prove two records
+ * are independent publications, so they are reported as identity uncertainty.
+ */
+export function analyzeStudyIdentityCoverage(analysis: ResearchQualityAnalysis): ResearchStudyIdentityCoverage {
+  const claims: ClaimStudyIdentityCoverage[] = analysis.claimAnalyses.map((claim) => {
+    const fallbackIdentityCount = claim.studyIds.filter(isFallbackIdentity).length
+    const stableIdentityCount = claim.studyCount - fallbackIdentityCount
+    const stableIdentityCoverage = claim.studyCount ? stableIdentityCount / claim.studyCount : 1
+    const uncertainIndependence = claim.studyCount >= 2 && fallbackIdentityCount > 0
+    return {
+      url: claim.url,
+      claimId: claim.claimId,
+      confidence: claim.confidence,
+      studyCount: claim.studyCount,
+      stableIdentityCount,
+      fallbackIdentityCount,
+      stableIdentityCoverage: round(stableIdentityCoverage),
+      uncertainIndependence,
+      highConfidenceUncertainIndependence: uncertainIndependence && claim.confidence >= 0.75,
+    }
+  })
+
+  const byProfile = new Map<string, typeof claims>()
+  for (const claim of claims) {
+    const list = byProfile.get(claim.url) ?? []
+    list.push(claim)
+    byProfile.set(claim.url, list)
+  }
+
+  const approvedStudyIdsByProfile = new Map<string, Set<string>>()
+  for (const claim of analysis.claimAnalyses) {
+    const ids = approvedStudyIdsByProfile.get(claim.url) ?? new Set<string>()
+    for (const studyId of claim.studyIds) ids.add(studyId)
+    approvedStudyIdsByProfile.set(claim.url, ids)
+  }
+
+  const profiles: ProfileStudyIdentityCoverage[] = analysis.profileAnalyses.map((profile) => {
+    const studyIds = approvedStudyIdsByProfile.get(profile.url) ?? new Set<string>()
+    const fallbackIdentityCount = [...studyIds].filter(isFallbackIdentity).length
+    const approvedStudyCount = studyIds.size
+    const stableIdentityCount = approvedStudyCount - fallbackIdentityCount
+    const stableIdentityCoverage = approvedStudyCount ? stableIdentityCount / approvedStudyCount : 1
+    const profileClaims = byProfile.get(profile.url) ?? []
+    const uncertainMultiStudyClaimCount = profileClaims.filter((claim) => claim.uncertainIndependence).length
+    const highConfidenceUncertainClaimCount = profileClaims.filter((claim) => claim.highConfidenceUncertainIndependence).length
+    const weakIdentityCoverage =
+      approvedStudyCount >= 3 &&
+      (stableIdentityCoverage < 0.8 || uncertainMultiStudyClaimCount >= 2)
+
+    return {
+      url: profile.url,
+      approvedStudyCount,
+      stableIdentityCount,
+      fallbackIdentityCount,
+      stableIdentityCoverage: round(stableIdentityCoverage),
+      uncertainMultiStudyClaimCount,
+      highConfidenceUncertainClaimCount,
+      weakIdentityCoverage,
+    }
+  })
+
+  return {
+    claims: claims.sort((a, b) =>
+      Number(b.highConfidenceUncertainIndependence) - Number(a.highConfidenceUncertainIndependence)
+      || Number(b.uncertainIndependence) - Number(a.uncertainIndependence)
+      || a.stableIdentityCoverage - b.stableIdentityCoverage
+      || a.url.localeCompare(b.url)
+      || a.claimId.localeCompare(b.claimId),
+    ),
+    profiles: profiles.sort((a, b) =>
+      Number(b.weakIdentityCoverage) - Number(a.weakIdentityCoverage)
+      || b.highConfidenceUncertainClaimCount - a.highConfidenceUncertainClaimCount
+      || a.stableIdentityCoverage - b.stableIdentityCoverage
+      || a.url.localeCompare(b.url),
+    ),
+    summary: {
+      approvedClaims: claims.length,
+      uncertainMultiStudyClaims: claims.filter((claim) => claim.uncertainIndependence).length,
+      highConfidenceUncertainClaims: claims.filter((claim) => claim.highConfidenceUncertainIndependence).length,
+      profilesWithWeakIdentityCoverage: profiles.filter((profile) => profile.weakIdentityCoverage).length,
+    },
+  }
+}

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -54,6 +54,7 @@ const {
   evidenceAgeSummary,
   legacyOnlyClaims,
   highConfidenceLegacyOnlyClaims,
+  studyIdentityCoverage,
 } = topology
 const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
@@ -65,13 +66,15 @@ const narrativeDominatedProfiles = analysis.profileAnalyses.filter((profile) => 
 const noPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.noPrimaryHuman)
 const unmappedPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.unmappedPrimaryHuman > 0)
 const unapprovedOnlyPrimaryHumanProfiles = analysis.profileAnalyses.filter((profile) => profile.unapprovedOnlyPrimaryHuman > 0)
+const uncertainIdentityClaims = studyIdentityCoverage.claims.filter((claim) => claim.uncertainIndependence)
+const weakIdentityProfiles = studyIdentityCoverage.profiles.filter((profile) => profile.weakIdentityCoverage || profile.uncertainMultiStudyClaimCount > 0)
 const corePassed = structuralFailures.length === 0 && sourceIntegrity.summary.withdrawn === 0
 const coreDurationMs = Date.now() - coreStarted
 
 results.push({
   id: 'canonical-core', label: 'Canonical claim/profile/source research-quality analysis', passed: corePassed,
   exitCode: corePassed ? 0 : 1, durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
   stderrTail: [structuralFailures.length ? `${structuralFailures.length} invalid evidence edge(s)` : '', sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : ''].filter(Boolean).join('; '),
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
@@ -123,19 +126,22 @@ const coreSummary = {
   profilesWithResearchGaps: researchGapQueue.length, canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
   systemicLoadBearingStudies: systemicLoadBearingStudies.length, repeatedEvidenceBundles: evidenceBundleReuse.length,
   narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length, nearDuplicateEvidencePairs: claimEvidenceOverlap.length,
-  crossPredicateNearDuplicateEvidencePairs: crossPredicateEvidenceOverlap.length, sourceIntegrity: sourceIntegrity.summary,
+  crossPredicateNearDuplicateEvidencePairs: crossPredicateEvidenceOverlap.length,
+  studyIdentityCoverage: studyIdentityCoverage.summary,
+  sourceIntegrity: sourceIntegrity.summary,
   evidenceGradeConsistency: evidenceGradeConsistency.totals, evidenceAge: evidenceAgeSummary, aiCitationReadiness: aiCitationReadiness.summary,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 12, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  schemaVersion: 13, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
   coreSummary, structuralFailures, citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
   withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
   oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
   topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100), topClaimEvidenceOverlap: claimEvidenceOverlap.slice(0, 150),
+  uncertainStudyIdentityClaims: uncertainIdentityClaims.slice(0, 100), weakStudyIdentityCoverageProfiles: weakIdentityProfiles.slice(0, 100),
   highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100), topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100),
   topResearchGaps: researchGapQueue.slice(0, 50), topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
   checks: results, contentIntegritySummary: readSummary('content-integrity.json'),
@@ -146,6 +152,7 @@ console.log(`Citation integrity: ${citationIntegrity.sources} sources · ${citat
 console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
 console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
 console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
+console.log(`Study identity coverage: ${studyIdentityCoverage.summary.uncertainMultiStudyClaims} uncertain multi-study claim(s) · ${studyIdentityCoverage.summary.highConfidenceUncertainClaims} high-confidence · ${studyIdentityCoverage.summary.profilesWithWeakIdentityCoverage} weak-coverage profile(s)`)
 console.log(`Mapping gaps: ${coreSummary.profilesWithUnmappedPrimaryHumanEvidence} profile(s) with unmapped primary-human evidence · ${coreSummary.profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims} with primary-human evidence only on unapproved claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
 console.log(`Citation report: ${path.relative(ROOT, citationReportPath)}`)


### PR DESCRIPTION
Adds stable-identifier coverage to the canonical research topology so multi-study support is not treated as fully independent when some canonical study identities fall back to source-local IDs. Claims and profiles now expose DOI/PMID-backed versus fallback identity coverage; high-confidence uncertainty and weak profile identity coverage feed a moderate remediation signal. Includes an end-to-end regression test and roll-up reporting without assuming fallback records are duplicates.