### PR TITLE
feat(research): detect evidence provenance concentration

### DIFF
--- a/lib/__tests__/research-provenance-concentration.test.ts
+++ b/lib/__tests__/research-provenance-concentration.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeProvenanceConcentration } from '@/lib/research-provenance-concentration'
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+
+function writeProfile(root: string, slug: string, record: Record<string, unknown>) {
+  const dir = path.join(root, 'public', 'data', 'herbs-detail')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, `${slug}.json`), JSON.stringify({ slug, ...record }))
+}
+
+function writeCache(root: string, records: Record<string, unknown>) {
+  const dir = path.join(root, 'ops', 'cache')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, 'pubmed-metadata.json'), JSON.stringify({ records }))
+}
+
+describe('research provenance concentration', () => {
+  it('flags repeated approved-claim dependence on one first-author lineage and journal', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'research-provenance-'))
+    try {
+      writeCache(root, {
+        '11111111': { authorList: ['Smith A', 'Jones B'], journal: 'Journal X' },
+        '22222222': { authorList: ['Smith A', 'Lee C'], journal: 'Journal X' },
+        '33333333': { authorList: ['Smith A', 'Patel D'], journal: 'Journal X' },
+      })
+      writeProfile(root, 'example', {
+        sources: [
+          { id: 's1', pmid: '11111111', studyClass: 'rct' },
+          { id: 's2', pmid: '22222222', studyClass: 'rct' },
+          { id: 's3', pmid: '33333333', studyClass: 'rct' },
+        ],
+        claimMap: [
+          { id: 'c1', predicate: 'supports_outcome', confidence: 0.8, reviewStatus: 'approved', sourceRefIds: ['s1', 's2'] },
+          { id: 'c2', predicate: 'supports_outcome', confidence: 0.8, reviewStatus: 'approved', sourceRefIds: ['s1'] },
+          { id: 'c3', predicate: 'supports_outcome', confidence: 0.8, reviewStatus: 'approved', sourceRefIds: ['s2'] },
+          { id: 'c4', predicate: 'supports_outcome', confidence: 0.8, reviewStatus: 'approved', sourceRefIds: ['s3'] },
+        ],
+      })
+
+      const result = analyzeProvenanceConcentration(analyzeResearchQuality(root))
+      const profile = result.profiles[0]
+
+      expect(profile).toMatchObject({
+        claimStudyEdges: 5,
+        authorKnownEdges: 5,
+        journalKnownEdges: 5,
+        dominantFirstAuthor: 'smith a',
+        dominantFirstAuthorEdges: 5,
+        dominantFirstAuthorStudyCount: 3,
+        dominantJournal: 'journal x',
+        dominantJournalEdges: 5,
+        dominantJournalStudyCount: 3,
+        firstAuthorConcentrated: true,
+        journalConcentrated: true,
+        provenanceConcentrated: true,
+      })
+      expect(result.summary.provenanceConcentratedProfiles).toBe(1)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not interpret missing author or journal metadata as concentration', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'research-provenance-missing-'))
+    try {
+      writeProfile(root, 'example', {
+        sources: [
+          { id: 's1', pmid: '11111111', studyClass: 'rct' },
+          { id: 's2', pmid: '22222222', studyClass: 'rct' },
+          { id: 's3', pmid: '33333333', studyClass: 'rct' },
+        ],
+        claimMap: [
+          { id: 'c1', predicate: 'supports_outcome', reviewStatus: 'approved', sourceRefIds: ['s1', 's2', 's3'] },
+          { id: 'c2', predicate: 'supports_outcome', reviewStatus: 'approved', sourceRefIds: ['s1', 's2', 's3'] },
+        ],
+      })
+
+      const profile = analyzeProvenanceConcentration(analyzeResearchQuality(root)).profiles[0]
+      expect(profile.authorMetadataCoverage).toBe(0)
+      expect(profile.journalMetadataCoverage).toBe(0)
+      expect(profile.firstAuthorConcentrated).toBe(false)
+      expect(profile.journalConcentrated).toBe(false)
+      expect(profile.provenanceConcentrated).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/lib/research-provenance-concentration.ts
+++ b/lib/research-provenance-concentration.ts
@@ -1,0 +1,187 @@
+import { canonicalStudyGroups } from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type ProvenanceConcentrationProfile = {
+  url: string
+  claimStudyEdges: number
+  authorKnownEdges: number
+  journalKnownEdges: number
+  authorMetadataCoverage: number
+  journalMetadataCoverage: number
+  dominantFirstAuthor: string | null
+  dominantFirstAuthorEdges: number
+  dominantFirstAuthorStudyCount: number
+  dominantFirstAuthorEdgeShare: number
+  dominantJournal: string | null
+  dominantJournalEdges: number
+  dominantJournalStudyCount: number
+  dominantJournalEdgeShare: number
+  firstAuthorConcentrated: boolean
+  journalConcentrated: boolean
+  provenanceConcentrated: boolean
+}
+
+export type ProvenanceConcentrationAnalysis = {
+  profiles: ProvenanceConcentrationProfile[]
+  summary: {
+    profilesAnalyzed: number
+    profilesWithSufficientAuthorMetadata: number
+    profilesWithSufficientJournalMetadata: number
+    firstAuthorConcentratedProfiles: number
+    journalConcentratedProfiles: number
+    provenanceConcentratedProfiles: number
+  }
+}
+
+type Provenance = { firstAuthor: string | null; journal: string | null }
+
+function round(value: number, digits = 3): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
+}
+
+function normalizeToken(value: unknown): string {
+  return String(value ?? '').trim().replace(/\s+/g, ' ')
+}
+
+function provenanceForGroup(
+  group: Array<Record<string, unknown>>,
+  cache: ResearchQualityAnalysis['cache'],
+): Provenance {
+  for (const source of group) {
+    const pmid = normalizeToken(source.pmid ?? source.pubmedId)
+    const meta = (cache[pmid] ?? {}) as { authorList?: unknown; authors?: unknown; journal?: unknown }
+    const authorList = Array.isArray(meta.authorList) ? meta.authorList.map(normalizeToken).filter(Boolean) : []
+    const firstAuthor = authorList[0]
+      || (Array.isArray(source.authorList) ? source.authorList.map(normalizeToken).filter(Boolean)[0] : '')
+      || normalizeToken(source.firstAuthor)
+    const journal = normalizeToken(source.journal || meta.journal)
+    if (firstAuthor || journal) {
+      return {
+        firstAuthor: firstAuthor ? firstAuthor.toLowerCase() : null,
+        journal: journal ? journal.toLowerCase() : null,
+      }
+    }
+  }
+  return { firstAuthor: null, journal: null }
+}
+
+function dominant(
+  edgeCounts: Map<string, number>,
+  studySets: Map<string, Set<string>>,
+): { key: string | null; edges: number; studies: number } {
+  const ranked = [...edgeCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+  const [key, edges] = ranked[0] ?? [null, 0]
+  return { key, edges, studies: key ? (studySets.get(key)?.size ?? 0) : 0 }
+}
+
+/**
+ * Measure whether approved claim-study edges are disproportionately carried by
+ * publications from the same first-author lineage or journal. Missing metadata
+ * only lowers coverage; it never counts as concentration.
+ */
+export function analyzeProvenanceConcentration(analysis: ResearchQualityAnalysis): ProvenanceConcentrationAnalysis {
+  const claimsByUrl = new Map<string, typeof analysis.claimAnalyses>()
+  for (const claim of analysis.claimAnalyses) {
+    const claims = claimsByUrl.get(claim.url) ?? []
+    claims.push(claim)
+    claimsByUrl.set(claim.url, claims)
+  }
+
+  const profiles: ProvenanceConcentrationProfile[] = []
+  for (const { url, record } of analysis.profiles) {
+    const claims = claimsByUrl.get(url) ?? []
+    if (!claims.length) continue
+
+    const groups = canonicalStudyGroups(record)
+    const provenanceByStudy = new Map<string, Provenance>()
+    for (const [studyId, group] of groups) provenanceByStudy.set(studyId, provenanceForGroup(group, analysis.cache))
+
+    const authorEdges = new Map<string, number>()
+    const journalEdges = new Map<string, number>()
+    const authorStudies = new Map<string, Set<string>>()
+    const journalStudies = new Map<string, Set<string>>()
+    let claimStudyEdges = 0
+    let authorKnownEdges = 0
+    let journalKnownEdges = 0
+
+    for (const claim of claims) {
+      for (const studyId of claim.studyIds) {
+        claimStudyEdges += 1
+        const provenance = provenanceByStudy.get(studyId)
+        if (!provenance) continue
+        if (provenance.firstAuthor) {
+          authorKnownEdges += 1
+          authorEdges.set(provenance.firstAuthor, (authorEdges.get(provenance.firstAuthor) ?? 0) + 1)
+          const studies = authorStudies.get(provenance.firstAuthor) ?? new Set<string>()
+          studies.add(studyId)
+          authorStudies.set(provenance.firstAuthor, studies)
+        }
+        if (provenance.journal) {
+          journalKnownEdges += 1
+          journalEdges.set(provenance.journal, (journalEdges.get(provenance.journal) ?? 0) + 1)
+          const studies = journalStudies.get(provenance.journal) ?? new Set<string>()
+          studies.add(studyId)
+          journalStudies.set(provenance.journal, studies)
+        }
+      }
+    }
+
+    const authorTop = dominant(authorEdges, authorStudies)
+    const journalTop = dominant(journalEdges, journalStudies)
+    const authorMetadataCoverage = claimStudyEdges ? authorKnownEdges / claimStudyEdges : 0
+    const journalMetadataCoverage = claimStudyEdges ? journalKnownEdges / claimStudyEdges : 0
+    const dominantFirstAuthorEdgeShare = authorKnownEdges ? authorTop.edges / authorKnownEdges : 0
+    const dominantJournalEdgeShare = journalKnownEdges ? journalTop.edges / journalKnownEdges : 0
+
+    const firstAuthorConcentrated =
+      authorKnownEdges >= 4
+      && authorMetadataCoverage >= 0.6
+      && authorTop.studies >= 2
+      && dominantFirstAuthorEdgeShare >= 0.6
+    const journalConcentrated =
+      journalKnownEdges >= 5
+      && journalMetadataCoverage >= 0.6
+      && journalTop.studies >= 3
+      && dominantJournalEdgeShare >= 0.7
+
+    profiles.push({
+      url,
+      claimStudyEdges,
+      authorKnownEdges,
+      journalKnownEdges,
+      authorMetadataCoverage: round(authorMetadataCoverage),
+      journalMetadataCoverage: round(journalMetadataCoverage),
+      dominantFirstAuthor: authorTop.key,
+      dominantFirstAuthorEdges: authorTop.edges,
+      dominantFirstAuthorStudyCount: authorTop.studies,
+      dominantFirstAuthorEdgeShare: round(dominantFirstAuthorEdgeShare),
+      dominantJournal: journalTop.key,
+      dominantJournalEdges: journalTop.edges,
+      dominantJournalStudyCount: journalTop.studies,
+      dominantJournalEdgeShare: round(dominantJournalEdgeShare),
+      firstAuthorConcentrated,
+      journalConcentrated,
+      provenanceConcentrated: firstAuthorConcentrated || journalConcentrated,
+    })
+  }
+
+  profiles.sort((a, b) =>
+    Number(b.provenanceConcentrated) - Number(a.provenanceConcentrated)
+    || Math.max(b.dominantFirstAuthorEdgeShare, b.dominantJournalEdgeShare) - Math.max(a.dominantFirstAuthorEdgeShare, a.dominantJournalEdgeShare)
+    || b.claimStudyEdges - a.claimStudyEdges
+    || a.url.localeCompare(b.url),
+  )
+
+  return {
+    profiles,
+    summary: {
+      profilesAnalyzed: profiles.length,
+      profilesWithSufficientAuthorMetadata: profiles.filter((profile) => profile.authorMetadataCoverage >= 0.6).length,
+      profilesWithSufficientJournalMetadata: profiles.filter((profile) => profile.journalMetadataCoverage >= 0.6).length,
+      firstAuthorConcentratedProfiles: profiles.filter((profile) => profile.firstAuthorConcentrated).length,
+      journalConcentratedProfiles: profiles.filter((profile) => profile.journalConcentrated).length,
+      provenanceConcentratedProfiles: profiles.filter((profile) => profile.provenanceConcentrated).length,
+    },
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,5 +1,6 @@
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
+import { analyzeProvenanceConcentration } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeStudyIdentityCoverage } from './research-study-identity-coverage'
 import {
@@ -29,6 +30,8 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const studyIdentityCoverage = analyzeStudyIdentityCoverage(analysis)
   const edgeWeightedDesignUsage = analyzeEdgeWeightedDesignUsage(analysis)
   const edgeWeightedNarrativeDominatedProfiles = edgeWeightedDesignUsage.filter((profile) => profile.edgeWeightedNarrativeDominated)
+  const provenanceConcentration = analyzeProvenanceConcentration(analysis)
+  const provenanceConcentratedProfiles = provenanceConcentration.profiles.filter((profile) => profile.provenanceConcentrated)
 
   return {
     crossProfileStudyLoad,
@@ -44,5 +47,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     studyIdentityCoverage,
     edgeWeightedDesignUsage,
     edgeWeightedNarrativeDominatedProfiles,
+    provenanceConcentration,
+    provenanceConcentratedProfiles,
   }
 }

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -57,6 +57,8 @@ const {
   studyIdentityCoverage,
   edgeWeightedDesignUsage,
   edgeWeightedNarrativeDominatedProfiles,
+  provenanceConcentration,
+  provenanceConcentratedProfiles,
 } = topology
 const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
@@ -76,7 +78,7 @@ const coreDurationMs = Date.now() - coreStarted
 results.push({
   id: 'canonical-core', label: 'Canonical claim/profile/source research-quality analysis', passed: corePassed,
   exitCode: corePassed ? 0 : 1, durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; edgeWeightedNarrative=${edgeWeightedNarrativeDominatedProfiles.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; edgeWeightedNarrative=${edgeWeightedNarrativeDominatedProfiles.length}; provenanceConcentrated=${provenanceConcentratedProfiles.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
   stderrTail: [structuralFailures.length ? `${structuralFailures.length} invalid evidence edge(s)` : '', sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : ''].filter(Boolean).join('; '),
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
@@ -123,6 +125,7 @@ const coreSummary = {
   weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
   weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
   narrativeDominatedProfiles: narrativeDominatedProfiles.length, edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.length,
+  provenanceConcentratedProfiles: provenanceConcentratedProfiles.length,
   profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
   profilesWithUnmappedPrimaryHumanEvidence: unmappedPrimaryHumanProfiles.length,
   profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims: unapprovedOnlyPrimaryHumanProfiles.length,
@@ -131,20 +134,22 @@ const coreSummary = {
   narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length, nearDuplicateEvidencePairs: claimEvidenceOverlap.length,
   crossPredicateNearDuplicateEvidencePairs: crossPredicateEvidenceOverlap.length,
   studyIdentityCoverage: studyIdentityCoverage.summary,
+  provenanceConcentration: provenanceConcentration.summary,
   sourceIntegrity: sourceIntegrity.summary,
   evidenceGradeConsistency: evidenceGradeConsistency.totals, evidenceAge: evidenceAgeSummary, aiCitationReadiness: aiCitationReadiness.summary,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 14, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', designUsage: 'lib/research-design-usage.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  schemaVersion: 15, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', designUsage: 'lib/research-design-usage.ts', provenanceConcentration: 'lib/research-provenance-concentration.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
   coreSummary, structuralFailures, citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
   withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
   oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
   topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100), topClaimEvidenceOverlap: claimEvidenceOverlap.slice(0, 150),
   edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.slice(0, 100), topEdgeWeightedDesignUsage: edgeWeightedDesignUsage.slice(0, 150),
+  provenanceConcentratedProfiles: provenanceConcentratedProfiles.slice(0, 100), topProvenanceConcentration: provenanceConcentration.profiles.slice(0, 150),
   uncertainStudyIdentityClaims: uncertainIdentityClaims.slice(0, 100), weakStudyIdentityCoverageProfiles: weakIdentityProfiles.slice(0, 100),
   highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100), topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100),
   topResearchGaps: researchGapQueue.slice(0, 50), topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
@@ -157,6 +162,7 @@ console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies �
 console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
 console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
 console.log(`Design usage: ${edgeWeightedNarrativeDominatedProfiles.length} profile(s) narrative-dominated by approved claim-study edges`)
+console.log(`Provenance: ${provenanceConcentration.summary.provenanceConcentratedProfiles} concentrated profile(s) · ${provenanceConcentration.summary.firstAuthorConcentratedProfiles} first-author · ${provenanceConcentration.summary.journalConcentratedProfiles} journal`)
 console.log(`Study identity coverage: ${studyIdentityCoverage.summary.uncertainMultiStudyClaims} uncertain multi-study claim(s) · ${studyIdentityCoverage.summary.highConfidenceUncertainClaims} high-confidence · ${studyIdentityCoverage.summary.profilesWithWeakIdentityCoverage} weak-coverage profile(s)`)
 console.log(`Mapping gaps: ${coreSummary.profilesWithUnmappedPrimaryHumanEvidence} profile(s) with unmapped primary-human evidence · ${coreSummary.profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims} with primary-human evidence only on unapproved claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)


### PR DESCRIPTION
Adds coverage-aware provenance topology for approved claim evidence. The canonical snapshot now measures whether claim-study edges are disproportionately carried by the same first-author lineage or journal, requiring multiple canonical studies and sufficient metadata coverage before flagging concentration. Missing author/journal metadata never counts as concentration. Includes focused tests and roll-up reporting.