### PR TITLE
SEO: canonicalize publisher and author schema identities

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'components/seo/**'
       - 'components/StructuredData.tsx'
+      - 'components/compare/CompareSchema.tsx'
       - 'components/editorial/ProfileDecisionPanel.tsx'
       - 'components/editorial/ScientificVerdictCard.tsx'
       - 'components/ui/EvidenceScoreBadge.tsx'
@@ -88,6 +89,7 @@ jobs:
         run: >-
           npx eslint
           components/StructuredData.tsx
+          components/compare/CompareSchema.tsx
           components/seo/SchemaGraphScript.tsx
           components/seo/CitationReadySummary.tsx
           components/seo/AnswerEngineTable.tsx

--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -4,11 +4,16 @@ on:
   pull_request:
     paths:
       - 'components/seo/**'
+      - 'components/StructuredData.tsx'
       - 'components/editorial/ProfileDecisionPanel.tsx'
       - 'components/editorial/ScientificVerdictCard.tsx'
       - 'components/ui/EvidenceScoreBadge.tsx'
       - 'components/ui/SafetyGaugeMeter.tsx'
       - 'src/components/editorial/LastUpdatedBadge.tsx'
+      - 'src/lib/schema-identities.ts'
+      - 'src/lib/schema-injector.ts'
+      - 'src/lib/__tests__/schema-injector.test.ts'
+      - 'lib/structured-data.ts'
       - 'app/info/content-licensing/**'
       - 'public/llms.txt'
       - 'app/robots.ts'
@@ -69,8 +74,12 @@ jobs:
       - name: Install dependencies
         run: npm ci --silent
 
-      - name: Run schema discovery and provenance tests
-        run: npx vitest run components/seo/__tests__/SchemaGraphScript.test.ts components/seo/__tests__/SchemaGraphScript.provenance.test.ts
+      - name: Run schema identity, discovery, and provenance tests
+        run: >-
+          npx vitest run
+          src/lib/__tests__/schema-injector.test.ts
+          components/seo/__tests__/SchemaGraphScript.test.ts
+          components/seo/__tests__/SchemaGraphScript.provenance.test.ts
 
       - name: Run canonical AI-search quality audit
         run: npm run audit:ai-citations
@@ -78,9 +87,11 @@ jobs:
       - name: Lint AI-search implementation files
         run: >-
           npx eslint
+          components/StructuredData.tsx
           components/seo/SchemaGraphScript.tsx
           components/seo/CitationReadySummary.tsx
           components/seo/AnswerEngineTable.tsx
+          components/seo/AuthorityJsonLd.tsx
           components/seo/__tests__/SchemaGraphScript.test.ts
           components/seo/__tests__/SchemaGraphScript.provenance.test.ts
           components/editorial/ProfileDecisionPanel.tsx
@@ -88,6 +99,10 @@ jobs:
           components/ui/EvidenceScoreBadge.tsx
           components/ui/SafetyGaugeMeter.tsx
           src/components/editorial/LastUpdatedBadge.tsx
+          src/lib/schema-identities.ts
+          src/lib/schema-injector.ts
+          src/lib/__tests__/schema-injector.test.ts
+          lib/structured-data.ts
           scripts/data/ai-entity-enrichment-lib.mjs
           scripts/data/ai-entity-enrichment-smoke.mjs
           scripts/data/build-runtime-summary-indexes.mjs

--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -22,6 +22,7 @@ on:
       - 'lib/research-quality-analysis.ts'
       - 'scripts/ci/audit-ai-*.mjs'
       - 'scripts/ci/audit-ai-*.ts'
+      - 'scripts/data/ai-entity-artifacts.mjs'
       - 'scripts/data/ai-entity-enrichment-lib.mjs'
       - 'scripts/data/ai-entity-enrichment-smoke.mjs'
       - 'scripts/data/build-runtime-summary-indexes.mjs'
@@ -105,6 +106,7 @@ jobs:
           src/lib/schema-injector.ts
           src/lib/__tests__/schema-injector.test.ts
           lib/structured-data.ts
+          scripts/data/ai-entity-artifacts.mjs
           scripts/data/ai-entity-enrichment-lib.mjs
           scripts/data/ai-entity-enrichment-smoke.mjs
           scripts/data/build-runtime-summary-indexes.mjs

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -4,7 +4,6 @@ import {
   AUTHOR_NAME,
   AUTHOR_SCHEMA_ID,
   AUTHOR_URL,
-  ORGANIZATION_SCHEMA_ID,
   WEBSITE_SCHEMA_ID,
   organizationSchemaIdentity,
 } from '@/src/lib/schema-identities'
