### PR TITLE
fix(research): calibrate same-family evidence diversity

### DIFF
--- a/lib/__tests__/research-evidence-diversity-replication.test.ts
+++ b/lib/__tests__/research-evidence-diversity-replication.test.ts
@@ -46,9 +46,42 @@ describe('claim evidence diversity replication semantics', () => {
     expect(result).toMatchObject({
       sameFamilyMultiStudySupport: true,
       replicatedPrimaryHumanSupport: true,
+      replicatedSynthesisSupport: false,
+      replicatedOtherHumanSupport: false,
       homogeneousMultiStudySupport: false,
-      highConfidenceHomogeneousMultiStudySupport: false,
       evidenceFamilies: ['primary-human'],
+    })
+  })
+
+  it('treats multiple syntheses as same-family synthesis support rather than a homogeneity defect', () => {
+    const [result] = analyzeClaimEvidenceDiversity(analysis([
+      claim('synthesis', ['systematic-review', 'meta-analysis']),
+    ]))
+
+    expect(result).toMatchObject({
+      sameFamilyMultiStudySupport: true,
+      replicatedSynthesisSupport: true,
+      homogeneousMultiStudySupport: false,
+      evidenceFamilies: ['synthesis'],
+    })
+  })
+
+  it('separates observational human replication from preclinical homogeneity', () => {
+    const [human, preclinical] = analyzeClaimEvidenceDiversity(analysis([
+      claim('observational', ['observational', 'case-report']),
+      claim('preclinical', ['animal', 'in-vitro']),
+    ])).sort((a, b) => a.claimId.localeCompare(b.claimId))
+
+    expect(human).toMatchObject({
+      claimId: 'observational',
+      replicatedOtherHumanSupport: true,
+      homogeneousMultiStudySupport: false,
+      evidenceFamilies: ['other-human'],
+    })
+    expect(preclinical).toMatchObject({
+      claimId: 'preclinical',
+      homogeneousMultiStudySupport: true,
+      evidenceFamilies: ['preclinical'],
     })
   })
 

