### PR TITLE
Consolidate provenance gap scoring

### DIFF
--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -32,6 +32,9 @@ export type StructuralCoverageFailure = {
   sourceRefId?: string
 }
 
+type MutableGap = { url: string; reasons: ResearchGapReason[] }
+type AddReason = (url: string, kind: string, weight: number, detail?: string) => void
+
 export const RESEARCH_GAP_DIMENSION_CAPS: Record<ResearchGapDimension, number> = {
   structural: 200,
   'claim-support': 160,
@@ -78,8 +81,6 @@ export const RESEARCH_GAP_WEIGHTS = {
   narrowCrossProfileEvidenceBundle: 12,
   homogeneousMultiStudySupport: 7,
   highConfidenceHomogeneousMultiStudyBonus: 5,
-  provenanceNarrowMultiStudySupport: 6,
-  highConfidenceProvenanceNarrowMultiStudyBonus: 4,
   nearDuplicateEvidenceSupport: 10,
   systemicLoadBearingStudyDependency: 8,
   provenanceConcentration: 10,
@@ -120,7 +121,6 @@ const DIMENSION_BY_KIND: Record<string, ResearchGapDimension> = {
   'narrow-repeated-evidence-bundle': 'concentration',
   'narrow-cross-profile-evidence-bundle': 'concentration',
   'homogeneous-multi-study-support': 'concentration',
-  'provenance-narrow-multi-study-support': 'concentration',
   'near-duplicate-claim-evidence-support': 'concentration',
   'systemic-load-bearing-study-dependency': 'concentration',
   'provenance-concentrated-evidence': 'concentration',
@@ -158,25 +158,33 @@ export function structuralCoverageFailures(analysis: ResearchQualityAnalysis): S
   ])
 }
 
