### PR TITLE
Remove duplicate semantic analysis from topology

### DIFF
--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -1,13 +1,11 @@
 import { analyzeClaimCitationMetadata } from './research-claim-citation-metadata'
 import { analyzeClaimEvidenceDiversity } from './research-claim-evidence-diversity'
-import { analyzeClaimLanguageCalibration } from './research-claim-language-calibration'
 import { analyzeClaimProvenanceIndependence } from './research-claim-provenance-independence'
 import { analyzeCrossProfileEvidenceBundles } from './research-cross-profile-bundles'
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import { analyzeProvenanceConcentration } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
-import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
 import { analyzeStudyClassConflicts } from './research-study-class-conflicts'
 import { analyzeStudyIdentityCoverage } from './research-study-identity-coverage'
 import {
@@ -19,9 +17,11 @@ import {
 export type ResearchQualityTopology = ReturnType<typeof buildResearchQualityTopology>
 
 /**
- * Build all derived evidence-topology products once from the canonical analysis.
+ * Build derived evidence-topology products once from the canonical analysis.
  * Policy and reporting should consume this snapshot rather than independently
- * walking the same claim/study graph again.
+ * walking the same claim/study graph again. Non-topology editorial analyses
+ * (semantic alignment and language calibration) stay in the canonical pipeline
+ * instead of being recomputed here.
  */
 export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) {
   const crossProfileStudyLoad = analyzeCrossProfileStudyLoad(analysis)
@@ -54,8 +54,6 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     (claim) => claim.highConfidenceProvenanceNarrowMultiStudySupport,
   )
   const studyClassConflicts = analyzeStudyClassConflicts(analysis)
-  const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
-  const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
 
   return {
@@ -83,8 +81,6 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     provenanceNarrowMultiStudyClaims,
     highConfidenceProvenanceNarrowMultiStudyClaims,
     studyClassConflicts,
-    semanticAlignment,
-    claimLanguageCalibration,
     claimCitationMetadata,
   }
 }


### PR DESCRIPTION
Stops research-quality topology from recomputing semantic alignment and claim-language calibration, which are authoritative non-topology analyses already run by the canonical pipeline. Keeps topology focused on derived claim/study graph products and reduces duplicate work without changing policy or report semantics.