### PR TITLE
refactor(nav): centralize core goal routing

### DIFF
--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { coreGoals, type CoreGoalSlug } from '@/lib/core-goals'
 import { buildPageMetadata } from '@/src/lib/seo'
 
 const TITLE = 'Start Here: Choose What You Are Researching'
@@ -13,27 +14,19 @@ export const metadata: Metadata = buildPageMetadata({
   openGraphType: 'website',
 })
 
+const pathDescriptions: Record<CoreGoalSlug, string> = {
+  sleep: 'Compare sleep-support evidence, timing, forms, and next-day tradeoffs.',
+  stress: 'Explore stress-related evidence without treating every calming mechanism as a proven outcome.',
+  anxiety: 'Use stricter evidence and safety framing for anxiety-adjacent research.',
+  focus: 'Research attention, cognition, stimulant tradeoffs, and non-stimulant approaches.',
+}
+
 const paths = [
-  {
-    label: 'Sleep',
-    href: '/guides/sleep/',
-    description: 'Compare sleep-support evidence, timing, forms, and next-day tradeoffs.',
-  },
-  {
-    label: 'Stress',
-    href: '/guides/stress/',
-    description: 'Explore stress-related evidence without treating every calming mechanism as a proven outcome.',
-  },
-  {
-    label: 'Anxiety',
-    href: '/guides/anxiety/',
-    description: 'Use stricter evidence and safety framing for anxiety-adjacent research.',
-  },
-  {
-    label: 'Focus',
-    href: '/guides/focus/',
-    description: 'Research attention, cognition, stimulant tradeoffs, and non-stimulant approaches.',
-  },
+  ...coreGoals.map((goal) => ({
+    label: goal.label,
+    href: goal.href,
+    description: pathDescriptions[goal.slug],
+  })),
   {
     label: 'Ingredient lookup',
     href: '/search/',
@@ -44,7 +37,7 @@ const paths = [
     href: '/safety-checker/',
     description: 'Screen combinations for documented or theoretical caution flags and open the full safety profiles.',
   },
-] as const
+]
 
 export default function StartHerePage() {
   return (

--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -1,3 +1,5 @@
+import { coreGoalPrefixes, coreGoals } from './core-goals'
+
 export interface PrimaryNavigationItem {
   label: string
   href: string
@@ -12,13 +14,15 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     label: 'Goals',
     href: '/goals',
     description: 'Start with what you are researching, then follow the evidence to relevant options',
-    activePrefixes: ['/goals', '/guides/mental-health', '/guides/adhd', '/guides/sleep', '/guides/stress', '/guides/anxiety', '/guides/focus'],
+    activePrefixes: ['/goals', '/guides/mental-health', '/guides/adhd', ...coreGoalPrefixes],
     children: [
       { section: 'Start here', label: 'Goal finder', href: '/goals', description: 'Choose the outcome or question you are actually researching' },
-      { section: 'Health goals', label: 'Sleep', href: '/guides/sleep', description: 'Sleep aids, timing, alternatives, and sleep-support evidence' },
-      { section: 'Health goals', label: 'Stress', href: '/guides/stress', description: 'Acute tension, chronic overload, burnout, and stress-support evidence' },
-      { section: 'Health goals', label: 'Anxiety', href: '/guides/anxiety', description: 'Calming supports, overthinking, tension, and anxiety-focused evidence' },
-      { section: 'Health goals', label: 'Focus & Cognition', href: '/guides/focus', description: 'Focus support, nootropics, and cognitive-performance evidence' },
+      ...coreGoals.map((goal) => ({
+        section: 'Health goals',
+        label: goal.label,
+        href: goal.href.replace(/\/$/, ''),
+        description: goal.description,
+      })),
       { section: 'Health goals', label: 'Mental Health', href: '/guides/mental-health', description: 'Conditions, treatment evidence, safety, and stigma-aware explainers' },
       { section: 'Health goals', label: 'ADHD', href: '/guides/adhd', description: 'Attention, executive function, nutrients, and treatment context' },
     ],


### PR DESCRIPTION
Centralize repeated goal labels and routes into one shared navigation definition, then consume it from primary navigation and the start page. No routes are removed.