-type MutableGap = { url: string; reasons: ResearchGapReason[] }
-type AddReason = (url: string, kind: string, weight: number, detail?: string) => void
-
 function addApprovedClaimReasons(analysis: ResearchQualityAnalysis, add: AddReason) {
   for (const claim of analysis.claimAnalyses) {
-    if (claim.structuredSupportTier === 'unsupported') add(claim.url, 'unsupported-approved-claim', RESEARCH_GAP_WEIGHTS.unsupportedApprovedClaim, claim.claimId)
-    for (const sourceRefId of claim.danglingSourceRefs) add(claim.url, 'dangling-claim-source-edge', RESEARCH_GAP_WEIGHTS.danglingClaimSourceEdge, `${claim.claimId} -> ${sourceRefId}`)
-
+    if (claim.structuredSupportTier === 'unsupported') {
+      add(claim.url, 'unsupported-approved-claim', RESEARCH_GAP_WEIGHTS.unsupportedApprovedClaim, claim.claimId)
+    }
+    for (const sourceRefId of claim.danglingSourceRefs) {
+      add(claim.url, 'dangling-claim-source-edge', RESEARCH_GAP_WEIGHTS.danglingClaimSourceEdge, `${claim.claimId} -> ${sourceRefId}`)
+    }
     if (claim.singleStudy) {
       const high = claim.confidence >= 0.75 ? RESEARCH_GAP_WEIGHTS.highConfidenceSingleStudyBonus : 0
       const veryHigh = claim.confidence >= 0.9 ? RESEARCH_GAP_WEIGHTS.veryHighConfidenceSingleStudyBonus : 0
       add(claim.url, 'single-study-approved-claim', RESEARCH_GAP_WEIGHTS.singleStudyApprovedClaim + high + veryHigh, `${claim.claimId} · confidence ${claim.confidence}`)
     }
-    if (claim.outcomeClaim && claim.primaryHuman === 0 && claim.synthesis > 0) add(claim.url, 'synthesis-only-approved-outcome', RESEARCH_GAP_WEIGHTS.synthesisOnlyApprovedOutcome, `${claim.claimId} · synthesis present but no primary-human study`)
+    if (claim.outcomeClaim && claim.primaryHuman === 0 && claim.synthesis > 0) {
+      add(claim.url, 'synthesis-only-approved-outcome', RESEARCH_GAP_WEIGHTS.synthesisOnlyApprovedOutcome, `${claim.claimId} · synthesis present but no primary-human study`)
+    }
 
     const confidenceBonus = claim.highConfidenceWeakStructured ? RESEARCH_GAP_WEIGHTS.highConfidenceWeakClaimBonus : 0
-    if (claim.structuredSupportTier === 'unclassified') add(claim.url, 'claim-support-unclassified', RESEARCH_GAP_WEIGHTS.unclassifiedStructuredSupport + confidenceBonus, `${claim.claimId} · ${claim.predicate}`)
-    else if (claim.structuredSupportTier === 'narrative-only') add(claim.url, 'claim-support-narrative-only', (claim.outcomeClaim ? RESEARCH_GAP_WEIGHTS.narrativeOnlyOutcomeSupport : RESEARCH_GAP_WEIGHTS.narrativeOnlyOtherStructuredSupport) + confidenceBonus, `${claim.claimId} · ${claim.predicate}`)
-    else if (claim.supportTier === 'indirect-only') add(claim.url, 'claim-support-indirect-only', RESEARCH_GAP_WEIGHTS.indirectOutcomeSupport + (claim.highConfidenceWeakOutcome ? RESEARCH_GAP_WEIGHTS.highConfidenceWeakClaimBonus : 0), claim.claimId)
+    if (claim.structuredSupportTier === 'unclassified') {
+      add(claim.url, 'claim-support-unclassified', RESEARCH_GAP_WEIGHTS.unclassifiedStructuredSupport + confidenceBonus, `${claim.claimId} · ${claim.predicate}`)
+    } else if (claim.structuredSupportTier === 'narrative-only') {
+      const base = claim.outcomeClaim ? RESEARCH_GAP_WEIGHTS.narrativeOnlyOutcomeSupport : RESEARCH_GAP_WEIGHTS.narrativeOnlyOtherStructuredSupport
+      add(claim.url, 'claim-support-narrative-only', base + confidenceBonus, `${claim.claimId} · ${claim.predicate}`)
+    } else if (claim.supportTier === 'indirect-only') {
+      const bonus = claim.highConfidenceWeakOutcome ? RESEARCH_GAP_WEIGHTS.highConfidenceWeakClaimBonus : 0
+      add(claim.url, 'claim-support-indirect-only', RESEARCH_GAP_WEIGHTS.indirectOutcomeSupport + bonus, claim.claimId)
+    }
   }
 }
 
@@ -184,10 +192,15 @@ function addEditorialBacklogReasons(analysis: ResearchQualityAnalysis, add: AddR
   for (const claim of analysis.structuredClaimAnalyses) {
     if (claim.approved) continue
     const detail = `${claim.claimId} · ${claim.predicate} · ${claim.reviewStatus || 'unreviewed'}`
-    if (claim.structuredSupportTier === 'unsupported') add(claim.url, 'unsupported-unapproved-structured-claim', RESEARCH_GAP_WEIGHTS.unsupportedUnapprovedStructuredClaim, detail)
-    else if (claim.structuredSupportTier === 'unclassified' || claim.structuredSupportTier === 'narrative-only') add(claim.url, `unapproved-claim-support-${claim.structuredSupportTier}`, RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim, detail)
-    else if (claim.structuredSupportTier === 'single-study') add(claim.url, 'unapproved-claim-support-single-study', RESEARCH_GAP_WEIGHTS.unapprovedSingleStudyStructuredClaim, detail)
-    else if (claim.supportTier === 'indirect-only') add(claim.url, 'unapproved-claim-support-indirect-only', RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim, detail)
+    if (claim.structuredSupportTier === 'unsupported') {
+      add(claim.url, 'unsupported-unapproved-structured-claim', RESEARCH_GAP_WEIGHTS.unsupportedUnapprovedStructuredClaim, detail)
+    } else if (claim.structuredSupportTier === 'unclassified' || claim.structuredSupportTier === 'narrative-only') {
+      add(claim.url, `unapproved-claim-support-${claim.structuredSupportTier}`, RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim, detail)
+    } else if (claim.structuredSupportTier === 'single-study') {
+      add(claim.url, 'unapproved-claim-support-single-study', RESEARCH_GAP_WEIGHTS.unapprovedSingleStudyStructuredClaim, detail)
+    } else if (claim.supportTier === 'indirect-only') {
+      add(claim.url, 'unapproved-claim-support-indirect-only', RESEARCH_GAP_WEIGHTS.weakUnapprovedStructuredClaim, detail)
+    }
   }
 }
 
