### PR TITLE
refactor(research): centralize gate-aware quality snapshot

### DIFF
--- a/lib/__tests__/research-quality-snapshot.test.ts
+++ b/lib/__tests__/research-quality-snapshot.test.ts
@@ -1,0 +1,25 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { buildResearchQualitySnapshot } from '@/lib/research-quality-snapshot'
+
+describe('canonical research-quality snapshot', () => {
+  it('builds analysis, topology, hard gate, remediation queue, and source integrity from one root', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'research-quality-snapshot-'))
+    try {
+      const snapshot = buildResearchQualitySnapshot(root)
+      expect(snapshot.analysis.profileAnalyses).toEqual([])
+      expect(snapshot.analysis.claimAnalyses).toEqual([])
+      expect(snapshot.gate.passed).toBe(true)
+      expect(snapshot.gate.summary.blockingFailures).toBe(0)
+      expect(snapshot.researchGapQueue).toEqual([])
+      expect(snapshot.topology.studyClassConflicts.summary.severeClassConflicts).toBe(0)
+      expect(snapshot.sourceIntegrity.summary.citedStudies).toBe(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -1,0 +1,32 @@
+import { analyzeResearchQuality, type ResearchQualityAnalysis } from './research-quality-analysis'
+import { buildResearchQualityGate, type ResearchQualityGate } from './research-quality-gate'
+import { buildResearchGapQueue } from './research-quality-policy'
+import { buildResearchQualityTopology, type ResearchQualityTopology } from './research-quality-topology'
+import { analyzeResearchSourceIntegrity } from './research-source-integrity'
+
+export type ResearchQualitySnapshot = {
+  analysis: ResearchQualityAnalysis
+  topology: ResearchQualityTopology
+  gate: ResearchQualityGate
+  researchGapQueue: ReturnType<typeof buildResearchGapQueue>
+  sourceIntegrity: ReturnType<typeof analyzeResearchSourceIntegrity>
+}
+
+/**
+ * Canonical execution boundary for research-quality consumers.
+ *
+ * Specialized reporters may format different views, but they should consume
+ * this snapshot instead of independently rebuilding analysis/topology/gate/policy
+ * state. The hard gate and softer remediation queue remain separate by design.
+ */
+export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQualitySnapshot {
+  const analysis = analyzeResearchQuality(root)
+  const topology = buildResearchQualityTopology(analysis)
+  return {
+    analysis,
+    topology,
+    gate: buildResearchQualityGate(analysis, topology),
+    researchGapQueue: buildResearchGapQueue(analysis, topology),
+    sourceIntegrity: analyzeResearchSourceIntegrity(analysis),
+  }
+}

--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -1,14 +1,15 @@
 #!/usr/bin/env npx tsx
-/** Claim-level evidence strength report derived from the canonical research-quality analysis. */
+/** Claim-level evidence strength report derived from the canonical research-quality snapshot. */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
 const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'claim-evidence-strength.json')
-const { claimAnalyses: claims, structuredClaimAnalyses } = analyzeResearchQuality(ROOT)
+const { analysis } = buildResearchQualitySnapshot(ROOT)
+const { claimAnalyses: claims, structuredClaimAnalyses } = analysis
 
 const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
   counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
@@ -59,7 +60,5 @@ console.log(`High-confidence weak outcomes      ${report.summary.highConfidenceW
 console.log(`Unapproved unsupported claims      ${report.summary.unapprovedUnsupportedStructuredClaims}`)
 console.log(`Unapproved weak structured claims  ${report.summary.unapprovedWeakStructuredClaims}`)
 console.log('\nStructured support tiers:')
-for (const [tier, count] of Object.entries(structuredTierCounts).sort((a, b) => b[1] - a[1])) {
-  console.log(`  ${tier.padEnd(26)} ${count}`)
-}
+for (const [tier, count] of Object.entries(structuredTierCounts).sort((a, b) => b[1] - a[1])) console.log(`  ${tier.padEnd(26)} ${count}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)

--- a/scripts/ci/audit-source-integrity.ts
+++ b/scripts/ci/audit-source-integrity.ts
@@ -3,8 +3,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
-import { analyzeResearchSourceIntegrity } from '../../lib/research-source-integrity'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 import { STUDY_CLASS_INFO, type StudyClass } from '../../lib/study-class'
 
 const ROOT = process.cwd()
@@ -12,8 +11,7 @@ const REPORTS_DIR = path.join(ROOT, 'ops', 'reports')
 const REPORT_PATH = path.join(REPORTS_DIR, 'source-integrity.json')
 
 function main() {
-  const analysis = analyzeResearchQuality(ROOT)
-  const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
+  const { sourceIntegrity } = buildResearchQualitySnapshot(ROOT)
   const { summary, withdrawn, mostReferenced, oldAndLoadBearing } = sourceIntegrity
 
   fs.mkdirSync(REPORTS_DIR, { recursive: true })
@@ -21,7 +19,7 @@ function main() {
     schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     currentYear: sourceIntegrity.currentYear,
-    source: 'lib/research-source-integrity.ts',
+    source: 'lib/research-quality-snapshot.ts -> lib/research-source-integrity.ts',
     summary,
     withdrawn,
     mostReferenced,
@@ -37,16 +35,12 @@ function main() {
   console.log(`Retracted / concern         ${summary.withdrawn}`)
   console.log(`Primary human ${summary.humanPrimary} · synthesis ${summary.synthesis} · other ${summary.citedStudies - summary.humanPrimary - summary.synthesis}`)
   console.log('\nDesign mix:')
-  for (const [design, count] of Object.entries(summary.designMix).sort((a, b) => b[1] - a[1])) {
-    console.log(`  ${String(count).padStart(4)}  ${STUDY_CLASS_INFO[design as StudyClass]?.label ?? design}`)
-  }
+  for (const [design, count] of Object.entries(summary.designMix).sort((a, b) => b[1] - a[1])) console.log(`  ${String(count).padStart(4)}  ${STUDY_CLASS_INFO[design as StudyClass]?.label ?? design}`)
   console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)
 
   if (withdrawn.length) {
     console.error(`\n[source-integrity] FAILED — ${withdrawn.length} retracted or withdrawn study still cited.\n`)
-    for (const study of withdrawn) {
-      console.error(`  PMID ${study.pmid} [${study.publicationTypes.join(', ')}] cited by ${study.pages.join(', ')}`)
-    }
+    for (const study of withdrawn) console.error(`  PMID ${study.pmid} [${study.publicationTypes.join(', ')}] cited by ${study.pages.join(', ')}`)
     process.exit(1)
   }
 }

--- a/scripts/ci/validate-research-coverage.ts
+++ b/scripts/ci/validate-research-coverage.ts
@@ -1,13 +1,10 @@
 #!/usr/bin/env npx tsx
-/** Thin CLI over the canonical research-quality hard gate. */
+/** Thin CLI over the canonical research-quality snapshot and hard gate. */
 
-import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
-import { buildResearchQualityGate } from '../../lib/research-quality-gate'
-import { buildResearchQualityTopology } from '../../lib/research-quality-topology'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
-const analysis = analyzeResearchQuality(process.cwd())
-const topology = buildResearchQualityTopology(analysis)
-const gate = buildResearchQualityGate(analysis, topology)
+const snapshot = buildResearchQualitySnapshot(process.cwd())
+const { topology, gate } = snapshot
 const unsupported = gate.structuralFailures.filter((failure) => failure.kind === 'unsupported-approved-claim')
 const dangling = gate.structuralFailures.filter((failure) => failure.kind === 'dangling-claim-source-edge')
 
@@ -24,14 +21,8 @@ if (gate.passed) {
 }
 
 console.error(`\n[research-coverage] FAILED — ${gate.summary.structuralFailures} invalid evidence edge(s), ${gate.summary.severeStudyClassConflicts} severe study-class conflict(s).`)
-for (const item of unsupported.slice(0, 25)) {
-  console.error(`  unsupported · ${item.url} · ${item.claimId}`)
-}
-for (const item of dangling.slice(0, 25)) {
-  console.error(`  dangling · ${item.url} · ${item.claimId} -> ${item.sourceRefId}`)
-}
-for (const conflict of gate.severeStudyClassConflicts.slice(0, 25)) {
-  console.error(`  class-conflict · ${conflict.url} · ${conflict.studyId} · ${conflict.classes.join(' <> ')}`)
-}
+for (const item of unsupported.slice(0, 25)) console.error(`  unsupported · ${item.url} · ${item.claimId}`)
+for (const item of dangling.slice(0, 25)) console.error(`  dangling · ${item.url} · ${item.claimId} -> ${item.sourceRefId}`)
+for (const conflict of gate.severeStudyClassConflicts.slice(0, 25)) console.error(`  class-conflict · ${conflict.url} · ${conflict.studyId} · ${conflict.classes.join(' <> ')}`)
 if (gate.summary.blockingFailures > 75) console.error(`  ...and ${gate.summary.blockingFailures - 75} more`)
 process.exit(1)


### PR DESCRIPTION
Latest-main replacement for #3456. Introduces one gate-aware ResearchQualitySnapshot that owns analysis, topology, canonical hard-gate evaluation, remediation queue, and source integrity. Refactors the research coverage CLI, claim-evidence-strength report, and source-integrity report to consume that snapshot instead of independently rebuilding pipeline state. Preserves the newly-landed canonical blocking gate as the single hard-failure authority and keeps softer remediation in policy. Includes a focused snapshot contract test.