### PR TITLE
Add claim-level evidence diversity topology

### DIFF
--- a/lib/research-claim-evidence-diversity.ts
+++ b/lib/research-claim-evidence-diversity.ts
@@ -1,0 +1,67 @@
+import {
+  NARRATIVE_STUDY_CLASSES,
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  SYNTHESIS_STUDY_CLASSES,
+} from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { StudyClass } from './study-class'
+
+export type EvidenceFamily = 'primary-human' | 'synthesis' | 'narrative' | 'other' | 'unclassified'
+
+export type ClaimEvidenceDiversity = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  studyCount: number
+  distinctDesignCount: number
+  distinctEvidenceFamilyCount: number
+  evidenceFamilies: EvidenceFamily[]
+  homogeneousMultiStudySupport: boolean
+  highConfidenceHomogeneousMultiStudySupport: boolean
+}
+
+function familyForDesign(design: StudyClass): EvidenceFamily {
+  if (PRIMARY_HUMAN_STUDY_CLASSES.has(design)) return 'primary-human'
+  if (SYNTHESIS_STUDY_CLASSES.has(design)) return 'synthesis'
+  if (NARRATIVE_STUDY_CLASSES.has(design)) return 'narrative'
+  if (design === 'unclassified') return 'unclassified'
+  return 'other'
+}
+
+/**
+ * Measure evidence diversity at the approved-claim level. Citation count alone
+ * can overstate robustness when several studies all come from one broad design
+ * family. This analysis does not downgrade same-family evidence automatically;
+ * it exposes homogeneous multi-study support as a topology signal for triage.
+ */
+export function analyzeClaimEvidenceDiversity(analysis: ResearchQualityAnalysis): ClaimEvidenceDiversity[] {
+  return analysis.claimAnalyses
+    .map((claim) => {
+      const distinctDesignCount = new Set(claim.designs).size
+      const evidenceFamilies = [...new Set(claim.designs.map(familyForDesign))].sort() as EvidenceFamily[]
+      const distinctEvidenceFamilyCount = evidenceFamilies.length
+      const homogeneousMultiStudySupport = claim.studyCount >= 2 && distinctEvidenceFamilyCount === 1
+
+      return {
+        url: claim.url,
+        claimId: claim.claimId,
+        predicate: claim.predicate,
+        confidence: claim.confidence,
+        studyCount: claim.studyCount,
+        distinctDesignCount,
+        distinctEvidenceFamilyCount,
+        evidenceFamilies,
+        homogeneousMultiStudySupport,
+        highConfidenceHomogeneousMultiStudySupport: homogeneousMultiStudySupport && claim.confidence >= 0.75,
+      }
+    })
+    .sort((a, b) =>
+      Number(b.highConfidenceHomogeneousMultiStudySupport) - Number(a.highConfidenceHomogeneousMultiStudySupport)
+      || Number(b.homogeneousMultiStudySupport) - Number(a.homogeneousMultiStudySupport)
+      || b.studyCount - a.studyCount
+      || b.confidence - a.confidence
+      || a.url.localeCompare(b.url)
+      || a.claimId.localeCompare(b.claimId),
+    )
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,3 +1,4 @@
+import { analyzeClaimEvidenceDiversity } from './research-claim-evidence-diversity'
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import { analyzeProvenanceConcentration } from './research-provenance-concentration'
@@ -32,6 +33,11 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const edgeWeightedNarrativeDominatedProfiles = edgeWeightedDesignUsage.filter((profile) => profile.edgeWeightedNarrativeDominated)
   const provenanceConcentration = analyzeProvenanceConcentration(analysis)
   const provenanceConcentratedProfiles = provenanceConcentration.profiles.filter((profile) => profile.provenanceConcentrated)
+  const claimEvidenceDiversity = analyzeClaimEvidenceDiversity(analysis)
+  const homogeneousMultiStudyClaims = claimEvidenceDiversity.filter((claim) => claim.homogeneousMultiStudySupport)
+  const highConfidenceHomogeneousMultiStudyClaims = claimEvidenceDiversity.filter(
+    (claim) => claim.highConfidenceHomogeneousMultiStudySupport,
+  )
 
   return {
     crossProfileStudyLoad,
@@ -49,5 +55,8 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     edgeWeightedNarrativeDominatedProfiles,
     provenanceConcentration,
     provenanceConcentratedProfiles,
+    claimEvidenceDiversity,
+    homogeneousMultiStudyClaims,
+    highConfidenceHomogeneousMultiStudyClaims,
   }
 }


### PR DESCRIPTION
Adds canonical claim-level evidence-diversity analysis to distinguish multi-study support that still comes from only one broad evidence family. Exposes homogeneous and high-confidence homogeneous multi-study claims through the canonical topology snapshot without yet changing scoring policy.