### PR TITLE
refactor(research): source gap report from canonical snapshot

### DIFF
--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -1,27 +1,24 @@
 #!/usr/bin/env npx tsx
-/** Build the prioritized remediation queue from canonical research-quality policy. */
+/** Build the prioritized remediation queue from the canonical research-quality snapshot. */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
-import {
-  buildResearchGapQueue,
-  RESEARCH_GAP_DIMENSION_CAPS,
-  RESEARCH_GAP_WEIGHTS,
-} from '../../lib/research-quality-policy'
+import { buildResearchGapQueue, RESEARCH_GAP_DIMENSION_CAPS, RESEARCH_GAP_WEIGHTS } from '../../lib/research-quality-policy'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
-const ranked = buildResearchGapQueue(analyzeResearchQuality(ROOT))
+const { analysis, topology } = buildResearchQualitySnapshot(ROOT)
+const ranked = buildResearchGapQueue(analysis, topology)
 
 const report = {
-  schemaVersion: 2,
+  schemaVersion: 3,
   generatedAt: new Date().toISOString(),
-  source: 'lib/research-quality-analysis.ts + lib/research-quality-topology.ts + lib/research-quality-policy.ts',
+  source: 'lib/research-quality-snapshot.ts -> lib/research-quality-policy.ts',
   scoring: {
-    note: 'Reasons are grouped into canonical dimensions. rawScore preserves the full diagnostic weight; score sums dimension-capped subtotals so correlated findings corroborate a weakness without unlimited double-counting. Scores are triage weights, not evidence grades.',
+    note: 'Reasons are grouped into canonical dimensions. rawScore preserves full diagnostic weight; score sums dimension-capped subtotals so correlated findings corroborate a weakness without unlimited double-counting. Scores are triage weights, not evidence grades.',
     dimensionCaps: RESEARCH_GAP_DIMENSION_CAPS,
     weights: {
       ...RESEARCH_GAP_WEIGHTS,


### PR DESCRIPTION
Moves build-research-gap-priorities.ts onto buildResearchQualitySnapshot so the operator report consumes the same analysis/topology snapshot as the canonical research-quality pipeline. This removes the last obvious independent graph build in the gap-report path while preserving the CLI/report surface.