### PR TITLE
Canonicalize research coverage hard gate

### DIFF
--- a/lib/research-quality-gate.ts
+++ b/lib/research-quality-gate.ts
@@ -1,0 +1,51 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import { structuralCoverageFailures, type StructuralCoverageFailure } from './research-quality-policy'
+import { buildResearchQualityTopology, type ResearchQualityTopology } from './research-quality-topology'
+import type { StudyClassConflict } from './research-study-class-conflicts'
+
+export type ResearchQualityGate = {
+  passed: boolean
+  structuralFailures: StructuralCoverageFailure[]
+  severeStudyClassConflicts: StudyClassConflict[]
+  summary: {
+    structuralFailures: number
+    unsupportedApprovedClaims: number
+    danglingClaimSourceEdges: number
+    severeStudyClassConflicts: number
+    blockingFailures: number
+  }
+}
+
+/**
+ * Canonical hard-gate decision for research coverage. Structural evidence-edge
+ * failures and severe cross-family canonical study-class conflicts are the only
+ * blockers owned here; softer research-quality signals remain remediation
+ * priorities in the gap policy rather than becoming accidental build failures.
+ */
+export function buildResearchQualityGate(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology = buildResearchQualityTopology(analysis),
+): ResearchQualityGate {
+  const structuralFailures = structuralCoverageFailures(analysis)
+  const severeStudyClassConflicts = topology.studyClassConflicts.severeConflicts
+  const unsupportedApprovedClaims = structuralFailures.filter(
+    (failure) => failure.kind === 'unsupported-approved-claim',
+  ).length
+  const danglingClaimSourceEdges = structuralFailures.filter(
+    (failure) => failure.kind === 'dangling-claim-source-edge',
+  ).length
+  const blockingFailures = structuralFailures.length + severeStudyClassConflicts.length
+
+  return {
+    passed: blockingFailures === 0,
+    structuralFailures,
+    severeStudyClassConflicts,
+    summary: {
+      structuralFailures: structuralFailures.length,
+      unsupportedApprovedClaims,
+      danglingClaimSourceEdges,
+      severeStudyClassConflicts: severeStudyClassConflicts.length,
+      blockingFailures,
+    },
+  }
+}

--- a/scripts/ci/validate-research-coverage.ts
+++ b/scripts/ci/validate-research-coverage.ts
@@ -1,39 +1,37 @@
 #!/usr/bin/env npx tsx
-/** Hard gate for structurally invalid approved-claim evidence and canonical study classification. */
+/** Thin CLI over the canonical research-quality hard gate. */
 
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
-import { structuralCoverageFailures } from '../../lib/research-quality-policy'
-import { analyzeStudyClassConflicts } from '../../lib/research-study-class-conflicts'
+import { buildResearchQualityGate } from '../../lib/research-quality-gate'
+import { buildResearchQualityTopology } from '../../lib/research-quality-topology'
 
 const analysis = analyzeResearchQuality(process.cwd())
-const failures = structuralCoverageFailures(analysis)
-const classConflicts = analyzeStudyClassConflicts(analysis)
-const unsupported = failures.filter((failure) => failure.kind === 'unsupported-approved-claim')
-const dangling = failures.filter((failure) => failure.kind === 'dangling-claim-source-edge')
-const severeClassConflicts = classConflicts.severeConflicts
+const topology = buildResearchQualityTopology(analysis)
+const gate = buildResearchQualityGate(analysis, topology)
+const unsupported = gate.structuralFailures.filter((failure) => failure.kind === 'unsupported-approved-claim')
+const dangling = gate.structuralFailures.filter((failure) => failure.kind === 'dangling-claim-source-edge')
 
 console.log('\nResearch coverage structural gate')
 console.log('='.repeat(72))
-console.log(`Approved claims with no source refs  ${unsupported.length}`)
-console.log(`Claim refs to missing profile source ${dangling.length}`)
-console.log(`Canonical study class conflicts      ${classConflicts.summary.studiesWithClassConflict}`)
-console.log(`Severe cross-family class conflicts  ${severeClassConflicts.length}`)
+console.log(`Approved claims with no source refs  ${gate.summary.unsupportedApprovedClaims}`)
+console.log(`Claim refs to missing profile source ${gate.summary.danglingClaimSourceEdges}`)
+console.log(`Canonical study class conflicts      ${topology.studyClassConflicts.summary.studiesWithClassConflict}`)
+console.log(`Severe cross-family class conflicts  ${gate.summary.severeStudyClassConflicts}`)
 
-if (failures.length === 0 && severeClassConflicts.length === 0) {
-  console.log('\n[research-coverage] PASS — approved evidence edges and canonical study classes are structurally valid.')
+if (gate.passed) {
+  console.log('\n[research-coverage] PASS — canonical research-quality blocking gate is clear.')
   process.exit(0)
 }
 
-console.error(`\n[research-coverage] FAILED — ${failures.length} invalid evidence edge(s), ${severeClassConflicts.length} severe study-class conflict(s).`)
+console.error(`\n[research-coverage] FAILED — ${gate.summary.structuralFailures} invalid evidence edge(s), ${gate.summary.severeStudyClassConflicts} severe study-class conflict(s).`)
 for (const item of unsupported.slice(0, 25)) {
   console.error(`  unsupported · ${item.url} · ${item.claimId}`)
 }
 for (const item of dangling.slice(0, 25)) {
   console.error(`  dangling · ${item.url} · ${item.claimId} -> ${item.sourceRefId}`)
 }
-for (const conflict of severeClassConflicts.slice(0, 25)) {
+for (const conflict of gate.severeStudyClassConflicts.slice(0, 25)) {
   console.error(`  class-conflict · ${conflict.url} · ${conflict.studyId} · ${conflict.classes.join(' <> ')}`)
 }
-const total = failures.length + severeClassConflicts.length
-if (total > 75) console.error(`  ...and ${total - 75} more`)
+if (gate.summary.blockingFailures > 75) console.error(`  ...and ${gate.summary.blockingFailures - 75} more`)
 process.exit(1)


### PR DESCRIPTION
Use one shared research-quality gate for structural evidence failures and severe study-class conflicts; make the existing validator a thin consumer.