### PR TITLE
Add claim-level provenance independence topology

### DIFF
--- a/lib/research-claim-provenance-independence.ts
+++ b/lib/research-claim-provenance-independence.ts
@@ -1,0 +1,75 @@
+import { buildStudyProvenanceIndex } from './research-provenance-concentration'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type ClaimProvenanceIndependence = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  studyCount: number
+  knownAuthorStudyCount: number
+  knownJournalStudyCount: number
+  distinctFirstAuthorCount: number
+  distinctJournalCount: number
+  sameFirstAuthorLineage: boolean
+  sameJournalLineage: boolean
+  provenanceNarrowMultiStudySupport: boolean
+  highConfidenceProvenanceNarrowMultiStudySupport: boolean
+}
+
+/**
+ * Detect multi-study claims whose apparent independence is narrowed by shared
+ * publication provenance. Missing metadata never counts as concentration: a
+ * claim must have provenance for at least two studies before author/journal
+ * lineage can trigger a finding.
+ */
+export function analyzeClaimProvenanceIndependence(
+  analysis: ResearchQualityAnalysis,
+): ClaimProvenanceIndependence[] {
+  const provenanceByUrl = new Map<string, ReturnType<typeof buildStudyProvenanceIndex>>()
+  for (const { url, record } of analysis.profiles) {
+    provenanceByUrl.set(url, buildStudyProvenanceIndex(record, analysis.cache))
+  }
+
+  return analysis.claimAnalyses
+    .filter((claim) => claim.studyCount >= 2)
+    .map((claim) => {
+      const provenance = provenanceByUrl.get(claim.url) ?? new Map()
+      const authors = claim.studyIds
+        .map((studyId) => provenance.get(studyId)?.firstAuthor ?? null)
+        .filter((value): value is string => Boolean(value))
+      const journals = claim.studyIds
+        .map((studyId) => provenance.get(studyId)?.journal ?? null)
+        .filter((value): value is string => Boolean(value))
+      const distinctFirstAuthorCount = new Set(authors).size
+      const distinctJournalCount = new Set(journals).size
+      const sameFirstAuthorLineage = authors.length >= 2 && distinctFirstAuthorCount === 1
+      const sameJournalLineage = journals.length >= 2 && distinctJournalCount === 1
+      const provenanceNarrowMultiStudySupport = sameFirstAuthorLineage || sameJournalLineage
+
+      return {
+        url: claim.url,
+        claimId: claim.claimId,
+        predicate: claim.predicate,
+        confidence: claim.confidence,
+        studyCount: claim.studyCount,
+        knownAuthorStudyCount: authors.length,
+        knownJournalStudyCount: journals.length,
+        distinctFirstAuthorCount,
+        distinctJournalCount,
+        sameFirstAuthorLineage,
+        sameJournalLineage,
+        provenanceNarrowMultiStudySupport,
+        highConfidenceProvenanceNarrowMultiStudySupport:
+          provenanceNarrowMultiStudySupport && claim.confidence >= 0.75,
+      }
+    })
+    .sort((a, b) =>
+      Number(b.highConfidenceProvenanceNarrowMultiStudySupport) - Number(a.highConfidenceProvenanceNarrowMultiStudySupport)
+      || Number(b.provenanceNarrowMultiStudySupport) - Number(a.provenanceNarrowMultiStudySupport)
+      || b.studyCount - a.studyCount
+      || b.confidence - a.confidence
+      || a.url.localeCompare(b.url)
+      || a.claimId.localeCompare(b.claimId),
+    )
+}

--- a/lib/research-provenance-concentration.ts
+++ b/lib/research-provenance-concentration.ts
@@ -1,5 +1,7 @@
-import { canonicalStudyGroups } from './research-coverage'
+import { canonicalStudyGroups, type ResearchProfile } from './research-coverage'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type StudyProvenance = { firstAuthor: string | null; journal: string | null }
 
 export type ProvenanceConcentrationProfile = {
   url: string
@@ -33,8 +35,6 @@ export type ProvenanceConcentrationAnalysis = {
   }
 }
 
