### PR TITLE
SEO: clean shared schema authorship and provenance roles

### DIFF
--- a/.github/workflows/schema-media-governance.yml
+++ b/.github/workflows/schema-media-governance.yml
@@ -7,6 +7,10 @@ on:
       - 'app/**'
       - 'components/**'
       - 'lib/**'
+      - 'src/lib/schema*.ts'
+      - 'src/lib/schema-*.ts'
+      - 'src/lib/__tests__/schema*.test.ts'
+      - 'src/lib/__tests__/schema-*.test.ts'
       - 'public/data/**'
       - 'data/evidence/**'
       - 'data/media/**'
@@ -20,6 +24,10 @@ on:
       - 'app/**'
       - 'components/**'
       - 'lib/**'
+      - 'src/lib/schema*.ts'
+      - 'src/lib/schema-*.ts'
+      - 'src/lib/__tests__/schema*.test.ts'
+      - 'src/lib/__tests__/schema-*.test.ts'
       - 'public/data/**'
       - 'data/evidence/**'
       - 'data/media/**'
@@ -48,6 +56,12 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      - name: Run shared schema regression tests
+        run: >-
+          npx vitest run
+          src/lib/__tests__/schema-graph.test.ts
+          src/lib/__tests__/schema-injector.test.ts
+          src/lib/__tests__/structured-data.test.ts
       - name: Build static export
         env:
           COMMIT_HASH: ${{ github.sha }}

