### PR TITLE
feat(research): enforce unique structured claim ids

### DIFF
--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -16,6 +16,8 @@ export type ResearchSnapshotInvariantReport = {
     unknownProfileReferences: number
     unknownClaimReferences: number
     countMismatches: number
+    duplicateClaimIds: number
+    missingClaimIds: number
   }
 }
 
@@ -23,11 +25,15 @@ function claimKey(url: string, claimId: string): string {
   return `${url}::${claimId}`
 }
 
+function text(value: unknown): string {
+  return String(value ?? '').trim()
+}
+
 /**
  * Cross-check the canonical research snapshot against itself. These are
- * implementation invariants, not scientific judgments: if they fail, two
- * derived products disagree about the same underlying graph and the snapshot
- * must not be treated as authoritative.
+ * implementation/data invariants, not scientific judgments: if they fail, two
+ * derived products can disagree about the same underlying graph and the
+ * snapshot must not be treated as authoritative.
  */
 export function validateResearchQualitySnapshotInvariants(
   analysis: ResearchQualityAnalysis,
@@ -45,6 +51,22 @@ export function validateResearchQualitySnapshotInvariants(
   }
   const requireApprovedClaim = (kind: string, url: string, claimId: string) => {
     if (!approvedClaimKeys.has(claimKey(url, claimId))) add(kind, `unknown approved claim ${url}::${claimId}`)
+  }
+
+  // Claim IDs are graph identities. Missing or duplicate IDs make downstream
+  // url::claimId indexes lossy even if the raw claim arrays still contain rows.
+  for (const profile of analysis.profiles) {
+    const claims = Array.isArray(profile.record.claimMap) ? profile.record.claimMap : []
+    const seen = new Set<string>()
+    for (let index = 0; index < claims.length; index += 1) {
+      const id = text(claims[index]?.id)
+      if (!id) {
+        add('missing-claim-id', `${profile.url} · claimMap[${index}]`)
+        continue
+      }
+      if (seen.has(id)) add('duplicate-claim-id', `${profile.url}::${id}`)
+      else seen.add(id)
+    }
   }
 
   if (topology.semanticAlignment.summary.approvedClaims !== analysis.claimAnalyses.length) {
@@ -102,6 +124,8 @@ export function validateResearchQualitySnapshotInvariants(
   const unknownProfileReferences = failures.filter((failure) => failure.kind.includes('unknown-profile')).length
   const unknownClaimReferences = failures.filter((failure) => failure.kind.includes('unknown-claim')).length
   const countMismatches = failures.filter((failure) => failure.kind.includes('mismatch')).length
+  const duplicateClaimIds = failures.filter((failure) => failure.kind === 'duplicate-claim-id').length
+  const missingClaimIds = failures.filter((failure) => failure.kind === 'missing-claim-id').length
 
   return {
     passed: failures.length === 0,
@@ -111,6 +135,8 @@ export function validateResearchQualitySnapshotInvariants(
       unknownProfileReferences,
       unknownClaimReferences,
       countMismatches,
+      duplicateClaimIds,
+      missingClaimIds,
     },
   }
 }


### PR DESCRIPTION
Adds canonical snapshot invariants for structured claim identity. Missing/blank claim IDs and duplicate IDs within the same profile now invalidate the research snapshot before downstream url::claimId indexes can silently collapse or overwrite claims.