### PR TITLE
fix(research): calibrate journal-only provenance narrowing

### DIFF
--- a/lib/__tests__/research-claim-provenance-independence.test.ts
+++ b/lib/__tests__/research-claim-provenance-independence.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeClaimProvenanceIndependence } from '@/lib/research-claim-provenance-independence'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+function analysis(
+  sources: Array<Record<string, unknown>>,
+  studyIds: string[],
+  confidence = 0.8,
+): ResearchQualityAnalysis {
+  return {
+    cache: {},
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: { slug: 'example', sources, claimMap: [] },
+    }],
+    claimAnalyses: [{
+      url: '/herbs/example/',
+      claimId: 'claim-1',
+      predicate: 'supports_outcome',
+      confidence,
+      studyIds,
+      studyCount: studyIds.length,
+    }],
+    structuredClaimAnalyses: [],
+    profileAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+}
+
+describe('claim provenance independence calibration', () => {
+  it('keeps two same-journal studies with different first authors descriptive rather than narrow', () => {
+    const input = analysis([
+      { id: 's1', pmid: '111', firstAuthor: 'Alpha A', journal: 'Journal X' },
+      { id: 's2', pmid: '222', firstAuthor: 'Beta B', journal: 'Journal X' },
+    ], ['pmid:111', 'pmid:222'])
+
+    const result = analyzeClaimProvenanceIndependence(input)[0]
+    expect(result.sameJournalLineage).toBe(true)
+    expect(result.sameFirstAuthorLineage).toBe(false)
+    expect(result.journalOnlyNarrowSupport).toBe(false)
+    expect(result.provenanceNarrowMultiStudySupport).toBe(false)
+  })
+
+  it('flags journal-only narrowing when three known studies all use the same journal', () => {
+    const input = analysis([
+      { id: 's1', pmid: '111', firstAuthor: 'Alpha A', journal: 'Journal X' },
+      { id: 's2', pmid: '222', firstAuthor: 'Beta B', journal: 'Journal X' },
+      { id: 's3', pmid: '333', firstAuthor: 'Gamma C', journal: 'Journal X' },
+    ], ['pmid:111', 'pmid:222', 'pmid:333'])
+
+    const result = analyzeClaimProvenanceIndependence(input)[0]
+    expect(result.journalOnlyNarrowSupport).toBe(true)
+    expect(result.provenanceNarrowMultiStudySupport).toBe(true)
+  })
+
+  it('still flags two studies sharing the same first-author lineage', () => {
+    const input = analysis([
+      { id: 's1', pmid: '111', firstAuthor: 'Alpha A', journal: 'Journal X' },
+      { id: 's2', pmid: '222', firstAuthor: 'Alpha A', journal: 'Journal Y' },
+    ], ['pmid:111', 'pmid:222'])
+
+    const result = analyzeClaimProvenanceIndependence(input)[0]
+    expect(result.sameFirstAuthorLineage).toBe(true)
+    expect(result.provenanceNarrowMultiStudySupport).toBe(true)
+  })
+})

--- a/lib/research-claim-provenance-independence.ts
+++ b/lib/research-claim-provenance-independence.ts
@@ -13,15 +13,19 @@ export type ClaimProvenanceIndependence = {
   distinctJournalCount: number
   sameFirstAuthorLineage: boolean
   sameJournalLineage: boolean
+  journalOnlyNarrowSupport: boolean
   provenanceNarrowMultiStudySupport: boolean
   highConfidenceProvenanceNarrowMultiStudySupport: boolean
 }
 
 /**
  * Detect multi-study claims whose apparent independence is narrowed by shared
- * publication provenance. Missing metadata never counts as concentration: a
- * claim must have provenance for at least two studies before author/journal
- * lineage can trigger a finding.
+ * publication provenance. Missing metadata never counts as concentration.
+ *
+ * Shared first-author lineage is meaningful with two studies. Journal-only
+ * overlap is weaker: two otherwise-independent papers in the same journal are
+ * common and should remain descriptive, so journal-only narrowing requires at
+ * least three known studies from the same journal.
  */
 export function analyzeClaimProvenanceIndependence(
   analysis: ResearchQualityAnalysis,
@@ -45,7 +49,8 @@ export function analyzeClaimProvenanceIndependence(
       const distinctJournalCount = new Set(journals).size
       const sameFirstAuthorLineage = authors.length >= 2 && distinctFirstAuthorCount === 1
       const sameJournalLineage = journals.length >= 2 && distinctJournalCount === 1
-      const provenanceNarrowMultiStudySupport = sameFirstAuthorLineage || sameJournalLineage
+      const journalOnlyNarrowSupport = journals.length >= 3 && distinctJournalCount === 1
+      const provenanceNarrowMultiStudySupport = sameFirstAuthorLineage || journalOnlyNarrowSupport
 
       return {
         url: claim.url,
@@ -59,6 +64,7 @@ export function analyzeClaimProvenanceIndependence(
         distinctJournalCount,
         sameFirstAuthorLineage,
         sameJournalLineage,
+        journalOnlyNarrowSupport,
         provenanceNarrowMultiStudySupport,
         highConfidenceProvenanceNarrowMultiStudySupport:
           provenanceNarrowMultiStudySupport && claim.confidence >= 0.75,


### PR DESCRIPTION
Refines claim-level provenance independence so two otherwise-independent studies published in the same journal remain a descriptive lineage signal rather than automatically becoming a remediation finding. Same-first-author lineage still triggers with 2+ studies; journal-only narrowing now requires 3+ known supporting studies from the same journal. Missing metadata behavior is unchanged. Adds focused regression coverage for two-study journal reuse, three-study journal concentration, and same-author reuse.