### PR TITLE
feat(research): detect canonical study class conflicts

### DIFF
--- a/lib/__tests__/research-study-class-conflicts.test.ts
+++ b/lib/__tests__/research-study-class-conflicts.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+import { analyzeStudyClassConflicts } from '@/lib/research-study-class-conflicts'
+
+function analyzeWithSources(sources: Array<Record<string, unknown>>) {
+  const root = mkdtempSync(path.join(tmpdir(), 'study-class-conflict-'))
+  const dir = path.join(root, 'public', 'data', 'herbs-detail')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, 'example.json'), JSON.stringify({
+    slug: 'example',
+    sources,
+    claimMap: [{ id: 'c1', predicate: 'supports_outcome', reviewStatus: 'approved', sourceRefIds: sources.map((source) => source.id) }],
+  }))
+  return { root, result: analyzeStudyClassConflicts(analyzeResearchQuality(root)) }
+}
+
+describe('canonical study classification conflicts', () => {
+  it('marks cross-family alias classifications as severe', () => {
+    const { root, result } = analyzeWithSources([
+      { id: 'a', pmid: '12345678', studyClass: 'rct' },
+      { id: 'b', pmid: '12345678', studyClass: 'narrative-review' },
+    ])
+    try {
+      expect(result.summary).toMatchObject({ studiesWithClassConflict: 1, severeClassConflicts: 1 })
+      expect(result.severeConflicts[0]).toMatchObject({
+        classes: ['narrative-review', 'rct'],
+        families: ['narrative', 'primary-human'],
+        severe: true,
+      })
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('reports same-family primary-human disagreements without making them severe', () => {
+    const { root, result } = analyzeWithSources([
+      { id: 'a', doi: '10.1000/example', studyClass: 'rct' },
+      { id: 'b', doi: '10.1000/example', studyClass: 'controlled-trial' },
+    ])
+    try {
+      expect(result.summary.studiesWithClassConflict).toBe(1)
+      expect(result.summary.severeClassConflicts).toBe(0)
+      expect(result.conflicts[0].families).toEqual(['primary-human'])
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('ignores aliases that agree on classification', () => {
+    const { root, result } = analyzeWithSources([
+      { id: 'a', pmid: '12345678', studyClass: 'rct' },
+      { id: 'b', pmid: '12345678', studyClass: 'rct' },
+    ])
+    try { expect(result.conflicts).toHaveLength(0) }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -3,6 +3,7 @@ import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import { analyzeProvenanceConcentration } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import { analyzeStudyClassConflicts } from './research-study-class-conflicts'
 import { analyzeStudyIdentityCoverage } from './research-study-identity-coverage'
 import {
   analyzeClaimEvidenceOverlap,
@@ -38,6 +39,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const highConfidenceHomogeneousMultiStudyClaims = claimEvidenceDiversity.filter(
     (claim) => claim.highConfidenceHomogeneousMultiStudySupport,
   )
+  const studyClassConflicts = analyzeStudyClassConflicts(analysis)
 
   return {
     crossProfileStudyLoad,
@@ -58,5 +60,6 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     claimEvidenceDiversity,
     homogeneousMultiStudyClaims,
     highConfidenceHomogeneousMultiStudyClaims,
+    studyClassConflicts,
   }
 }

--- a/lib/research-study-class-conflicts.ts
+++ b/lib/research-study-class-conflicts.ts
@@ -1,0 +1,94 @@
+import {
+  NARRATIVE_STUDY_CLASSES,
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  SYNTHESIS_STUDY_CLASSES,
+  canonicalStudyGroups,
+  sourceStudyClass,
+} from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { StudyClass } from './study-class'
+
+export type StudyClassFamily =
+  | 'primary-human'
+  | 'synthesis'
+  | 'narrative'
+  | 'other-human'
+  | 'preclinical'
+  | 'regulatory'
+  | 'unclassified'
+
+export type StudyClassConflict = {
+  url: string
+  studyId: string
+  sourceIds: string[]
+  classes: StudyClass[]
+  families: StudyClassFamily[]
+  severe: boolean
+}
+
+export type StudyClassConflictAnalysis = {
+  conflicts: StudyClassConflict[]
+  severeConflicts: StudyClassConflict[]
+  summary: {
+    canonicalStudiesChecked: number
+    studiesWithClassConflict: number
+    severeClassConflicts: number
+  }
+}
+
+function familyForStudyClass(studyClass: StudyClass): StudyClassFamily {
+  if (PRIMARY_HUMAN_STUDY_CLASSES.has(studyClass)) return 'primary-human'
+  if (SYNTHESIS_STUDY_CLASSES.has(studyClass)) return 'synthesis'
+  if (NARRATIVE_STUDY_CLASSES.has(studyClass)) return 'narrative'
+  if (studyClass === 'observational' || studyClass === 'case-report') return 'other-human'
+  if (studyClass === 'animal' || studyClass === 'in-vitro') return 'preclinical'
+  if (studyClass === 'regulatory-guidance') return 'regulatory'
+  return 'unclassified'
+}
+
+/**
+ * Detect contradictory classifications across source rows that canonicalize to
+ * one PMID/DOI-backed study. Same-family ambiguity is advisory; cross-family
+ * disagreement is severe because it can alter the evidence interpretation.
+ */
+export function analyzeStudyClassConflicts(analysis: ResearchQualityAnalysis): StudyClassConflictAnalysis {
+  const conflicts: StudyClassConflict[] = []
+  let canonicalStudiesChecked = 0
+
+  for (const { url, record } of analysis.profiles) {
+    for (const [studyId, group] of canonicalStudyGroups(record)) {
+      canonicalStudiesChecked += 1
+      if (group.length < 2) continue
+
+      const classes = [...new Set(
+        group
+          .map((source) => sourceStudyClass(source, analysis.cache))
+          .filter((studyClass) => studyClass !== 'unclassified'),
+      )].sort() as StudyClass[]
+      if (classes.length < 2) continue
+
+      const families = [...new Set(classes.map(familyForStudyClass))].sort() as StudyClassFamily[]
+      conflicts.push({
+        url,
+        studyId,
+        sourceIds: group.map((source) => String(source.id ?? '')).filter(Boolean).sort(),
+        classes,
+        families,
+        severe: families.length > 1,
+      })
+    }
+  }
+
+  conflicts.sort((a, b) => Number(b.severe) - Number(a.severe) || a.url.localeCompare(b.url) || a.studyId.localeCompare(b.studyId))
+  const severeConflicts = conflicts.filter((conflict) => conflict.severe)
+
+  return {
+    conflicts,
+    severeConflicts,
+    summary: {
+      canonicalStudiesChecked,
+      studiesWithClassConflict: conflicts.length,
+      severeClassConflicts: severeConflicts.length,
+    },
+  }
+}


### PR DESCRIPTION
Latest-main, conflict-resistant implementation. Adds canonical study-class conflict analysis and focused tests, and exposes the result through the shared research-quality topology without replacing newer evidence-diversity, semantic-alignment, or language-calibration work. Cross-family disagreements are identified as severe; blocking integration will follow as a minimal gate patch after this diagnostic layer lands.