### PR TITLE
refactor(library): align master directory with primary navigation

### DIFF
--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -36,9 +36,9 @@ export const metadata: Metadata = {
 const quickStarts = [
   {
     title: 'I have a health goal',
-    description: 'Start with organized guidance for sleep, ADHD, anxiety, focus, or mental health.',
-    href: '/guides/',
-    action: 'Browse topics',
+    description: 'Choose the outcome or question first, then follow the evidence to relevant options.',
+    href: '/goals/',
+    action: 'Choose a goal',
     Icon: Brain,
   },
   {
@@ -65,10 +65,12 @@ const directorySections = [
     description: 'Start with the problem you are trying to understand rather than guessing which ingredient page to open.',
     Icon: Brain,
     links: [
+      { label: 'Goal finder', href: '/goals/', detail: 'Choose the outcome or question you are researching' },
       { label: 'Mental Health', href: '/guides/mental-health/', detail: 'Conditions, treatment evidence, safety, and stigma-aware explainers' },
       { label: 'ADHD', href: '/guides/adhd/', detail: 'Attention, executive function, nutrients, and treatment context' },
       { label: 'Sleep', href: '/guides/sleep/', detail: 'Sleep aids, alternatives, and sleep-hygiene evidence' },
-      { label: 'Anxiety & Stress', href: '/guides/anxiety/', detail: 'Calming supports, adaptogens, and stress-management evidence' },
+      { label: 'Stress', href: '/guides/stress/', detail: 'Acute tension, chronic overload, burnout, and stress-support evidence' },
+      { label: 'Anxiety', href: '/guides/anxiety/', detail: 'Calming supports, overthinking, tension, and anxiety-focused evidence' },
       { label: 'Focus & Cognition', href: '/guides/focus/', detail: 'Focus support, nootropics, and cognitive performance' },
       { label: 'More supplement topics', href: '/guides/other/', detail: 'Forms, quality, routines, advanced compounds, and harm reduction' },
     ],
@@ -179,10 +181,11 @@ export default function SiteDirectoryPage() {
           <aside className='rounded-3xl border border-brand-900/10 bg-brand-50/55 p-5'>
             <p className='text-sm font-bold text-ink'>How the site is organized</p>
             <ol className='mt-4 space-y-4 text-sm leading-6 text-muted'>
-              <li><strong className='text-ink'>1. Topics</strong> answer a health or practical question.</li>
+              <li><strong className='text-ink'>1. Goals</strong> start with the outcome or question you are researching.</li>
               <li><strong className='text-ink'>2. Ingredients</strong> provide structured herb and compound profiles.</li>
-              <li><strong className='text-ink'>3. Research</strong> explains evidence, mechanisms, and uncertainty.</li>
-              <li><strong className='text-ink'>4. Tools</strong> help check safety, evidence strength, and dosing context.</li>
+              <li><strong className='text-ink'>3. Compare</strong> puts options side by side by evidence and tradeoffs.</li>
+              <li><strong className='text-ink'>4. Safety</strong> surfaces interactions, contraindications, and stacking context.</li>
+              <li><strong className='text-ink'>5. Research</strong> explains evidence, methods, citations, and uncertainty.</li>
             </ol>
           </aside>
         </div>


### PR DESCRIPTION
## Summary
- Routes the health-goal quick start through the canonical `/goals/` finder instead of bypassing it to `/guides/`.
- Adds the Goal finder to the health-goal directory section.
- Splits Stress and Anxiety into their real distinct hubs instead of labeling an Anxiety URL as `Anxiety & Stress`.
- Updates the “How the site is organized” explainer to match the actual top-level architecture: Goals, Ingredients, Compare, Safety, Research.

## Why
The master directory had drifted from the global navigation. It taught a different taxonomy than the header and incorrectly merged Stress into an Anxiety route. This makes the site explain itself consistently.

## Regression contract
- No routes are removed.
- Existing guide, ingredient, research, safety, and specialty links remain available.
- This only corrects routing hierarchy and labels to match the canonical navigation model.