--- a/lib/research-claim-evidence-diversity.ts
+++ b/lib/research-claim-evidence-diversity.ts
@@ -6,7 +6,14 @@ import {
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import type { StudyClass } from './study-class'
 
-export type EvidenceFamily = 'primary-human' | 'synthesis' | 'narrative' | 'other' | 'unclassified'
+export type EvidenceFamily =
+  | 'primary-human'
+  | 'synthesis'
+  | 'other-human'
+  | 'narrative'
+  | 'regulatory'
+  | 'preclinical'
+  | 'unclassified'
 
 export type ClaimEvidenceDiversity = {
   url: string
@@ -19,25 +26,37 @@ export type ClaimEvidenceDiversity = {
   evidenceFamilies: EvidenceFamily[]
   sameFamilyMultiStudySupport: boolean
   replicatedPrimaryHumanSupport: boolean
+  replicatedSynthesisSupport: boolean
+  replicatedOtherHumanSupport: boolean
   homogeneousMultiStudySupport: boolean
   highConfidenceHomogeneousMultiStudySupport: boolean
 }
+
+const NARROW_HOMOGENEOUS_FAMILIES = new Set<EvidenceFamily>([
+  'narrative',
+  'preclinical',
+  'unclassified',
+])
 
 function familyForDesign(design: StudyClass): EvidenceFamily {
   if (PRIMARY_HUMAN_STUDY_CLASSES.has(design)) return 'primary-human'
   if (SYNTHESIS_STUDY_CLASSES.has(design)) return 'synthesis'
   if (NARRATIVE_STUDY_CLASSES.has(design)) return 'narrative'
-  if (design === 'unclassified') return 'unclassified'
-  return 'other'
+  if (design === 'observational' || design === 'case-report') return 'other-human'
+  if (design === 'animal' || design === 'in-vitro') return 'preclinical'
+  if (design === 'regulatory-guidance') return 'regulatory'
+  return 'unclassified'
 }
 
 /**
- * Measure evidence diversity at the approved-claim level. Same-family support is
- * descriptive, not automatically weak: multiple primary-human trials are useful
- * replication and must not be penalized merely because they share a family.
- * `homogeneousMultiStudySupport` is therefore reserved for narrow same-family
- * support that still lacks direct primary-human diversity (narrative, synthesis,
- * other/indirect, or unclassified evidence only).
+ * Measure evidence diversity at the approved-claim level without turning
+ * legitimate replication into a defect. Same-family evidence is descriptive;
+ * only narrative, preclinical, or unclassified same-family bundles are treated
+ * as a narrow homogeneity gap.
+ *
+ * Multiple primary-human studies, multiple syntheses, and multiple
+ * observational/case-report human studies remain visible as replication-like
+ * topology but are not penalized merely for sharing a broad evidence family.
  */
 export function analyzeClaimEvidenceDiversity(analysis: ResearchQualityAnalysis): ClaimEvidenceDiversity[] {
   return analysis.claimAnalyses
@@ -48,7 +67,11 @@ export function analyzeClaimEvidenceDiversity(analysis: ResearchQualityAnalysis)
       const sameFamilyMultiStudySupport = claim.studyCount >= 2 && distinctEvidenceFamilyCount === 1
       const onlyFamily = sameFamilyMultiStudySupport ? evidenceFamilies[0] : null
       const replicatedPrimaryHumanSupport = sameFamilyMultiStudySupport && onlyFamily === 'primary-human'
-      const homogeneousMultiStudySupport = sameFamilyMultiStudySupport && onlyFamily !== 'primary-human'
+      const replicatedSynthesisSupport = sameFamilyMultiStudySupport && onlyFamily === 'synthesis'
+      const replicatedOtherHumanSupport = sameFamilyMultiStudySupport && onlyFamily === 'other-human'
+      const homogeneousMultiStudySupport = Boolean(
+        sameFamilyMultiStudySupport && onlyFamily && NARROW_HOMOGENEOUS_FAMILIES.has(onlyFamily),
+      )
 
       return {
         url: claim.url,
@@ -61,6 +84,8 @@ export function analyzeClaimEvidenceDiversity(analysis: ResearchQualityAnalysis)
         evidenceFamilies,
         sameFamilyMultiStudySupport,
         replicatedPrimaryHumanSupport,
+        replicatedSynthesisSupport,
+        replicatedOtherHumanSupport,
         homogeneousMultiStudySupport,
         highConfidenceHomogeneousMultiStudySupport: homogeneousMultiStudySupport && claim.confidence >= 0.75,
       }
@@ -69,6 +94,8 @@ export function analyzeClaimEvidenceDiversity(analysis: ResearchQualityAnalysis)
       Number(b.highConfidenceHomogeneousMultiStudySupport) - Number(a.highConfidenceHomogeneousMultiStudySupport)
       || Number(b.homogeneousMultiStudySupport) - Number(a.homogeneousMultiStudySupport)
       || Number(b.replicatedPrimaryHumanSupport) - Number(a.replicatedPrimaryHumanSupport)
+      || Number(b.replicatedSynthesisSupport) - Number(a.replicatedSynthesisSupport)
+      || Number(b.replicatedOtherHumanSupport) - Number(a.replicatedOtherHumanSupport)
       || b.studyCount - a.studyCount
       || b.confidence - a.confidence
       || a.url.localeCompare(b.url)


### PR DESCRIPTION
Refines claim evidence-family topology so legitimate same-family replication is not conflated with narrow support. Splits the old broad `other` family into observational/case-report human, regulatory, and preclinical evidence; multiple syntheses and other-human studies remain descriptive replication-like signals, while `homogeneousMultiStudySupport` is reserved for narrative, preclinical, or unclassified same-family bundles. Expands regression coverage for primary-human, synthesis, observational-human, preclinical, narrative, and mixed-family cases.