### PR TITLE
refactor(research): make canonical runner consume topology once

### DIFF
--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -8,15 +8,11 @@ import path from 'node:path'
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
 import { analyzeCitationIntegrity, writeCitationIntegrityReport } from '../../lib/citation-integrity.mjs'
 import { analyzeEvidenceGradeConsistency, writeEvidenceGradeConsistencyReport } from '../../lib/evidence-grade-consistency'
-import { analyzeClaimLanguageCalibration } from '../../lib/research-claim-language-calibration'
 import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import { buildResearchQualityGate } from '../../lib/research-quality-gate'
 import { buildResearchGapQueue } from '../../lib/research-quality-policy'
 import { buildResearchQualityTopology } from '../../lib/research-quality-topology'
-import {
-  analyzeResearchSemanticAlignment,
-  writeResearchSemanticAlignmentReport,
-} from '../../lib/research-semantic-alignment'
+import { writeResearchSemanticAlignmentReport } from '../../lib/research-semantic-alignment'
 import { analyzeResearchSourceIntegrity } from '../../lib/research-source-integrity'
 
 const ROOT = process.cwd()
@@ -27,8 +23,20 @@ const externalChecks = [
   { id: 'content-integrity', label: 'Structured content integrity', command: process.execPath, args: ['scripts/ci/audit-content-integrity.mjs'] },
 ] as const
 
