### PR TITLE
SEO: unify generic article citations with the canonical source ledger

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -3,6 +3,8 @@ name: AI search quality check
 on:
   pull_request:
     paths:
+      - 'app/articles/**'
+      - 'components/References.tsx'
       - 'components/seo/**'
       - 'components/StructuredData.tsx'
       - 'components/compare/CompareSchema.tsx'
@@ -11,6 +13,9 @@ on:
       - 'components/ui/EvidenceScoreBadge.tsx'
       - 'components/ui/SafetyGaugeMeter.tsx'
       - 'src/components/editorial/LastUpdatedBadge.tsx'
+      - 'src/components/evidence/WhatEvidenceShows.tsx'
+      - 'src/lib/article-citation-metadata.ts'
+      - 'src/lib/__tests__/article-citation-metadata.test.ts'
       - 'src/lib/schema-identities.ts'
       - 'src/lib/schema-injector.ts'
       - 'src/lib/__tests__/schema-injector.test.ts'
@@ -76,9 +81,10 @@ jobs:
       - name: Install dependencies
         run: npm ci --silent
 
-      - name: Run schema identity, discovery, and provenance tests
+      - name: Run schema, article citation, discovery, and provenance tests
         run: >-
           npx vitest run
+          src/lib/__tests__/article-citation-metadata.test.ts
           src/lib/__tests__/schema-injector.test.ts
           components/seo/__tests__/SchemaGraphScript.test.ts
           components/seo/__tests__/SchemaGraphScript.provenance.test.ts
@@ -89,6 +95,8 @@ jobs:
       - name: Lint AI-search implementation files
         run: >-
           npx eslint
+          app/articles/[slug]/page.tsx
+          components/References.tsx
           components/StructuredData.tsx
           components/compare/CompareSchema.tsx
           components/seo/SchemaGraphScript.tsx
@@ -102,6 +110,9 @@ jobs:
           components/ui/EvidenceScoreBadge.tsx
           components/ui/SafetyGaugeMeter.tsx
           src/components/editorial/LastUpdatedBadge.tsx
+          src/components/evidence/WhatEvidenceShows.tsx
+          src/lib/article-citation-metadata.ts
+          src/lib/__tests__/article-citation-metadata.test.ts
           src/lib/schema-identities.ts
           src/lib/schema-injector.ts
           src/lib/__tests__/schema-injector.test.ts

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { allArticleMonographs, allBlogPosts } from '../../../.content-collections/generated'
 
 import ArticleMdx from '@/components/articles/ArticleMdx'
+import References, { type Ref } from '@/components/References'
 import JsonLd from '@/components/seo/JsonLd'
 import ContentCards from '@/components/content/ContentCards'
 import WhatEvidenceShows from '@/src/components/evidence/WhatEvidenceShows'
@@ -15,11 +16,74 @@ import {
   resolveRelatedArticles,
 } from '@/src/lib/article-citation-metadata'
 import { SITE_URL, buildPageMetadata, compactMetaTitle } from '../../../src/lib/seo'
