### PR TITLE
refactor(research): include semantic and language analyses in topology

### DIFF
--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,8 +1,10 @@
 import { analyzeClaimEvidenceDiversity } from './research-claim-evidence-diversity'
+import { analyzeClaimLanguageCalibration } from './research-claim-language-calibration'
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import { analyzeProvenanceConcentration } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
 import { analyzeStudyClassConflicts } from './research-study-class-conflicts'
 import { analyzeStudyIdentityCoverage } from './research-study-identity-coverage'
 import {
@@ -40,6 +42,8 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     (claim) => claim.highConfidenceHomogeneousMultiStudySupport,
   )
   const studyClassConflicts = analyzeStudyClassConflicts(analysis)
+  const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
+  const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
 
   return {
     crossProfileStudyLoad,
@@ -61,5 +65,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     homogeneousMultiStudyClaims,
     highConfidenceHomogeneousMultiStudyClaims,
     studyClassConflicts,
+    semanticAlignment,
+    claimLanguageCalibration,
   }
 }


### PR DESCRIPTION
Moves semantic alignment and claim-language calibration into the shared derived research-quality topology snapshot while preserving their standalone analyzer/report APIs. This gives policy and reporting a common computed object and establishes the path to removing duplicate runner-side analysis passes.