-type CheckResult = { id: string; label: string; passed: boolean; exitCode: number; durationMs: number; stdoutTail: string; stderrTail: string }
-function tail(value: string, maxLines = 24): string { return value.split(/\r?\n/).filter(Boolean).slice(-maxLines).join('\n') }
+type CheckResult = {
+  id: string
+  label: string
+  passed: boolean
+  exitCode: number
+  durationMs: number
+  stdoutTail: string
+  stderrTail: string
+}
+
+function tail(value: string, maxLines = 24): string {
+  return value.split(/\r?\n/).filter(Boolean).slice(-maxLines).join('\n')
+}
+
 function readSummary(fileName: string): unknown {
   const file = path.join(REPORT_DIR, fileName)
   if (!fs.existsSync(file)) return null
@@ -44,17 +52,15 @@ const coreStarted = Date.now()
 const analysis = analyzeResearchQuality(ROOT)
 const topology = buildResearchQualityTopology(analysis)
 const gate = buildResearchQualityGate(analysis, topology)
-const structuralFailures = gate.structuralFailures
 const researchGapQueue = buildResearchGapQueue(analysis, topology)
 const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
-const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
-const semanticReportPath = writeResearchSemanticAlignmentReport(semanticAlignment, ROOT)
-const languageCalibration = analyzeClaimLanguageCalibration(analysis)
 const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
-const citationReportPath = writeCitationIntegrityReport(citationIntegrity, ROOT)
 const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(ROOT)
-const evidenceGradeReportPath = writeEvidenceGradeConsistencyReport(evidenceGradeConsistency, ROOT)
+const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
+
 const {
+  semanticAlignment,
+  claimLanguageCalibration: languageCalibration,
   crossProfileStudyLoad,
   systemicLoadBearingStudies,
   evidenceBundleReuse,
@@ -76,9 +82,16 @@ const {
   provenanceNarrowMultiStudyClaims,
   highConfidenceProvenanceNarrowMultiStudyClaims,
   studyClassConflicts,
+  crossProfileEvidenceBundles,
+  narrowCrossProfileEvidenceBundles,
+  claimCitationMetadata,
 } = topology
-const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
+
+const semanticReportPath = writeResearchSemanticAlignmentReport(semanticAlignment, ROOT)
+const citationReportPath = writeCitationIntegrityReport(citationIntegrity, ROOT)
+const evidenceGradeReportPath = writeEvidenceGradeConsistencyReport(evidenceGradeConsistency, ROOT)
 const aiCitationReportPath = writeAiCitationReadinessReport(aiCitationReadiness, ROOT)
+
 const weakApprovedOutcomes = analysis.claimAnalyses.filter((claim) => claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier))
 const unsupportedUnapprovedClaims = analysis.structuredClaimAnalyses.filter((claim) => !claim.approved && claim.supportTier === 'unsupported')
 const weakUnapprovedOutcomes = analysis.structuredClaimAnalyses.filter((claim) => !claim.approved && claim.outcomeClaim && ['unsupported', 'unclassified', 'narrative-only', 'indirect-only'].includes(claim.supportTier))
@@ -93,10 +106,25 @@ const corePassed = gate.passed && sourceIntegrity.summary.withdrawn === 0
 const coreDurationMs = Date.now() - coreStarted
 
 results.push({
-  id: 'canonical-core', label: 'Canonical claim/profile/source research-quality analysis', passed: corePassed,
-  exitCode: corePassed ? 0 : 1, durationMs: coreDurationMs,
-  stdoutTail: `profiles=${analysis.profileAnalyses.length}; approvedClaims=${analysis.claimAnalyses.length}; sourceStudies=${sourceIntegrity.summary.citedStudies}; gaps=${researchGapQueue.length}; blocking=${gate.summary.blockingFailures}; severeClassConflicts=${gate.summary.severeStudyClassConflicts}; systemicStudies=${systemicLoadBearingStudies.length}; narrowEvidenceBundles=${narrowRepeatedEvidenceBundles.length}; homogeneousMultiStudy=${homogeneousMultiStudyClaims.length}; provenanceNarrowMultiStudy=${provenanceNarrowMultiStudyClaims.length}; nearDuplicatePairs=${claimEvidenceOverlap.length}; edgeWeightedNarrative=${edgeWeightedNarrativeDominatedProfiles.length}; provenanceConcentrated=${provenanceConcentratedProfiles.length}; identityUncertain=${studyIdentityCoverage.summary.uncertainMultiStudyClaims}; semanticMismatches=${semanticAlignment.summary.anyMismatch}; causalWithoutControlled=${languageCalibration.summary.causalWithoutControlledSupport}; legacyOnly=${legacyOnlyClaims.length}; aiBelow70=${aiCitationReadiness.summary.below70}`,
-  stderrTail: [gate.summary.structuralFailures ? `${gate.summary.structuralFailures} invalid evidence edge(s)` : '', gate.summary.severeStudyClassConflicts ? `${gate.summary.severeStudyClassConflicts} severe study-class conflict(s)` : '', sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : ''].filter(Boolean).join('; '),
+  id: 'canonical-core',
+  label: 'Canonical claim/profile/source research-quality analysis',
+  passed: corePassed,
+  exitCode: corePassed ? 0 : 1,
+  durationMs: coreDurationMs,
+  stdoutTail: [
+    `profiles=${analysis.profileAnalyses.length}`,
+    `approvedClaims=${analysis.claimAnalyses.length}`,
+    `sourceStudies=${sourceIntegrity.summary.citedStudies}`,
+    `gaps=${researchGapQueue.length}`,
+    `blocking=${gate.summary.blockingFailures}`,
+    `semanticMismatches=${semanticAlignment.summary.anyMismatch}`,
+    `causalWithoutControlled=${languageCalibration.summary.causalWithoutControlledSupport}`,
+  ].join('; '),
+  stderrTail: [
+    gate.summary.structuralFailures ? `${gate.summary.structuralFailures} invalid evidence edge(s)` : '',
+    gate.summary.severeStudyClassConflicts ? `${gate.summary.severeStudyClassConflicts} severe study-class conflict(s)` : '',
+    sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : '',
+  ].filter(Boolean).join('; '),
 })
 console.log(`${corePassed ? 'PASS' : 'FAIL'}  Canonical claim/profile/source research-quality analysis  (${coreDurationMs}ms)`)
 if (!corePassed) failed = true
@@ -107,10 +135,9 @@ results.push({
   passed: citationIntegrity.passed,
   exitCode: citationIntegrity.passed ? 0 : 1,
   durationMs: 0,
-  stdoutTail: `sources=${citationIntegrity.sources}; blocking=${citationIntegrity.blocking.length}; duplicateProfileRefs=${citationIntegrity.duplicateProfileSources.length}; pairConflicts=${citationIntegrity.identifierPairConflicts.length}; titleConflicts=${citationIntegrity.conflicts.length}`,
+  stdoutTail: `sources=${citationIntegrity.sources}; blocking=${citationIntegrity.blockingCount}`,
   stderrTail: citationIntegrity.passed ? '' : `${citationIntegrity.blockingCount} citation identity problem(s)`,
 })
-console.log(`${citationIntegrity.passed ? 'PASS' : 'FAIL'}  Citation identity integrity  (in-process)`)
 if (!citationIntegrity.passed) failed = true
 
 const gradesPassed = evidenceGradeConsistency.invalid.length === 0
@@ -120,92 +147,147 @@ results.push({
   passed: gradesPassed,
   exitCode: gradesPassed ? 0 : 1,
   durationMs: 0,
-  stdoutTail: `profiles=${evidenceGradeConsistency.totals.profiles}; flaggedIndexable=${evidenceGradeConsistency.totals.flaggedIndexable}; contradictions=${evidenceGradeConsistency.totals.contradictionsIndexable}`,
+  stdoutTail: `profiles=${evidenceGradeConsistency.totals.profiles}; contradictions=${evidenceGradeConsistency.totals.contradictionsIndexable}`,
   stderrTail: gradesPassed ? '' : `${evidenceGradeConsistency.invalid.length} non-canonical published grade(s)`,
 })
-console.log(`${gradesPassed ? 'PASS' : 'FAIL'}  Evidence grade consistency  (in-process)`)
 if (!gradesPassed) failed = true
 
 for (const check of externalChecks) {
-  const started = Date.now(); const run = spawnSync(check.command, check.args, { cwd: ROOT, encoding: 'utf8', env: process.env })
-  const exitCode = run.status ?? 1; const passed = exitCode === 0; const durationMs = Date.now() - started
-  const stdout = String(run.stdout ?? ''); const stderr = String(run.stderr ?? '')
+  const started = Date.now()
+  const run = spawnSync(check.command, check.args, { cwd: ROOT, encoding: 'utf8', env: process.env })
+  const exitCode = run.status ?? 1
+  const passed = exitCode === 0
+  const durationMs = Date.now() - started
+  const stdout = String(run.stdout ?? '')
+  const stderr = String(run.stderr ?? '')
   results.push({ id: check.id, label: check.label, passed, exitCode, durationMs, stdoutTail: tail(stdout), stderrTail: tail(stderr) })
-  console.log(`${passed ? 'PASS' : 'FAIL'}  ${check.label}  (${durationMs}ms)`)
-  if (!passed) { failed = true; const detail = tail(stderr || stdout, 10); if (detail) console.error(detail) }
+  if (!passed) {
+    failed = true
+    const detail = tail(stderr || stdout, 10)
+    if (detail) console.error(detail)
+  }
 }
 
 const coreSummary = {
-  profiles: analysis.profileAnalyses.length, structuredClaims: analysis.structuredClaimAnalyses.length, approvedClaims: analysis.claimAnalyses.length,
+  profiles: analysis.profileAnalyses.length,
+  structuredClaims: analysis.structuredClaimAnalyses.length,
+  approvedClaims: analysis.claimAnalyses.length,
   researchQualityGate: gate.summary,
-  structuralFailures: gate.summary.structuralFailures, severeStudyClassConflicts: gate.summary.severeStudyClassConflicts,
+  structuralFailures: gate.summary.structuralFailures,
+  severeStudyClassConflicts: gate.summary.severeStudyClassConflicts,
   withdrawnCitedStudies: sourceIntegrity.summary.withdrawn,
   citationIntegrityProblems: citationIntegrity.blockingCount,
   semanticAlignment: semanticAlignment.summary,
   claimLanguageCalibration: languageCalibration.summary,
-  weakApprovedOutcomeClaims: weakApprovedOutcomes.length, unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
-  weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length, overDependentProfiles: overDependentProfiles.length,
-  narrativeDominatedProfiles: narrativeDominatedProfiles.length, edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.length,
+  claimCitationMetadata: claimCitationMetadata.summary,
+  weakApprovedOutcomeClaims: weakApprovedOutcomes.length,
+  unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
+  weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length,
+  overDependentProfiles: overDependentProfiles.length,
+  narrativeDominatedProfiles: narrativeDominatedProfiles.length,
+  edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.length,
   provenanceConcentratedProfiles: provenanceConcentratedProfiles.length,
   homogeneousMultiStudyClaims: homogeneousMultiStudyClaims.length,
   highConfidenceHomogeneousMultiStudyClaims: highConfidenceHomogeneousMultiStudyClaims.length,
   provenanceNarrowMultiStudyClaims: provenanceNarrowMultiStudyClaims.length,
   highConfidenceProvenanceNarrowMultiStudyClaims: highConfidenceProvenanceNarrowMultiStudyClaims.length,
+  crossProfileEvidenceBundles: crossProfileEvidenceBundles.length,
+  narrowCrossProfileEvidenceBundles: narrowCrossProfileEvidenceBundles.length,
   profilesWithApprovedClaimsButNoPrimaryHumanStudy: noPrimaryHumanProfiles.length,
   profilesWithUnmappedPrimaryHumanEvidence: unmappedPrimaryHumanProfiles.length,
   profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims: unapprovedOnlyPrimaryHumanProfiles.length,
-  profilesWithResearchGaps: researchGapQueue.length, canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
-  systemicLoadBearingStudies: systemicLoadBearingStudies.length, repeatedEvidenceBundles: evidenceBundleReuse.length,
-  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length, nearDuplicateEvidencePairs: claimEvidenceOverlap.length,
+  profilesWithResearchGaps: researchGapQueue.length,
+  canonicalStudiesSupportingApprovedClaims: crossProfileStudyLoad.length,
+  systemicLoadBearingStudies: systemicLoadBearingStudies.length,
+  repeatedEvidenceBundles: evidenceBundleReuse.length,
+  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.length,
+  nearDuplicateEvidencePairs: claimEvidenceOverlap.length,
   crossPredicateNearDuplicateEvidencePairs: crossPredicateEvidenceOverlap.length,
   studyClassConflicts: studyClassConflicts.summary,
   studyIdentityCoverage: studyIdentityCoverage.summary,
   provenanceConcentration: provenanceConcentration.summary,
   sourceIntegrity: sourceIntegrity.summary,
-  evidenceGradeConsistency: evidenceGradeConsistency.totals, evidenceAge: evidenceAgeSummary, aiCitationReadiness: aiCitationReadiness.summary,
+  evidenceGradeConsistency: evidenceGradeConsistency.totals,
+  evidenceAge: evidenceAgeSummary,
+  aiCitationReadiness: aiCitationReadiness.summary,
 }
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 20, generatedAt: new Date().toISOString(), passed: !failed,
-  source: { analysis: 'lib/research-quality-analysis.ts', topology: 'lib/research-quality-topology.ts', policy: 'lib/research-quality-policy.ts', gate: 'lib/research-quality-gate.ts', claimEvidenceDiversity: 'lib/research-claim-evidence-diversity.ts', claimProvenanceIndependence: 'lib/research-claim-provenance-independence.ts', semanticAlignment: 'lib/research-semantic-alignment.ts', claimLanguageCalibration: 'lib/research-claim-language-calibration.ts', designUsage: 'lib/research-design-usage.ts', provenanceConcentration: 'lib/research-provenance-concentration.ts', studyIdentityCoverage: 'lib/research-study-identity-coverage.ts', studyClassConflicts: 'lib/research-study-class-conflicts.ts', citationIntegrity: 'lib/citation-integrity.mjs', sourceIntegrity: 'lib/research-source-integrity.ts', evidenceGradeConsistency: 'lib/evidence-grade-consistency.ts', aiCitationReadiness: 'lib/ai-citation-readiness.ts' },
-  coreSummary, structuralFailures, severeStudyClassConflicts: gate.severeStudyClassConflicts, studyClassConflicts: studyClassConflicts.conflicts.slice(0, 150), citationIntegrity: { blocking: citationIntegrity.blocking, duplicateProfileSources: citationIntegrity.duplicateProfileSources, identifierPairConflicts: citationIntegrity.identifierPairConflicts, conflicts: citationIntegrity.conflicts, missingCounts: citationIntegrity.missingCounts },
-  semanticAlignment: { summary: semanticAlignment.summary, highConfidenceMismatches: semanticAlignment.highConfidenceMismatches.slice(0, 100), findings: semanticAlignment.findings.slice(0, 200) },
-  claimLanguageCalibration: { summary: languageCalibration.summary, highConfidenceFindings: languageCalibration.highConfidenceFindings.slice(0, 100), findings: languageCalibration.findings.slice(0, 200) },
-  withdrawnCitedStudies: sourceIntegrity.withdrawn, evidenceGradeInvalid: evidenceGradeConsistency.invalid, evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
-  oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100), systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
-  topCrossProfileStudyLoad: crossProfileStudyLoad.slice(0, 100), narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
-  homogeneousMultiStudyClaims: homogeneousMultiStudyClaims.slice(0, 150), highConfidenceHomogeneousMultiStudyClaims: highConfidenceHomogeneousMultiStudyClaims.slice(0, 100),
+  schemaVersion: 21,
+  generatedAt: new Date().toISOString(),
+  passed: !failed,
+  source: {
+    analysis: 'lib/research-quality-analysis.ts',
+    topology: 'lib/research-quality-topology.ts',
+    policy: 'lib/research-quality-policy.ts',
+    gate: 'lib/research-quality-gate.ts',
+  },
+  coreSummary,
+  structuralFailures: gate.structuralFailures,
+  severeStudyClassConflicts: gate.severeStudyClassConflicts,
+  studyClassConflicts: studyClassConflicts.conflicts.slice(0, 150),
+  citationIntegrity: {
+    blocking: citationIntegrity.blocking,
+    duplicateProfileSources: citationIntegrity.duplicateProfileSources,
+    identifierPairConflicts: citationIntegrity.identifierPairConflicts,
+    conflicts: citationIntegrity.conflicts,
+    missingCounts: citationIntegrity.missingCounts,
+  },
+  semanticAlignment: {
+    summary: semanticAlignment.summary,
+    highConfidenceMismatches: semanticAlignment.highConfidenceMismatches.slice(0, 100),
+    highConfidenceConcentration: semanticAlignment.highConfidenceConcentrationFindings.slice(0, 100),
+    highConfidenceCoverageGaps: semanticAlignment.highConfidenceCoverageGapFindings.slice(0, 100),
+  },
+  claimLanguageCalibration: {
+    summary: languageCalibration.summary,
+    highConfidenceFindings: languageCalibration.highConfidenceFindings.slice(0, 100),
+    highConfidenceDirectEvidenceFindings: languageCalibration.highConfidenceDirectEvidenceFindings.slice(0, 100),
+  },
+  claimCitationMetadata: {
+    summary: claimCitationMetadata.summary,
+    highConfidenceLowCoverageClaims: claimCitationMetadata.highConfidenceLowCoverageClaims.slice(0, 100),
+  },
+  withdrawnCitedStudies: sourceIntegrity.withdrawn,
+  evidenceGradeInvalid: evidenceGradeConsistency.invalid,
+  evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
+  oldAndLoadBearingStudies: sourceIntegrity.oldAndLoadBearing.slice(0, 100),
+  systemicLoadBearingStudies: systemicLoadBearingStudies.slice(0, 50),
+  narrowRepeatedEvidenceBundles: narrowRepeatedEvidenceBundles.slice(0, 100),
+  narrowCrossProfileEvidenceBundles: narrowCrossProfileEvidenceBundles.slice(0, 100),
+  homogeneousMultiStudyClaims: homogeneousMultiStudyClaims.slice(0, 150),
+  provenanceNarrowMultiStudyClaims: provenanceNarrowMultiStudyClaims.slice(0, 150),
   topClaimEvidenceDiversity: claimEvidenceDiversity.slice(0, 200),
