### PR TITLE
test(research): extend snapshot invariants to source integrity

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -5,9 +5,11 @@ import type { ResearchQualityGate } from '../research-quality-gate'
 import type { ResearchGapItem } from '../research-quality-policy'
 import { validateResearchQualitySnapshotInvariants } from '../research-quality-snapshot-invariants'
 import type { ResearchQualityTopology } from '../research-quality-topology'
+import type { ResearchSourceIntegrity } from '../research-source-integrity'
 
 function fixtures() {
   const analysis = {
+    profiles: [{ url: '/herbs/example', record: { claimMap: [], sources: [] } }],
     profileAnalyses: [{ url: '/herbs/example' }],
     claimAnalyses: [{ url: '/herbs/example', claimId: 'claim-1' }],
   } as unknown as ResearchQualityAnalysis
@@ -39,49 +41,83 @@ function fixtures() {
   } as ResearchQualityGate
 
   const queue: ResearchGapItem[] = []
-  return { analysis, topology, gate, queue }
+  const sourceIntegrity = {
+    summary: { citedStudies: 1, withdrawn: 0 },
+    withdrawn: [],
+    studies: [{ pmid: '123', pageCount: 1, pages: ['/herbs/example'] }],
+  } as unknown as ResearchSourceIntegrity
+
+  return { analysis, topology, gate, queue, sourceIntegrity }
 }
 
 describe('research quality snapshot invariants', () => {
   it('accepts a self-consistent canonical snapshot', () => {
-    const { analysis, topology, gate, queue } = fixtures()
-    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue)
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(true)
     expect(report.summary.failures).toBe(0)
   })
 
   it('detects semantic approved-claim count drift', () => {
-    const { analysis, topology, gate, queue } = fixtures()
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
     topology.semanticAlignment.summary.approvedClaims = 2
-    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue)
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(false)
     expect(report.failures.map((failure) => failure.kind)).toContain('semantic-approved-claim-count-mismatch')
   })
 
   it('detects derived findings that reference an unknown approved claim', () => {
-    const { analysis, topology, gate, queue } = fixtures()
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
     topology.claimCitationMetadata.claims = [
       { url: '/herbs/example', claimId: 'missing-claim' },
     ] as typeof topology.claimCitationMetadata.claims
-    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue)
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(false)
     expect(report.summary.unknownClaimReferences).toBe(1)
   })
 
   it('detects remediation rows that reference an unknown profile', () => {
-    const { analysis, topology, gate } = fixtures()
+    const { analysis, topology, gate, sourceIntegrity } = fixtures()
     const queue = [{ url: '/herbs/missing' }] as ResearchGapItem[]
-    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue)
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(false)
     expect(report.summary.unknownProfileReferences).toBe(1)
   })
 
   it('detects gate summary and pass-state drift', () => {
-    const { analysis, topology, gate, queue } = fixtures()
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
     gate.summary.blockingFailures = 1
-    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue)
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     const kinds = report.failures.map((failure) => failure.kind)
     expect(kinds).toContain('gate-blocking-count-mismatch')
     expect(kinds).toContain('gate-pass-state-mismatch')
+  })
+
+  it('detects source-integrity count drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    sourceIntegrity.summary.citedStudies = 2
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.passed).toBe(false)
+    expect(report.failures.map((failure) => failure.kind)).toContain('source-study-count-mismatch')
+    expect(report.summary.sourceIntegrityFailures).toBe(1)
+  })
+
+  it('detects source rows that reference unknown profiles', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    sourceIntegrity.studies[0].pages = ['/herbs/missing']
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.passed).toBe(false)
+    expect(report.failures.map((failure) => failure.kind)).toContain('source-unknown-profile')
+  })
+
+  it('detects duplicate source identities and page-count drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    sourceIntegrity.studies.push({ ...sourceIntegrity.studies[0] })
+    sourceIntegrity.summary.citedStudies = 2
+    sourceIntegrity.studies[0].pageCount = 2
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    const kinds = report.failures.map((failure) => failure.kind)
+    expect(kinds).toContain('source-duplicate-pmid')
+    expect(kinds).toContain('source-page-count-mismatch')
   })
 })

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -2,6 +2,7 @@ import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import type { ResearchQualityGate } from './research-quality-gate'
 import type { ResearchGapItem } from './research-quality-policy'
 import type { ResearchQualityTopology } from './research-quality-topology'
