### PR TITLE
feat(research): add edge-weighted design topology

### DIFF
--- a/lib/__tests__/research-design-usage.test.ts
+++ b/lib/__tests__/research-design-usage.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeEdgeWeightedDesignUsage } from '@/lib/research-design-usage'
+import type { ClaimQualityAnalysis, ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+function claim(
+  claimId: string,
+  designs: ClaimQualityAnalysis['designs'],
+): ClaimQualityAnalysis {
+  const studyIds = designs.map((_, index) => `${claimId}-study-${index}`)
+  return {
+    url: '/herbs/example/',
+    claimId,
+    reviewStatus: 'approved',
+    approved: true,
+    predicate: 'supports_outcome',
+    confidence: 0.7,
+    sourceRefCount: studyIds.length,
+    validSourceRefCount: studyIds.length,
+    danglingSourceRefs: [],
+    studyIds,
+    studyCount: studyIds.length,
+    classifiedStudyCount: designs.filter((design) => design !== 'unclassified').length,
+    primaryHuman: designs.filter((design) => design === 'rct').length,
+    synthesis: designs.filter((design) => design === 'systematic-review' || design === 'meta-analysis').length,
+    narrative: designs.filter((design) => design === 'narrative-review').length,
+    designs,
+    outcomeClaim: true,
+    supportTier: 'human-supported',
+    structuredSupportTier: studyIds.length === 1 ? 'single-study' : 'adequate',
+    weakStructuredClaim: studyIds.length === 1,
+    highConfidenceWeakStructured: false,
+    highConfidenceWeakOutcome: false,
+    singleStudy: studyIds.length === 1,
+    aliasCollapsed: false,
+  }
+}
+
+function analysis(claims: ClaimQualityAnalysis[]): ResearchQualityAnalysis {
+  return {
+    cache: {},
+    profiles: [],
+    profileAnalyses: [],
+    claimAnalyses: claims,
+    structuredClaimAnalyses: claims,
+  }
+}
+
+describe('edge-weighted research design usage', () => {
+  it('flags narrative dominance when review evidence carries most approved claim edges', () => {
+    const input = analysis([
+      claim('c1', ['narrative-review', 'rct']),
+      claim('c2', ['narrative-review']),
+      claim('c3', ['narrative-review']),
+      claim('c4', ['narrative-review', 'rct']),
+      claim('c5', ['narrative-review']),
+    ])
+
+    const result = analyzeEdgeWeightedDesignUsage(input)[0]
+
+    expect(result).toMatchObject({
+      claimStudyEdges: 7,
+      classifiedEdges: 7,
+      narrativeReviewEdges: 5,
+      primaryHumanEdges: 2,
+      edgeWeightedNarrativeDominated: true,
+    })
+    expect(result.narrativeReviewEdgeShare).toBeCloseTo(5 / 7, 3)
+    expect(result.narrativeToPrimaryHumanEdgeRatio).toBe(2.5)
+  })
+
+  it('does not flag a balanced claim-edge mix', () => {
+    const input = analysis([
+      claim('c1', ['rct', 'narrative-review']),
+      claim('c2', ['rct']),
+      claim('c3', ['narrative-review']),
+    ])
+
+    const result = analyzeEdgeWeightedDesignUsage(input)[0]
+    expect(result.primaryHumanEdges).toBe(2)
+    expect(result.narrativeReviewEdges).toBe(2)
+    expect(result.edgeWeightedNarrativeDominated).toBe(false)
+  })
+
+  it('tracks unclassified edges without letting them distort classified-design shares', () => {
+    const input = analysis([
+      claim('c1', ['narrative-review', 'unclassified']),
+      claim('c2', ['rct', 'unclassified']),
+    ])
+
+    const result = analyzeEdgeWeightedDesignUsage(input)[0]
+    expect(result).toMatchObject({
+      claimStudyEdges: 4,
+      classifiedEdges: 2,
+      unclassifiedEdges: 2,
+      narrativeReviewEdgeShare: 0.5,
+      primaryHumanEdgeShare: 0.5,
+    })
+  })
+})

--- a/lib/research-design-usage.ts
+++ b/lib/research-design-usage.ts
@@ -1,0 +1,107 @@
+import {
+  NARRATIVE_STUDY_CLASSES,
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  SYNTHESIS_STUDY_CLASSES,
+} from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type EdgeWeightedDesignUsage = {
+  url: string
+  claimStudyEdges: number
+  classifiedEdges: number
+  unclassifiedEdges: number
+  primaryHumanEdges: number
+  synthesisEdges: number
+  narrativeReviewEdges: number
+  otherClassifiedEdges: number
+  primaryHumanEdgeShare: number
+  synthesisEdgeShare: number
+  narrativeReviewEdgeShare: number
+  narrativeToPrimaryHumanEdgeRatio: number | null
+  edgeWeightedNarrativeDominated: boolean
+}
+
+function round(value: number, digits = 3): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
+}
+
+/**
+ * Count study-design usage by approved claim-study edge rather than only by
+ * unique study inventory. This answers a different question: which evidence
+ * classes actually carry the site's approved claims most often?
+ */
+export function analyzeEdgeWeightedDesignUsage(analysis: ResearchQualityAnalysis): EdgeWeightedDesignUsage[] {
+  const byUrl = new Map<string, {
+    claimStudyEdges: number
+    classifiedEdges: number
+    unclassifiedEdges: number
+    primaryHumanEdges: number
+    synthesisEdges: number
+    narrativeReviewEdges: number
+    otherClassifiedEdges: number
+  }>()
+
+  for (const claim of analysis.claimAnalyses) {
+    const item = byUrl.get(claim.url) ?? {
+      claimStudyEdges: 0,
+      classifiedEdges: 0,
+      unclassifiedEdges: 0,
+      primaryHumanEdges: 0,
+      synthesisEdges: 0,
+      narrativeReviewEdges: 0,
+      otherClassifiedEdges: 0,
+    }
+
+    for (const design of claim.designs) {
+      item.claimStudyEdges += 1
+      if (design === 'unclassified') {
+        item.unclassifiedEdges += 1
+        continue
+      }
+
+      item.classifiedEdges += 1
+      if (PRIMARY_HUMAN_STUDY_CLASSES.has(design)) item.primaryHumanEdges += 1
+      else if (SYNTHESIS_STUDY_CLASSES.has(design)) item.synthesisEdges += 1
+      else if (NARRATIVE_STUDY_CLASSES.has(design)) item.narrativeReviewEdges += 1
+      else item.otherClassifiedEdges += 1
+    }
+
+    byUrl.set(claim.url, item)
+  }
+
+  return [...byUrl.entries()]
+    .map(([url, item]) => {
+      const denominator = item.classifiedEdges || 1
+      const primaryHumanEdgeShare = item.primaryHumanEdges / denominator
+      const synthesisEdgeShare = item.synthesisEdges / denominator
+      const narrativeReviewEdgeShare = item.narrativeReviewEdges / denominator
+      const narrativeToPrimaryHumanEdgeRatio = item.primaryHumanEdges > 0
+        ? item.narrativeReviewEdges / item.primaryHumanEdges
+        : item.narrativeReviewEdges > 0
+          ? null
+          : 0
+      const edgeWeightedNarrativeDominated =
+        item.classifiedEdges >= 4
+        && item.narrativeReviewEdges >= 3
+        && narrativeReviewEdgeShare >= 0.6
+        && (item.primaryHumanEdges === 0 || item.narrativeReviewEdges >= item.primaryHumanEdges * 2)
+
+      return {
+        url,
+        ...item,
+        primaryHumanEdgeShare: round(primaryHumanEdgeShare),
+        synthesisEdgeShare: round(synthesisEdgeShare),
+        narrativeReviewEdgeShare: round(narrativeReviewEdgeShare),
+        narrativeToPrimaryHumanEdgeRatio:
+          narrativeToPrimaryHumanEdgeRatio === null ? null : round(narrativeToPrimaryHumanEdgeRatio),
+        edgeWeightedNarrativeDominated,
+      }
+    })
+    .sort((a, b) =>
+      Number(b.edgeWeightedNarrativeDominated) - Number(a.edgeWeightedNarrativeDominated)
+      || b.narrativeReviewEdgeShare - a.narrativeReviewEdgeShare
+      || b.claimStudyEdges - a.claimStudyEdges
+      || a.url.localeCompare(b.url),
+    )
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,3 +1,4 @@
+import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeStudyIdentityCoverage } from './research-study-identity-coverage'
@@ -26,6 +27,8 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const legacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.allKnownEvidenceOlderThan10Years)
   const highConfidenceLegacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.highConfidenceLegacyOnlyClaim)
   const studyIdentityCoverage = analyzeStudyIdentityCoverage(analysis)
