### PR TITLE
feat(research): enforce snapshot invariants

### DIFF
--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -1,0 +1,116 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { ResearchQualityGate } from './research-quality-gate'
+import type { ResearchGapItem } from './research-quality-policy'
+import type { ResearchQualityTopology } from './research-quality-topology'
+
+export type ResearchSnapshotInvariantFailure = {
+  kind: string
+  detail: string
+}
+
+export type ResearchSnapshotInvariantReport = {
+  passed: boolean
+  failures: ResearchSnapshotInvariantFailure[]
+  summary: {
+    failures: number
+    unknownProfileReferences: number
+    unknownClaimReferences: number
+    countMismatches: number
+  }
+}
+
+function claimKey(url: string, claimId: string): string {
+  return `${url}::${claimId}`
+}
+
+/**
+ * Cross-check the canonical research snapshot against itself. These are
+ * implementation invariants, not scientific judgments: if they fail, two
+ * derived products disagree about the same underlying graph and the snapshot
+ * must not be treated as authoritative.
+ */
+export function validateResearchQualitySnapshotInvariants(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology,
+  gate: ResearchQualityGate,
+  researchGapQueue: ResearchGapItem[],
+): ResearchSnapshotInvariantReport {
+  const failures: ResearchSnapshotInvariantFailure[] = []
+  const profileUrls = new Set(analysis.profileAnalyses.map((profile) => profile.url))
+  const approvedClaimKeys = new Set(analysis.claimAnalyses.map((claim) => claimKey(claim.url, claim.claimId)))
+
+  const add = (kind: string, detail: string) => failures.push({ kind, detail })
+  const requireProfile = (kind: string, url: string, detail: string) => {
+    if (!profileUrls.has(url)) add(kind, `${detail}: unknown profile ${url}`)
+  }
+  const requireApprovedClaim = (kind: string, url: string, claimId: string) => {
+    if (!approvedClaimKeys.has(claimKey(url, claimId))) add(kind, `unknown approved claim ${url}::${claimId}`)
+  }
+
+  if (topology.semanticAlignment.summary.approvedClaims !== analysis.claimAnalyses.length) {
+    add(
+      'semantic-approved-claim-count-mismatch',
+      `semantic=${topology.semanticAlignment.summary.approvedClaims}; analysis=${analysis.claimAnalyses.length}`,
+    )
+  }
+
+  if (gate.summary.structuralFailures !== gate.structuralFailures.length) {
+    add('gate-structural-count-mismatch', `summary=${gate.summary.structuralFailures}; rows=${gate.structuralFailures.length}`)
+  }
+  if (gate.summary.severeStudyClassConflicts !== gate.severeStudyClassConflicts.length) {
+    add(
+      'gate-study-class-count-mismatch',
+      `summary=${gate.summary.severeStudyClassConflicts}; rows=${gate.severeStudyClassConflicts.length}`,
+    )
+  }
+  if (gate.summary.blockingFailures !== gate.structuralFailures.length + gate.severeStudyClassConflicts.length) {
+    add(
+      'gate-blocking-count-mismatch',
+      `summary=${gate.summary.blockingFailures}; computed=${gate.structuralFailures.length + gate.severeStudyClassConflicts.length}`,
+    )
+  }
+  if (gate.passed !== (gate.summary.blockingFailures === 0)) {
+    add('gate-pass-state-mismatch', `passed=${gate.passed}; blocking=${gate.summary.blockingFailures}`)
+  }
+
+  for (const finding of topology.semanticAlignment.findings) {
+    requireProfile('semantic-unknown-profile', finding.url, finding.claimId)
+    requireApprovedClaim('semantic-unknown-claim', finding.url, finding.claimId)
+  }
+  for (const finding of topology.semanticAlignment.concentrationFindings) {
+    requireApprovedClaim('semantic-concentration-unknown-claim', finding.url, finding.claimId)
+  }
+  for (const finding of topology.claimLanguageCalibration.directEvidenceFindings) {
+    requireApprovedClaim('language-calibration-unknown-claim', finding.url, finding.claimId)
+  }
+  for (const claim of topology.claimCitationMetadata.claims) {
+    requireApprovedClaim('citation-metadata-unknown-claim', claim.url, claim.claimId)
+  }
+  for (const claim of topology.claimEvidenceDiversity) {
+    requireApprovedClaim('evidence-diversity-unknown-claim', claim.url, claim.claimId)
+  }
+  for (const claim of topology.claimProvenanceIndependence) {
+    requireApprovedClaim('provenance-independence-unknown-claim', claim.url, claim.claimId)
+  }
+  for (const claim of topology.claimEvidenceAge) {
+    requireApprovedClaim('evidence-age-unknown-claim', claim.url, claim.claimId)
+  }
+  for (const gap of researchGapQueue) {
+    requireProfile('gap-queue-unknown-profile', gap.url, 'research gap queue')
+  }
+
+  const unknownProfileReferences = failures.filter((failure) => failure.kind.includes('unknown-profile')).length
+  const unknownClaimReferences = failures.filter((failure) => failure.kind.includes('unknown-claim')).length
+  const countMismatches = failures.filter((failure) => failure.kind.includes('mismatch')).length
+
+  return {
+    passed: failures.length === 0,
+    failures,
+    summary: {
+      failures: failures.length,
+      unknownProfileReferences,
+      unknownClaimReferences,
+      countMismatches,
+    },
+  }
+}

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -23,13 +23,22 @@ export type ResearchQualitySnapshot = {
  * Specialized reporters may format different views, but they should consume
  * this snapshot instead of independently rebuilding analysis/topology/gate/policy
  * state. The hard gate and softer remediation queue remain separate by design.
- * Snapshot invariants detect implementation contradictions between those views.
+ * Snapshot invariants are implementation contracts: contradictory derived views
+ * invalidate the snapshot itself and therefore fail every canonical consumer.
  */
 export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQualitySnapshot {
   const analysis = analyzeResearchQuality(root)
   const topology = buildResearchQualityTopology(analysis)
   const gate = buildResearchQualityGate(analysis, topology)
   const researchGapQueue = buildResearchGapQueue(analysis, topology)
+  const invariants = validateResearchQualitySnapshotInvariants(analysis, topology, gate, researchGapQueue)
+
+  if (!invariants.passed) {
+    const details = invariants.failures.slice(0, 10).map((failure) => `${failure.kind}: ${failure.detail}`).join('; ')
+    throw new Error(
+      `[research-quality-snapshot] ${invariants.summary.failures} internal invariant failure(s): ${details}`,
+    )
+  }
 
   return {
     analysis,
@@ -37,6 +46,6 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
     gate,
     researchGapQueue,
     sourceIntegrity: analyzeResearchSourceIntegrity(analysis),
-    invariants: validateResearchQualitySnapshotInvariants(analysis, topology, gate, researchGapQueue),
+    invariants,
   }
 }

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -1,6 +1,10 @@
 import { analyzeResearchQuality, type ResearchQualityAnalysis } from './research-quality-analysis'
 import { buildResearchQualityGate, type ResearchQualityGate } from './research-quality-gate'
 import { buildResearchGapQueue } from './research-quality-policy'
+import {
+  validateResearchQualitySnapshotInvariants,
+  type ResearchSnapshotInvariantReport,
+} from './research-quality-snapshot-invariants'
 import { buildResearchQualityTopology, type ResearchQualityTopology } from './research-quality-topology'
 import { analyzeResearchSourceIntegrity } from './research-source-integrity'
 
@@ -10,6 +14,7 @@ export type ResearchQualitySnapshot = {
   gate: ResearchQualityGate
   researchGapQueue: ReturnType<typeof buildResearchGapQueue>
   sourceIntegrity: ReturnType<typeof analyzeResearchSourceIntegrity>
+  invariants: ResearchSnapshotInvariantReport
 }
 
 /**
@@ -18,15 +23,20 @@ export type ResearchQualitySnapshot = {
  * Specialized reporters may format different views, but they should consume
  * this snapshot instead of independently rebuilding analysis/topology/gate/policy
  * state. The hard gate and softer remediation queue remain separate by design.
+ * Snapshot invariants detect implementation contradictions between those views.
  */
 export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQualitySnapshot {
   const analysis = analyzeResearchQuality(root)
   const topology = buildResearchQualityTopology(analysis)
+  const gate = buildResearchQualityGate(analysis, topology)
+  const researchGapQueue = buildResearchGapQueue(analysis, topology)
+
   return {
     analysis,
     topology,
-    gate: buildResearchQualityGate(analysis, topology),
-    researchGapQueue: buildResearchGapQueue(analysis, topology),
+    gate,
+    researchGapQueue,
     sourceIntegrity: analyzeResearchSourceIntegrity(analysis),
+    invariants: validateResearchQualitySnapshotInvariants(analysis, topology, gate, researchGapQueue),
   }
 }


### PR DESCRIPTION
Adds consistency checks to the canonical research-quality snapshot so derived research views cannot silently disagree.