### PR TITLE
refactor(research): reuse canonical remediation queue

### DIFF
--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -4,14 +4,13 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { buildResearchGapQueue, RESEARCH_GAP_DIMENSION_CAPS, RESEARCH_GAP_WEIGHTS } from '../../lib/research-quality-policy'
+import { RESEARCH_GAP_DIMENSION_CAPS, RESEARCH_GAP_WEIGHTS } from '../../lib/research-quality-policy'
 import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
 const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
-const { analysis, topology } = buildResearchQualitySnapshot(ROOT)
-const ranked = buildResearchGapQueue(analysis, topology)
+const { researchGapQueue: ranked } = buildResearchQualitySnapshot(ROOT)
 
 const report = {
   schemaVersion: 3,


### PR DESCRIPTION
Removes the remaining duplicate policy execution from `build-research-gap-priorities.ts`. The report now consumes `researchGapQueue` directly from `buildResearchQualitySnapshot()` instead of rebuilding the queue from snapshot analysis/topology. Scoring metadata and report format are unchanged; this makes the snapshot the single execution path for canonical remediation ranking.