@@ -197,7 +210,10 @@ function addProfileReasons(analysis: ResearchQualityAnalysis, add: AddReason) {
       const concentrationBonus = Math.round(Math.min(15, profile.studyConcentrationIndex * 20))
       add(profile.url, 'high-study-dependency', Math.round(25 + profile.dominantStudySupportedClaimShare * 30 + concentrationBonus), `${Math.round(profile.dominantStudySupportedClaimShare * 100)}% of supported approved claims depend on one canonical study; effective study count ${profile.effectiveStudyCount}`)
     }
-    if (profile.narrativeDominatedVsPrimaryHuman) add(profile.url, 'narrative-review-dominated-profile', RESEARCH_GAP_WEIGHTS.narrativeReviewDominatedProfile, profile.narrativeToPrimaryHumanRatio === null ? 'no primary-human studies' : `${profile.narrativeToPrimaryHumanRatio}:1 narrative-to-primary-human ratio`)
+    if (profile.narrativeDominatedVsPrimaryHuman) {
+      const detail = profile.narrativeToPrimaryHumanRatio === null ? 'no primary-human studies' : `${profile.narrativeToPrimaryHumanRatio}:1 narrative-to-primary-human ratio`
+      add(profile.url, 'narrative-review-dominated-profile', RESEARCH_GAP_WEIGHTS.narrativeReviewDominatedProfile, detail)
+    }
     if (profile.noPrimaryHuman) add(profile.url, 'approved-claims-without-primary-human-study', RESEARCH_GAP_WEIGHTS.noPrimaryHumanStudy)
 
     const mappingBonus = profile.noPrimaryHuman ? RESEARCH_GAP_WEIGHTS.mappingGapNoApprovedPrimaryBonus : 0
