### PR TITLE
feat(research): detect cross-profile evidence bundle reuse

### DIFF
--- a/lib/__tests__/research-cross-profile-bundles.test.ts
+++ b/lib/__tests__/research-cross-profile-bundles.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeCrossProfileEvidenceBundles } from '@/lib/research-cross-profile-bundles'
+import type { ClaimQualityAnalysis, ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+function claim(url: string, claimId: string, studyIds: string[]): ClaimQualityAnalysis {
+  return {
+    url,
+    claimId,
+    reviewStatus: 'approved',
+    approved: true,
+    predicate: 'supports_outcome',
+    confidence: 0.8,
+    sourceRefCount: studyIds.length,
+    validSourceRefCount: studyIds.length,
+    danglingSourceRefs: [],
+    studyIds,
+    studyCount: studyIds.length,
+    classifiedStudyCount: studyIds.length,
+    primaryHuman: studyIds.length,
+    synthesis: 0,
+    narrative: 0,
+    designs: studyIds.map(() => 'rct' as const),
+    outcomeClaim: true,
+    supportTier: 'human-supported',
+    structuredSupportTier: 'adequate',
+    weakStructuredClaim: false,
+    highConfidenceWeakStructured: false,
+    highConfidenceWeakOutcome: false,
+    singleStudy: false,
+    aliasCollapsed: false,
+  }
+}
+
+function analysis(claims: ClaimQualityAnalysis[]): ResearchQualityAnalysis {
+  return { cache: {}, profiles: [], profileAnalyses: [], claimAnalyses: claims, structuredClaimAnalyses: claims }
+}
+
+describe('cross-profile evidence bundle reuse', () => {
+  it('flags a two-study bundle reused by three approved claims across two profiles', () => {
+    const result = analyzeCrossProfileEvidenceBundles(analysis([
+      claim('/herbs/a/', 'a1', ['s1', 's2']),
+      claim('/herbs/a/', 'a2', ['s2', 's1']),
+      claim('/compounds/b/', 'b1', ['s1', 's2']),
+    ]))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      studyIds: ['s1', 's2'],
+      studyCount: 2,
+      profileCount: 2,
+      approvedClaimCount: 3,
+      narrowCrossProfileBundle: true,
+    })
+  })
+
+  it('does not duplicate the single-study load-bearing analysis', () => {
+    const result = analyzeCrossProfileEvidenceBundles(analysis([
+      claim('/herbs/a/', 'a1', ['single']),
+      claim('/compounds/b/', 'b1', ['single']),
+      claim('/compounds/c/', 'c1', ['single']),
+    ]))
+    expect(result).toHaveLength(0)
+  })
+
+  it('reports broader multi-study bundles across profiles without calling them narrow', () => {
+    const result = analyzeCrossProfileEvidenceBundles(analysis([
+      claim('/herbs/a/', 'a1', ['s1', 's2', 's3']),
+      claim('/compounds/b/', 'b1', ['s1', 's2', 's3']),
+    ]))
+    expect(result[0]).toMatchObject({ profileCount: 2, studyCount: 3, narrowCrossProfileBundle: false })
+  })
+})

