### PR TITLE
refactor(research): route remaining reporters through canonical snapshot

### DIFF
--- a/scripts/ci/audit-ai-citation-topology.ts
+++ b/scripts/ci/audit-ai-citation-topology.ts
@@ -3,13 +3,13 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
-import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
 const strict = process.argv.includes('--strict')
 const entityRoot = path.join(ROOT, 'public', 'data', 'ai-entities')
 
-const analysis = analyzeResearchQuality(ROOT)
+const { analysis } = buildResearchQualitySnapshot(ROOT)
 const report = buildAiCitationReadiness(analysis, ROOT)
 const output = writeAiCitationReadinessReport(report, ROOT)
 const { summary } = report

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -1,26 +1,24 @@
 #!/usr/bin/env npx tsx
-/** Build the prioritized remediation queue from canonical research-quality policy. */
+/** Build the prioritized remediation queue from the canonical research-quality snapshot. */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
-import {
-  RESEARCH_GAP_DIMENSION_CAPS,
-  RESEARCH_GAP_WEIGHTS,
-} from '../../lib/research-quality-policy'
+import { buildResearchGapQueue, RESEARCH_GAP_DIMENSION_CAPS, RESEARCH_GAP_WEIGHTS } from '../../lib/research-quality-policy'
 import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
-const { researchGapQueue: ranked } = buildResearchQualitySnapshot(ROOT)
+const { analysis, topology } = buildResearchQualitySnapshot(ROOT)
+const ranked = buildResearchGapQueue(analysis, topology)
 
 const report = {
-  schemaVersion: 2,
+  schemaVersion: 3,
   generatedAt: new Date().toISOString(),
-  source: 'lib/research-quality-snapshot.ts',
+  source: 'lib/research-quality-snapshot.ts -> lib/research-quality-policy.ts',
   scoring: {
-    note: 'Reasons are grouped into canonical dimensions. rawScore preserves the full diagnostic weight; score sums dimension-capped subtotals so correlated findings corroborate a weakness without unlimited double-counting. Scores are triage weights, not evidence grades.',
+    note: 'Reasons are grouped into canonical dimensions. rawScore preserves full diagnostic weight; score sums dimension-capped subtotals so correlated findings corroborate a weakness without unlimited double-counting. Scores are triage weights, not evidence grades.',
     dimensionCaps: RESEARCH_GAP_DIMENSION_CAPS,
     weights: {
       ...RESEARCH_GAP_WEIGHTS,

--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -4,22 +4,21 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { analyzeResearchQuality } from '../../lib/research-quality-analysis'
 import {
-  buildResearchGapQueue,
   RESEARCH_GAP_DIMENSION_CAPS,
   RESEARCH_GAP_WEIGHTS,
 } from '../../lib/research-quality-policy'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
-const ranked = buildResearchGapQueue(analyzeResearchQuality(ROOT))
+const { researchGapQueue: ranked } = buildResearchQualitySnapshot(ROOT)
 
 const report = {
   schemaVersion: 2,
   generatedAt: new Date().toISOString(),
-  source: 'lib/research-quality-analysis.ts + lib/research-quality-topology.ts + lib/research-quality-policy.ts',
+  source: 'lib/research-quality-snapshot.ts',
   scoring: {
     note: 'Reasons are grouped into canonical dimensions. rawScore preserves the full diagnostic weight; score sums dimension-capped subtotals so correlated findings corroborate a weakness without unlimited double-counting. Scores are triage weights, not evidence grades.',
     dimensionCaps: RESEARCH_GAP_DIMENSION_CAPS,


### PR DESCRIPTION
Continuation of the research-quality consolidation. Migrates the AI citation topology audit and prioritized research-gap report to consume `buildResearchQualitySnapshot()` rather than independently rebuilding research analysis/policy state. This reduces duplicate execution paths and makes `lib/research-quality-snapshot.ts` the canonical producer for these reporters without changing their output semantics.