+import type { ResearchSourceIntegrity } from './research-source-integrity'
 
 export type ResearchSnapshotInvariantFailure = {
   kind: string
@@ -18,6 +19,7 @@ export type ResearchSnapshotInvariantReport = {
     countMismatches: number
     duplicateClaimIds: number
     missingClaimIds: number
+    sourceIntegrityFailures: number
   }
 }
 
@@ -40,6 +42,7 @@ export function validateResearchQualitySnapshotInvariants(
   topology: ResearchQualityTopology,
   gate: ResearchQualityGate,
   researchGapQueue: ResearchGapItem[],
+  sourceIntegrity?: ResearchSourceIntegrity,
 ): ResearchSnapshotInvariantReport {
   const failures: ResearchSnapshotInvariantFailure[] = []
   const profileUrls = new Set(analysis.profileAnalyses.map((profile) => profile.url))
@@ -121,11 +124,39 @@ export function validateResearchQualitySnapshotInvariants(
     requireProfile('gap-queue-unknown-profile', gap.url, 'research gap queue')
   }
 
+  if (sourceIntegrity) {
+    if (sourceIntegrity.summary.citedStudies !== sourceIntegrity.studies.length) {
+      add(
+        'source-study-count-mismatch',
+        `summary=${sourceIntegrity.summary.citedStudies}; rows=${sourceIntegrity.studies.length}`,
+      )
+    }
+    if (sourceIntegrity.summary.withdrawn !== sourceIntegrity.withdrawn.length) {
+      add(
+        'source-withdrawn-count-mismatch',
+        `summary=${sourceIntegrity.summary.withdrawn}; rows=${sourceIntegrity.withdrawn.length}`,
+      )
+    }
+
+    const seenPmids = new Set<string>()
+    for (const study of sourceIntegrity.studies) {
+      if (seenPmids.has(study.pmid)) add('source-duplicate-pmid', study.pmid)
+      else seenPmids.add(study.pmid)
+
+      const uniquePages = new Set(study.pages)
+      if (study.pageCount !== uniquePages.size) {
+        add('source-page-count-mismatch', `${study.pmid}: pageCount=${study.pageCount}; pages=${uniquePages.size}`)
+      }
+      for (const url of uniquePages) requireProfile('source-unknown-profile', url, `PMID ${study.pmid}`)
+    }
+  }
+
   const unknownProfileReferences = failures.filter((failure) => failure.kind.includes('unknown-profile')).length
   const unknownClaimReferences = failures.filter((failure) => failure.kind.includes('unknown-claim')).length
   const countMismatches = failures.filter((failure) => failure.kind.includes('mismatch')).length
   const duplicateClaimIds = failures.filter((failure) => failure.kind === 'duplicate-claim-id').length
   const missingClaimIds = failures.filter((failure) => failure.kind === 'missing-claim-id').length
+  const sourceIntegrityFailures = failures.filter((failure) => failure.kind.startsWith('source-')).length
 
   return {
     passed: failures.length === 0,
@@ -137,6 +168,7 @@ export function validateResearchQualitySnapshotInvariants(
       countMismatches,
       duplicateClaimIds,
       missingClaimIds,
+      sourceIntegrityFailures,
     },
   }
 }

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -31,7 +31,14 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
   const topology = buildResearchQualityTopology(analysis)
   const gate = buildResearchQualityGate(analysis, topology)
   const researchGapQueue = buildResearchGapQueue(analysis, topology)
-  const invariants = validateResearchQualitySnapshotInvariants(analysis, topology, gate, researchGapQueue)
+  const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
+  const invariants = validateResearchQualitySnapshotInvariants(
+    analysis,
+    topology,
+    gate,
+    researchGapQueue,
+    sourceIntegrity,
+  )
 
   if (!invariants.passed) {
     const details = invariants.failures.slice(0, 10).map((failure) => `${failure.kind}: ${failure.detail}`).join('; ')
@@ -45,7 +52,7 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
     topology,
     gate,
     researchGapQueue,
-    sourceIntegrity: analyzeResearchSourceIntegrity(analysis),
+    sourceIntegrity,
     invariants,
   }
 }


### PR DESCRIPTION
Extends the canonical research-quality snapshot invariant layer to cover source-integrity consistency too. The snapshot now computes source integrity before validation and checks cited-study counts, withdrawn counts, duplicate PMIDs, per-study page counts, and source references to unknown profiles. Also repairs the recently-added invariant fixture by giving it a real `analysis.profiles` shape and adds focused regression coverage for source drift.