--- a/lib/research-cross-profile-bundles.ts
+++ b/lib/research-cross-profile-bundles.ts
@@ -1,0 +1,75 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type CrossProfileEvidenceBundleReuse = {
+  studyIds: string[]
+  studyCount: number
+  profileCount: number
+  approvedClaimCount: number
+  outcomeClaimCount: number
+  highConfidenceClaimCount: number
+  profiles: string[]
+  predicates: string[]
+  claims: Array<{ url: string; claimId: string; predicate: string; confidence: number }>
+  narrowCrossProfileBundle: boolean
+}
+
+/**
+ * Detect the same canonical multi-study evidence bundle being reused across
+ * different profiles. Single-study reuse is intentionally left to the existing
+ * cross-profile study-load analysis; this focuses on narrow 2-study bundles
+ * that can otherwise look diversified while still being copied site-wide.
+ */
+export function analyzeCrossProfileEvidenceBundles(
+  analysis: ResearchQualityAnalysis,
+): CrossProfileEvidenceBundleReuse[] {
+  const groups = new Map<string, {
+    studyIds: string[]
+    profiles: Set<string>
+    claims: Array<{ url: string; claimId: string; predicate: string; confidence: number; outcomeClaim: boolean }>
+  }>()
+
+  for (const claim of analysis.claimAnalyses) {
+    if (claim.studyIds.length < 2) continue
+    const studyIds = [...claim.studyIds].sort()
+    const key = studyIds.join('|')
+    const item = groups.get(key) ?? { studyIds, profiles: new Set<string>(), claims: [] }
+    item.profiles.add(claim.url)
+    item.claims.push({
+      url: claim.url,
+      claimId: claim.claimId,
+      predicate: claim.predicate,
+      confidence: claim.confidence,
+      outcomeClaim: claim.outcomeClaim,
+    })
+    groups.set(key, item)
+  }
+
+  return [...groups.values()]
+    .filter((item) => item.profiles.size >= 2)
+    .map((item) => {
+      const approvedClaimCount = item.claims.length
+      const studyCount = item.studyIds.length
+      const profileCount = item.profiles.size
+      return {
+        studyIds: item.studyIds,
+        studyCount,
+        profileCount,
+        approvedClaimCount,
+        outcomeClaimCount: item.claims.filter((claim) => claim.outcomeClaim).length,
+        highConfidenceClaimCount: item.claims.filter((claim) => claim.confidence >= 0.75).length,
+        profiles: [...item.profiles].sort(),
+        predicates: [...new Set(item.claims.map((claim) => claim.predicate))].sort(),
+        claims: item.claims
+          .map(({ url, claimId, predicate, confidence }) => ({ url, claimId, predicate, confidence }))
+          .sort((a, b) => a.url.localeCompare(b.url) || a.claimId.localeCompare(b.claimId)),
+        narrowCrossProfileBundle: studyCount <= 2 && profileCount >= 2 && approvedClaimCount >= 3,
+      }
+    })
+    .sort((a, b) =>
+      Number(b.narrowCrossProfileBundle) - Number(a.narrowCrossProfileBundle)
+      || b.profileCount - a.profileCount
+      || b.approvedClaimCount - a.approvedClaimCount
+      || a.studyCount - b.studyCount
+      || a.studyIds.join('|').localeCompare(b.studyIds.join('|')),
+    )
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,5 +1,6 @@
 import { analyzeClaimEvidenceDiversity } from './research-claim-evidence-diversity'
 import { analyzeClaimLanguageCalibration } from './research-claim-language-calibration'
+import { analyzeCrossProfileEvidenceBundles } from './research-cross-profile-bundles'
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import { analyzeProvenanceConcentration } from './research-provenance-concentration'
@@ -23,6 +24,8 @@ export type ResearchQualityTopology = ReturnType<typeof buildResearchQualityTopo
 export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) {
   const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
   const systemicLoadBearingStudies = crossProfileStudyLoad.filter((study) => study.systemicLoadBearing)
+  const crossProfileEvidenceBundles = analyzeCrossProfileEvidenceBundles(analysis)
+  const narrowCrossProfileEvidenceBundles = crossProfileEvidenceBundles.filter((bundle) => bundle.narrowCrossProfileBundle)
   const evidenceBundleReuse = analyzeEvidenceBundleReuse(analysis)
   const narrowRepeatedEvidenceBundles = evidenceBundleReuse.filter((bundle) => bundle.narrowRepeatedEvidenceBundle)
   const claimEvidenceOverlap = analyzeClaimEvidenceOverlap(analysis)
@@ -48,6 +51,8 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   return {
     crossProfileStudyLoad,
     systemicLoadBearingStudies,
+    crossProfileEvidenceBundles,
+    narrowCrossProfileEvidenceBundles,
     evidenceBundleReuse,
     narrowRepeatedEvidenceBundles,
     claimEvidenceOverlap,


### PR DESCRIPTION
Adds a canonical topology analysis for the same multi-study evidence bundle being reused across different profiles. It intentionally excludes single-study reuse already covered by systemic study-load analysis, flags narrow two-study bundles reused across multiple approved claims/profiles, and reports broader cross-profile bundles separately. Includes focused regression tests.