### PR TITLE
feat(research): distinguish direct controlled causal support

### DIFF
--- a/lib/__tests__/research-claim-language-direct-evidence.test.ts
+++ b/lib/__tests__/research-claim-language-direct-evidence.test.ts
@@ -1,0 +1,68 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeClaimLanguageCalibration } from '@/lib/research-claim-language-calibration'
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+
+function run(studyClass: string) {
+  const root = mkdtempSync(path.join(tmpdir(), 'claim-language-direct-'))
+  const dir = path.join(root, 'public', 'data', 'herbs-detail')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, 'example.json'), JSON.stringify({
+    slug: 'example',
+    sources: [{ id: 's1', pmid: '12345678', studyClass }],
+    claimMap: [{
+      id: 'c1',
+      claim: 'Improves sleep symptoms in adults',
+      predicate: 'supports_outcome',
+      confidence: 0.85,
+      reviewStatus: 'approved',
+      sourceRefIds: ['s1'],
+    }],
+  }))
+  return { root, report: analyzeClaimLanguageCalibration(analyzeResearchQuality(root)) }
+}
+
+describe('direct controlled evidence for causal claim language', () => {
+  it('separates synthesis-only causal support from directly linked controlled-human support', () => {
+    const { root, report } = run('systematic-review')
+    try {
+      expect(report.summary).toMatchObject({
+        directCausalOutcomeClaims: 1,
+        causalWithoutDirectControlledSupport: 1,
+        highConfidenceCausalWithoutDirectControlledSupport: 1,
+        synthesisOnlyCausalSupport: 1,
+        highConfidenceSynthesisOnlyCausalSupport: 1,
+        causalWithoutControlledSupport: 0,
+      })
+      expect(report.synthesisOnlyFindings[0]).toMatchObject({
+        controlledHuman: 0,
+        synthesis: 1,
+        causalWithoutDirectControlledSupport: true,
+        synthesisOnlyCausalSupport: true,
+        causalWithoutControlledSupport: false,
+      })
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('does not flag direct causal language when a controlled human trial is linked', () => {
+    const { root, report } = run('rct')
+    try {
+      expect(report.summary.causalWithoutDirectControlledSupport).toBe(0)
+      expect(report.directEvidenceFindings).toHaveLength(0)
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('preserves the stricter legacy finding for causal language backed only by narrative evidence', () => {
+    const { root, report } = run('narrative-review')
+    try {
+      expect(report.summary.causalWithoutDirectControlledSupport).toBe(1)
+      expect(report.summary.causalWithoutControlledSupport).toBe(1)
+      expect(report.summary.synthesisOnlyCausalSupport).toBe(0)
+      expect(report.findings).toHaveLength(1)
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})

--- a/lib/research-claim-language-calibration.ts
+++ b/lib/research-claim-language-calibration.ts
@@ -15,6 +15,8 @@ export type ClaimLanguageCalibrationFinding = {
   uncontrolledHuman: number
   synthesis: number
   narrative: number
+  causalWithoutDirectControlledSupport: boolean
+  synthesisOnlyCausalSupport: boolean
   causalWithoutControlledSupport: boolean
   highConfidenceCausalWithoutControlledSupport: boolean
 }
@@ -24,11 +26,18 @@ export type ClaimLanguageCalibrationReport = {
   summary: {
     approvedOutcomeClaims: number
     directCausalOutcomeClaims: number
+    causalWithoutDirectControlledSupport: number
+    highConfidenceCausalWithoutDirectControlledSupport: number
+    synthesisOnlyCausalSupport: number
+    highConfidenceSynthesisOnlyCausalSupport: number
     causalWithoutControlledSupport: number
     highConfidenceCausalWithoutControlledSupport: number
   }
   findings: ClaimLanguageCalibrationFinding[]
   highConfidenceFindings: ClaimLanguageCalibrationFinding[]
+  directEvidenceFindings: ClaimLanguageCalibrationFinding[]
+  highConfidenceDirectEvidenceFindings: ClaimLanguageCalibrationFinding[]
+  synthesisOnlyFindings: ClaimLanguageCalibrationFinding[]
 }
 
 const CAUSAL_PATTERNS: Array<[string, RegExp]> = [
@@ -87,6 +96,7 @@ function rawClaimIndex(analysis: ResearchQualityAnalysis): Map<string, ResearchC
 export function analyzeClaimLanguageCalibration(analysis: ResearchQualityAnalysis): ClaimLanguageCalibrationReport {
   const rawClaims = rawClaimIndex(analysis)
   const findings: ClaimLanguageCalibrationFinding[] = []
+  const directEvidenceFindings: ClaimLanguageCalibrationFinding[] = []
   let approvedOutcomeClaims = 0
   let directCausalOutcomeClaims = 0
 
@@ -107,12 +117,14 @@ export function analyzeClaimLanguageCalibration(analysis: ResearchQualityAnalysi
     const uncontrolledHuman = claim.designs.filter((design) => design === 'uncontrolled-trial').length
     const synthesis = claim.synthesis
     const narrative = claim.narrative
-    const causalWithoutControlledSupport = controlledHuman === 0 && synthesis === 0
+    const causalWithoutDirectControlledSupport = controlledHuman === 0
+    const synthesisOnlyCausalSupport = causalWithoutDirectControlledSupport && synthesis > 0
+    // Compatibility: this remains the stricter legacy finding where neither
+    // direct controlled-human evidence nor synthesis is linked.
+    const causalWithoutControlledSupport = causalWithoutDirectControlledSupport && synthesis === 0
     const highConfidenceCausalWithoutControlledSupport = causalWithoutControlledSupport && claim.confidence >= 0.75
 
-    if (!causalWithoutControlledSupport) continue
-
-    findings.push({
+    const finding: ClaimLanguageCalibrationFinding = {
       url: claim.url,
       claimId: claim.claimId,
       confidence: claim.confidence,
@@ -123,23 +135,40 @@ export function analyzeClaimLanguageCalibration(analysis: ResearchQualityAnalysi
       uncontrolledHuman,
       synthesis,
       narrative,
+      causalWithoutDirectControlledSupport,
+      synthesisOnlyCausalSupport,
       causalWithoutControlledSupport,
       highConfidenceCausalWithoutControlledSupport,
-    })
+    }
+
+    if (causalWithoutDirectControlledSupport) directEvidenceFindings.push(finding)
+    if (causalWithoutControlledSupport) findings.push(finding)
   }
 
-  findings.sort((a, b) => b.confidence - a.confidence || a.url.localeCompare(b.url) || a.claimId.localeCompare(b.claimId))
+  const sorter = (a: ClaimLanguageCalibrationFinding, b: ClaimLanguageCalibrationFinding) =>
+    b.confidence - a.confidence || a.url.localeCompare(b.url) || a.claimId.localeCompare(b.claimId)
+  findings.sort(sorter)
+  directEvidenceFindings.sort(sorter)
   const highConfidenceFindings = findings.filter((finding) => finding.highConfidenceCausalWithoutControlledSupport)
+  const highConfidenceDirectEvidenceFindings = directEvidenceFindings.filter((finding) => finding.confidence >= 0.75)
+  const synthesisOnlyFindings = directEvidenceFindings.filter((finding) => finding.synthesisOnlyCausalSupport)
 
   return {
     generatedAt: new Date().toISOString(),
     summary: {
       approvedOutcomeClaims,
       directCausalOutcomeClaims,
+      causalWithoutDirectControlledSupport: directEvidenceFindings.length,
+      highConfidenceCausalWithoutDirectControlledSupport: highConfidenceDirectEvidenceFindings.length,
+      synthesisOnlyCausalSupport: synthesisOnlyFindings.length,
+      highConfidenceSynthesisOnlyCausalSupport: synthesisOnlyFindings.filter((finding) => finding.confidence >= 0.75).length,
       causalWithoutControlledSupport: findings.length,
       highConfidenceCausalWithoutControlledSupport: highConfidenceFindings.length,
     },
     findings,
     highConfidenceFindings,
+    directEvidenceFindings,
+    highConfidenceDirectEvidenceFindings,
+    synthesisOnlyFindings,
   }
 }


### PR DESCRIPTION
Extends claim-language calibration without changing the existing stricter finding. Direct causal outcome language now separately reports when no directly linked controlled-human study exists, including a distinct synthesis-only causal-support bucket. Existing causalWithoutControlledSupport remains backward-compatible for claims with neither controlled-human nor synthesis support. Includes focused regression tests.