--- a/src/lib/__tests__/schema-graph.test.ts
+++ b/src/lib/__tests__/schema-graph.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { buildGoalSchemaGraph, buildProfileSchemaGraph, buildSchemaGraph, buildSeoEntrySchemaGraph, buildCompareHubSchemaGraph, buildCompareDetailSchemaGraph } from '../schema-graph'
+import {
+  buildGoalSchemaGraph,
+  buildProfileSchemaGraph,
+  buildSchemaGraph,
+  buildSeoEntrySchemaGraph,
+  buildCompareHubSchemaGraph,
+  buildCompareDetailSchemaGraph,
+} from '../schema-graph'
+import {
+  AUTHOR_SCHEMA_ID,
+  ORGANIZATION_SCHEMA_ID,
+  WEBSITE_SCHEMA_ID,
+} from '../schema-identities'
 
 describe('schema-graph', () => {
   it('builds a single @context graph without nested contexts', () => {
@@ -22,12 +34,47 @@ describe('schema-graph', () => {
     expect(Array.isArray(graph['@graph'])).toBe(true)
     const nodes = graph['@graph'] as Record<string, unknown>[]
     expect(nodes.length).toBeGreaterThanOrEqual(2)
-    for (const node of nodes) {
-      expect(node['@context']).toBeUndefined()
-    }
+    for (const node of nodes) expect(node['@context']).toBeUndefined()
+
     const webpage = nodes.find(node => node['@id'] === 'https://thehippiescientist.net/herbs/ashwagandha/#webpage')
     expect(webpage?.url).toBe('https://thehippiescientist.net/herbs/ashwagandha/')
     expect(webpage?.mainEntityOfPage).toBe('https://thehippiescientist.net/herbs/ashwagandha/')
+    expect(webpage?.author).toEqual({ '@id': AUTHOR_SCHEMA_ID })
+    expect(webpage?.publisher).toEqual({ '@id': ORGANIZATION_SCHEMA_ID })
+    expect(webpage?.isPartOf).toEqual({ '@id': WEBSITE_SCHEMA_ID })
+    expect(webpage?.reviewedBy).toBeUndefined()
+
+    const evidenceArticle = nodes.find(node => node['@id'] === 'https://thehippiescientist.net/herbs/ashwagandha/#evidence-review')
+    expect(evidenceArticle?.author).toEqual({ '@id': AUTHOR_SCHEMA_ID })
+    expect(evidenceArticle?.publisher).toEqual({ '@id': ORGANIZATION_SCHEMA_ID })
+    expect(evidenceArticle?.datePublished).toBeUndefined()
+  })
+
+  it('adds review provenance only when a real review date exists', () => {
+    const graph = buildProfileSchemaGraph({
+      kind: 'compound',
+      slug: 'magnesium',
+      compound: {
+        name: 'Magnesium',
+        slug: 'magnesium',
+        description: 'Test compound profile.',
+      },
+      reviewedAt: '2026-08-01',
+      modifiedAt: '2026-08-02',
+      breadcrumbs: [
+        { name: 'Compounds', url: 'https://thehippiescientist.net/compounds/' },
+        { name: 'Magnesium', url: 'https://thehippiescientist.net/compounds/magnesium/' },
+      ],
+    })
+
+    const nodes = graph['@graph'] as Record<string, unknown>[]
+    const webpage = nodes.find(node => node['@id'] === 'https://thehippiescientist.net/compounds/magnesium/#webpage')
+    const evidenceArticle = nodes.find(node => node['@id'] === 'https://thehippiescientist.net/compounds/magnesium/#evidence-review')
+
+    expect(webpage?.dateReviewed).toBe('2026-08-01')
+    expect(webpage?.reviewedBy).toEqual({ '@id': ORGANIZATION_SCHEMA_ID })
+    expect(evidenceArticle?.datePublished).toBeUndefined()
+    expect(evidenceArticle?.dateModified).toBe('2026-08-02')
   })
 
   it('includes FAQ node when questions exist', () => {
@@ -52,26 +99,28 @@ describe('schema-graph', () => {
     expect(graph['@graph']).toEqual([])
   })
 
-  it('builds a consolidated SEO entry page schema graph', () => {
+  it('builds a consolidated SEO entry graph without invented publication date', () => {
     const graph = buildSeoEntrySchemaGraph({
       route: 'best-supplements-for-sleep',
       title: 'Best Supplements for Sleep | The Hippie Scientist',
       description: 'Find the best sleep options.',
       h1: 'Best Supplements for Sleep',
-      faqs: [
-        { question: 'What is the best supplement for sleep?', answer: 'Magnesium and Apigenin.' }
-      ]
+      faqs: [{ question: 'What is the best supplement for sleep?', answer: 'Magnesium and Apigenin.' }],
     })
 
     expect(graph['@context']).toBe('https://schema.org')
     const nodes = graph['@graph'] as Record<string, unknown>[]
-    expect(nodes.length).toBe(3) // Article, BreadcrumbList, FAQPage
+    expect(nodes.length).toBe(3)
 
     const article = nodes.find(n => n['@type'] === 'Article')
     expect(article?.headline).toBe('Best Supplements for Sleep | The Hippie Scientist')
     expect(article?.url).toBe('https://thehippiescientist.net/best-supplements-for-sleep/')
     expect(article?.breadcrumb).toBeUndefined()
     expect(article?.hasPart).toEqual({ '@id': 'https://thehippiescientist.net/best-supplements-for-sleep/#faq' })
+    expect(article?.isPartOf).toEqual({ '@id': WEBSITE_SCHEMA_ID })
+    expect(article?.author).toEqual({ '@id': AUTHOR_SCHEMA_ID })
+    expect(article?.publisher).toEqual({ '@id': ORGANIZATION_SCHEMA_ID })
+    expect(article?.datePublished).toBeUndefined()
 
     const breadcrumb = nodes.find(n => n['@type'] === 'BreadcrumbList')
     expect(breadcrumb?.['@id']).toBe('https://thehippiescientist.net/best-supplements-for-sleep/#breadcrumb')
@@ -87,26 +136,27 @@ describe('schema-graph', () => {
       description: 'Compare side by side.',
       breadcrumbs: [
         { name: 'Home', url: 'https://thehippiescientist.net/' },
-        { name: 'Compare', url: 'https://thehippiescientist.net/guides/compare/' }
+        { name: 'Compare', url: 'https://thehippiescientist.net/guides/compare/' },
       ],
       comparisonPairs: [
-        { name: 'Ashwagandha vs Rhodiola', url: '/guides/compare/ashwagandha-vs-rhodiola' }
-      ]
+        { name: 'Ashwagandha vs Rhodiola', url: '/guides/compare/ashwagandha-vs-rhodiola' },
+      ],
     })
 
     expect(graph['@context']).toBe('https://schema.org')
     const nodes = graph['@graph'] as Record<string, unknown>[]
-    expect(nodes.length).toBe(3) // CollectionPage, BreadcrumbList, ItemList
+    expect(nodes.length).toBe(3)
 
     const collection = nodes.find(n => n['@type'] === 'CollectionPage')
     expect(collection?.name).toBe('Compare Supplements | The Hippie Scientist')
     expect(collection?.url).toBe('https://thehippiescientist.net/guides/compare/')
+    expect(collection?.isPartOf).toEqual({ '@id': WEBSITE_SCHEMA_ID })
 
     const itemList = nodes.find(n => n['@type'] === 'ItemList')
     expect(itemList?.numberOfItems).toBe(1)
   })
 
-  it('builds a consolidated Compare Detail page schema graph', () => {
+  it('uses neutral Substance semantics for herbs in compare detail graphs', () => {
     const graph = buildCompareDetailSchemaGraph({
       path: '/guides/compare/ashwagandha-vs-rhodiola',
       title: 'Ashwagandha vs Rhodiola | The Hippie Scientist',
@@ -114,23 +164,24 @@ describe('schema-graph', () => {
       breadcrumbs: [
         { name: 'Home', url: 'https://thehippiescientist.net/' },
         { name: 'Compare', url: 'https://thehippiescientist.net/guides/compare/' },
-        { name: 'Ashwagandha vs Rhodiola', url: 'https://thehippiescientist.net/guides/compare/ashwagandha-vs-rhodiola/' }
+        { name: 'Ashwagandha vs Rhodiola', url: 'https://thehippiescientist.net/guides/compare/ashwagandha-vs-rhodiola/' },
       ],
       entities: [
         { name: 'Ashwagandha', url: '/herbs/ashwagandha', type: 'herb' },
-        { name: 'Rhodiola', url: '/herbs/rhodiola', type: 'herb' }
-      ]
+        { name: 'Rhodiola', url: '/herbs/rhodiola', type: 'herb' },
+      ],
     })
 
     expect(graph['@context']).toBe('https://schema.org')
     const nodes = graph['@graph'] as Record<string, unknown>[]
-    expect(nodes.length).toBe(2) // MedicalWebPage, BreadcrumbList
+    expect(nodes.length).toBe(2)
 
     const webpage = nodes.find(n => Array.isArray(n['@type']) && n['@type'].includes('MedicalWebPage'))
     expect(webpage?.name).toBe('Ashwagandha vs Rhodiola | The Hippie Scientist')
+    expect(webpage?.isPartOf).toEqual({ '@id': WEBSITE_SCHEMA_ID })
     expect(webpage?.about).toEqual([
-      { '@type': 'MedicalTherapy', name: 'Ashwagandha', url: 'https://thehippiescientist.net/herbs/ashwagandha/' },
-      { '@type': 'MedicalTherapy', name: 'Rhodiola', url: 'https://thehippiescientist.net/herbs/rhodiola/' }
+      { '@type': 'Substance', name: 'Ashwagandha', url: 'https://thehippiescientist.net/herbs/ashwagandha/' },
+      { '@type': 'Substance', name: 'Rhodiola', url: 'https://thehippiescientist.net/herbs/rhodiola/' },
     ])
   })
 })

--- a/src/lib/__tests__/schema-injector.test.ts
+++ b/src/lib/__tests__/schema-injector.test.ts
@@ -48,7 +48,7 @@ describe('serializeJsonLd', () => {
     expect(parsed.safetyWarnings).toBeUndefined()
   })
 
-  it('canonicalizes the first-party organization identity without touching its role', () => {
+  it('canonicalizes the first-party organization identity without touching publisher role', () => {
     const parsed = JSON.parse(serializeJsonLd({
       '@type': 'Article',
       publisher: {
@@ -58,8 +58,25 @@ describe('serializeJsonLd', () => {
       },
     }))
 
+    expect(parsed.publisher['@type']).toBe('Organization')
     expect(parsed.publisher['@id']).toBe(ORGANIZATION_SCHEMA_ID)
     expect(parsed.publisher.url).toBe('https://thehippiescientist.net')
+  })
+
+  it('converts a legacy first-party Organization author into the canonical Person', () => {
+    const parsed = JSON.parse(serializeJsonLd({
+      '@type': 'Article',
+      author: {
+        '@type': 'Organization',
+        name: 'The Hippie Scientist',
+        url: 'https://thehippiescientist.net',
+      },
+    }))
+
+    expect(parsed.author['@type']).toBe('Person')
+    expect(parsed.author['@id']).toBe(AUTHOR_SCHEMA_ID)
+    expect(parsed.author.url).toBe(AUTHOR_URL)
+    expect(parsed.author.affiliation['@id']).toBe(ORGANIZATION_SCHEMA_ID)
   })
 
   it('canonicalizes the first-party author identity recursively', () => {

--- a/src/lib/schema-graph.ts
+++ b/src/lib/schema-graph.ts
@@ -10,6 +10,11 @@ import {
   type HerbJsonLdArgs,
 } from './seo'
 import {
+  AUTHOR_SCHEMA_ID,
+  ORGANIZATION_SCHEMA_ID,
+  WEBSITE_SCHEMA_ID,
+} from './schema-identities'
+import {
   buildFAQPageFromComparisonRows,
   buildFocusClusterBreadcrumb,
   buildWorkbookEntitySchema,
@@ -87,11 +92,16 @@ export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
         mainEntityOfPage: canonical,
         mainEntity: { '@id': `${canonical}#entity` },
         hasPart: { '@id': evidenceArticleId },
+        isPartOf: { '@id': WEBSITE_SCHEMA_ID },
         ...(args.modifiedAt ? { dateModified: args.modifiedAt } : {}),
-        ...(args.reviewedAt ? { dateReviewed: args.reviewedAt } : {}),
-        reviewedBy: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-        author: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-        publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
+        ...(args.reviewedAt
+          ? {
+              dateReviewed: args.reviewedAt,
+              reviewedBy: { '@id': ORGANIZATION_SCHEMA_ID },
+            }
+          : {}),
+        author: { '@id': AUTHOR_SCHEMA_ID },
+        publisher: { '@id': ORGANIZATION_SCHEMA_ID },
       }
     : null
 
@@ -121,9 +131,8 @@ export function buildProfileSchemaGraph(args: ProfileSchemaGraphArgs) {
     mainEntityOfPage: { '@id': webpageId },
     about: { '@id': `${canonical}#entity` },
     articleSection: ['Evidence Summary', 'Safety & Cautions'],
-    author: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-    publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-    ...(args.reviewedAt ? { datePublished: args.reviewedAt } : {}),
+    author: { '@id': AUTHOR_SCHEMA_ID },
+    publisher: { '@id': ORGANIZATION_SCHEMA_ID },
     ...(args.modifiedAt ? { dateModified: args.modifiedAt } : {}),
   }
 
@@ -222,7 +231,7 @@ export function buildToolPageSchemaGraph(args: {
     headline: args.title,
     description: args.description,
     url: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
+    isPartOf: { '@id': WEBSITE_SCHEMA_ID },
     breadcrumb: { '@id': breadcrumbId },
     medicalAudience: 'Consumer',
     ...(faqQuestions.length ? { hasPart: { '@id': faqId } } : {}),
@@ -272,10 +281,9 @@ export function buildSeoEntrySchemaGraph(args: {
     description: args.description,
     url: canonical,
     mainEntityOfPage: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
-    author: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-    publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-    datePublished: '2026-01-01',
+    isPartOf: { '@id': WEBSITE_SCHEMA_ID },
+    author: { '@id': AUTHOR_SCHEMA_ID },
+    publisher: { '@id': ORGANIZATION_SCHEMA_ID },
     ...(args.faqs.length ? { hasPart: { '@id': faqId } } : {}),
   }
 
@@ -330,7 +338,7 @@ export function buildCompareHubSchemaGraph(args: {
     name: args.title,
     description: args.description,
     url: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
+    isPartOf: { '@id': WEBSITE_SCHEMA_ID },
     breadcrumb: { '@id': breadcrumbId },
     mainEntity: { '@id': itemListId },
     ...(faqQuestions.length ? { hasPart: { '@id': faqId } } : {}),
@@ -392,7 +400,7 @@ export function buildGuideHubSchemaGraph(args: {
     name: args.title,
     description: args.description,
     url: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
+    isPartOf: { '@id': WEBSITE_SCHEMA_ID },
     breadcrumb: { '@id': breadcrumbId },
     mainEntity: { '@id': itemListId },
   }
@@ -434,10 +442,10 @@ export function buildCompareDetailSchemaGraph(args: {
     name: args.title,
     description: args.description,
     url: canonical,
-    isPartOf: { '@type': 'WebSite', name: 'The Hippie Scientist', url: SITE_URL },
+    isPartOf: { '@id': WEBSITE_SCHEMA_ID },
     breadcrumb: { '@id': breadcrumbId },
     about: args.entities.map(entity => ({
-      '@type': entity.type === 'herb' ? 'MedicalTherapy' : 'ChemicalSubstance',
+      '@type': entity.type === 'herb' ? 'Substance' : 'ChemicalSubstance',
       name: entity.name,
       url: normalizeCanonical(toAbsoluteUrl(entity.url)),
     })),

--- a/src/lib/schema-identities.ts
+++ b/src/lib/schema-identities.ts
@@ -54,21 +54,33 @@ function hasSchemaType(node: Record<string, unknown>, expected: string): boolean
 }
 
 /**
- * Canonicalize only the site's two first-party authority entities. This runs at
- * the JSON-LD serialization boundary so older builders cannot accidentally emit
- * a second anonymous publisher/author identity. Third-party people and
- * organizations are left untouched.
+ * Canonicalize only the site's two first-party authority entities. The
+ * relationship name matters: historical builders sometimes used the site
+ * Organization as an Article `author`; that exact first-party author role is
+ * normalized to the canonical Person. Publisher/reviewer Organization roles
+ * remain organizations. Third-party identities are never rewritten.
  */
-export function normalizeSiteSchemaIdentities(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(normalizeSiteSchemaIdentities)
+export function normalizeSiteSchemaIdentities(value: unknown, relationship = ''): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeSiteSchemaIdentities(entry, relationship))
+  }
   if (!value || typeof value !== 'object') return value
 
   const source = value as Record<string, unknown>
   const normalized = Object.fromEntries(
-    Object.entries(source).map(([key, child]) => [key, normalizeSiteSchemaIdentities(child)]),
+    Object.entries(source).map(([key, child]) => [
+      key,
+      normalizeSiteSchemaIdentities(child, key),
+    ]),
   ) as Record<string, unknown>
 
-  if (hasSchemaType(normalized, 'Organization') && normalized.name === SITE_NAME) {
+  const isFirstPartyOrganization = hasSchemaType(normalized, 'Organization') && normalized.name === SITE_NAME
+
+  if (relationship === 'author' && isFirstPartyOrganization) {
+    return authorSchemaIdentity()
+  }
+
+  if (isFirstPartyOrganization) {
     return {
       ...normalized,
       '@id': ORGANIZATION_SCHEMA_ID,


### PR DESCRIPTION
Fixes #3431

## Summary
- routes shared schema graphs through the canonical WebSite, Person author, and Organization publisher IDs
- removes organizational Article authorship from profile evidence and SEO-entry graph builders
- emits `reviewedBy` only when a real profile review date exists
- stops mislabeling a review date as the evidence Article publication date
- removes the legacy `2026-01-01` SEO-entry publication placeholder instead of pretending it is factual
- normalizes legacy exact THS Organization `author` relationships to the canonical Willie Person at the JSON-LD serialization boundary, fixing older callers without rewriting each page
- changes herb entities in compare-detail `about` markup from `MedicalTherapy` to neutral `Substance`
- makes Schema and Media Governance actually watch shared `src/lib/schema*` sources and run their focused unit suite before the full build/audits

## Relevant URLs
- `/herbs/<slug>/`
- `/compounds/<slug>/`
- `/guides/compare/<slug>/`
- SEO entry pages produced by `buildSeoEntrySchemaGraph`
- generic Article pages that still contain the historical THS Organization author fallback

## Acceptance criteria
- Shared editorial Article nodes use the canonical Person author and canonical Organization publisher.
- Shared WebPage/CollectionPage graphs refer to the canonical WebSite ID.
- Profile `reviewedBy` is absent without a review date and resolves to the canonical Organization when a review date exists.
- Profile review dates are not emitted as Article `datePublished`.
- SEO-entry graphs do not emit the legacy placeholder publication date.
- Historical exact THS Organization author objects serialize as the canonical Person; publisher/reviewer roles remain Organization.
- Third-party authors/publishers remain untouched.
- Herbs in compare-detail `about` markup use `Substance`, not `MedicalTherapy`.
- Schema governance runs for shared `src/lib/schema*` changes.

## Validation commands
- `npx vitest run src/lib/__tests__/schema-graph.test.ts src/lib/__tests__/schema-injector.test.ts src/lib/__tests__/structured-data.test.ts`
- `npm run typecheck`
- `npm run build:deploy`
- `node scripts/ci/audit-structured-data.mjs`
- `node scripts/ci/audit-schema-policy.mjs`
- Schema and Media Governance
- Atomic upgrade gate

## Before → after metrics
- Organization-as-author objects in `buildProfileSchemaGraph`: 2 → 0.
- Organization-as-author objects in `buildSeoEntrySchemaGraph`: 1 → 0.
- Hard-coded `datePublished: 2026-01-01` in the shared SEO-entry graph: 1 → 0.
- Unconditional profile `reviewedBy` emission: 1 path → 0; now conditional on `reviewedAt`.
- Herb compare-detail `MedicalTherapy` typing: 1 shared branch → 0; now `Substance`.
- Schema governance coverage for `src/lib/schema*`: absent from path filter → explicit trigger + targeted unit suite.
- New schema pipelines introduced: 0; existing schema governance is extended.

## Generator/source-of-truth decision
`src/lib/schema-identities.ts` remains the canonical first-party identity contract, `src/lib/schema-graph.ts` remains the shared graph builder, `serializeJsonLd()` remains the HTML publication boundary, and Schema and Media Governance remains the schema release gate. Dates are emitted only from supplied editorial provenance; no publication date is invented when the source does not provide one.

## Regression contract
- The first-party publisher remains the canonical Organization.
- The first-party editorial author remains the canonical Person.
- A THS Organization may remain a reviewer/publisher but must not survive in an `author` relationship.
- Third-party identity roles are never rewritten.
- `reviewedBy` cannot exist on the shared profile graph without `dateReviewed`.
- A review date cannot be repurposed as `datePublished`.
- Placeholder publication dates must not return.
- Herb comparison entities must not imply treatment by using `MedicalTherapy`.

## AI SEO / trust impact
Answer engines receive a cleaner graph: one author, one publisher, one WebSite identity, truthful temporal semantics, and neutral herb entity typing rather than implied treatment semantics.