### PR TITLE
refactor(nav): remove redundant core goal prefixes

### DIFF
--- a/lib/core-goals.ts
+++ b/lib/core-goals.ts
@@ -33,5 +33,3 @@ export const coreGoals: readonly CoreGoal[] = [
     description: 'Compare focus-support options by stimulation profile, onset, evidence, and risk',
   },
 ] as const
-
-export const coreGoalPrefixes = coreGoals.map((goal) => goal.href.replace(/\/$/, ''))

--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -1,4 +1,4 @@
-import { coreGoalPrefixes, coreGoals } from './core-goals'
+import { coreGoals } from './core-goals'
 
 export interface PrimaryNavigationItem {
   label: string
@@ -14,7 +14,7 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     label: 'Goals',
     href: '/goals',
     description: 'Start with what you are researching, then follow the evidence to relevant options',
-    activePrefixes: ['/goals', '/guides/mental-health', '/guides/adhd', ...coreGoalPrefixes],
+    activePrefixes: ['/goals', '/guides/mental-health', '/guides/adhd'],
     children: [
       { section: 'Start here', label: 'Goal finder', href: '/goals', description: 'Choose the outcome or question you are actually researching' },
       ...coreGoals.map((goal) => ({


### PR DESCRIPTION
## Summary
- Removes `coreGoalPrefixes` from the shared goal module.
- Simplifies the Goals active-prefix list to rely on `/goals`, which already covers every core goal route.

## Why
After moving core goal destinations into `/goals/*`, separately deriving each goal prefix became redundant maintenance code.

## Regression contract
- Active navigation behavior for `/goals/*` remains unchanged.
- Mental Health and ADHD guide prefixes remain explicit because they still live outside `/goals`.