@@ -29,14 +28,10 @@ function normalizeCanonicalUrl(value: string): string {
 
   try {
     const url = new URL(trimmed, SITE_URL)
-
-    // Preserve third-party URLs exactly as supplied. Internal page routes use
-    // the site's trailing-slash canonical convention, while root and assets do not.
     if (url.origin !== SITE_URL) return trimmed
     if (url.pathname !== '/' && !url.pathname.endsWith('/') && !hasFileExtension(url.pathname)) {
       url.pathname = `${url.pathname}/`
     }
-
     return url.toString()
   } catch {
     return trimmed
@@ -59,7 +54,7 @@ export interface StructuredDataProps {
   description: string
   datePublished: string
   dateModified?: string
-  /** Reserved for backward compatibility. The canonical author identity is site-governed. */
+  /** Backward-compatible custom author display name. */
   authorName?: string
   image?: string
   faqs?: FAQItem[]
@@ -100,12 +95,17 @@ export default function StructuredData({
   const webpageId = isMonetized ? `${canonicalPageUrl}#supplement` : `${canonicalPageUrl}#webpage`
   const breadcrumbId = `${canonicalPageUrl}#breadcrumb`
   const faqId = `${canonicalPageUrl}#faq`
-  const author = {
-    '@type': 'Person',
-    '@id': AUTHOR_SCHEMA_ID,
-    name: authorName,
-    url: AUTHOR_URL,
-  }
+  const author = authorName === AUTHOR_NAME
+    ? {
+        '@type': 'Person',
+        '@id': AUTHOR_SCHEMA_ID,
+        name: AUTHOR_NAME,
+        url: AUTHOR_URL,
+      }
+    : {
+        '@type': 'Person',
+        name: authorName,
+      }
   const publisher = organizationSchemaIdentity()
 
   if (isMonetized) {

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -1,12 +1,14 @@
 import JsonLd from './seo/JsonLd'
+import { SITE_URL } from '@/src/lib/site'
+import {
+  AUTHOR_NAME,
+  AUTHOR_SCHEMA_ID,
+  AUTHOR_URL,
+  ORGANIZATION_SCHEMA_ID,
+  WEBSITE_SCHEMA_ID,
+  organizationSchemaIdentity,
+} from '@/src/lib/schema-identities'
 
-const SITE_URL = 'https://thehippiescientist.net'
-const SITE_NAME = 'The Hippie Scientist'
-const DEFAULT_AUTHOR = 'Willie B. Randolph III'
-const WEBSITE_ID = `${SITE_URL}/#website`
-const ORGANIZATION_ID = `${SITE_URL}/#organization`
-const AUTHOR_URL = `${SITE_URL}/info/author/`
-const AUTHOR_ID = `${AUTHOR_URL}#person`
 const MIN_FAQ_SCHEMA_ITEMS = 2
 
 const FAQ_FALLBACK_ANSWER_PREFIXES = [
@@ -57,6 +59,7 @@ export interface StructuredDataProps {
   description: string
   datePublished: string
   dateModified?: string
+  /** Reserved for backward compatibility. The canonical author identity is site-governed. */
   authorName?: string
   image?: string
   faqs?: FAQItem[]
@@ -81,7 +84,7 @@ export default function StructuredData({
   description,
   datePublished,
   dateModified,
-  authorName = DEFAULT_AUTHOR,
+  authorName = AUTHOR_NAME,
   image = `${SITE_URL}/og-default.jpg`,
   faqs,
   breadcrumbs,
@@ -97,6 +100,13 @@ export default function StructuredData({
   const webpageId = isMonetized ? `${canonicalPageUrl}#supplement` : `${canonicalPageUrl}#webpage`
   const breadcrumbId = `${canonicalPageUrl}#breadcrumb`
   const faqId = `${canonicalPageUrl}#faq`
+  const author = {
+    '@type': 'Person',
+    '@id': AUTHOR_SCHEMA_ID,
+    name: authorName,
+    url: AUTHOR_URL,
+  }
+  const publisher = organizationSchemaIdentity()
 
   if (isMonetized) {
     schemas.push({
@@ -110,23 +120,9 @@ export default function StructuredData({
       url: canonicalPageUrl,
       datePublished,
       dateModified: dateModified ?? datePublished,
-      author: {
-        '@type': 'Person',
-        '@id': AUTHOR_ID,
-        name: authorName,
-        url: AUTHOR_URL,
-      },
-      publisher: {
-        '@type': 'Organization',
-        '@id': ORGANIZATION_ID,
-        name: SITE_NAME,
-        url: SITE_URL,
-        logo: {
-          '@type': 'ImageObject',
-          url: `${SITE_URL}/logo.svg`,
-        },
-      },
-      isPartOf: { '@id': WEBSITE_ID },
+      author,
+      publisher,
+      isPartOf: { '@id': WEBSITE_SCHEMA_ID },
       ...(hasBreadcrumbs ? { breadcrumb: { '@id': breadcrumbId } } : {}),
       ...(hasFaqSchema ? { hasPart: { '@id': faqId } } : {}),
       mainEntityOfPage: {
@@ -147,29 +143,13 @@ export default function StructuredData({
       datePublished,
       dateModified: dateModified ?? datePublished,
       ...(dateModified ? { lastReviewed: dateModified } : {}),
-      author: {
-        '@type': 'Person',
-        '@id': AUTHOR_ID,
-        name: authorName,
-        url: AUTHOR_URL,
-      },
-      publisher: {
-        '@type': 'Organization',
-        '@id': ORGANIZATION_ID,
-        name: SITE_NAME,
-        url: SITE_URL,
-        logo: {
-          '@type': 'ImageObject',
-          url: `${SITE_URL}/logo.svg`,
-        },
-      },
-      isPartOf: { '@id': WEBSITE_ID },
+      author,
+      publisher,
+      isPartOf: { '@id': WEBSITE_SCHEMA_ID },
       ...(hasBreadcrumbs ? { breadcrumb: { '@id': breadcrumbId } } : {}),
       ...(hasFaqSchema ? { hasPart: { '@id': faqId } } : {}),
-      medicalAudience: {
-        '@type': 'MedicalAudience',
-        audienceType: 'Patient',
-      },
+      // Educational research content is not a clinical service. Avoid Patient
+      // audience markup that could imply a clinician-patient relationship.
       mainEntityOfPage: {
         '@type': 'WebPage',
         '@id': canonicalPageUrl,
@@ -177,9 +157,6 @@ export default function StructuredData({
     })
   }
 
-  // FAQPage should only be emitted when there are enough meaningful Q&A pairs
-  // for rich-result eligibility. A one-item FAQ block creates avoidable schema
-  // noise across thin/partial pages without adding search value.
   if (hasFaqSchema) {
     schemas.push({
       '@context': 'https://schema.org',

--- a/components/compare/CompareSchema.tsx
+++ b/components/compare/CompareSchema.tsx
@@ -1,7 +1,10 @@
 import type { CompareItem } from '@/lib/compare'
 import JsonLd from '@/components/seo/JsonLd'
-
-const SITE_URL = 'https://thehippiescientist.net'
+import { SITE_URL } from '@/src/lib/site'
+import {
+  AUTHOR_SCHEMA_ID,
+  ORGANIZATION_SCHEMA_ID,
+} from '@/src/lib/schema-identities'
 
 interface FAQItem {
   question: string
@@ -33,16 +36,8 @@ export function buildCompareSchema({ item1, item2, slug, faqs, dateModified, cit
         '@type': 'Article',
         headline,
         description,
-        author: {
-          '@type': 'Organization',
-          name: 'The Hippie Scientist',
-          url: SITE_URL,
-        },
-        publisher: {
-          '@type': 'Organization',
-          name: 'The Hippie Scientist',
-          url: SITE_URL,
-        },
+        author: { '@id': AUTHOR_SCHEMA_ID },
+        publisher: { '@id': ORGANIZATION_SCHEMA_ID },
         ...(dateModified ? { dateModified } : {}),
         ...(citationUrls.length ? { citation: [...new Set(citationUrls)].filter(Boolean) } : {}),
         url: pageUrl,

--- a/components/seo/AuthorityJsonLd.tsx
+++ b/components/seo/AuthorityJsonLd.tsx
@@ -1,9 +1,10 @@
 import { buildSchemaGraph } from '../../src/lib/schema-graph'
 import { serializeJsonLd } from '../../src/lib/schema-injector'
 import { SITE_URL } from '../../src/lib/seo'
-
-const WEBSITE_ID = `${SITE_URL}/#website`
-const ORGANIZATION_ID = `${SITE_URL}/#organization`
+import {
+  ORGANIZATION_SCHEMA_ID,
+  WEBSITE_SCHEMA_ID,
+} from '../../src/lib/schema-identities'
 
 type FaqItem = { question: string; answer: string }
 
@@ -72,8 +73,8 @@ export default function AuthorityJsonLd({
     headline: title,
     description,
     url: canonical,
-    isPartOf: { '@id': WEBSITE_ID },
-    publisher: { '@id': ORGANIZATION_ID },
+    isPartOf: { '@id': WEBSITE_SCHEMA_ID },
+    publisher: { '@id': ORGANIZATION_SCHEMA_ID },
     ...(type !== 'Article' && breadcrumbs.length ? { breadcrumb: { '@id': breadcrumbId } } : {}),
     ...(meaningfulFaqItems.length ? { hasPart: { '@id': faqId } } : {}),
     ...(citationUrls.length ? { citation: [...new Set(citationUrls)].filter(Boolean) } : {}),

--- a/components/seo/AuthorityJsonLd.tsx
+++ b/components/seo/AuthorityJsonLd.tsx
@@ -2,6 +2,7 @@ import { buildSchemaGraph } from '../../src/lib/schema-graph'
 import { serializeJsonLd } from '../../src/lib/schema-injector'
 import { SITE_URL } from '../../src/lib/seo'
 import {
+  AUTHOR_SCHEMA_ID,
   ORGANIZATION_SCHEMA_ID,
   WEBSITE_SCHEMA_ID,
 } from '../../src/lib/schema-identities'
@@ -24,29 +25,21 @@ type AuthorityJsonLdProps = {
 function normalizeFaqItem(item: FaqItem): FaqItem | null {
   const question = String(item.question || '').trim()
   const answer = String(item.answer || '').trim()
-
-  if (question.length < 12 || answer.length <= 50) {
-    return null
-  }
-
+  if (question.length < 12 || answer.length <= 50) return null
   return { question, answer }
 }
 
 function getMeaningfulFaqItems(items: FaqItem[] | undefined): FaqItem[] {
   const seenQuestions = new Set<string>()
   const meaningfulItems: FaqItem[] = []
-
   for (const item of items ?? []) {
     const normalized = normalizeFaqItem(item)
     if (!normalized) continue
-
     const questionKey = normalized.question.toLowerCase()
     if (seenQuestions.has(questionKey)) continue
-
     seenQuestions.add(questionKey)
     meaningfulItems.push(normalized)
   }
-
   return meaningfulItems
 }
 
@@ -65,6 +58,7 @@ export default function AuthorityJsonLd({
   const breadcrumbId = `${canonical}#breadcrumb`
   const faqId = `${canonical}#faq`
   const meaningfulFaqItems = getMeaningfulFaqItems(faqItems)
+  const hasEditorialAuthor = type === 'Article' || type === 'MedicalWebPage'
 
   const webpage = {
     '@type': type === 'MedicalWebPage' ? ['MedicalWebPage', 'WebPage'] : type,
@@ -74,6 +68,7 @@ export default function AuthorityJsonLd({
     description,
     url: canonical,
     isPartOf: { '@id': WEBSITE_SCHEMA_ID },
+    ...(hasEditorialAuthor ? { author: { '@id': AUTHOR_SCHEMA_ID } } : {}),
     publisher: { '@id': ORGANIZATION_SCHEMA_ID },
     ...(type !== 'Article' && breadcrumbs.length ? { breadcrumb: { '@id': breadcrumbId } } : {}),
     ...(meaningfulFaqItems.length ? { hasPart: { '@id': faqId } } : {}),
@@ -93,9 +88,8 @@ export default function AuthorityJsonLd({
       }
     : null
 
-  const faq =
-    meaningfulFaqItems.length > 0
-      ? {
+  const faq = meaningfulFaqItems.length > 0
+    ? {
         '@type': 'FAQPage',
         '@id': faqId,
         url: canonical,
@@ -106,16 +100,14 @@ export default function AuthorityJsonLd({
           acceptedAnswer: { '@type': 'Answer', text: item.answer },
         })),
       }
-      : null
+    : null
 
   const graph = buildSchemaGraph([webpage, breadcrumb, faq])
 
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: serializeJsonLd(graph),
-      }}
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(graph) }}
     />
   )
 }

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,5 +1,10 @@
-const SITE_URL = 'https://thehippiescientist.net'
-const AUTHOR_URL = `${SITE_URL}/info/author/`
+import { SITE_URL } from '@/src/lib/site'
+import {
+  AUTHOR_SCHEMA_ID,
+  ORGANIZATION_SCHEMA_ID,
+  authorSchemaIdentity,
+  organizationSchemaIdentity,
+} from '@/src/lib/schema-identities'
 
 function toIsoDate(value: unknown): string | undefined {
   if (typeof value !== 'string' || !value.trim()) return undefined
@@ -10,25 +15,14 @@ function toIsoDate(value: unknown): string | undefined {
 export function buildOrganizationSchema() {
   return {
     '@context': 'https://schema.org',
-    '@type': 'Organization',
-    '@id': `${SITE_URL}/#organization`,
-    name: 'The Hippie Scientist',
-    url: SITE_URL,
-    logo: {
-      '@type': 'ImageObject',
-      url: `${SITE_URL}/logo.svg`,
-    },
+    ...organizationSchemaIdentity(),
   }
 }
 
 export function buildPersonSchema() {
   return {
     '@context': 'https://schema.org',
-    '@type': 'Person',
-    '@id': `${AUTHOR_URL}#person`,
-    name: 'Willie B. Randolph III',
-    url: AUTHOR_URL,
-    affiliation: { '@id': `${SITE_URL}/#organization` },
+    ...authorSchemaIdentity(),
   }
 }
 
@@ -51,8 +45,8 @@ export function buildMedicalWebPageSchema(entity: Record<string, unknown>, type:
       name: entity.name,
       description,
     },
-    author: { '@id': `${AUTHOR_URL}#person` },
-    publisher: { '@id': `${SITE_URL}/#organization` },
+    author: { '@id': AUTHOR_SCHEMA_ID },
+    publisher: { '@id': ORGANIZATION_SCHEMA_ID },
   }
 }
 
@@ -70,8 +64,8 @@ export function buildArticleSchema(post: Record<string, unknown>) {
     ...(dateModified ? { dateModified } : {}),
     mainEntityOfPage: url,
     url,
-    author: { '@id': `${AUTHOR_URL}#person` },
-    publisher: { '@id': `${SITE_URL}/#organization` },
+    author: { '@id': AUTHOR_SCHEMA_ID },
+    publisher: { '@id': ORGANIZATION_SCHEMA_ID },
     ...(post.image ? { image: post.image } : {}),
   }
 }
@@ -88,8 +82,8 @@ export function buildDatasetSchema(dataset: Record<string, unknown>) {
     url,
     ...(datePublished ? { datePublished } : {}),
     ...(dateModified ? { dateModified } : {}),
-    creator: { '@id': `${SITE_URL}/#organization` },
-    publisher: { '@id': `${SITE_URL}/#organization` },
+    creator: { '@id': ORGANIZATION_SCHEMA_ID },
+    publisher: { '@id': ORGANIZATION_SCHEMA_ID },
     ...(dataset.license ? { license: dataset.license } : {}),
     ...(dataset.distribution ? { distribution: dataset.distribution } : {}),
   }

--- a/scripts/ci/audit-ai-entity-completeness.mjs
+++ b/scripts/ci/audit-ai-entity-completeness.mjs
@@ -10,11 +10,86 @@ const DATA_DIR = DATA_DIR_ARG ? DATA_DIR_ARG.split('=')[1] : 'public/data'
 const FAIL_BELOW_ARG = process.argv.find((arg) => arg.startsWith('--fail-average-below='))
 const FAIL_BELOW = FAIL_BELOW_ARG ? Number(FAIL_BELOW_ARG.split('=')[1]) : null
 
+const SITE_URL = 'https://thehippiescientist.net'
+const SITE_NAME = 'The Hippie Scientist'
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+const AUTHOR_NAME = 'Willie B. Randolph III'
+const AUTHOR_URL = `${SITE_URL}/info/author/`
+const AUTHOR_ID = `${AUTHOR_URL}#person`
+
 async function readJson(fileName) {
   const filePath = path.resolve(ROOT, DATA_DIR, fileName)
   const raw = await fs.readFile(filePath, 'utf8')
   const parsed = JSON.parse(raw)
   return Array.isArray(parsed) ? parsed : []
+}
+
+function schemaTypes(node) {
+  const raw = node?.['@type']
+  return Array.isArray(raw) ? raw.map(String) : raw ? [String(raw)] : []
+}
+
+function walkNodes(value, output = []) {
+  if (!value || typeof value !== 'object') return output
+  if (Array.isArray(value)) {
+    value.forEach((entry) => walkNodes(entry, output))
+    return output
+  }
+  output.push(value)
+  Object.values(value).forEach((entry) => walkNodes(entry, output))
+  return output
+}
+
+function validateArtifactIdentity(payload, label) {
+  const errors = []
+  for (const node of walkNodes(payload)) {
+    const types = schemaTypes(node)
+
+    if (types.includes('Organization') && node.name === SITE_NAME) {
+      if (node['@id'] !== ORGANIZATION_ID) errors.push(`${label}: first-party Organization missing canonical @id`)
+      if (node.url !== SITE_URL) errors.push(`${label}: first-party Organization missing canonical url`)
+    }
+
+    if (types.includes('Person') && node.name === AUTHOR_NAME) {
+      if (node['@id'] !== AUTHOR_ID) errors.push(`${label}: first-party author missing canonical @id`)
+      if (node.url !== AUTHOR_URL) errors.push(`${label}: first-party author missing canonical url`)
+    }
+
+    if (types.includes('Article')) {
+      if (node.author?.name === SITE_NAME || node.author?.['@id'] === ORGANIZATION_ID) {
+        errors.push(`${label}: first-party evidence Article still uses Organization as author`)
+      }
+      if (node.author?.['@id'] === AUTHOR_ID && node.author?.['@type'] !== 'Person') {
+        errors.push(`${label}: canonical author id is not typed as Person`)
+      }
+      if (node.publisher?.['@id'] === ORGANIZATION_ID && node.publisher?.['@type'] !== 'Organization') {
+        errors.push(`${label}: canonical publisher id is not typed as Organization`)
+      }
+    }
+  }
+  return [...new Set(errors)]
+}
+
+async function auditGeneratedIdentityArtifacts() {
+  const root = path.resolve(ROOT, DATA_DIR, 'ai-entities')
+  const errors = []
+
+  for (const kind of ['herb', 'compound']) {
+    const directory = path.join(root, kind)
+    let names = []
+    try {
+      names = await fs.readdir(directory)
+    } catch {
+      continue
+    }
+
+    for (const name of names.filter((entry) => entry.endsWith('.json'))) {
+      const payload = JSON.parse(await fs.readFile(path.join(directory, name), 'utf8'))
+      errors.push(...validateArtifactIdentity(payload, `${kind}/${name}`))
+    }
+  }
+
+  return [...new Set(errors)]
 }
 
 async function main() {
@@ -29,12 +104,14 @@ async function main() {
     compounds,
   })
 
+  const identityErrors = await auditGeneratedIdentityArtifacts()
   const { summary, priorities } = report
   console.log('AI entity completeness audit')
   console.log(`Entities: ${summary.entities}`)
   console.log(`Average score: ${summary.averageScore}/100`)
   console.log(`Profiles scoring 80+: ${summary.strongProfiles}`)
   console.log(`Profiles below 50: ${summary.weakProfiles}`)
+  console.log(`Identity-role errors: ${identityErrors.length}`)
   console.log('')
   console.log('Top 20 enrichment priorities:')
 
@@ -47,6 +124,12 @@ async function main() {
   console.log('- ops/reports/ai-entity-completeness.json')
   console.log('- ops/reports/ai-entity-completeness.md')
   console.log('- public/data/ai-entities/manifest.json')
+
+  if (identityErrors.length) {
+    console.error('\nGenerated AI entity identity/role violations:')
+    identityErrors.slice(0, 100).forEach((error) => console.error(`- ${error}`))
+    process.exit(1)
+  }
 
   if (Number.isFinite(FAIL_BELOW) && summary.averageScore < FAIL_BELOW) {
     console.error(`Average completeness ${summary.averageScore} is below required threshold ${FAIL_BELOW}.`)

--- a/scripts/ci/audit-schema-policy.mjs
+++ b/scripts/ci/audit-schema-policy.mjs
@@ -10,6 +10,13 @@ if (!fs.existsSync(outDir)) {
   process.exit(1)
 }
 
+const SITE_URL = 'https://thehippiescientist.net'
+const SITE_NAME = 'The Hippie Scientist'
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+const AUTHOR_NAME = 'Willie B. Randolph III'
+const AUTHOR_URL = `${SITE_URL}/info/author/`
+const AUTHOR_ID = `${AUTHOR_URL}#person`
+
 const bannedTypes = new Set([
   'Physician',
   'MedicalOrganization',
@@ -21,7 +28,7 @@ const bannedTypes = new Set([
   'MedicalBusiness',
 ])
 const recognized = new Set([
-  'Organization', 'Person', 'BreadcrumbList', 'Article', 'BlogPosting', 'Dataset',
+  'Organization', 'Person', 'BreadcrumbList', 'Article', 'BlogPosting', 'ScholarlyArticle', 'Dataset',
   'ImageObject', 'FAQPage', 'MedicalWebPage', 'WebPage', 'WebSite', 'ProfilePage',
   'CollectionPage', 'ItemList', 'ListItem', 'Question', 'Answer', 'Substance',
   'ChemicalSubstance', 'DefinedTerm', 'Offer', 'Product', 'SoftwareApplication',
@@ -80,12 +87,34 @@ function nameOfReference(value) {
   return String(value.name || value['@id'] || '')
 }
 
+function validateFirstPartyIdentity(node, route, types) {
+  if (types.includes('Organization') && node.name === SITE_NAME) {
+    if (node['@id'] !== ORGANIZATION_ID) {
+      errors.push(`${route}: first-party Organization must resolve to ${ORGANIZATION_ID}`)
+    }
+    if (node.url !== SITE_URL) {
+      errors.push(`${route}: first-party Organization must use canonical url ${SITE_URL}`)
+    }
+  }
+
+  if (types.includes('Person') && node.name === AUTHOR_NAME) {
+    if (node['@id'] !== AUTHOR_ID) {
+      errors.push(`${route}: first-party author Person must resolve to ${AUTHOR_ID}`)
+    }
+    if (node.url !== AUTHOR_URL) {
+      errors.push(`${route}: first-party author Person must use canonical url ${AUTHOR_URL}`)
+    }
+  }
+}
+
 function validateNode(node, route) {
   const types = typesOf(node)
   for (const type of types) {
     typeCounts[type] = (typeCounts[type] || 0) + 1
     if (bannedTypes.has(type)) errors.push(`${route}: banned credential/clinical schema type ${type}`)
   }
+
+  validateFirstPartyIdentity(node, route, types)
 
   if (types.includes('Person')) {
     if (!node.name) errors.push(`${route}: Person schema is missing name`)
@@ -103,12 +132,16 @@ function validateNode(node, route) {
     if (!Array.isArray(node.itemListElement) || !node.itemListElement.length) errors.push(`${route}: BreadcrumbList has no items`)
   }
 
-  if (types.includes('Article') || types.includes('BlogPosting')) {
+  if (types.includes('Article') || types.includes('BlogPosting') || types.includes('ScholarlyArticle')) {
     if (!node.headline) errors.push(`${route}: Article/BlogPosting is missing headline`)
     dateCheck(node, route, 'datePublished')
     dateCheck(node, route, 'dateModified')
     if (node.reviewedBy && !node.dateReviewed) errors.push(`${route}: reviewedBy is present without a truthful dateReviewed event`)
     dateCheck(node, route, 'dateReviewed')
+
+    if (node.author?.['@type'] === 'Organization' && node.author?.name === SITE_NAME) {
+      warnings.push(`${route}: Article uses organizational authorship; prefer the canonical Person when the visible byline names the author`)
+    }
   }
 
   if (types.includes('Dataset')) {

--- a/scripts/data/ai-entity-artifacts.mjs
+++ b/scripts/data/ai-entity-artifacts.mjs
@@ -3,8 +3,20 @@ import path from 'node:path'
 import { hasUsefulStructuredValue } from '../../lib/data-quality.mjs'
 import { buildAiEntityArtifacts as buildBaseAiEntityArtifacts } from './ai-entity-enrichment-lib.mjs'
 
-function normalizeSchemaTypes(value) {
-  if (Array.isArray(value)) return value.map(normalizeSchemaTypes)
+const SITE_URL = 'https://thehippiescientist.net'
+const SITE_NAME = 'The Hippie Scientist'
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+const AUTHOR_NAME = 'Willie B. Randolph III'
+const AUTHOR_URL = `${SITE_URL}/info/author/`
+const AUTHOR_ID = `${AUTHOR_URL}#person`
+
+function schemaTypes(value) {
+  const raw = value?.['@type']
+  return Array.isArray(raw) ? raw.map(String) : raw ? [String(raw)] : []
+}
+
+function normalizeArtifactSchema(value, relationship = '') {
+  if (Array.isArray(value)) return value.map((entry) => normalizeArtifactSchema(entry, relationship))
   if (!value || typeof value !== 'object') return value
 
   const normalized = {}
@@ -19,8 +31,45 @@ function normalizeSchemaTypes(value) {
         continue
       }
     }
-    normalized[key] = normalizeSchemaTypes(entry)
+    normalized[key] = normalizeArtifactSchema(entry, key)
   }
+
+  const types = schemaTypes(normalized)
+  const isFirstPartyOrganization = types.includes('Organization') && normalized.name === SITE_NAME
+  const isFirstPartyPerson = types.includes('Person') && normalized.name === AUTHOR_NAME
+
+  // AI entity shards bypass the React/HTML serializer, so normalize their
+  // first-party identities here at the publication boundary. For editorial
+  // authorship, convert the historical organizational author object into the
+  // canonical Person; publisher/reviewer Organization roles remain organizations.
+  if (relationship === 'author' && isFirstPartyOrganization) {
+    return {
+      ...normalized,
+      '@type': 'Person',
+      '@id': AUTHOR_ID,
+      name: AUTHOR_NAME,
+      url: AUTHOR_URL,
+      affiliation: { '@id': ORGANIZATION_ID },
+    }
+  }
+
+  if (isFirstPartyOrganization) {
+    return {
+      ...normalized,
+      '@id': ORGANIZATION_ID,
+      url: SITE_URL,
+    }
+  }
+
+  if (isFirstPartyPerson) {
+    return {
+      ...normalized,
+      '@id': AUTHOR_ID,
+      url: AUTHOR_URL,
+      affiliation: normalized.affiliation || { '@id': ORGANIZATION_ID },
+    }
+  }
+
   return normalized
 }
 
@@ -37,10 +86,10 @@ async function normalizeArtifactDirectory(directory) {
     .map(async (name) => {
       const filePath = path.join(directory, name)
       const raw = await fs.readFile(filePath, 'utf8')
-      if (!raw.includes('MedicalSubstance')) return
       const parsed = JSON.parse(raw)
-      const normalized = normalizeSchemaTypes(parsed)
-      await fs.writeFile(filePath, `${JSON.stringify(normalized)}\n`, 'utf8')
+      const normalized = normalizeArtifactSchema(parsed)
+      const next = `${JSON.stringify(normalized)}\n`
+      if (next !== raw) await fs.writeFile(filePath, next, 'utf8')
     }))
 }
 
@@ -49,10 +98,6 @@ function mergeSummaryWithDetail(summary, detail) {
 
   const merged = { ...detail }
   for (const [key, value] of Object.entries(summary || {})) {
-    // The root arrays are the governance/runtime authority. Keep every useful
-    // root value, but let the richer detail payload fill fields that were
-    // intentionally omitted or collapsed by summary generation (citations,
-    // claims, review provenance, relationships, safety detail, identifiers).
     if (hasUsefulStructuredValue(value) || !hasUsefulStructuredValue(merged[key])) {
       merged[key] = value
     }

--- a/scripts/data/ai-entity-enrichment-smoke.mjs
+++ b/scripts/data/ai-entity-enrichment-smoke.mjs
@@ -6,6 +6,11 @@ import os from 'node:os'
 import path from 'node:path'
 import { buildAiEntityArtifacts } from './ai-entity-artifacts.mjs'
 
+const SITE_URL = 'https://thehippiescientist.net'
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+const AUTHOR_URL = `${SITE_URL}/info/author/`
+const AUTHOR_ID = `${AUTHOR_URL}#person`
+
 const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ths-ai-entity-'))
 const previousCwd = process.cwd()
 
@@ -108,6 +113,16 @@ try {
   assert.ok(herbArtifact['@graph'].some((node) => Array.isArray(node['@type']) && node['@type'].includes('Substance')))
   assert.ok(!JSON.stringify(herbArtifact).includes('MedicalSubstance'))
   assert.ok(!JSON.stringify(compoundArtifact).includes('MedicalSubstance'))
+
+  const evidenceArticle = herbArtifact['@graph'].find((node) => node['@type'] === 'Article')
+  assert.equal(evidenceArticle?.author?.['@type'], 'Person')
+  assert.equal(evidenceArticle?.author?.['@id'], AUTHOR_ID)
+  assert.equal(evidenceArticle?.author?.url, AUTHOR_URL)
+  assert.equal(evidenceArticle?.publisher?.['@type'], 'Organization')
+  assert.equal(evidenceArticle?.publisher?.['@id'], ORGANIZATION_ID)
+  assert.equal(evidenceArticle?.publisher?.url, SITE_URL)
+  assert.equal(evidenceArticle?.reviewedBy?.['@id'], ORGANIZATION_ID)
+
   assert.equal(manifest.entities.find((entry) => entry.slug === 'test-herb')?.dataUrl, '/data/ai-entities/herb/test-herb.json')
   for (let index = 1; index < manifest.entities.length; index += 1) {
     assert.ok(

--- a/src/lib/__tests__/schema-injector.test.ts
+++ b/src/lib/__tests__/schema-injector.test.ts
@@ -3,10 +3,11 @@ import {
   serializeJsonLd,
   buildHerbArticleSchema,
 } from '../schema-injector'
-
-// ---------------------------------------------------------------------------
-// serializeJsonLd
-// ---------------------------------------------------------------------------
+import {
+  AUTHOR_SCHEMA_ID,
+  AUTHOR_URL,
+  ORGANIZATION_SCHEMA_ID,
+} from '../schema-identities'
 
 describe('serializeJsonLd', () => {
   it('produces valid JSON', () => {
@@ -47,6 +48,45 @@ describe('serializeJsonLd', () => {
     expect(parsed.safetyWarnings).toBeUndefined()
   })
 
+  it('canonicalizes the first-party organization identity without touching its role', () => {
+    const parsed = JSON.parse(serializeJsonLd({
+      '@type': 'Article',
+      publisher: {
+        '@type': 'Organization',
+        name: 'The Hippie Scientist',
+        url: 'https://thehippiescientist.net',
+      },
+    }))
+
+    expect(parsed.publisher['@id']).toBe(ORGANIZATION_SCHEMA_ID)
+    expect(parsed.publisher.url).toBe('https://thehippiescientist.net')
+  })
+
+  it('canonicalizes the first-party author identity recursively', () => {
+    const parsed = JSON.parse(serializeJsonLd({
+      '@type': 'Article',
+      author: {
+        '@type': 'Person',
+        name: 'Willie B. Randolph III',
+      },
+    }))
+
+    expect(parsed.author['@id']).toBe(AUTHOR_SCHEMA_ID)
+    expect(parsed.author.url).toBe(AUTHOR_URL)
+    expect(parsed.author.affiliation['@id']).toBe(ORGANIZATION_SCHEMA_ID)
+  })
+
+  it('does not rewrite third-party people or organizations', () => {
+    const parsed = JSON.parse(serializeJsonLd({
+      author: { '@type': 'Person', name: 'External Reviewer', url: 'https://example.org/reviewer' },
+      publisher: { '@type': 'Organization', name: 'Example Journal', url: 'https://example.org' },
+    }))
+
+    expect(parsed.author['@id']).toBeUndefined()
+    expect(parsed.publisher['@id']).toBeUndefined()
+    expect(parsed.author.url).toBe('https://example.org/reviewer')
+  })
+
   it('round-trips cleanly through JSON.parse', () => {
     const node = { '@type': 'Article', headline: 'A & B < C > D', url: 'https://example.com/' }
     const serialized = serializeJsonLd(node)
@@ -55,10 +95,6 @@ describe('serializeJsonLd', () => {
     expect(parsed.headline).toBe('A & B < C > D')
   })
 })
-
-// ---------------------------------------------------------------------------
-// buildHerbArticleSchema — Google Rich Results compliance
-// ---------------------------------------------------------------------------
 
 describe('buildHerbArticleSchema', () => {
   const base = {
@@ -76,23 +112,15 @@ describe('buildHerbArticleSchema', () => {
     expect(schema['@type']).toEqual(expect.arrayContaining(['ScholarlyArticle', 'Article']))
   })
 
-  it('includes headline (required for Article rich results)', () => {
+  it('includes headline and image', () => {
     const schema = buildHerbArticleSchema(base)
     expect(schema.headline).toBe(base.headline)
-  })
-
-  it('includes image (required for Article rich results)', () => {
-    const schema = buildHerbArticleSchema(base)
     expect(schema.image).toBe(base.image)
   })
 
-  it('includes datePublished (required for Article rich results)', () => {
+  it('includes publication and modification dates when supplied', () => {
     const schema = buildHerbArticleSchema(base)
     expect(schema.datePublished).toBe('2026-01-15')
-  })
-
-  it('includes dateModified when provided', () => {
-    const schema = buildHerbArticleSchema(base)
     expect(schema.dateModified).toBe('2026-06-14')
   })
 
@@ -102,28 +130,34 @@ describe('buildHerbArticleSchema', () => {
     expect(schema.dateModified).toBeUndefined()
   })
 
-  it('includes author.name (required for Article rich results)', () => {
+  it('uses the canonical Person as the default author', () => {
     const schema = buildHerbArticleSchema(base)
     const author = schema.author as Record<string, unknown>
-    expect(typeof author.name).toBe('string')
-    expect((author.name as string).length).toBeGreaterThan(0)
+    expect(author['@type']).toBe('Person')
+    expect(author.name).toBe('Willie B. Randolph III')
+    expect(author['@id']).toBe(AUTHOR_SCHEMA_ID)
+    expect(author.url).toBe(AUTHOR_URL)
   })
 
-  it('defaults author name to The Hippie Scientist', () => {
-    const schema = buildHerbArticleSchema(base)
-    const author = schema.author as Record<string, unknown>
-    expect(author.name).toBe('The Hippie Scientist')
-  })
-
-  it('accepts a custom author name', () => {
-    const schema = buildHerbArticleSchema({ ...base, authorName: 'Custom Author' })
+  it('keeps a genuinely custom author distinct from the canonical author ID', () => {
+    const schema = buildHerbArticleSchema({
+      ...base,
+      authorName: 'Custom Author',
+      authorUrl: 'https://example.org/custom-author',
+    })
     const author = schema.author as Record<string, unknown>
     expect(author.name).toBe('Custom Author')
+    expect(author.url).toBe('https://example.org/custom-author')
+    expect(author['@id']).toBeUndefined()
   })
 
-  it('publisher matches author (required for Article rich results)', () => {
+  it('uses the canonical Organization as publisher rather than duplicating the author', () => {
     const schema = buildHerbArticleSchema(base)
-    expect(schema.author).toEqual(schema.publisher)
+    const publisher = schema.publisher as Record<string, unknown>
+    expect(publisher['@type']).toBe('Organization')
+    expect(publisher['@id']).toBe(ORGANIZATION_SCHEMA_ID)
+    expect(publisher.name).toBe('The Hippie Scientist')
+    expect(schema.author).not.toEqual(schema.publisher)
   })
 
   it('includes mainEntityOfPage linking back to the URL', () => {

--- a/src/lib/schema-identities.ts
+++ b/src/lib/schema-identities.ts
@@ -47,3 +47,43 @@ export function authorSchemaIdentity() {
     affiliation: organizationSchemaRef(),
   }
 }
+
+function hasSchemaType(node: Record<string, unknown>, expected: string): boolean {
+  const type = node['@type']
+  return Array.isArray(type) ? type.includes(expected) : type === expected
+}
+
+/**
+ * Canonicalize only the site's two first-party authority entities. This runs at
+ * the JSON-LD serialization boundary so older builders cannot accidentally emit
+ * a second anonymous publisher/author identity. Third-party people and
+ * organizations are left untouched.
+ */
+export function normalizeSiteSchemaIdentities(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeSiteSchemaIdentities)
+  if (!value || typeof value !== 'object') return value
+
+  const source = value as Record<string, unknown>
+  const normalized = Object.fromEntries(
+    Object.entries(source).map(([key, child]) => [key, normalizeSiteSchemaIdentities(child)]),
+  ) as Record<string, unknown>
+
+  if (hasSchemaType(normalized, 'Organization') && normalized.name === SITE_NAME) {
+    return {
+      ...normalized,
+      '@id': ORGANIZATION_SCHEMA_ID,
+      url: SITE_URL,
+    }
+  }
+
+  if (hasSchemaType(normalized, 'Person') && normalized.name === AUTHOR_NAME) {
+    return {
+      ...normalized,
+      '@id': AUTHOR_SCHEMA_ID,
+      url: AUTHOR_URL,
+      affiliation: normalized.affiliation ?? organizationSchemaRef(),
+    }
+  }
+
+  return normalized
+}

--- a/src/lib/schema-identities.ts
+++ b/src/lib/schema-identities.ts
@@ -1,0 +1,49 @@
+import { SITE_NAME, SITE_URL } from './site'
+
+export const WEBSITE_SCHEMA_ID = `${SITE_URL}/#website`
+export const ORGANIZATION_SCHEMA_ID = `${SITE_URL}/#organization`
+export const AUTHOR_NAME = 'Willie B. Randolph III'
+export const AUTHOR_URL = `${SITE_URL}/info/author/`
+export const AUTHOR_SCHEMA_ID = `${AUTHOR_URL}#person`
+
+export const ORGANIZATION_SOCIAL_URLS = [
+  'https://x.com/TheHippieSci',
+  'https://www.instagram.com/thehippiesci',
+  'https://www.youtube.com/@TheHippieSci',
+] as const
+
+export function organizationSchemaRef() {
+  return { '@id': ORGANIZATION_SCHEMA_ID }
+}
+
+export function websiteSchemaRef() {
+  return { '@id': WEBSITE_SCHEMA_ID }
+}
+
+export function authorSchemaRef() {
+  return { '@id': AUTHOR_SCHEMA_ID }
+}
+
+export function organizationSchemaIdentity() {
+  return {
+    '@type': 'Organization',
+    '@id': ORGANIZATION_SCHEMA_ID,
+    name: SITE_NAME,
+    url: SITE_URL,
+    logo: {
+      '@type': 'ImageObject',
+      url: `${SITE_URL}/logo.svg`,
+    },
+    sameAs: [...ORGANIZATION_SOCIAL_URLS],
+  }
+}
+
+export function authorSchemaIdentity() {
+  return {
+    '@type': 'Person',
+    '@id': AUTHOR_SCHEMA_ID,
+    name: AUTHOR_NAME,
+    url: AUTHOR_URL,
+    affiliation: organizationSchemaRef(),
+  }
+}

--- a/src/lib/schema-injector.ts
+++ b/src/lib/schema-injector.ts
@@ -9,11 +9,19 @@
  * Informational herb profiles are not commercial product listings, so no
  * Product node is emitted here — Product schema was intentionally removed.
  *
- * Serialization: serializeJsonLd() centralises schema sanitization and the
- * HTML-safe escaping used when writing JSON-LD script payloads.
+ * Serialization: serializeJsonLd() centralises schema sanitization, first-party
+ * identity normalization, and HTML-safe escaping for JSON-LD script payloads.
  */
 
 import { sanitizeJsonLdPayload } from '@/lib/json-ld-sanitize'
+import {
+  AUTHOR_NAME,
+  AUTHOR_URL,
+  ORGANIZATION_SCHEMA_ID,
+  authorSchemaRef,
+  normalizeSiteSchemaIdentities,
+  organizationSchemaIdentity,
+} from './schema-identities'
 
 export type JsonLdNode = Record<string, unknown>
 
@@ -23,13 +31,14 @@ export type JsonLdNode = Record<string, unknown>
 
 /**
  * Sanitizes and serializes a JSON-LD payload for use in an HTML script element.
- * Escapes <, >, and & to their Unicode escape sequences so an untrusted value
- * cannot break out of the enclosing <script> tag.
+ * First-party author/publisher objects are normalized to their canonical IDs,
+ * then <, >, and & are escaped so values cannot break out of the script tag.
  */
 export function serializeJsonLd(node: unknown): string {
   const sanitized = sanitizeJsonLdPayload(node)
+  const normalized = normalizeSiteSchemaIdentities(sanitized)
 
-  return JSON.stringify(sanitized ?? {})
+  return JSON.stringify(normalized ?? {})
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
     .replace(/&/g, '\\u0026')
@@ -52,9 +61,9 @@ export type HerbArticleSchemaArgs = {
   datePublished?: string
   /** ISO 8601 date, e.g. "2026-06-14" */
   dateModified?: string
-  /** Author/publisher display name */
+  /** Author display name. The canonical site author remains Willie unless explicitly different. */
   authorName?: string
-  /** Author/publisher absolute URL */
+  /** Author absolute URL. */
   authorUrl?: string
   /**
    * Evidence grade string emitted as a PropertyValue, e.g. "B — Moderate".
@@ -72,33 +81,28 @@ export type HerbArticleSchemaArgs = {
 
 /**
  * Builds a Schema.org Article node for a herb evidence profile page.
- *
- * Google Rich Results minimum required fields:
- *   - headline (required)
- *   - image   (required for Article rich result appearance)
- *   - datePublished (required)
- *   - author.name (required)
- *
- * Supply image, datePublished, and authorName to unlock Article rich results.
  */
 export function buildHerbArticleSchema(args: HerbArticleSchemaArgs): JsonLdNode {
-  const publisher: JsonLdNode = {
-    '@type': 'Organization',
-    name: args.authorName ?? 'The Hippie Scientist',
-    url: args.authorUrl ?? 'https://thehippiescientist.net',
-  }
+  const isCanonicalAuthor =
+    (!args.authorName || args.authorName === AUTHOR_NAME)
+    && (!args.authorUrl || args.authorUrl === AUTHOR_URL)
+
+  const author: JsonLdNode = isCanonicalAuthor
+    ? { '@type': 'Person', ...authorSchemaRef(), name: AUTHOR_NAME, url: AUTHOR_URL }
+    : {
+        '@type': 'Person',
+        name: args.authorName ?? AUTHOR_NAME,
+        ...(args.authorUrl ? { url: args.authorUrl } : {}),
+      }
 
   const node: JsonLdNode = {
     '@context': 'https://schema.org',
-    // ScholarlyArticle is a Schema.org subtype of Article — keeps Article rich
-    // result eligibility while providing stronger AI-search discovery signals
-    // for botanical research pages.
     '@type': ['ScholarlyArticle', 'Article'],
     headline: args.headline,
     description: args.description,
     url: args.url,
-    author: publisher,
-    publisher: publisher,
+    author,
+    publisher: organizationSchemaIdentity(),
     mainEntityOfPage: {
       '@type': 'WebPage',
       '@id': args.url,
@@ -109,11 +113,25 @@ export function buildHerbArticleSchema(args: HerbArticleSchemaArgs): JsonLdNode 
   if (args.datePublished) node.datePublished = args.datePublished
   if (args.dateModified) node.dateModified = args.dateModified
 
+  if (args.evidenceGrade) {
+    node.additionalProperty = {
+      '@type': 'PropertyValue',
+      name: 'Evidence grade',
+      value: args.evidenceGrade,
+    }
+  }
+
   if (args.citations && args.citations.length > 0) {
     node.citation = args.citations.map(title => ({
       '@type': 'CreativeWork',
       name: title,
     }))
+  }
+
+  // Defensive assertion for future refactors: publisher must resolve to the
+  // canonical organization rather than reusing the Person author object.
+  if ((node.publisher as Record<string, unknown>)['@id'] !== ORGANIZATION_SCHEMA_ID) {
+    throw new Error('Herb article publisher identity drifted from canonical organization')
   }
 
   return node

--- a/src/lib/schema-injector.ts
+++ b/src/lib/schema-injector.ts
@@ -65,16 +65,11 @@ export type HerbArticleSchemaArgs = {
   authorName?: string
   /** Author absolute URL. */
   authorUrl?: string
-  /**
-   * Evidence grade string emitted as a PropertyValue, e.g. "B — Moderate".
-   * Provides structured context for automated parsers without polluting
-   * the core Article fields.
-   */
+  /** Evidence grade retained for API compatibility; not emitted as Article additionalProperty. */
   evidenceGrade?: string
   /**
    * Optional list of cited sources emitted as schema:citation nodes.
    * Each entry should be a descriptive title or full bibliographic reference.
-   * Strengthens AI-search discovery signals for scholarly herb research pages.
    */
   citations?: string[]
 }
@@ -113,14 +108,6 @@ export function buildHerbArticleSchema(args: HerbArticleSchemaArgs): JsonLdNode 
   if (args.datePublished) node.datePublished = args.datePublished
   if (args.dateModified) node.dateModified = args.dateModified
 
-  if (args.evidenceGrade) {
-    node.additionalProperty = {
-      '@type': 'PropertyValue',
-      name: 'Evidence grade',
-      value: args.evidenceGrade,
-    }
-  }
-
   if (args.citations && args.citations.length > 0) {
     node.citation = args.citations.map(title => ({
       '@type': 'CreativeWork',
@@ -128,8 +115,6 @@ export function buildHerbArticleSchema(args: HerbArticleSchemaArgs): JsonLdNode 
     }))
   }
 
-  // Defensive assertion for future refactors: publisher must resolve to the
-  // canonical organization rather than reusing the Person author object.
   if ((node.publisher as Record<string, unknown>)['@id'] !== ORGANIZATION_SCHEMA_ID) {
     throw new Error('Herb article publisher identity drifted from canonical organization')
   }


### PR DESCRIPTION
Fixes #3427

## Summary
- centralizes the canonical WebSite, Organization, and author Person IDs in `src/lib/schema-identities.ts`
- normalizes only the site's exact first-party Organization and Person identities at the shared HTML JSON-LD serialization boundary
- keeps third-party people and organizations untouched
- separates editorial author/publisher roles in herb Article, comparison, Authority, and shared structured-data surfaces
- removes `MedicalAudience: Patient` from educational/harm-reduction structured data
- normalizes the static `/data/ai-entities/*` publication boundary, which bypasses the HTML serializer
- verifies identities in serializer tests, AI entity smoke output, the regenerated entity corpus, and built HTML
- reuses the existing entity-completeness and schema-policy gates instead of creating another audit pipeline

## Relevant URLs
- `/info/author/`
- `/herbs/<slug>/`
- `/compounds/<slug>/`
- `/guides/compare/<slug>/`
- `/data/ai-entities/herb/<slug>.json`
- `/data/ai-entities/compound/<slug>.json`

## Acceptance criteria
- The Hippie Scientist Organization resolves to `https://thehippiescientist.net/#organization` with the canonical site URL.
- Willie B. Randolph III resolves to `https://thehippiescientist.net/info/author/#person` with the canonical author URL.
- Editorial Article authorship uses the canonical Person where this site's byline is the author; publisher uses the canonical Organization.
- Third-party Person/Organization nodes are not rewritten.
- Public AI entity shards follow the same first-party identity and role contract as rendered HTML.
- Educational pages do not emit Patient-targeted medicalAudience semantics.
- Identity regressions fail through existing AI entity/schema gates rather than a new parallel validator.

## Validation commands
- `node scripts/data/ai-entity-enrichment-smoke.mjs`
- `npx vitest run src/lib/__tests__/schema-injector.test.ts components/seo/__tests__/SchemaGraphScript.test.ts components/seo/__tests__/SchemaGraphScript.provenance.test.ts`
- `npm run audit:ai-citations`
- `node scripts/ci/audit-ai-entity-completeness.mjs`
- `node scripts/ci/audit-schema-policy.mjs` after production build
- `npm run typecheck`
- AI search quality check / Schema and Media Governance / Atomic upgrade gate

## Before → after metrics
- First-party schema identity authorities: multiple anonymous/duplicated objects → 1 canonical Organization ID + 1 canonical Person ID + 1 canonical WebSite ID.
- Shared herb Article author/publisher role objects: 1 Organization reused for both roles → canonical Person author + canonical Organization publisher.
- Public AI shard first-party identity normalization: HTML-only → HTML + static AI entity publication boundary.
- AI shard identity regression coverage: smoke type checks only → author/publisher/reviewer ID and role assertions + full generated-corpus audit.
- Patient-targeted audience markers on the shared educational StructuredData path: 1 → 0.
- New independent identity audit pipelines: 0 → 0; existing gates are extended.

## Generator/source-of-truth decision
`src/lib/schema-identities.ts` is the shared first-party identity contract. `serializeJsonLd()` is the HTML JSON-LD publication boundary. `scripts/data/ai-entity-artifacts.mjs` is the static AI-entity publication boundary. The existing AI entity completeness audit and built-output schema policy remain the enforcement authorities for their respective outputs. Source scientific facts, claims, evidence grades, reviewers, and third-party citation identities are not changed by this PR.

## Regression contract
- Exact first-party Organization/Person nodes must always carry their canonical IDs and URLs.
- A custom or third-party author must never inherit Willie B. Randolph III's canonical Person ID.
- Third-party organizations must never be rewritten to The Hippie Scientist.
- AI entity evidence Articles must not use the first-party Organization as their author.
- Publisher identity must remain the canonical Organization.
- Patient-targeted `medicalAudience` remains forbidden for general educational pages.
- No personal `sameAs`, credential, medical-specialty, or clinical-service claims may be fabricated.

## AI SEO / trust impact
Both canonical HTML JSON-LD and public AI entity shards converge on the same first-party entities, reducing entity fragmentation for answer engines while making authorship and publisher roles more truthful.
