### PR TITLE
polish(homepage): restore single email CTA hierarchy

### DIFF
--- a/src/lib/__tests__/lead-magnets.test.ts
+++ b/src/lib/__tests__/lead-magnets.test.ts
@@ -41,7 +41,8 @@ describe('contextual lead magnets', () => {
     expect(getContextualLeadMagnet('/about/').slug).toBe('supplement-evidence-starter-kit')
   })
 
-  it('suppresses the contextual capture on resource and policy pages', () => {
+  it('suppresses the contextual capture where another primary capture or policy boundary owns the page', () => {
+    expect(shouldShowContextualLeadMagnet('/')).toBe(false)
     expect(shouldShowContextualLeadMagnet('/lead-magnets/sleep-supplement-evidence-guide/')).toBe(false)
     expect(shouldShowContextualLeadMagnet('/privacy/')).toBe(false)
     expect(shouldShowContextualLeadMagnet('/terms/')).toBe(false)

--- a/src/lib/lead-magnets.ts
+++ b/src/lib/lead-magnets.ts
@@ -144,6 +144,7 @@ export function getContextualLeadMagnet(pathname: string): LeadMagnet {
 
 export function shouldShowContextualLeadMagnet(pathname: string) {
   const path = pathname.toLowerCase()
+  if (path === '/') return false
   if (path.startsWith('/lead-magnets/')) return false
   if (path.startsWith('/api/')) return false
   if (path.includes('/privacy') || path.includes('/terms') || path.includes('/corrections')) return false


### PR DESCRIPTION
## Visual issue
The live homepage renders two safety/evidence email captures near the bottom: the dedicated footer homepage checklist plus the global contextual lead magnet. The repo's own homepage conversion test states the intended design is one owned-audience conversion surface.

## Change
- Suppress the contextual lead magnet only on `/`.
- Keep the footer's dedicated homepage safety-checklist capture unchanged.
- Preserve contextual lead magnets on ingredient, guide, article, tool, and other eligible routes.
- Add regression coverage for the homepage suppression rule.

## Result
Cleaner bottom-page hierarchy, less repeated CTA weight, and no conversion surface loss.