-  provenanceNarrowMultiStudyClaims: provenanceNarrowMultiStudyClaims.slice(0, 150), highConfidenceProvenanceNarrowMultiStudyClaims: highConfidenceProvenanceNarrowMultiStudyClaims.slice(0, 100),
   topClaimProvenanceIndependence: claimProvenanceIndependence.slice(0, 200),
-  topRepeatedEvidenceBundles: evidenceBundleReuse.slice(0, 100), topClaimEvidenceOverlap: claimEvidenceOverlap.slice(0, 150),
-  edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.slice(0, 100), topEdgeWeightedDesignUsage: edgeWeightedDesignUsage.slice(0, 150),
-  provenanceConcentratedProfiles: provenanceConcentratedProfiles.slice(0, 100), topProvenanceConcentration: provenanceConcentration.profiles.slice(0, 150),
-  uncertainStudyIdentityClaims: uncertainIdentityClaims.slice(0, 100), weakStudyIdentityCoverageProfiles: weakIdentityProfiles.slice(0, 100),
-  highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100), topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100),
-  topResearchGaps: researchGapQueue.slice(0, 50), topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
-  checks: results, contentIntegritySummary: readSummary('content-integrity.json'),
+  topClaimEvidenceOverlap: claimEvidenceOverlap.slice(0, 150),
+  edgeWeightedNarrativeDominatedProfiles: edgeWeightedNarrativeDominatedProfiles.slice(0, 100),
+  topEdgeWeightedDesignUsage: edgeWeightedDesignUsage.slice(0, 150),
+  provenanceConcentratedProfiles: provenanceConcentratedProfiles.slice(0, 100),
+  topProvenanceConcentration: provenanceConcentration.profiles.slice(0, 150),
+  uncertainStudyIdentityClaims: uncertainIdentityClaims.slice(0, 100),
+  weakStudyIdentityCoverageProfiles: weakIdentityProfiles.slice(0, 100),
+  highConfidenceLegacyOnlyClaims: highConfidenceLegacyOnlyClaims.slice(0, 100),
+  topLegacyOnlyClaims: legacyOnlyClaims.slice(0, 100),
+  topResearchGaps: researchGapQueue.slice(0, 50),
+  topAiCitationRemediation: aiCitationReadiness.profiles.slice(0, 50),
+  checks: results,
+  contentIntegritySummary: readSummary('content-integrity.json'),
 }, null, 2)}\n`)
 
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
 console.log(`Research gate: ${gate.summary.blockingFailures} blocking · ${gate.summary.structuralFailures} structural · ${gate.summary.severeStudyClassConflicts} severe study-class conflict(s)`)
-console.log(`Citation integrity: ${citationIntegrity.sources} sources · ${citationIntegrity.blockingCount} blocking identity problems`)
-console.log(`Source integrity: ${sourceIntegrity.summary.citedStudies} studies · ${sourceIntegrity.summary.withdrawn} withdrawn/concern · ${sourceIntegrity.summary.oldAndLoadBearing} old load-bearing`)
-console.log(`Evidence grades: ${evidenceGradeConsistency.totals.invalidPublishedGrades} invalid · ${evidenceGradeConsistency.totals.contradictionsIndexable} indexable contradictions`)
-console.log(`Evidence topology: ${coreSummary.systemicLoadBearingStudies} systemic studies · ${coreSummary.narrowRepeatedEvidenceBundles} narrow repeated bundles · ${coreSummary.homogeneousMultiStudyClaims} homogeneous multi-study claims (${coreSummary.highConfidenceHomogeneousMultiStudyClaims} high-confidence) · ${coreSummary.provenanceNarrowMultiStudyClaims} provenance-narrow multi-study claims (${coreSummary.highConfidenceProvenanceNarrowMultiStudyClaims} high-confidence) · ${coreSummary.nearDuplicateEvidencePairs} near-duplicate claim pairs (${coreSummary.crossPredicateNearDuplicateEvidencePairs} cross-predicate) · ${evidenceAgeSummary.legacyOnly10Years} legacy-only claims`)
-console.log(`Study classes: ${studyClassConflicts.summary.studiesWithClassConflict} conflict(s) · ${studyClassConflicts.summary.severeClassConflicts} severe cross-family`)
-console.log(`Design usage: ${edgeWeightedNarrativeDominatedProfiles.length} profile(s) narrative-dominated by approved claim-study edges`)
-console.log(`Provenance: ${provenanceConcentration.summary.provenanceConcentratedProfiles} concentrated profile(s) · ${provenanceConcentration.summary.firstAuthorConcentratedProfiles} first-author · ${provenanceConcentration.summary.journalConcentratedProfiles} journal`)
-console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explicit mismatch(es) · ${semanticAlignment.summary.highConfidenceMismatches} high-confidence · ${semanticAlignment.summary.roleMismatches} role · ${semanticAlignment.summary.domainMismatches} domain · ${semanticAlignment.summary.populationMismatches} population`)
-console.log(`Language calibration: ${languageCalibration.summary.causalWithoutControlledSupport} direct-causal outcome claim(s) without controlled/synthesis support · ${languageCalibration.summary.highConfidenceCausalWithoutControlledSupport} high-confidence`)
-console.log(`Study identity coverage: ${studyIdentityCoverage.summary.uncertainMultiStudyClaims} uncertain multi-study claim(s) · ${studyIdentityCoverage.summary.highConfidenceUncertainClaims} high-confidence · ${studyIdentityCoverage.summary.profilesWithWeakIdentityCoverage} weak-coverage profile(s)`)
-console.log(`Mapping gaps: ${coreSummary.profilesWithUnmappedPrimaryHumanEvidence} profile(s) with unmapped primary-human evidence · ${coreSummary.profilesWithPrimaryHumanEvidenceOnlyOnUnapprovedClaims} with primary-human evidence only on unapproved claims`)
-console.log(`AI citation remediation: ${aiCitationReadiness.summary.below70} below 70 · ${aiCitationReadiness.summary.contradictions} contradiction(s)`)
+console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explicit mismatch(es) · ${semanticAlignment.summary.highConfidenceMismatches} high-confidence`)
+console.log(`Language calibration: ${languageCalibration.summary.causalWithoutControlledSupport} unsupported direct-causal claim(s)`)
+console.log(`Gap queue: ${researchGapQueue.length} profile(s) prioritized`)
 console.log(`Semantic report: ${path.relative(ROOT, semanticReportPath)}`)
 console.log(`Citation report: ${path.relative(ROOT, citationReportPath)}`)
 console.log(`Evidence-grade report: ${path.relative(ROOT, evidenceGradeReportPath)}`)
 console.log(`AI report: ${path.relative(ROOT, aiCitationReportPath)}`)
 console.log(`Roll-up report: ${path.relative(ROOT, REPORT_PATH)}`)
-if (failed) { console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.'); process.exit(1) }
-console.log('\n[research-quality] PASS — one canonical analysis/topology/policy/gate snapshot plus semantic alignment, claim-language calibration, citation/source integrity, evidence grades, and structured integrity agree.')
+
+if (failed) {
+  console.error('\n[research-quality] FAILED — one or more authoritative research checks failed.')
+  process.exit(1)
+}
+console.log('\n[research-quality] PASS — one canonical analysis/topology/policy/gate snapshot plus citation/source integrity, evidence grades, and structured integrity agree.')


### PR DESCRIPTION
Removes duplicate semantic-alignment and claim-language analysis passes from scripts/ci/research-quality.ts. The runner now builds ResearchQualityTopology once and consumes semantic alignment, language calibration, claim citation metadata, bundle reuse, provenance, design, freshness, and related derived products from that canonical snapshot. The roll-up is simplified, schema version advances, and newly landed topology products remain represented without re-walking the claim graph.