+  const edgeWeightedDesignUsage = analyzeEdgeWeightedDesignUsage(analysis)
+  const edgeWeightedNarrativeDominatedProfiles = edgeWeightedDesignUsage.filter((profile) => profile.edgeWeightedNarrativeDominated)
 
   return {
     crossProfileStudyLoad,
@@ -39,5 +42,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     legacyOnlyClaims,
     highConfidenceLegacyOnlyClaims,
     studyIdentityCoverage,
+    edgeWeightedDesignUsage,
+    edgeWeightedNarrativeDominatedProfiles,
   }
 }

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -55,6 +55,8 @@ const {
   legacyOnlyClaims,
   highConfidenceLegacyOnlyClaims,
   studyIdentityCoverage,
+  edgeWeightedDesignUsage,
+  edgeWeightedNarrativeDominatedProfiles,
 } = topology
 const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
@@ -74,7 +76,7 @@ const coreDurationMs = Date.now() - coreStarted
 results.push({
   id: 'canonical-core', label: 'Canonical claim/profile/source research-quality analysis', passed: corePassed,
   exitCode: corePassed ? 0 : 1, durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; edgeWeightedNarrative=${edgeWeightedNarrativeDominatedProfiles.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
   stderrTail: [structuralFailures.length ? `${structuralFailures.length} invalid evidence edge(s)` : '', sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : ''].filter(Boolean).join('; '),
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
@@ -120,7 +122,8 @@ const coreSummary = {
   citationIntegrityProblems: citationIntegrity.blockingCount,
   weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
   weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
-  narrativeDominatedProfiles: narrativeDominatedProfiles.length, profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
+  narrativeDominatedProfiles: narrativeDominatedProfiles.length, edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.length,
+  profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
   profilesWithUnmappedPrimaryHumanEvidence: unmappedPrimaryHumanProfiles.length,
   profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims: unapprovedOnlyPrimaryHumanProfiles.length,
   profilesWithResearchGaps: researchGapQueue.length, canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
@@ -134,13 +137,14 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 13, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  schemaVersion: 14, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', designUsage: 'lib/research-design-usage.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
   coreSummary, structuralFailures, citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
   withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
   oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
   topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100), topClaimEvidenceOverlap: claimEvidenceOverlap.slice(0, 150),
+  edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.slice(0, 100), topEdgeWeightedDesignUsage: edgeWeightedDesignUsage.slice(0, 150),
   uncertainStudyIdentityClaims: uncertainIdentityClaims.slice(0, 100), weakStudyIdentityCoverageProfiles: weakIdentityProfiles.slice(0, 100),
   highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100), topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100),
   topResearchGaps: researchGapQueue.slice(0, 50), topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
@@ -152,6 +156,7 @@ console.log(`Citation integrity: ${citationIntegrity.sources} sources · ${citat
 console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
 console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
 console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
+console.log(`Design usage: ${edgeWeightedNarrativeDominatedProfiles.length} profile(s) narrative-dominated by approved claim-study edges`)
 console.log(`Study identity coverage: ${studyIdentityCoverage.summary.uncertainMultiStudyClaims} uncertain multi-study claim(s) · ${studyIdentityCoverage.summary.highConfidenceUncertainClaims} high-confidence · ${studyIdentityCoverage.summary.profilesWithWeakIdentityCoverage} weak-coverage profile(s)`)
 console.log(`Mapping gaps: ${coreSummary.profilesWithUnmappedPrimaryHumanEvidence} profile(s) with unmapped primary-human evidence · ${coreSummary.profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims} with primary-human evidence only on unapproved claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)


### PR DESCRIPTION
Adds approved claim-study edge weighting to research design topology. Unique study inventory remains intact, while the canonical topology now also measures how often primary-human, synthesis, narrative-review, other, and unclassified designs actually carry approved claims. This detects profiles where a small number of narrative reviews are reused across many claims despite a superficially balanced unique-study inventory. Includes focused tests and canonical roll-up reporting. Participant-count extraction remains excluded because its current output is explicitly an unreviewed human-review queue.