### PR TITLE
feat(research): calibrate causal claim language to study design

### DIFF
--- a/lib/research-claim-language-calibration.ts
+++ b/lib/research-claim-language-calibration.ts
@@ -1,0 +1,145 @@
+import {
+  approvedClaims,
+  type ResearchClaim,
+} from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type ClaimLanguageCalibrationFinding = {
+  url: string
+  claimId: string
+  confidence: number
+  claim: string
+  causalTerms: string[]
+  hedged: boolean
+  controlledHuman: number
+  uncontrolledHuman: number
+  synthesis: number
+  narrative: number
+  causalWithoutControlledSupport: boolean
+  highConfidenceCausalWithoutControlledSupport: boolean
+}
+
+export type ClaimLanguageCalibrationReport = {
+  generatedAt: string
+  summary: {
+    approvedOutcomeClaims: number
+    directCausalOutcomeClaims: number
+    causalWithoutControlledSupport: number
+    highConfidenceCausalWithoutControlledSupport: number
+  }
+  findings: ClaimLanguageCalibrationFinding[]
+  highConfidenceFindings: ClaimLanguageCalibrationFinding[]
+}
+
+const CAUSAL_PATTERNS: Array<[string, RegExp]> = [
+  ['improves', /\bimprov(?:e|es|ed|ing)\b/i],
+  ['reduces', /\breduc(?:e|es|ed|ing)\b/i],
+  ['increases', /\bincreas(?:e|es|ed|ing)\b/i],
+  ['decreases', /\bdecreas(?:e|es|ed|ing)\b/i],
+  ['lowers', /\blower(?:s|ed|ing)?\b/i],
+  ['raises', /\brais(?:e|es|ed|ing)\b/i],
+  ['prevents', /\bprevent(?:s|ed|ing)?\b/i],
+  ['treats', /\btreat(?:s|ed|ing)?\b/i],
+  ['causes', /\bcaus(?:e|es|ed|ing)\b/i],
+  ['enhances', /\benhanc(?:e|es|ed|ing)\b/i],
+  ['protects', /\bprotect(?:s|ed|ing)?\b/i],
+]
+
+const HEDGE_PATTERNS = [
+  /\bmay\b/i,
+  /\bmight\b/i,
+  /\bcould\b/i,
+  /\bpossible\b/i,
+  /\bpossibly\b/i,
+  /\bsuggest(?:s|ed)?\b/i,
+  /\bappears?\b/i,
+  /\bassociated with\b/i,
+  /\bwas associated\b/i,
+  /\bpotential(?:ly)?\b/i,
+  /\bpreliminary\b/i,
+  /\blimited evidence\b/i,
+  /\buncertain\b/i,
+  /\bnot establish\b/i,
+]
+
+function text(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function causalTerms(value: string): string[] {
+  return CAUSAL_PATTERNS.filter(([, pattern]) => pattern.test(value)).map(([label]) => label)
+}
+
+function isHedged(value: string): boolean {
+  return HEDGE_PATTERNS.some((pattern) => pattern.test(value))
+}
+
+function rawClaimIndex(analysis: ResearchQualityAnalysis): Map<string, ResearchClaim> {
+  const index = new Map<string, ResearchClaim>()
+  for (const { url, record } of analysis.profiles) {
+    for (const claim of approvedClaims(record)) {
+      index.set(`${url}::${text(claim.id)}`, claim)
+    }
+  }
+  return index
+}
+
+export function analyzeClaimLanguageCalibration(analysis: ResearchQualityAnalysis): ClaimLanguageCalibrationReport {
+  const rawClaims = rawClaimIndex(analysis)
+  const findings: ClaimLanguageCalibrationFinding[] = []
+  let approvedOutcomeClaims = 0
+  let directCausalOutcomeClaims = 0
+
+  for (const claim of analysis.claimAnalyses) {
+    if (!claim.outcomeClaim) continue
+    approvedOutcomeClaims += 1
+
+    const raw = rawClaims.get(`${claim.url}::${claim.claimId}`)
+    const claimText = text(raw?.claim)
+    if (!claimText) continue
+
+    const terms = causalTerms(claimText)
+    const hedged = isHedged(claimText)
+    if (!terms.length || hedged) continue
+    directCausalOutcomeClaims += 1
+
+    const controlledHuman = claim.designs.filter((design) => design === 'rct' || design === 'controlled-trial').length
+    const uncontrolledHuman = claim.designs.filter((design) => design === 'uncontrolled-trial').length
+    const synthesis = claim.synthesis
+    const narrative = claim.narrative
+    const causalWithoutControlledSupport = controlledHuman === 0 && synthesis === 0
+    const highConfidenceCausalWithoutControlledSupport = causalWithoutControlledSupport && claim.confidence >= 0.75
+
+    if (!causalWithoutControlledSupport) continue
+
+    findings.push({
+      url: claim.url,
+      claimId: claim.claimId,
+      confidence: claim.confidence,
+      claim: claimText,
+      causalTerms: terms,
+      hedged,
+      controlledHuman,
+      uncontrolledHuman,
+      synthesis,
+      narrative,
+      causalWithoutControlledSupport,
+      highConfidenceCausalWithoutControlledSupport,
+    })
+  }
+
+  findings.sort((a, b) => b.confidence - a.confidence || a.url.localeCompare(b.url) || a.claimId.localeCompare(b.claimId))
+  const highConfidenceFindings = findings.filter((finding) => finding.highConfidenceCausalWithoutControlledSupport)
+
+  return {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      approvedOutcomeClaims,
+      directCausalOutcomeClaims,
+      causalWithoutControlledSupport: findings.length,
+      highConfidenceCausalWithoutControlledSupport: highConfidenceFindings.length,
+    },
+    findings,
+    highConfidenceFindings,
+  }
+}

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -8,6 +8,7 @@ import path from 'node:path'
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
 import { analyzeCitationIntegrity, writeCitationIntegrityReport } from '../../lib/citation-integrity.mjs'
 import { analyzeEvidenceGradeConsistency, writeEvidenceGradeConsistencyReport } from '../../lib/evidence-grade-consistency'