-type Provenance = { firstAuthor: string | null; journal: string | null }
-
 function round(value: number, digits = 3): number {
   const scale = 10 ** digits
   return Math.round(value * scale) / scale
@@ -47,7 +47,7 @@ function normalizeToken(value: unknown): string {
 function provenanceForGroup(
   group: Array<Record<string, unknown>>,
   cache: ResearchQualityAnalysis['cache'],
-): Provenance {
+): StudyProvenance {
   for (const source of group) {
     const pmid = normalizeToken(source.pmid ?? source.pubmedId)
     const meta = (cache[pmid] ?? {}) as { authorList?: unknown; authors?: unknown; journal?: unknown }
@@ -64,6 +64,18 @@ function provenanceForGroup(
     }
   }
   return { firstAuthor: null, journal: null }
+}
+
+/** Build the canonical provenance lookup once so profile- and claim-level topology share identical metadata resolution. */
+export function buildStudyProvenanceIndex(
+  record: ResearchProfile,
+  cache: ResearchQualityAnalysis['cache'],
+): Map<string, StudyProvenance> {
+  const index = new Map<string, StudyProvenance>()
+  for (const [studyId, group] of canonicalStudyGroups(record)) {
+    index.set(studyId, provenanceForGroup(group, cache))
+  }
+  return index
 }
 
 function dominant(
@@ -93,10 +105,7 @@ export function analyzeProvenanceConcentration(analysis: ResearchQualityAnalysis
     const claims = claimsByUrl.get(url) ?? []
     if (!claims.length) continue
 
-    const groups = canonicalStudyGroups(record)
-    const provenanceByStudy = new Map<string, Provenance>()
-    for (const [studyId, group] of groups) provenanceByStudy.set(studyId, provenanceForGroup(group, analysis.cache))
-
+    const provenanceByStudy = buildStudyProvenanceIndex(record, analysis.cache)
     const authorEdges = new Map<string, number>()
     const journalEdges = new Map<string, number>()
     const authorStudies = new Map<string, Set<string>>()

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,6 +1,7 @@
 import { analyzeClaimCitationMetadata } from './research-claim-citation-metadata'
 import { analyzeClaimEvidenceDiversity } from './research-claim-evidence-diversity'
 import { analyzeClaimLanguageCalibration } from './research-claim-language-calibration'
+import { analyzeClaimProvenanceIndependence } from './research-claim-provenance-independence'
 import { analyzeCrossProfileEvidenceBundles } from './research-cross-profile-bundles'
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
@@ -45,6 +46,13 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const highConfidenceHomogeneousMultiStudyClaims = claimEvidenceDiversity.filter(
     (claim) => claim.highConfidenceHomogeneousMultiStudySupport,
   )
+  const claimProvenanceIndependence = analyzeClaimProvenanceIndependence(analysis)
+  const provenanceNarrowMultiStudyClaims = claimProvenanceIndependence.filter(
+    (claim) => claim.provenanceNarrowMultiStudySupport,
+  )
+  const highConfidenceProvenanceNarrowMultiStudyClaims = claimProvenanceIndependence.filter(
+    (claim) => claim.highConfidenceProvenanceNarrowMultiStudySupport,
+  )
   const studyClassConflicts = analyzeStudyClassConflicts(analysis)
   const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
@@ -71,6 +79,9 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     claimEvidenceDiversity,
     homogeneousMultiStudyClaims,
     highConfidenceHomogeneousMultiStudyClaims,
+    claimProvenanceIndependence,
+    provenanceNarrowMultiStudyClaims,
+    highConfidenceProvenanceNarrowMultiStudyClaims,
     studyClassConflicts,
     semanticAlignment,
     claimLanguageCalibration,


### PR DESCRIPTION
Refactors study provenance resolution into one reusable canonical index and adds claim-level author/journal lineage analysis for multi-study approved claims. Missing metadata never counts as concentration. Integrates provenance-narrow and high-confidence provenance-narrow claims into the canonical topology snapshot without changing remediation weights yet.