@@ -206,57 +222,73 @@ function addProfileReasons(analysis: ResearchQualityAnalysis, add: AddReason) {
 
     const unclassifiedStudies = Number(profile.designMix.unclassified ?? 0)
     const coverage = profile.canonicalStudyCount ? Math.max(0, profile.canonicalStudyCount - unclassifiedStudies) / profile.canonicalStudyCount : 1
-    if (profile.canonicalStudyCount >= 3 && coverage < 0.7) add(profile.url, 'poor-study-metadata-coverage', RESEARCH_GAP_WEIGHTS.poorStudyMetadataCoverage, `${Math.round(coverage * 100)}% of canonical studies have classified designs`)
+    if (profile.canonicalStudyCount >= 3 && coverage < 0.7) {
+      add(profile.url, 'poor-study-metadata-coverage', RESEARCH_GAP_WEIGHTS.poorStudyMetadataCoverage, `${Math.round(coverage * 100)}% of canonical studies have classified designs`)
+    }
   }
 }
 
 function addTopologyReasons(topology: ResearchQualityTopology, add: AddReason) {
-  for (const bundle of topology.narrowRepeatedEvidenceBundles) add(bundle.url, 'narrow-repeated-evidence-bundle', RESEARCH_GAP_WEIGHTS.narrowRepeatedEvidenceBundle + Math.min(10, Math.max(0, bundle.approvedClaimCount - 3) * 2), `${bundle.approvedClaimCount} approved claims reuse the same ${bundle.studyCount}-study bundle`)
-  for (const claim of topology.homogeneousMultiStudyClaims) add(claim.url, 'homogeneous-multi-study-support', RESEARCH_GAP_WEIGHTS.homogeneousMultiStudySupport + (claim.highConfidenceHomogeneousMultiStudySupport ? RESEARCH_GAP_WEIGHTS.highConfidenceHomogeneousMultiStudyBonus : 0), `${claim.claimId} · ${claim.studyCount} studies but one evidence family (${claim.evidenceFamilies.join(', ')})`)
-
-  for (const claim of topology.provenanceNarrowMultiStudyClaims) {
-    const highConfidenceBonus = claim.highConfidenceProvenanceNarrowMultiStudySupport
-      ? RESEARCH_GAP_WEIGHTS.highConfidenceProvenanceNarrowMultiStudyBonus
-      : 0
-    const lineage = [
-      claim.sameFirstAuthorLineage ? 'same first-author lineage' : '',
-      claim.sameJournalLineage ? 'same journal' : '',
-    ].filter(Boolean).join(' + ')
-    add(
-      claim.url,
-      'provenance-narrow-multi-study-support',
-      RESEARCH_GAP_WEIGHTS.provenanceNarrowMultiStudySupport + highConfidenceBonus,
-      `${claim.claimId} · ${claim.studyCount} studies but ${lineage}${highConfidenceBonus ? ' · high confidence' : ''}`,
-    )
+  for (const bundle of topology.narrowRepeatedEvidenceBundles) {
+    const bonus = Math.min(10, Math.max(0, bundle.approvedClaimCount - 3) * 2)
+    add(bundle.url, 'narrow-repeated-evidence-bundle', RESEARCH_GAP_WEIGHTS.narrowRepeatedEvidenceBundle + bonus, `${bundle.approvedClaimCount} approved claims reuse the same ${bundle.studyCount}-study bundle`)
+  }
+  for (const claim of topology.homogeneousMultiStudyClaims) {
+    const bonus = claim.highConfidenceHomogeneousMultiStudySupport ? RESEARCH_GAP_WEIGHTS.highConfidenceHomogeneousMultiStudyBonus : 0
+    add(claim.url, 'homogeneous-multi-study-support', RESEARCH_GAP_WEIGHTS.homogeneousMultiStudySupport + bonus, `${claim.claimId} · ${claim.studyCount} studies but one evidence family (${claim.evidenceFamilies.join(', ')})`)
   }
 
   const overlapByProfile = new Map<string, typeof topology.claimEvidenceOverlap>()
-  for (const overlap of topology.claimEvidenceOverlap) overlapByProfile.set(overlap.url, [...(overlapByProfile.get(overlap.url) ?? []), overlap])
-  for (const [url, overlaps] of overlapByProfile) add(url, 'near-duplicate-claim-evidence-support', RESEARCH_GAP_WEIGHTS.nearDuplicateEvidenceSupport + Math.min(10, Math.max(0, overlaps.length - 1) * 2), `${overlaps.length} claim pairs share near-duplicate evidence; ${overlaps.filter((item) => item.differentPredicates).length} cross-predicate`)
+  for (const overlap of topology.claimEvidenceOverlap) {
+    overlapByProfile.set(overlap.url, [...(overlapByProfile.get(overlap.url) ?? []), overlap])
+  }
+  for (const [url, overlaps] of overlapByProfile) {
+    const bonus = Math.min(10, Math.max(0, overlaps.length - 1) * 2)
+    add(url, 'near-duplicate-claim-evidence-support', RESEARCH_GAP_WEIGHTS.nearDuplicateEvidenceSupport + bonus, `${overlaps.length} claim pairs share near-duplicate evidence; ${overlaps.filter((item) => item.differentPredicates).length} cross-predicate`)
+  }
 
   const systemicByProfile = new Map<string, { studies: number; claims: number }>()
-  for (const study of topology.systemicLoadBearingStudies) for (const url of study.profiles) {
-    const item = systemicByProfile.get(url) ?? { studies: 0, claims: 0 }
-    item.studies += 1
-    item.claims += study.claims.filter((claim) => claim.url === url).length
-    systemicByProfile.set(url, item)
+  for (const study of topology.systemicLoadBearingStudies) {
+    for (const url of study.profiles) {
+      const item = systemicByProfile.get(url) ?? { studies: 0, claims: 0 }
+      item.studies += 1
+      item.claims += study.claims.filter((claim) => claim.url === url).length
+      systemicByProfile.set(url, item)
+    }
   }
-  for (const [url, item] of systemicByProfile) add(url, 'systemic-load-bearing-study-dependency', RESEARCH_GAP_WEIGHTS.systemicLoadBearingStudyDependency + Math.min(12, Math.max(0, item.studies - 1) * 2), `${item.studies} site-wide load-bearing studies support ${item.claims} claims on this profile`)
+  for (const [url, item] of systemicByProfile) {
+    const bonus = Math.min(12, Math.max(0, item.studies - 1) * 2)
+    add(url, 'systemic-load-bearing-study-dependency', RESEARCH_GAP_WEIGHTS.systemicLoadBearingStudyDependency + bonus, `${item.studies} site-wide load-bearing studies support ${item.claims} claims on this profile`)
+  }
 
-  for (const design of topology.edgeWeightedNarrativeDominatedProfiles) add(design.url, 'edge-weighted-narrative-dominance', RESEARCH_GAP_WEIGHTS.edgeWeightedNarrativeDominance, `${Math.round(design.narrativeReviewEdgeShare * 100)}% of classified approved claim-study edges are narrative reviews`)
-  for (const provenance of topology.provenanceConcentratedProfiles) add(provenance.url, 'provenance-concentrated-evidence', RESEARCH_GAP_WEIGHTS.provenanceConcentration + (provenance.firstAuthorConcentrated ? RESEARCH_GAP_WEIGHTS.firstAuthorConcentrationBonus : 0) + (provenance.journalConcentrated ? RESEARCH_GAP_WEIGHTS.journalConcentrationBonus : 0), `first-author share ${Math.round(provenance.dominantFirstAuthorEdgeShare * 100)}%; journal share ${Math.round(provenance.dominantJournalEdgeShare * 100)}%`)
+  for (const design of topology.edgeWeightedNarrativeDominatedProfiles) {
+    add(design.url, 'edge-weighted-narrative-dominance', RESEARCH_GAP_WEIGHTS.edgeWeightedNarrativeDominance, `${Math.round(design.narrativeReviewEdgeShare * 100)}% of classified approved claim-study edges are narrative reviews`)
+  }
+  for (const provenance of topology.provenanceConcentratedProfiles) {
+    const weight = RESEARCH_GAP_WEIGHTS.provenanceConcentration
+      + (provenance.firstAuthorConcentrated ? RESEARCH_GAP_WEIGHTS.firstAuthorConcentrationBonus : 0)
+      + (provenance.journalConcentrated ? RESEARCH_GAP_WEIGHTS.journalConcentrationBonus : 0)
+    add(provenance.url, 'provenance-concentrated-evidence', weight, `first-author share ${Math.round(provenance.dominantFirstAuthorEdgeShare * 100)}%; journal share ${Math.round(provenance.dominantJournalEdgeShare * 100)}%`)
+  }
 
   for (const identity of topology.studyIdentityCoverage.profiles) {
     if (identity.uncertainMultiStudyClaimCount === 0 && !identity.weakIdentityCoverage) continue
-    add(identity.url, 'uncertain-study-identity-independence', RESEARCH_GAP_WEIGHTS.uncertainStudyIdentityCoverage + (identity.highConfidenceUncertainClaimCount > 0 ? RESEARCH_GAP_WEIGHTS.highConfidenceIdentityUncertaintyBonus : 0) + (identity.weakIdentityCoverage ? RESEARCH_GAP_WEIGHTS.weakIdentityCoverageBonus : 0), `${identity.uncertainMultiStudyClaimCount} multi-study claims include fallback identities; ${Math.round(identity.stableIdentityCoverage * 100)}% stable identity coverage`)
+    const weight = RESEARCH_GAP_WEIGHTS.uncertainStudyIdentityCoverage
+      + (identity.highConfidenceUncertainClaimCount > 0 ? RESEARCH_GAP_WEIGHTS.highConfidenceIdentityUncertaintyBonus : 0)
+      + (identity.weakIdentityCoverage ? RESEARCH_GAP_WEIGHTS.weakIdentityCoverageBonus : 0)
+    add(identity.url, 'uncertain-study-identity-independence', weight, `${identity.uncertainMultiStudyClaimCount} multi-study claims include fallback identities; ${Math.round(identity.stableIdentityCoverage * 100)}% stable identity coverage`)
   }
 
   for (const freshness of topology.claimEvidenceAge) {
-    if (freshness.studyCount > 0 && freshness.knownYearCount === 0) add(freshness.url, 'unknown-evidence-year-metadata', RESEARCH_GAP_WEIGHTS.unknownEvidenceYearMetadata, `${freshness.claimId} · publication year unknown for all ${freshness.studyCount} studies`)
-    else if (freshness.legacyOnlyOutcomeClaim) add(freshness.url, 'legacy-only-outcome-evidence', RESEARCH_GAP_WEIGHTS.legacyOnlyOutcomeClaim + (freshness.highConfidenceLegacyOnlyClaim ? RESEARCH_GAP_WEIGHTS.highConfidenceLegacyOnlyBonus : 0), `${freshness.claimId} · newest known supporting study ${freshness.newestYear ?? 'unknown'}`)
+    if (freshness.studyCount > 0 && freshness.knownYearCount === 0) {
+      add(freshness.url, 'unknown-evidence-year-metadata', RESEARCH_GAP_WEIGHTS.unknownEvidenceYearMetadata, `${freshness.claimId} · publication year unknown for all ${freshness.studyCount} studies`)
+    } else if (freshness.legacyOnlyOutcomeClaim) {
+      const bonus = freshness.highConfidenceLegacyOnlyClaim ? RESEARCH_GAP_WEIGHTS.highConfidenceLegacyOnlyBonus : 0
+      add(freshness.url, 'legacy-only-outcome-evidence', RESEARCH_GAP_WEIGHTS.legacyOnlyOutcomeClaim + bonus, `${freshness.claimId} · newest known supporting study ${freshness.newestYear ?? 'unknown'}`)
+    }
   }
 
-  for (const signal of buildAggregatedTopologyGapSignals(topology, {
+  const aggregatedWeights = {
     narrowCrossProfileEvidenceBundle: RESEARCH_GAP_WEIGHTS.narrowCrossProfileEvidenceBundle,
     semanticMismatch: RESEARCH_GAP_WEIGHTS.semanticMismatch,
     highConfidenceSemanticMismatchBonus: RESEARCH_GAP_WEIGHTS.highConfidenceSemanticMismatchBonus,
@@ -275,7 +307,10 @@ function addTopologyReasons(topology: ResearchQualityTopology, add: AddReason) {
     highConfidenceProvenanceNarrowBonus: RESEARCH_GAP_WEIGHTS.highConfidenceProvenanceNarrowBonus,
     severeStudyClassConflict: RESEARCH_GAP_WEIGHTS.severeStudyClassConflict,
     studyClassAmbiguity: RESEARCH_GAP_WEIGHTS.studyClassAmbiguity,
-  })) add(signal.url, signal.kind, signal.weight, signal.detail)
+  }
+  for (const signal of buildAggregatedTopologyGapSignals(topology, aggregatedWeights)) {
+    add(signal.url, signal.kind, signal.weight, signal.detail)
+  }
 }
 
 function finalizeGap(item: MutableGap): ResearchGapItem {
@@ -283,10 +318,17 @@ function finalizeGap(item: MutableGap): ResearchGapItem {
     scores[reason.dimension] = (scores[reason.dimension] ?? 0) + reason.weight
     return scores
   }, {})
-  const dimensionScores = Object.fromEntries(Object.entries(dimensionRawScores).map(([dimension, raw]) => [dimension, Math.min(Number(raw), RESEARCH_GAP_DIMENSION_CAPS[dimension as ResearchGapDimension])])) as Partial<Record<ResearchGapDimension, number>>
+  const dimensionScores = Object.fromEntries(
+    Object.entries(dimensionRawScores).map(([dimension, raw]) => [
+      dimension,
+      Math.min(Number(raw), RESEARCH_GAP_DIMENSION_CAPS[dimension as ResearchGapDimension]),
+    ]),
+  ) as Partial<Record<ResearchGapDimension, number>>
   const rawScore = Object.values(dimensionRawScores).reduce((sum, value) => sum + Number(value ?? 0), 0)
   const score = Object.values(dimensionScores).reduce((sum, value) => sum + Number(value ?? 0), 0)
-  const cappedDimensions = Object.entries(dimensionRawScores).filter(([dimension, raw]) => Number(raw) > RESEARCH_GAP_DIMENSION_CAPS[dimension as ResearchGapDimension]).map(([dimension]) => dimension as ResearchGapDimension)
+  const cappedDimensions = Object.entries(dimensionRawScores)
+    .filter(([dimension, raw]) => Number(raw) > RESEARCH_GAP_DIMENSION_CAPS[dimension as ResearchGapDimension])
+    .map(([dimension]) => dimension as ResearchGapDimension)
   const reasonCounts = item.reasons.reduce<Record<string, number>>((counts, reason) => {
     counts[reason.kind] = (counts[reason.kind] ?? 0) + 1
     return counts
@@ -294,7 +336,10 @@ function finalizeGap(item: MutableGap): ResearchGapItem {
   return { ...item, score: Math.round(score), rawScore: Math.round(rawScore), dimensionScores, dimensionRawScores, cappedDimensions, reasonCounts }
 }
 
-export function buildResearchGapQueue(analysis: ResearchQualityAnalysis, topology: ResearchQualityTopology = buildResearchQualityTopology(analysis)): ResearchGapItem[] {
+export function buildResearchGapQueue(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology = buildResearchQualityTopology(analysis),
+): ResearchGapItem[] {
   const queue = new Map<string, MutableGap>()
   const add: AddReason = (url, kind, weight, detail) => {
     if (!url || weight <= 0) return
@@ -306,5 +351,7 @@ export function buildResearchGapQueue(analysis: ResearchQualityAnalysis, topolog
   addEditorialBacklogReasons(analysis, add)
   addProfileReasons(analysis, add)
   addTopologyReasons(topology, add)
-  return [...queue.values()].map(finalizeGap).sort((a, b) => b.score - a.score || b.rawScore - a.rawScore || b.reasons.length - a.reasons.length || a.url.localeCompare(b.url))
+  return [...queue.values()]
+    .map(finalizeGap)
+    .sort((a, b) => b.score - a.score || b.rawScore - a.rawScore || b.reasons.length - a.reasons.length || a.url.localeCompare(b.url))
 }


### PR DESCRIPTION
Removes the older per-claim provenance-narrow scoring path and duplicate/conflicting weight keys. Keeps only the newer aggregated-per-profile provenance signal from research-quality-policy-topology-signals.ts, preserving concentration caps while preventing correlated double-counting. Also tightens the policy file structure without changing unrelated scoring semantics.