+import {
+  AUTHOR_NAME,
+  AUTHOR_SCHEMA_ID,
+  AUTHOR_URL,
+  ORGANIZATION_SCHEMA_ID,
+} from '@/src/lib/schema-identities'
 
 const articlePages = [...allArticleMonographs, ...allBlogPosts]
 
 type PageProps = {
   params: Promise<{ slug: string }>
+}
+
+type ArticleReference = Ref & {
+  sourceId?: string
+}
+
+function normalizeArticleReferences(references: readonly unknown[]): ArticleReference[] {
+  return references.map((raw, index) => {
+    const ref = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+    const title = String(ref.title || `Source ${index + 1}`).trim()
+    const authors = typeof ref.authors === 'string' ? ref.authors.trim() : undefined
+    const year = typeof ref.year === 'string' || typeof ref.year === 'number' ? ref.year : undefined
+    const pmid = typeof ref.pmid === 'string' ? ref.pmid.trim() : undefined
+    const doi = typeof ref.doi === 'string' ? ref.doi.trim().replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '') : undefined
+    const explicitUrl = typeof ref.url === 'string' ? ref.url.trim() : ''
+    const url = explicitUrl
+      || (doi ? `https://doi.org/${doi}` : '')
+      || (pmid ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` : '')
+      || undefined
+
+    return {
+      n: index + 1,
+      title,
+      text: [authors, year ? String(year) : ''].filter(Boolean).join(' · '),
+      authors,
+      year,
+      pmid,
+      doi,
+      url,
+      sourceId: doi ? `doi:${doi.toLowerCase()}` : pmid ? `pmid:${pmid}` : url,
+    }
+  })
+}
+
+function citationSchema(ref: ArticleReference) {
+  const identifiers = [
+    ref.pmid ? { '@type': 'PropertyValue', propertyID: 'PMID', value: ref.pmid } : null,
+    ref.doi ? { '@type': 'PropertyValue', propertyID: 'DOI', value: ref.doi } : null,
+  ].filter(Boolean)
+
+  return {
+    '@type': 'ScholarlyArticle',
+    ...(ref.sourceId ? { '@id': ref.sourceId.startsWith('http') ? ref.sourceId : ref.url } : {}),
+    name: ref.title,
+    ...(ref.year ? { datePublished: String(ref.year) } : {}),
+    ...(identifiers.length ? { identifier: identifiers } : {}),
+    ...(ref.url ? { url: ref.url } : {}),
+    ...(ref.authors
+      ? {
+          additionalProperty: {
+            '@type': 'PropertyValue',
+            name: 'Authors as cited',
+            value: ref.authors,
+          },
+        }
+      : {}),
+  }
 }
 
 export function generateStaticParams() {
@@ -48,14 +112,16 @@ export default async function ArticleMonographPage({ params }: PageProps) {
   const pagePath = `/articles/${page.slug}/`
   const relatedPages = resolveRelatedArticles(page, articlePages)
   const { keyTakeaways, citationQuestions, canonicalConcepts } = normalizeCitationMetadata(page)
+  const articleReferences = normalizeArticleReferences(page.references)
   const citationReadySummary = buildCitationReadySummary({
     description: page.description,
     keyTakeaways,
-    sourceCount: page.references.length,
+    sourceCount: articleReferences.length,
     evidenceGrade: page.evidenceGrade,
   })
 
-  const author = 'author' in page ? page.author : undefined
+  const sourceAuthor = 'author' in page && typeof page.author === 'string' ? page.author.trim() : ''
+  const author = sourceAuthor || AUTHOR_NAME
   const reviewEvent = latestReviewForPage(editorialReviewEvents, pagePath)
   const lastReviewed = reviewEvent?.reviewedAt
   const reviewedBy = reviewEvent?.reviewerName
@@ -79,52 +145,43 @@ export default async function ArticleMonographPage({ params }: PageProps) {
     keywords: page.tags,
     articleSection: page.category,
     ...(canonicalConcepts.length > 0 ? { about: canonicalConcepts } : {}),
-    author: author
-      ? { '@type': 'Person', name: author }
-      : { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-    publisher: { '@type': 'Organization', name: 'The Hippie Scientist', url: SITE_URL },
-    citation: page.references.map((ref) => ({
-      '@type': 'ScholarlyArticle',
-      headline: ref.title,
-      author: ref.authors,
-      datePublished: ref.year,
-      identifier: ref.pmid ? `PMID:${ref.pmid}` : undefined,
-      url: ref.url || (ref.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${ref.pmid}/` : undefined),
-    })),
+    author: author === AUTHOR_NAME
+      ? { '@type': 'Person', '@id': AUTHOR_SCHEMA_ID, name: AUTHOR_NAME, url: AUTHOR_URL }
+      : { '@type': 'Person', name: author },
+    publisher: { '@id': ORGANIZATION_SCHEMA_ID },
+    citation: articleReferences.map(citationSchema),
   }
 
-  const takeawaySchema =
-    keyTakeaways.length > 0
-      ? {
-          '@context': 'https://schema.org',
-          '@type': 'ItemList',
-          name: `${page.title}: Scientific Takeaways`,
-          itemListElement: keyTakeaways.map((takeaway, index) => ({
-            '@type': 'ListItem',
-            position: index + 1,
-            name: takeaway,
-          })),
-        }
-      : null
+  const takeawaySchema = keyTakeaways.length > 0
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'ItemList',
+        name: `${page.title}: Scientific Takeaways`,
+        itemListElement: keyTakeaways.map((takeaway, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          name: takeaway,
+        })),
+      }
+    : null
 
-  const medicalPageSchema =
-    lastReviewed || page.references.length > 0
-      ? {
-          '@context': 'https://schema.org',
-          '@type': 'MedicalWebPage',
-          url: `${SITE_URL}${pagePath}`,
-          ...(lastReviewed ? { lastReviewed } : {}),
-          ...(reviewerLabel
-            ? {
-                reviewedBy: {
-                  '@type': 'Person',
-                  name: reviewedBy,
-                  ...(reviewerCredential ? { honorificSuffix: reviewerCredential } : {}),
-                },
-              }
-            : {}),
-        }
-      : null
+  const medicalPageSchema = lastReviewed || articleReferences.length > 0
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'MedicalWebPage',
+        url: `${SITE_URL}${pagePath}`,
+        ...(lastReviewed ? { lastReviewed } : {}),
+        ...(reviewerLabel
+          ? {
+              reviewedBy: {
+                '@type': 'Person',
+                name: reviewedBy,
+                ...(reviewerCredential ? { honorificSuffix: reviewerCredential } : {}),
+              },
+            }
+          : {}),
+      }
+    : null
 
   const hasResearchBrief = citationQuestions.length > 0 || keyTakeaways.length > 0
 
