### PR TITLE
polish(profile): tighten decision-stack spacing

### DIFF
--- a/components/editorial/EvidenceConfidence.tsx
+++ b/components/editorial/EvidenceConfidence.tsx
@@ -24,17 +24,19 @@ export function EvidenceConfidence({
   whyNotHigher,
   whyNotLower,
   practicalTakeaway,
+  className = 'my-4',
 }: {
   title?: string
   grade: string
   whyNotHigher: string[]
   whyNotLower?: string[]
   practicalTakeaway: ReactNode
+  className?: string
 }) {
   const gradeStyle = GRADE_STYLE[String(grade).toLowerCase()] ?? GRADE_STYLE.moderate
 
   return (
-    <section className="not-prose my-4">
+    <section className={`not-prose ${className}`}>
       <details className="group border-y border-[color:var(--hs-hairline-strong)] !bg-transparent !p-0 !shadow-none">
         <summary className="flex min-h-12 cursor-pointer list-none flex-wrap items-center justify-between gap-3 py-3 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hs-gold)] [&::-webkit-details-marker]:hidden">
           <span className="flex flex-wrap items-center gap-3">

--- a/components/editorial/ProfileDecisionPanel.tsx
+++ b/components/editorial/ProfileDecisionPanel.tsx
@@ -39,6 +39,7 @@ export function ProfileDecisionPanel({
           whyNotHigher={verdict.evidenceConfidence.whyNotHigher}
           whyNotLower={verdict.evidenceConfidence.whyNotLower}
           practicalTakeaway={verdict.evidenceConfidence.practicalTakeaway}
+          className="my-0"
         />
       ) : null}
 


### PR DESCRIPTION
Profile-only visual rhythm fix: let the shared evidence explainer accept a class override, then remove its built-in margin inside ProfileDecisionPanel where the parent already owns spacing. Other editorial usages keep their existing layout.