+import { analyzeClaimLanguageCalibration } from '../../lib/research-claim-language-calibration'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchGapQueue, structuralCoverageFailures } from '../../lib/research-quality-policy'
 import { buildResearchQualityTopology } from '../../lib/research-quality-topology'
@@ -46,6 +47,7 @@ const researchGapQueue = buildResearchGapQueue(analysis, topology)
 const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
 const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
 const semanticReportPath = writeResearchSemanticAlignmentReport(semanticAlignment, ROOT)
+const languageCalibration = analyzeClaimLanguageCalibration(analysis)
 const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
 const citationReportPath = writeCitationIntegrityReport(citationIntegrity, ROOT)
 const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(ROOT)
@@ -84,7 +86,7 @@ const coreDurationMs = Date.now() - coreStarted
 results.push({
   id: 'canonical-core', label: 'Canonical claim/profile/source research-quality analysis', passed: corePassed,
   exitCode: corePassed ? 0 : 1, durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; edgeWeightedNarrative=${edgeWeightedNarrativeDominatedProfiles.length}; provenanceConcentrated=${provenanceConcentratedProfiles.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; semanticMismatches=${semanticAlignment.summary.anyMismatch}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
+  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; edgeWeightedNarrative=${edgeWeightedNarrativeDominatedProfiles.length}; provenanceConcentrated=${provenanceConcentratedProfiles.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; semanticMismatches=${semanticAlignment.summary.anyMismatch}; causalWithoutControlled=${languageCalibration.summary.causalWithoutControlledSupport}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
   stderrTail: [structuralFailures.length ? `${structuralFailures.length} invalid evidence edge(s)` : '', sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : ''].filter(Boolean).join('; '),
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
@@ -129,6 +131,7 @@ const coreSummary = {
   structuralFailures: structuralFailures.length, withdrawnCitedStudies: sourceIntegrity.summary.withdrawn,
   citationIntegrityProblems: citationIntegrity.blockingCount,
   semanticAlignment: semanticAlignment.summary,
+  claimLanguageCalibration: languageCalibration.summary,
   weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
   weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
   narrativeDominatedProfiles: narrativeDominatedProfiles.length, edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.length,
@@ -148,10 +151,11 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 16, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', semanticAlignment: 'lib/research-semantic-alignment.ts', designUsage: 'lib/research-design-usage.ts', provenanceConcentration: 'lib/research-provenance-concentration.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
+  schemaVersion: 17, generatedAt: new Date().toISOString(), passed: !failed,
+  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', semanticAlignment: 'lib/research-semantic-alignment.ts', claimLanguageCalibration: 'lib/research-claim-language-calibration.ts', designUsage: 'lib/research-design-usage.ts', provenanceConcentration: 'lib/research-provenance-concentration.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
   coreSummary, structuralFailures, citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
   semanticAlignment: { summary: semanticAlignment.summary, highConfidenceMismatches: semanticAlignment.highConfidenceMismatches.slice(0, 100), findings: semanticAlignment.findings.slice(0, 200) },
+  claimLanguageCalibration: { summary: languageCalibration.summary, highConfidenceFindings: languageCalibration.highConfidenceFindings.slice(0, 100), findings: languageCalibration.findings.slice(0, 200) },
   withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
   oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
   topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
@@ -172,6 +176,7 @@ console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} system
 console.log(`Design usage: ${edgeWeightedNarrativeDominatedProfiles.length} profile(s) narrative-dominated by approved claim-study edges`)
 console.log(`Provenance: ${provenanceConcentration.summary.provenanceConcentratedProfiles} concentrated profile(s) · ${provenanceConcentration.summary.firstAuthorConcentratedProfiles} first-author · ${provenanceConcentration.summary.journalConcentratedProfiles} journal`)
 console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explicit mismatch(es) · ${semanticAlignment.summary.highConfidenceMismatches} high-confidence · ${semanticAlignment.summary.roleMismatches} role · ${semanticAlignment.summary.domainMismatches} domain · ${semanticAlignment.summary.populationMismatches} population`)
+console.log(`Language calibration: ${languageCalibration.summary.causalWithoutControlledSupport} direct-causal outcome claim(s) without controlled/synthesis support · ${languageCalibration.summary.highConfidenceCausalWithoutControlledSupport} high-confidence`)
 console.log(`Study identity coverage: ${studyIdentityCoverage.summary.uncertainMultiStudyClaims} uncertain multi-study claim(s) · ${studyIdentityCoverage.summary.highConfidenceUncertainClaims} high-confidence · ${studyIdentityCoverage.summary.profilesWithWeakIdentityCoverage} weak-coverage profile(s)`)
 console.log(`Mapping gaps: ${coreSummary.profilesWithUnmappedPrimaryHumanEvidence} profile(s) with unmapped primary-human evidence · ${coreSummary.profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims} with primary-human evidence only on unapproved claims`)
 console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
@@ -181,4 +186,4 @@ console.log(`Evidence-grade report: ${path.relative(ROOT, evidenceGradeReportPat
 console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
 if (failed) { console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.'); process.exit(1) }
-console.log('\n[research-quality] PASS — one canonical analysis/topology/policy snapshot plus semantic alignment, citation/source integrity, evidence grades, and structured integrity agree.')
+console.log('\n[research-quality] PASS — one canonical analysis/topology/policy snapshot plus semantic alignment, claim-language calibration, citation/source integrity, evidence grades, and structured integrity agree.')


### PR DESCRIPTION
Adds a claim-language calibration layer to the canonical research-quality pipeline. Approved outcome claims using direct causal verbs are identified and checked for controlled-human or synthesis support. Claims that make unhedged causal assertions while relying only on uncontrolled/indirect evidence are surfaced, with a high-confidence subset prioritized. This remains advisory and is included in the unified schema/report rather than creating another standalone quality system.