@@ -137,20 +194,14 @@ export default async function ArticleMonographPage({ params }: PageProps) {
       <header className="hero-shell rounded-[2rem] border p-6 sm:p-8 lg:p-10">
         <div className="flex flex-wrap items-center gap-2.5">
           <span className="identity-kicker">{page.category}</span>
-          {page.evidenceGrade ? (
-            <span className="identity-kicker">Evidence {page.evidenceGrade}</span>
-          ) : null}
+          {page.evidenceGrade ? <span className="identity-kicker">Evidence {page.evidenceGrade}</span> : null}
           {factualUpdated ? (
-            <time dateTime={factualUpdated} className="identity-meta">
-              Factual update {factualUpdated}
-            </time>
+            <time dateTime={factualUpdated} className="identity-meta">Factual update {factualUpdated}</time>
           ) : null}
           {templateUpdated ? (
             <>
               <span aria-hidden="true" className="identity-meta">·</span>
-              <time dateTime={templateUpdated} className="identity-meta">
-                Template revision {templateUpdated}
-              </time>
+              <time dateTime={templateUpdated} className="identity-meta">Template revision {templateUpdated}</time>
             </>
           ) : null}
           <span aria-hidden="true" className="identity-meta">·</span>
@@ -166,37 +217,32 @@ export default async function ArticleMonographPage({ params }: PageProps) {
             id={`article-evidence-${page.slug}`}
             summary={citationReadySummary}
             evidenceGrade={page.evidenceGrade}
-            sourceCount={page.references.length}
+            sourceCount={articleReferences.length}
+            referencesHref={articleReferences.length ? '#references' : undefined}
           />
         </div>
 
         <div className="mt-6 flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-[color:var(--hs-hairline)] pt-4 text-xs text-[color:var(--hs-body)]">
-          {author ? (
-            <span>
-              Written by <span className="font-semibold text-[color:var(--hs-ink)]">{author}</span>
-            </span>
-          ) : null}
+          <span>
+            Written by <span className="font-semibold text-[color:var(--hs-ink)]">{author}</span>
+          </span>
           {reviewerLabel ? (
             <>
               <span aria-hidden="true">·</span>
-              <span>
-                Reviewed by <span className="font-semibold text-[color:var(--hs-ink)]">{reviewerLabel}</span>
-              </span>
+              <span>Reviewed by <span className="font-semibold text-[color:var(--hs-ink)]">{reviewerLabel}</span></span>
             </>
           ) : null}
           {lastReviewed ? (
             <>
               <span aria-hidden="true">·</span>
-              <span>
-                Last reviewed <time dateTime={lastReviewed}>{lastReviewed}</time>
-              </span>
+              <span>Last reviewed <time dateTime={lastReviewed}>{lastReviewed}</time></span>
             </>
           ) : null}
-          {page.references.length > 0 ? (
+          {articleReferences.length > 0 ? (
             <>
               <span aria-hidden="true">·</span>
               <a href="#references" className="font-semibold text-[color:var(--tone-ink)] hover:underline">
-                {page.references.length} cited sources
+                {articleReferences.length} cited sources
               </a>
             </>
           ) : null}
@@ -218,9 +264,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
                 </h2>
                 <ul className="mt-5 divide-y divide-[color:var(--hs-hairline)] text-sm leading-6 text-[color:var(--hs-body)]">
                   {citationQuestions.map((question) => (
-                    <li key={question} className="py-3 first:pt-0 last:pb-0">
-                      {question}
-                    </li>
+                    <li key={question} className="py-3 first:pt-0 last:pb-0">{question}</li>
                   ))}
                 </ul>
               </div>
@@ -254,27 +298,10 @@ export default async function ArticleMonographPage({ params }: PageProps) {
         </ContentCards>
       </div>
 
-      {page.references.length > 0 ? (
-        <section id="references" className="mt-8 scroll-mt-24 border-t border-[color:var(--hs-hairline)] py-8">
-          <h2 className="text-lg font-bold text-ink">References</h2>
-          <ol className="mt-4 list-decimal space-y-2 pl-5 text-sm leading-6 text-muted marker:font-semibold marker:text-brand-800">
-            {page.references.map((ref, index) => (
-              <li key={`${ref.title}-${index}`} id={`ref-${ref.pmid || index + 1}`} className="scroll-mt-24">
-                {ref.authors ? `${ref.authors} ` : ''}
-                {ref.title}
-                {ref.year ? ` (${ref.year})` : ''}
-                {ref.url ? (
-                  <>
-                    {' — '}
-                    <a href={ref.url} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-800 hover:underline">
-                      Source
-                    </a>
-                  </>
-                ) : null}
-              </li>
-            ))}
-          </ol>
-        </section>
+      {articleReferences.length > 0 ? (
+        <div className="mt-8">
+          <References refs={articleReferences} />
+        </div>
       ) : null}
 
       {relatedPages.length > 0 ? (

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -4,14 +4,16 @@ import { notFound } from 'next/navigation'
 import { allArticleMonographs, allBlogPosts } from '../../../.content-collections/generated'
 
 import ArticleMdx from '@/components/articles/ArticleMdx'
-import References, { type Ref } from '@/components/References'
+import References from '@/components/References'
 import JsonLd from '@/components/seo/JsonLd'
 import ContentCards from '@/components/content/ContentCards'
 import WhatEvidenceShows from '@/src/components/evidence/WhatEvidenceShows'
 import { editorialReviewEvents } from '@/data/editorial/reviews'
 import { latestReviewForPage } from '@/lib/editorial-provenance'
 import {
+  buildArticleReferenceSchema,
   buildCitationReadySummary,
+  normalizeArticleReferences,
   normalizeCitationMetadata,
   resolveRelatedArticles,
 } from '@/src/lib/article-citation-metadata'
@@ -27,63 +29,6 @@ const articlePages = [...allArticleMonographs, ...allBlogPosts]
 
 type PageProps = {
   params: Promise<{ slug: string }>
-}
-
-type ArticleReference = Ref & {
-  sourceId?: string
-}
-
-function normalizeArticleReferences(references: readonly unknown[]): ArticleReference[] {
-  return references.map((raw, index) => {
-    const ref = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
-    const title = String(ref.title || `Source ${index + 1}`).trim()
-    const authors = typeof ref.authors === 'string' ? ref.authors.trim() : undefined
-    const year = typeof ref.year === 'string' || typeof ref.year === 'number' ? ref.year : undefined
-    const pmid = typeof ref.pmid === 'string' ? ref.pmid.trim() : undefined
-    const doi = typeof ref.doi === 'string' ? ref.doi.trim().replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '') : undefined
-    const explicitUrl = typeof ref.url === 'string' ? ref.url.trim() : ''
-    const url = explicitUrl
-      || (doi ? `https://doi.org/${doi}` : '')
-      || (pmid ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` : '')
-      || undefined
-
-    return {
-      n: index + 1,
-      title,
-      text: [authors, year ? String(year) : ''].filter(Boolean).join(' · '),
-      authors,
-      year,
-      pmid,
-      doi,
-      url,
-      sourceId: doi ? `doi:${doi.toLowerCase()}` : pmid ? `pmid:${pmid}` : url,
-    }
-  })
-}
-
-function citationSchema(ref: ArticleReference) {
-  const identifiers = [
-    ref.pmid ? { '@type': 'PropertyValue', propertyID: 'PMID', value: ref.pmid } : null,
-    ref.doi ? { '@type': 'PropertyValue', propertyID: 'DOI', value: ref.doi } : null,
-  ].filter(Boolean)
-
-  return {
-    '@type': 'ScholarlyArticle',
-    ...(ref.sourceId ? { '@id': ref.sourceId.startsWith('http') ? ref.sourceId : ref.url } : {}),
-    name: ref.title,
-    ...(ref.year ? { datePublished: String(ref.year) } : {}),
-    ...(identifiers.length ? { identifier: identifiers } : {}),
-    ...(ref.url ? { url: ref.url } : {}),
-    ...(ref.authors
-      ? {
-          additionalProperty: {
-            '@type': 'PropertyValue',
-            name: 'Authors as cited',
-            value: ref.authors,
-          },
-        }
-      : {}),
-  }
 }
 
 export function generateStaticParams() {
@@ -149,7 +94,7 @@ export default async function ArticleMonographPage({ params }: PageProps) {
       ? { '@type': 'Person', '@id': AUTHOR_SCHEMA_ID, name: AUTHOR_NAME, url: AUTHOR_URL }
       : { '@type': 'Person', name: author },
     publisher: { '@id': ORGANIZATION_SCHEMA_ID },
-    citation: articleReferences.map(citationSchema),
+    citation: articleReferences.map(buildArticleReferenceSchema),
   }
 
   const takeawaySchema = keyTakeaways.length > 0

--- a/components/References.tsx
+++ b/components/References.tsx
@@ -42,7 +42,7 @@ export default function References({ refs }: { refs: Ref[] }) {
           return (
             <li
               key={ref.n}
-              id={citationId}
+              id={`ref-${ref.n}`}
               data-citation-source="true"
               data-citation-id={citationId}
               data-citation-authors={ref.authors || undefined}

--- a/components/References.tsx
+++ b/components/References.tsx
@@ -45,6 +45,8 @@ export default function References({ refs }: { refs: Ref[] }) {
               id={citationId}
               data-citation-source="true"
               data-citation-id={citationId}
+              data-citation-authors={ref.authors || undefined}
+              data-citation-journal={ref.journal || undefined}
               data-pmid={ref.pmid || undefined}
               data-doi={ref.doi || undefined}
               itemScope
@@ -63,8 +65,6 @@ export default function References({ refs }: { refs: Ref[] }) {
                   {ref.title || ref.text}
                 </cite>
                 {ref.title ? <span> {ref.text}</span> : null}
-                {ref.authors ? <meta itemProp="author" content={ref.authors} /> : null}
-                {ref.journal ? <meta itemProp="isPartOf" content={ref.journal} /> : null}
                 {ref.year ? <meta itemProp="datePublished" content={String(ref.year)} /> : null}
                 {ref.pmid ? <meta itemProp="identifier" content={`PMID:${ref.pmid}`} /> : null}
                 {ref.doi ? <meta itemProp="identifier" content={`DOI:${ref.doi}`} /> : null}

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -9,6 +9,10 @@ const MANIFEST = path.join(ROOT, 'public', 'data', 'ai-entities', 'manifest.json
 const SCHEMA = path.join(ROOT, 'components', 'seo', 'SchemaGraphScript.tsx')
 const CITATION_SUMMARY = path.join(ROOT, 'components', 'seo', 'CitationReadySummary.tsx')
 const ANSWER_TABLE = path.join(ROOT, 'components', 'seo', 'AnswerEngineTable.tsx')
+const ARTICLE_EVIDENCE = path.join(ROOT, 'src', 'components', 'evidence', 'WhatEvidenceShows.tsx')
+const ARTICLE_CITATIONS = path.join(ROOT, 'src', 'lib', 'article-citation-metadata.ts')
+const ARTICLE_PAGE = path.join(ROOT, 'app', 'articles', '[slug]', 'page.tsx')
+const REFERENCES = path.join(ROOT, 'components', 'References.tsx')
 const EVIDENCE_BADGE = path.join(ROOT, 'components', 'ui', 'EvidenceScoreBadge.tsx')
 const SAFETY_GAUGE = path.join(ROOT, 'components', 'ui', 'SafetyGaugeMeter.tsx')
 const VERDICT_CARD = path.join(ROOT, 'components', 'editorial', 'ScientificVerdictCard.tsx')
@@ -108,6 +112,40 @@ function auditSharedExtractionPrimitives() {
   if (!existsSync(LICENSING_PAGE)) add('warn', 'attribution', 'public content licensing/attribution policy page is missing')
 }
 
+function auditArticleExtractionPrimitives() {
+  requireSignals(ARTICLE_EVIDENCE, 'article-semantics', 'WhatEvidenceShows', [
+    ['data-answer-engine-summary="true"', 'answer-engine summary marker'],
+    ['data-claim="true"', 'claim marker'],
+    ['data-evidence="true"', 'evidence marker'],
+    ['data-citation-sources="true"', 'claim-adjacent source marker'],
+    ['referencesHref', 'reference-ledger target support'],
+  ])
+
+  requireSignals(REFERENCES, 'article-semantics', 'References', [
+    ['id={`ref-${ref.n}`}', 'stable ordinal source anchors'],
+    ['data-citation-source=', 'citation-source marker'],
+    ['itemType="https://schema.org/CreativeWork"', 'CreativeWork source semantics'],
+  ])
+
+  requireSignals(ARTICLE_CITATIONS, 'article-semantics', 'article-citation-metadata', [
+    ['evidenceSourceUrl', 'canonical evidence source URL primitive'],
+    ['evidenceStudyId', 'canonical evidence source identity primitive'],
+    ['normalizeArticleReferences', 'article reference normalizer'],
+    ['buildArticleReferenceSchema', 'conservative scholarly citation schema builder'],
+  ])
+
+  requireSignals(ARTICLE_PAGE, 'article-semantics', 'generic article page', [
+    ['<References refs={articleReferences}', 'shared durable reference ledger'],
+    ["referencesHref={articleReferences.length ? '#references' : undefined}", 'claim-adjacent references target'],
+    ['articleReferences.map(buildArticleReferenceSchema)', 'canonical article citation schema builder'],
+  ])
+
+  const articleCitations = text(ARTICLE_CITATIONS)
+  if (/author\s*:/.test(articleCitations.split('buildArticleReferenceSchema')[1]?.split('buildCitationReadySummary')[0] || '')) {
+    add('error', 'article-semantics', 'article scholarly citation builder promotes free-form reference authors into structured author nodes')
+  }
+}
+
 function auditProfilePrimitives() {
   requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
     ['data-evidence="true"', 'evidence marker'],
@@ -149,8 +187,8 @@ function auditExtractability() {
 
   for (const file of candidates) {
     const source = text(file)
-    if (/quick answer|CitationReadySummary|TL;DR/i.test(source)) quick++
-    if (/Evidence Summary|evidence grade|EvidenceGrade|EvidenceBadge/i.test(source)) evidence++
+    if (/quick answer|CitationReadySummary|TL;DR|WhatEvidenceShows/i.test(source)) quick++
+    if (/Evidence Summary|evidence grade|EvidenceGrade|EvidenceBadge|WhatEvidenceShows/i.test(source)) evidence++
     if (/References|Citations|CompareCitations|Sources/i.test(source)) references++
     if (/SchemaGraphScript|JsonLd|JSON-LD|AuthorityJsonLd|CompareSchema/i.test(source)) schema++
     if (/Safety|contraindication|interaction/i.test(source)) safety++
@@ -184,6 +222,7 @@ function auditAntiPatterns() {
 auditDiscovery()
 auditMachineReadable()
 auditSharedExtractionPrimitives()
+auditArticleExtractionPrimitives()
 auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()

--- a/src/components/evidence/WhatEvidenceShows.tsx
+++ b/src/components/evidence/WhatEvidenceShows.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 type WhatEvidenceShowsProps = {
   summary: string
   evidenceGrade?: string | null
@@ -5,6 +7,7 @@ type WhatEvidenceShowsProps = {
   keyPoints?: string[]
   limitation?: string | null
   id?: string
+  referencesHref?: string
 }
 
 export default function WhatEvidenceShows({
@@ -14,18 +17,23 @@ export default function WhatEvidenceShows({
   keyPoints = [],
   limitation,
   id = 'what-the-evidence-shows',
+  referencesHref,
 }: WhatEvidenceShowsProps) {
   const visiblePoints = keyPoints.filter(Boolean).slice(0, 3)
 
   return (
     <section
+      id={id}
       aria-labelledby={`${id}-title`}
-      className="rounded-2xl border border-[color:var(--hs-hairline)] bg-white/70 p-5 shadow-sm dark:bg-white/5 sm:p-6"
+      data-answer-engine-summary="true"
+      className="scroll-mt-24 rounded-2xl border border-[color:var(--hs-hairline)] bg-white/70 p-5 shadow-sm dark:bg-white/5 sm:p-6"
     >
       <div className="flex flex-wrap items-center gap-2">
         <p className="section-label">What the evidence actually shows</p>
         {evidenceGrade ? (
-          <span className="identity-kicker">Evidence {evidenceGrade}</span>
+          <span data-evidence="true" data-evidence-grade={evidenceGrade} className="identity-kicker">
+            Evidence {evidenceGrade}
+          </span>
         ) : null}
         {sourceCount > 0 ? (
           <span className="identity-meta">{sourceCount} cited source{sourceCount === 1 ? '' : 's'}</span>
@@ -38,6 +46,7 @@ export default function WhatEvidenceShows({
       <p
         className="mt-2 text-base leading-7 text-[color:var(--hs-body)]"
         data-citation-ready-summary="true"
+        data-claim="true"
         itemProp="abstract"
       >
         {summary}
@@ -55,9 +64,17 @@ export default function WhatEvidenceShows({
       ) : null}
 
       {limitation ? (
-        <p className="mt-4 border-t border-[color:var(--hs-hairline)] pt-3 text-sm leading-6 text-muted">
+        <p data-limitation="true" className="mt-4 border-t border-[color:var(--hs-hairline)] pt-3 text-sm leading-6 text-muted">
           <strong className="text-ink">Important limitation:</strong> {limitation}
         </p>
+      ) : null}
+
+      {referencesHref && sourceCount > 0 ? (
+        <div data-citation-sources="true" className="mt-4 border-t border-[color:var(--hs-hairline)] pt-3 text-sm">
+          <Link href={referencesHref} className="font-semibold text-brand-700 underline underline-offset-4 hover:text-brand-900">
+            Review the {sourceCount} cited source{sourceCount === 1 ? '' : 's'}
+          </Link>
+        </div>
       ) : null}
     </section>
   )

--- a/src/lib/__tests__/article-citation-metadata.test.ts
+++ b/src/lib/__tests__/article-citation-metadata.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildArticleReferenceSchema,
   buildCitationReadySummary,
+  normalizeArticleReferences,
   normalizeCitationMetadata,
+  normalizeDoi,
   resolveRelatedArticles,
 } from '../article-citation-metadata'
 
@@ -66,6 +69,82 @@ describe('buildCitationReadySummary', () => {
 
     expect(summary.match(/Keep this conclusion\./g)).toHaveLength(1)
     expect(sentenceCount(summary)).toBe(2)
+  })
+})
+
+describe('article reference normalization', () => {
+  it('normalizes DOI URLs and keeps ordinal anchors independent of source identity', () => {
+    const refs = normalizeArticleReferences([
+      {
+        title: 'Trial one',
+        authors: 'Example A, Example B',
+        journal: 'Example Journal',
+        year: 2025,
+        doi: 'https://doi.org/10.1000/ABC.123',
+      },
+      {
+        title: 'Trial two',
+        pmid: '12345678',
+      },
+    ])
+
+    expect(refs[0]).toMatchObject({
+      n: 1,
+      doi: '10.1000/ABC.123',
+      url: 'https://doi.org/10.1000/ABC.123',
+      sourceId: 'doi:10.1000/abc.123',
+    })
+    expect(refs[1]).toMatchObject({
+      n: 2,
+      pmid: '12345678',
+      url: 'https://pubmed.ncbi.nlm.nih.gov/12345678/',
+      sourceId: 'pmid:12345678',
+    })
+  })
+
+  it('prefers an explicit source URL while preserving PMID/DOI identifiers', () => {
+    const [ref] = normalizeArticleReferences([
+      {
+        title: 'Trial',
+        pmid: '12345678',
+        doi: 'doi:10.1000/test',
+        url: 'https://example.org/full-text',
+      },
+    ])
+
+    expect(ref.url).toBe('https://example.org/full-text')
+    expect(ref.pmid).toBe('12345678')
+    expect(ref.doi).toBe('10.1000/test')
+  })
+
+  it('keeps free-form author strings out of structured scholarly author nodes', () => {
+    const [ref] = normalizeArticleReferences([
+      { title: 'Trial', authors: 'Smith J, Doe R', pmid: '12345678', year: '2025' },
+    ])
+    const schema = buildArticleReferenceSchema(ref)
+
+    expect(schema['@type']).toBe('ScholarlyArticle')
+    expect(schema['@id']).toBe('https://pubmed.ncbi.nlm.nih.gov/12345678/')
+    expect(schema).not.toHaveProperty('author')
+    expect(schema.identifier).toEqual([
+      { '@type': 'PropertyValue', propertyID: 'PMID', value: '12345678' },
+    ])
+  })
+
+  it('does not invent a URL or structured identity when only title metadata exists', () => {
+    const [ref] = normalizeArticleReferences([{ title: 'Narrative source' }])
+    const schema = buildArticleReferenceSchema(ref)
+
+    expect(ref.n).toBe(1)
+    expect(ref.sourceId).toBe('title:narrative-source')
+    expect(ref.url).toBeUndefined()
+    expect(schema).not.toHaveProperty('@id')
+    expect(schema).not.toHaveProperty('url')
+  })
+
+  it('normalizes common DOI prefixes without lowercasing the visible DOI value', () => {
+    expect(normalizeDoi(' DOI: 10.1000/ABC.XYZ ')).toBe('10.1000/ABC.XYZ')
+    expect(normalizeDoi('https://dx.doi.org/10.1000/ABC.XYZ')).toBe('10.1000/ABC.XYZ')
   })
 })
 

--- a/src/lib/article-citation-metadata.ts
+++ b/src/lib/article-citation-metadata.ts
@@ -2,6 +2,7 @@ import {
   articleCitationOverrides,
   citationRelationshipTargets,
 } from '@/src/data/article-citation-overrides'
+import { evidenceSourceUrl, evidenceStudyId } from '@/lib/evidence-study'
 
 export type ArticleRelationshipRecord = {
   slug: string
@@ -23,6 +24,29 @@ export type CitationReadySummaryInput = {
   keyTakeaways?: string[]
   sourceCount?: number
   evidenceGrade?: string | null
+}
+
+export type ArticleReferenceInput = {
+  title?: unknown
+  authors?: unknown
+  journal?: unknown
+  year?: unknown
+  pmid?: unknown
+  doi?: unknown
+  url?: unknown
+}
+
+export type NormalizedArticleReference = {
+  n: number
+  title: string
+  text: string
+  authors?: string
+  journal?: string
+  year?: string | number
+  pmid?: string
+  doi?: string
+  url?: string
+  sourceId: string
 }
 
 const CAVEAT_PATTERN = /\b(?:limit(?:ation|ed|s)?|uncertain(?:ty)?|mixed|inconsistent|small|short[- ]term|preliminary|exploratory|not established|not proven|does not establish|cannot establish|unknown|unclear|lack(?:s|ing)?|sparse|indirect|heterogeneous|specific extract|specific population)\b/i
@@ -100,6 +124,77 @@ function preserveAuthoredCaveat(selected: string[], authoredSentences: string[])
 
   if (selected.length < 4) return [...selected, caveat]
   return [...selected.slice(0, 3), caveat]
+}
+
+function cleanOptionalString(value: unknown): string | undefined {
+  const text = typeof value === 'string' ? value.trim() : ''
+  return text || undefined
+}
+
+export function normalizeDoi(value: unknown): string | undefined {
+  const raw = cleanOptionalString(value)
+  if (!raw) return undefined
+  return raw
+    .replace(/^doi:\s*/i, '')
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .trim() || undefined
+}
+
+/**
+ * Normalize article references onto the same source identity/URL primitives used
+ * by the evidence-study system. Ordinal `n` is the durable page anchor; PMID,
+ * DOI, URL, and title feed a separate stable research-source identity.
+ */
+export function normalizeArticleReferences(
+  references: readonly ArticleReferenceInput[],
+): NormalizedArticleReference[] {
+  return references.map((ref, index) => {
+    const title = cleanOptionalString(ref.title) || `Source ${index + 1}`
+    const authors = cleanOptionalString(ref.authors)
+    const journal = cleanOptionalString(ref.journal)
+    const pmid = cleanOptionalString(ref.pmid)
+    const doi = normalizeDoi(ref.doi)
+    const year = typeof ref.year === 'number' && Number.isFinite(ref.year)
+      ? ref.year
+      : cleanOptionalString(ref.year)
+    const explicitUrl = cleanOptionalString(ref.url)
+    const url = evidenceSourceUrl({ pmid, doi, url: explicitUrl })
+    const sourceId = evidenceStudyId({ pmid, doi, url, title })
+
+    return {
+      n: index + 1,
+      title,
+      text: [authors, journal, year ? String(year) : ''].filter(Boolean).join(' · '),
+      authors,
+      journal,
+      year,
+      pmid,
+      doi,
+      url,
+      sourceId,
+    }
+  })
+}
+
+/**
+ * Build conservative citation JSON-LD from known identifiers. Free-form author
+ * strings remain visible in the source ledger but are not promoted into fake
+ * structured Person/Organization nodes.
+ */
+export function buildArticleReferenceSchema(ref: NormalizedArticleReference) {
+  const identifiers = [
+    ref.pmid ? { '@type': 'PropertyValue', propertyID: 'PMID', value: ref.pmid } : null,
+    ref.doi ? { '@type': 'PropertyValue', propertyID: 'DOI', value: ref.doi } : null,
+  ].filter((value): value is { '@type': string; propertyID: string; value: string } => Boolean(value))
+
+  return {
+    '@type': 'ScholarlyArticle',
+    ...(ref.url ? { '@id': ref.url } : {}),
+    name: ref.title,
+    ...(ref.year ? { datePublished: String(ref.year) } : {}),
+    ...(identifiers.length ? { identifier: identifiers } : {}),
+    ...(ref.url ? { url: ref.url } : {}),
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #3437

## Summary
- moves generic article reference normalization into the existing `article-citation-metadata` module instead of keeping a page-local PMID/DOI parser
- reuses `evidenceSourceUrl()` and `evidenceStudyId()` from the canonical evidence-study system for source URL and identity resolution
- gives every article reference a stable ordinal `#ref-N` page anchor independent of PMID/DOI availability
- replaces the generic article page's custom references list with the shared durable `References` source ledger
- preserves PMID/DOI/year/URL as real citation identifiers while keeping free-form author/journal strings visible and machine-readable without promoting them into fake structured Person/Organization entities
- builds conservative `ScholarlyArticle` citation nodes from known title/date/identifier/URL data only
- upgrades `WhatEvidenceShows` with answer-engine claim/evidence/limitation/source markers and an optional claim-adjacent reference-ledger link
- makes the generic article answer surface link directly to `#references` when citations exist
- adds focused tests for DOI normalization, PMID/DOI URL resolution, ordinal anchors, source identity, and conservative citation schema
- extends the canonical AI-search audit/workflow to own the generic article citation surface

## Relevant URLs
- `/articles/<slug>/`
- individual source anchors `/articles/<slug>/#ref-N`
- shared article answer/evidence block on generic article pages

## Acceptance criteria
- Generic article references use stable ordinal `#ref-N` anchors regardless of PMID/DOI presence.
- PMID/DOI/source URL resolution reuses the canonical evidence-study primitives.
- Article citation JSON-LD preserves real title/date/identifier/URL data but does not turn free-form author strings into structured author entities.
- The visible article source ledger uses the shared `References` component.
- Free-form citation authors/journals remain visible/data-addressable but are not emitted as invalid `author`/`isPartOf` microdata values.
- The article direct-answer block links to the source ledger when sources exist and exposes claim/evidence/source markers.
- Existing callers of `WhatEvidenceShows` remain compatible when no reference target is provided.
- The canonical AI-search audit checks this article citation contract.

## Validation commands
- `npx vitest run src/lib/__tests__/article-citation-metadata.test.ts`
- `npm run audit:ai-citations`
- `npm run typecheck`
- `npm run build:deploy`
- AI search quality check
- Schema and Media Governance
- Atomic upgrade gate

## Before → after metrics
- Generic article reference anchor conventions: 2 (`#ref-PMID` and `#ref-N`) → 1 stable ordinal `#ref-N` convention.
- Generic article reference renderers: custom page-local ledger + shared ledger elsewhere → 1 shared `References` ledger.
- Generic article PMID/DOI URL/identity parsers: 1 page-local implementation → 0; canonical evidence-study primitives reused.
- Free-form citation author strings promoted into `ScholarlyArticle.author`: 1 shared article path → 0.
- Free-form citation author/journal strings promoted into incompatible shared microdata entity properties: 2 properties → 0; retained as citation data attributes/visible text.
- Generic article answer blocks with claim-adjacent source target: 0 → all generic articles with references.
- Article citation normalization regression tests: 0 focused cases → 5+ identifier/identity/schema cases.
- New AI-search audit pipelines: 0; existing answer-engine audit/orchestrator is extended.

## Generator/source-of-truth decision
`lib/evidence-study.ts` remains the canonical study identity/source-URL authority. `src/lib/article-citation-metadata.ts` is the article-specific adapter from authored reference metadata into that canonical identity model. `components/References.tsx` remains the visible source-ledger authority, and `scripts/ci/audit-ai-answer-engine-readiness.mjs` remains the extractability contract within the existing `audit:ai-citations` orchestrator. No new scientific claims or citation metadata are inferred.

## Regression contract
- Page anchor identity (`ref-N`) must remain independent of external identifier availability.
- PMID/DOI values must never be fabricated.
- A missing URL may be derived only from a real PMID or DOI through the canonical evidence source helper.
- Free-form authors must not be promoted to structured Person/Organization nodes without structured source data.
- Third-party citation metadata must remain third-party and must not inherit first-party identities.
- Generic article answer blocks with sources must retain a direct source-ledger target.
- Article pages must not reintroduce a separate references renderer or independent PMID/DOI identity parser.

## AI SEO / trust impact
Generic articles now expose the same durable, source-adjacent citation anatomy as the stronger comparison/profile surfaces: a direct answer, stable source anchors, canonical research-source identities, and conservative scholarly citation schema that does not overstate what the reference metadata actually knows.