### PR TITLE
refactor(research): aggregate topology gap signals

### DIFF
--- a/lib/__tests__/research-quality-policy-topology-signals.test.ts
+++ b/lib/__tests__/research-quality-policy-topology-signals.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildAggregatedTopologyGapSignals } from '@/lib/research-quality-policy-topology-signals'
+import type { ResearchQualityTopology } from '@/lib/research-quality-topology'
+
+const weights = {
+  narrowCrossProfileEvidenceBundle: 12,
+  semanticMismatch: 18,
+  highConfidenceSemanticMismatchBonus: 10,
+  semanticSingleSource: 12,
+  semanticSupportConcentration: 8,
+  highConfidenceSemanticConcentrationBonus: 6,
+  semanticMetadataCoverageGap: 6,
+  highConfidenceSemanticCoverageGapBonus: 4,
+  causalWithoutControlledOrSynthesis: 18,
+  causalWithoutDirectControlled: 10,
+  synthesisOnlyCausalSupport: 7,
+  highConfidenceCausalLanguageBonus: 8,
+  claimCitationMetadataGap: 8,
+  highConfidenceCitationMetadataBonus: 4,
+  provenanceNarrowMultiStudySupport: 8,
+  highConfidenceProvenanceNarrowBonus: 4,
+  severeStudyClassConflict: 100,
+  studyClassAmbiguity: 5,
+}
+
+function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopology {
+  return {
+    narrowCrossProfileEvidenceBundles: [],
+    semanticAlignment: { findings: [], concentrationFindings: [], coverageGapFindings: [] },
+    claimLanguageCalibration: { directEvidenceFindings: [] },
+    claimCitationMetadata: { lowCoverageClaims: [] },
+    provenanceNarrowMultiStudyClaims: [],
+    studyClassConflicts: { conflicts: [], severeConflicts: [] },
+    ...overrides,
+  } as unknown as ResearchQualityTopology
+}
+
+describe('aggregated topology gap signals', () => {
+  it('collapses multiple semantic mismatches on one profile into one signal', () => {
+    const findings = [
+      { url: '/herbs/a/', claimId: 'c1', confidence: 0.9, roleMismatch: true, domainMismatch: false, populationMismatch: false },
+      { url: '/herbs/a/', claimId: 'c2', confidence: 0.8, roleMismatch: false, domainMismatch: true, populationMismatch: false },
+      { url: '/herbs/a/', claimId: 'c3', confidence: 0.6, roleMismatch: false, domainMismatch: false, populationMismatch: true },
+    ]
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      semanticAlignment: { findings, concentrationFindings: [], coverageGapFindings: [] },
+    }), weights)
+
+    const semantic = signals.filter((signal) => signal.kind === 'semantic-claim-source-mismatch')
+    expect(semantic).toHaveLength(1)
+    expect(semantic[0]).toMatchObject({ url: '/herbs/a/' })
+    expect(semantic[0].detail).toContain('3 approved claim(s)')
+    expect(semantic[0].detail).toContain('2 high-confidence')
+  })
+
+  it('routes narrow multi-study provenance once per affected profile', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      provenanceNarrowMultiStudyClaims: [
+        { url: '/herbs/a/', highConfidenceProvenanceNarrowMultiStudySupport: true, sameFirstAuthorLineage: true, sameJournalLineage: false },
+        { url: '/herbs/a/', highConfidenceProvenanceNarrowMultiStudySupport: false, sameFirstAuthorLineage: false, sameJournalLineage: true },
+      ],
+    }), weights)
+
+    const provenance = signals.filter((signal) => signal.kind === 'claim-provenance-narrow-multi-study-support')
+    expect(provenance).toHaveLength(1)
+    expect(provenance[0].detail).toContain('2 multi-study approved claim(s)')
+  })
+
+  it('keeps severe and advisory study-class conflicts distinct', () => {
+    const severe = { url: '/herbs/a/', severe: true }
+    const advisory = { url: '/herbs/b/', severe: false }
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      studyClassConflicts: { conflicts: [severe, advisory], severeConflicts: [severe] },
+    }), weights)
+
+    expect(signals.find((signal) => signal.url === '/herbs/a/')).toMatchObject({
+      kind: 'severe-canonical-study-class-conflict',
+      weight: 100,
+    })
+    expect(signals.find((signal) => signal.url === '/herbs/b/')).toMatchObject({
+      kind: 'canonical-study-class-ambiguity',
+      weight: 5,
+    })
+  })
+})

