### PR TITLE
refactor(guides): surface Stress in the canonical directory

### DIFF
--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -44,6 +44,13 @@ const SECTIONS = [
     articles: ['Best supplements for sleep', 'Magnesium for sleep', 'Magnesium vs melatonin', 'Sleep stack guide', 'Herbs for sleep'],
   },
   {
+    title: 'Stress',
+    href: '/guides/stress/',
+    desc: 'Evidence-aware guides for acute tension, chronic overload, burnout, adaptogens, and stress-support decisions.',
+    color: 'border-l-orange-500',
+    articles: ['Stress support', 'Adaptogens', 'Ashwagandha', 'Rhodiola', 'L-theanine'],
+  },
+  {
     title: 'Anxiety',
     href: '/guides/anxiety/',
     desc: 'Evidence-graded guides for anxious thoughts, physical tension, and calm — with safety warnings kept visible.',


### PR DESCRIPTION
## Summary
- Adds the existing `/guides/stress/` hub to the canonical `/guides/` directory.
- Gives Stress the same first-class discoverability as Sleep, Anxiety, and Focus.

## Why
Stress is one of the site's core goals but was missing from the Evidence Library directory, creating a navigation gap and inconsistent taxonomy.

## Regression contract
- No routes are removed.
- Existing guide sections remain unchanged.