--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -1,0 +1,169 @@
+import type { ResearchQualityTopology } from './research-quality-topology'
+
+export type AggregatedTopologyGapWeights = {
+  narrowCrossProfileEvidenceBundle: number
+  semanticMismatch: number
+  highConfidenceSemanticMismatchBonus: number
+  semanticSingleSource: number
+  semanticSupportConcentration: number
+  highConfidenceSemanticConcentrationBonus: number
+  semanticMetadataCoverageGap: number
+  highConfidenceSemanticCoverageGapBonus: number
+  causalWithoutControlledOrSynthesis: number
+  causalWithoutDirectControlled: number
+  synthesisOnlyCausalSupport: number
+  highConfidenceCausalLanguageBonus: number
+  claimCitationMetadataGap: number
+  highConfidenceCitationMetadataBonus: number
+  provenanceNarrowMultiStudySupport: number
+  highConfidenceProvenanceNarrowBonus: number
+  severeStudyClassConflict: number
+  studyClassAmbiguity: number
+}
+
+export type AggregatedTopologyGapSignal = {
+  url: string
+  kind: string
+  weight: number
+  detail: string
+}
+
+function groupByUrl<T extends { url: string }>(items: readonly T[]): Map<string, T[]> {
+  const grouped = new Map<string, T[]>()
+  for (const item of items) {
+    const values = grouped.get(item.url) ?? []
+    values.push(item)
+    grouped.set(item.url, values)
+  }
+  return grouped
+}
+
+/**
+ * Collapse claim-level and bundle-level topology findings to one reason per
+ * profile/root issue before dimension-capped scoring. This preserves signal
+ * strength while preventing dozens of closely-related claims from swamping the
+ * remediation queue.
+ */
+export function buildAggregatedTopologyGapSignals(
+  topology: ResearchQualityTopology,
+  weights: AggregatedTopologyGapWeights,
+): AggregatedTopologyGapSignal[] {
+  const signals: AggregatedTopologyGapSignal[] = []
+
+  const crossProfile = new Map<string, { bundles: number; claims: number; maxProfiles: number }>()
+  for (const bundle of topology.narrowCrossProfileEvidenceBundles) {
+    for (const url of bundle.profiles) {
+      const item = crossProfile.get(url) ?? { bundles: 0, claims: 0, maxProfiles: 0 }
+      item.bundles += 1
+      item.claims += bundle.claims.filter((claim) => claim.url === url).length
+      item.maxProfiles = Math.max(item.maxProfiles, bundle.profileCount)
+      crossProfile.set(url, item)
+    }
+  }
+  for (const [url, item] of crossProfile) {
+    signals.push({
+      url,
+      kind: 'narrow-cross-profile-evidence-bundle',
+      weight: weights.narrowCrossProfileEvidenceBundle + Math.min(8, Math.max(0, item.bundles - 1) * 2),
+      detail: `${item.bundles} narrow multi-study bundle(s) reused across profiles; ${item.claims} approved claim(s) on this profile affected; widest reuse spans ${item.maxProfiles} profiles`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.semanticAlignment.findings)) {
+    const highConfidence = items.filter((item) => item.confidence >= 0.75).length
+    signals.push({
+      url,
+      kind: 'semantic-claim-source-mismatch',
+      weight: weights.semanticMismatch + Math.min(10, Math.max(0, items.length - 1) * 2) + (highConfidence ? weights.highConfidenceSemanticMismatchBonus : 0),
+      detail: `${items.length} approved claim(s) have explicit semantic mismatch; ${highConfidence} high-confidence; role ${items.filter((item) => item.roleMismatch).length}, domain ${items.filter((item) => item.domainMismatch).length}, population ${items.filter((item) => item.populationMismatch).length}`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.semanticAlignment.concentrationFindings)) {
+    const highConfidence = items.filter((item) => item.confidence >= 0.75).length
+    const singleSource = items.filter((item) => item.semanticSingleSource).length
+    signals.push({
+      url,
+      kind: 'semantic-support-concentration',
+      weight: (singleSource ? weights.semanticSingleSource : weights.semanticSupportConcentration)
+        + Math.min(6, Math.max(0, items.length - 1))
+        + (highConfidence ? weights.highConfidenceSemanticConcentrationBonus : 0),
+      detail: `${items.length} approved claim(s) have concentrated semantic support; ${singleSource} effectively single-source; ${highConfidence} high-confidence`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.semanticAlignment.coverageGapFindings)) {
+    const highConfidence = items.filter((item) => item.confidence >= 0.75).length
+    const minCoverage = Math.min(...items.map((item) => item.semanticMetadataCoverage))
+    signals.push({
+      url,
+      kind: 'semantic-metadata-coverage-gap',
+      weight: weights.semanticMetadataCoverageGap + Math.min(6, Math.max(0, items.length - 1)) + (highConfidence ? weights.highConfidenceSemanticCoverageGapBonus : 0),
+      detail: `${items.length} approved claim(s) have <50% semantically comparable source coverage; ${highConfidence} high-confidence; minimum coverage ${Math.round(minCoverage * 100)}%`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.claimLanguageCalibration.directEvidenceFindings)) {
+    const highConfidence = items.filter((item) => item.confidence >= 0.75).length
+    const strict = items.filter((item) => item.causalWithoutControlledSupport).length
+    const synthesisOnly = items.filter((item) => item.synthesisOnlyCausalSupport).length
+    const base = strict > 0
+      ? weights.causalWithoutControlledOrSynthesis
+      : synthesisOnly === items.length
+        ? weights.synthesisOnlyCausalSupport
+        : weights.causalWithoutDirectControlled
+    signals.push({
+      url,
+      kind: strict > 0
+        ? 'causal-language-without-controlled-or-synthesis'
+        : synthesisOnly === items.length
+          ? 'synthesis-only-causal-language'
+          : 'causal-language-without-direct-controlled-study',
+      weight: base + Math.min(8, Math.max(0, items.length - 1) * 2) + (highConfidence ? weights.highConfidenceCausalLanguageBonus : 0),
+      detail: `${items.length} direct-causal outcome claim(s) lack directly linked controlled-human evidence; ${strict} lack both controlled-human and synthesis support; ${synthesisOnly} synthesis-only; ${highConfidence} high-confidence`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.claimCitationMetadata.lowCoverageClaims)) {
+    const highConfidence = items.filter((item) => item.highConfidenceLowMetadataCoverage).length
+    const minCoverage = Math.min(...items.map((item) => item.fieldMetadataCoverage))
+    signals.push({
+      url,
+      kind: 'claim-citation-metadata-gap',
+      weight: weights.claimCitationMetadataGap + Math.min(6, Math.max(0, items.length - 1)) + (highConfidence ? weights.highConfidenceCitationMetadataBonus : 0),
+      detail: `${items.length} approved claim(s) rely on studies with <70% citation-field completeness; ${highConfidence} high-confidence; minimum field coverage ${Math.round(minCoverage * 100)}%`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.provenanceNarrowMultiStudyClaims)) {
+    const highConfidence = items.filter((item) => item.highConfidenceProvenanceNarrowMultiStudySupport).length
+    const sameAuthor = items.filter((item) => item.sameFirstAuthorLineage).length
+    const sameJournal = items.filter((item) => item.sameJournalLineage).length
+    signals.push({
+      url,
+      kind: 'claim-provenance-narrow-multi-study-support',
+      weight: weights.provenanceNarrowMultiStudySupport + Math.min(6, Math.max(0, items.length - 1)) + (highConfidence ? weights.highConfidenceProvenanceNarrowBonus : 0),
+      detail: `${items.length} multi-study approved claim(s) have narrow publication provenance; ${sameAuthor} same-first-author lineage; ${sameJournal} same-journal lineage; ${highConfidence} high-confidence`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.studyClassConflicts.severeConflicts)) {
+    signals.push({
+      url,
+      kind: 'severe-canonical-study-class-conflict',
+      weight: weights.severeStudyClassConflict,
+      detail: `${items.length} canonical study classification conflict(s) cross evidence families; structural gate also blocks these`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.studyClassConflicts.conflicts.filter((item) => !item.severe))) {
+    signals.push({
+      url,
+      kind: 'canonical-study-class-ambiguity',
+      weight: weights.studyClassAmbiguity,
+      detail: `${items.length} canonical study/studies have same-family design classification ambiguity`,
+    })
+  }
+
+  return signals.sort((a, b) => b.weight - a.weight || a.url.localeCompare(b.url) || a.kind.localeCompare(b.kind))
+}

--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -1,4 +1,5 @@
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import { buildAggregatedTopologyGapSignals } from './research-quality-policy-topology-signals'
 import { buildResearchQualityTopology, type ResearchQualityTopology } from './research-quality-topology'
 
 export type ResearchGapDimension =
@@ -82,9 +83,13 @@ export const RESEARCH_GAP_WEIGHTS = {
   provenanceConcentration: 10,
   firstAuthorConcentrationBonus: 6,
   journalConcentrationBonus: 4,
+  provenanceNarrowMultiStudySupport: 8,
+  highConfidenceProvenanceNarrowBonus: 4,
   uncertainStudyIdentityCoverage: 10,
   highConfidenceIdentityUncertaintyBonus: 8,
   weakIdentityCoverageBonus: 6,
+  severeStudyClassConflict: 100,
+  studyClassAmbiguity: 5,
   legacyOnlyOutcomeClaim: 8,
   highConfidenceLegacyOnlyBonus: 4,
   unknownEvidenceYearMetadata: 4,
@@ -99,6 +104,7 @@ export const RESEARCH_GAP_WEIGHTS = {
 const DIMENSION_BY_KIND: Record<string, ResearchGapDimension> = {
   'unsupported-approved-claim': 'structural',
   'dangling-claim-source-edge': 'structural',
+  'severe-canonical-study-class-conflict': 'structural',
   'synthesis-only-approved-outcome': 'claim-support',
   'semantic-claim-source-mismatch': 'semantic',
   'semantic-single-source-support': 'semantic',
@@ -115,6 +121,7 @@ const DIMENSION_BY_KIND: Record<string, ResearchGapDimension> = {
   'near-duplicate-claim-evidence-support': 'concentration',
   'systemic-load-bearing-study-dependency': 'concentration',
   'provenance-concentrated-evidence': 'concentration',
+  'claim-provenance-narrow-multi-study-support': 'concentration',
   'narrative-review-dominated-profile': 'evidence-mix',
   'edge-weighted-narrative-dominance': 'evidence-mix',
   'approved-claims-without-primary-human-study': 'evidence-mix',
@@ -123,6 +130,7 @@ const DIMENSION_BY_KIND: Record<string, ResearchGapDimension> = {
   'uncertain-study-identity-independence': 'identity',
   'poor-study-metadata-coverage': 'metadata',
   'claim-citation-metadata-gap': 'metadata',
+  'canonical-study-class-ambiguity': 'metadata',
   'unknown-evidence-year-metadata': 'metadata',
   'legacy-only-outcome-evidence': 'freshness',
 }
@@ -199,37 +207,8 @@ function addProfileReasons(analysis: ResearchQualityAnalysis, add: AddReason) {
   }
 }
 
-function addSemanticReasons(topology: ResearchQualityTopology, add: AddReason) {
-  for (const finding of topology.semanticAlignment.findings) {
-    const bonus = finding.confidence >= 0.75 ? RESEARCH_GAP_WEIGHTS.highConfidenceSemanticMismatchBonus : 0
-    add(finding.url, 'semantic-claim-source-mismatch', RESEARCH_GAP_WEIGHTS.semanticMismatch + bonus, `${finding.claimId} · ${finding.reasons.join('; ')}`)
-  }
-  for (const finding of topology.semanticAlignment.concentrationFindings) {
-    const base = finding.semanticSingleSource ? RESEARCH_GAP_WEIGHTS.semanticSingleSource : RESEARCH_GAP_WEIGHTS.semanticSupportConcentration
-    const bonus = finding.confidence >= 0.75 ? RESEARCH_GAP_WEIGHTS.highConfidenceSemanticConcentrationBonus : 0
-    add(finding.url, finding.semanticSingleSource ? 'semantic-single-source-support' : 'semantic-support-concentration', base + bonus, `${finding.claimId} · ${finding.alignedSourceCount}/${finding.sourceCount} linked sources explicitly align`)
-  }
-  for (const finding of topology.semanticAlignment.coverageGapFindings) {
-    const bonus = finding.confidence >= 0.75 ? RESEARCH_GAP_WEIGHTS.highConfidenceSemanticCoverageGapBonus : 0
-    add(finding.url, 'semantic-metadata-coverage-gap', RESEARCH_GAP_WEIGHTS.semanticMetadataCoverageGap + bonus, `${finding.claimId} · ${Math.round(finding.semanticMetadataCoverage * 100)}% semantically comparable source coverage`)
-  }
-
-  const strictKeys = new Set(topology.claimLanguageCalibration.findings.map((finding) => `${finding.url}::${finding.claimId}`))
-  const synthesisKeys = new Set(topology.claimLanguageCalibration.synthesisOnlyFindings.map((finding) => `${finding.url}::${finding.claimId}`))
-  for (const finding of topology.claimLanguageCalibration.directEvidenceFindings) {
-    const key = `${finding.url}::${finding.claimId}`
-    const high = finding.confidence >= 0.75 ? RESEARCH_GAP_WEIGHTS.highConfidenceCausalLanguageBonus : 0
-    if (strictKeys.has(key)) add(finding.url, 'causal-language-without-controlled-or-synthesis', RESEARCH_GAP_WEIGHTS.causalWithoutControlledOrSynthesis + high, `${finding.claimId} · ${finding.causalTerms.join(', ')}`)
-    else if (synthesisKeys.has(key)) add(finding.url, 'synthesis-only-causal-language', RESEARCH_GAP_WEIGHTS.synthesisOnlyCausalSupport + high, `${finding.claimId} · causal language has synthesis but no directly linked controlled-human study`)
-    else add(finding.url, 'causal-language-without-direct-controlled-study', RESEARCH_GAP_WEIGHTS.causalWithoutDirectControlled + high, `${finding.claimId} · causal language lacks directly linked controlled-human study`)
-  }
-}
-
 function addTopologyReasons(topology: ResearchQualityTopology, add: AddReason) {
   for (const bundle of topology.narrowRepeatedEvidenceBundles) add(bundle.url, 'narrow-repeated-evidence-bundle', RESEARCH_GAP_WEIGHTS.narrowRepeatedEvidenceBundle + Math.min(10, Math.max(0, bundle.approvedClaimCount - 3) * 2), `${bundle.approvedClaimCount} approved claims reuse the same ${bundle.studyCount}-study bundle`)
-  for (const bundle of topology.narrowCrossProfileEvidenceBundles) {
-    for (const url of bundle.profiles) add(url, 'narrow-cross-profile-evidence-bundle', RESEARCH_GAP_WEIGHTS.narrowCrossProfileEvidenceBundle + Math.min(8, Math.max(0, bundle.profileCount - 2) * 2), `${bundle.approvedClaimCount} claims across ${bundle.profileCount} profiles reuse the same ${bundle.studyCount}-study bundle`)
-  }
   for (const claim of topology.homogeneousMultiStudyClaims) add(claim.url, 'homogeneous-multi-study-support', RESEARCH_GAP_WEIGHTS.homogeneousMultiStudySupport + (claim.highConfidenceHomogeneousMultiStudySupport ? RESEARCH_GAP_WEIGHTS.highConfidenceHomogeneousMultiStudyBonus : 0), `${claim.claimId} · ${claim.studyCount} studies but one evidence family (${claim.evidenceFamilies.join(', ')})`)
 
   const overlapByProfile = new Map<string, typeof topology.claimEvidenceOverlap>()
@@ -253,14 +232,31 @@ function addTopologyReasons(topology: ResearchQualityTopology, add: AddReason) {
     add(identity.url, 'uncertain-study-identity-independence', RESEARCH_GAP_WEIGHTS.uncertainStudyIdentityCoverage + (identity.highConfidenceUncertainClaimCount > 0 ? RESEARCH_GAP_WEIGHTS.highConfidenceIdentityUncertaintyBonus : 0) + (identity.weakIdentityCoverage ? RESEARCH_GAP_WEIGHTS.weakIdentityCoverageBonus : 0), `${identity.uncertainMultiStudyClaimCount} multi-study claims include fallback identities; ${Math.round(identity.stableIdentityCoverage * 100)}% stable identity coverage`)
   }
 
-  for (const metadata of topology.claimCitationMetadata.lowCoverageClaims) add(metadata.url, 'claim-citation-metadata-gap', RESEARCH_GAP_WEIGHTS.claimCitationMetadataGap + (metadata.highConfidenceLowMetadataCoverage ? RESEARCH_GAP_WEIGHTS.highConfidenceCitationMetadataBonus : 0), `${metadata.claimId} · ${Math.round(metadata.fieldMetadataCoverage * 100)}% citation field completeness across ${metadata.studyCount} studies`)
-
   for (const freshness of topology.claimEvidenceAge) {
     if (freshness.studyCount > 0 && freshness.knownYearCount === 0) add(freshness.url, 'unknown-evidence-year-metadata', RESEARCH_GAP_WEIGHTS.unknownEvidenceYearMetadata, `${freshness.claimId} · publication year unknown for all ${freshness.studyCount} studies`)
     else if (freshness.legacyOnlyOutcomeClaim) add(freshness.url, 'legacy-only-outcome-evidence', RESEARCH_GAP_WEIGHTS.legacyOnlyOutcomeClaim + (freshness.highConfidenceLegacyOnlyClaim ? RESEARCH_GAP_WEIGHTS.highConfidenceLegacyOnlyBonus : 0), `${freshness.claimId} · newest known supporting study ${freshness.newestYear ?? 'unknown'}`)
   }
 
-  addSemanticReasons(topology, add)
+  for (const signal of buildAggregatedTopologyGapSignals(topology, {
+    narrowCrossProfileEvidenceBundle: RESEARCH_GAP_WEIGHTS.narrowCrossProfileEvidenceBundle,
+    semanticMismatch: RESEARCH_GAP_WEIGHTS.semanticMismatch,
+    highConfidenceSemanticMismatchBonus: RESEARCH_GAP_WEIGHTS.highConfidenceSemanticMismatchBonus,
+    semanticSingleSource: RESEARCH_GAP_WEIGHTS.semanticSingleSource,
+    semanticSupportConcentration: RESEARCH_GAP_WEIGHTS.semanticSupportConcentration,
+    highConfidenceSemanticConcentrationBonus: RESEARCH_GAP_WEIGHTS.highConfidenceSemanticConcentrationBonus,
+    semanticMetadataCoverageGap: RESEARCH_GAP_WEIGHTS.semanticMetadataCoverageGap,
+    highConfidenceSemanticCoverageGapBonus: RESEARCH_GAP_WEIGHTS.highConfidenceSemanticCoverageGapBonus,
+    causalWithoutControlledOrSynthesis: RESEARCH_GAP_WEIGHTS.causalWithoutControlledOrSynthesis,
+    causalWithoutDirectControlled: RESEARCH_GAP_WEIGHTS.causalWithoutDirectControlled,
+    synthesisOnlyCausalSupport: RESEARCH_GAP_WEIGHTS.synthesisOnlyCausalSupport,
+    highConfidenceCausalLanguageBonus: RESEARCH_GAP_WEIGHTS.highConfidenceCausalLanguageBonus,
+    claimCitationMetadataGap: RESEARCH_GAP_WEIGHTS.claimCitationMetadataGap,
+    highConfidenceCitationMetadataBonus: RESEARCH_GAP_WEIGHTS.highConfidenceCitationMetadataBonus,
+    provenanceNarrowMultiStudySupport: RESEARCH_GAP_WEIGHTS.provenanceNarrowMultiStudySupport,
+    highConfidenceProvenanceNarrowBonus: RESEARCH_GAP_WEIGHTS.highConfidenceProvenanceNarrowBonus,
+    severeStudyClassConflict: RESEARCH_GAP_WEIGHTS.severeStudyClassConflict,
+    studyClassAmbiguity: RESEARCH_GAP_WEIGHTS.studyClassAmbiguity,
+  })) add(signal.url, signal.kind, signal.weight, signal.detail)
 }
 
 function finalizeGap(item: MutableGap): ResearchGapItem {


### PR DESCRIPTION
Replaces repetitive per-claim/per-bundle research-gap scoring loops with one profile-level topology signal aggregator. Semantic mismatch/coverage/concentration, causal-language calibration, claim-linked citation metadata, and cross-profile narrow evidence bundles now produce one root-cause reason per profile before dimension caps are applied. Also integrates newly-landed claim-level provenance-independence findings and study-class conflict/ambiguity remediation while preserving the separate severe-conflict structural gate. Focused tests lock one-signal-per-profile aggregation.