### PR TITLE
feat(research): detect stale syntheses relative to newer trials

### DIFF
--- a/lib/__tests__/research-evidence-age-synthesis-refresh.test.ts
+++ b/lib/__tests__/research-evidence-age-synthesis-refresh.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from '@/lib/research-evidence-age'
+import type { ClaimQualityAnalysis, ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+function claim(
+  studyIds: string[],
+  designs: ClaimQualityAnalysis['designs'],
+  confidence = 0.8,
+): ClaimQualityAnalysis {
+  return {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    reviewStatus: 'approved',
+    approved: true,
+    predicate: 'supports_outcome',
+    confidence,
+    sourceRefCount: studyIds.length,
+    validSourceRefCount: studyIds.length,
+    danglingSourceRefs: [],
+    studyIds,
+    studyCount: studyIds.length,
+    classifiedStudyCount: designs.length,
+    primaryHuman: designs.filter((design) => ['rct', 'controlled-trial', 'uncontrolled-trial'].includes(design)).length,
+    synthesis: designs.filter((design) => ['systematic-review', 'meta-analysis'].includes(design)).length,
+    narrative: 0,
+    designs,
+    outcomeClaim: true,
+    supportTier: 'human-supported',
+    structuredSupportTier: studyIds.length === 1 ? 'single-study' : 'adequate',
+    weakStructuredClaim: studyIds.length === 1,
+    highConfidenceWeakStructured: false,
+    highConfidenceWeakOutcome: false,
+    singleStudy: studyIds.length === 1,
+    aliasCollapsed: false,
+  }
+}
+
+function analysis(years: Array<number | undefined>, designs: ClaimQualityAnalysis['designs']): ResearchQualityAnalysis {
+  const sources = years.map((year, index) => ({
+    id: `s${index + 1}`,
+    ...(year ? { year } : {}),
+    studyClass: designs[index],
+  }))
+  const studyIds = sources.map((source) => `source-ref:${source.id}`)
+  const qualityClaim = claim(studyIds, designs)
+  return {
+    cache: {},
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: { slug: 'example', sources, claimMap: [] },
+    }],
+    claimAnalyses: [qualityClaim],
+    structuredClaimAnalyses: [qualityClaim],
+    profileAnalyses: [],
+  }
+}
+
+describe('design-aware synthesis freshness', () => {
+  it('flags a synthesis that is at least five years older than newer primary-human evidence', () => {
+    const [result] = analyzeClaimEvidenceAge(
+      analysis([2018, 2023], ['systematic-review', 'rct']),
+      2026,
+    )
+
+    expect(result).toMatchObject({
+      newestSynthesisYear: 2018,
+      newestPrimaryHumanYear: 2023,
+      synthesisLagYears: 5,
+      synthesisOutpacedByNewerPrimaryEvidence: true,
+      highConfidenceSynthesisRefreshGap: true,
+    })
+    expect(summarizeEvidenceAge([result]).synthesisOutpacedClaims).toBe(1)
+  })
+
+  it('does not flag a four-year synthesis lag', () => {
+    const [result] = analyzeClaimEvidenceAge(
+      analysis([2019, 2023], ['meta-analysis', 'controlled-trial']),
+      2026,
+    )
+
+    expect(result.synthesisLagYears).toBe(4)
+    expect(result.synthesisOutpacedByNewerPrimaryEvidence).toBe(false)
+  })
+
+  it('does not invent a refresh gap when either side lacks a known year', () => {
+    const [missingSynthesisYear] = analyzeClaimEvidenceAge(
+      analysis([undefined, 2024], ['systematic-review', 'rct']),
+      2026,
+    )
+    const [noSynthesis] = analyzeClaimEvidenceAge(
+      analysis([2020, 2024], ['rct', 'controlled-trial']),
+      2026,
+    )
+
+    expect(missingSynthesisYear.synthesisLagYears).toBeNull()
+    expect(missingSynthesisYear.synthesisOutpacedByNewerPrimaryEvidence).toBe(false)
+    expect(noSynthesis.synthesisLagYears).toBeNull()
+    expect(noSynthesis.synthesisOutpacedByNewerPrimaryEvidence).toBe(false)
+  })
+})

--- a/lib/research-evidence-age.ts
+++ b/lib/research-evidence-age.ts
@@ -1,5 +1,12 @@
-import { canonicalStudyGroups, type ResearchSource } from './research-coverage'
+import {
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  SYNTHESIS_STUDY_CLASSES,
+  canonicalStudyGroups,
+  type ResearchSource,
+} from './research-coverage'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export const SYNTHESIS_REFRESH_LAG_YEARS = 5
 
 export type ClaimEvidenceAge = {
   url: string
@@ -14,6 +21,13 @@ export type ClaimEvidenceAge = {
   newestYear: number | null
   medianYear: number | null
   newestEvidenceAge: number | null
+  primaryHumanKnownYearCount: number
+  synthesisKnownYearCount: number
+  newestPrimaryHumanYear: number | null
+  newestSynthesisYear: number | null
+  synthesisLagYears: number | null
+  synthesisOutpacedByNewerPrimaryEvidence: boolean
+  highConfidenceSynthesisRefreshGap: boolean
   allKnownEvidenceOlderThan10Years: boolean
   allKnownEvidenceOlderThan15Years: boolean
   legacyOnlyOutcomeClaim: boolean
@@ -25,6 +39,8 @@ export type EvidenceAgeSummary = {
   claimsWithKnownStudyYears: number
   claimsWithUnknownStudyYears: number
   claimsWithOnlyUnknownStudyYears: number
+  synthesisOutpacedClaims: number
+  highConfidenceSynthesisRefreshGaps: number
   legacyOnly10Years: number
   legacyOnly15Years: number
   legacyOnlyOutcomeClaims: number
@@ -85,6 +101,11 @@ export function canonicalStudyYearMap(analysis: ResearchQualityAnalysis): Map<st
  * studies can remain valid. A claim is "legacy-only" only when every study
  * with a known publication year is older than the threshold; unknown years are
  * retained separately so missing metadata cannot masquerade as fresh evidence.
+ *
+ * A separate design-aware refresh signal detects when the newest linked primary
+ * human study is at least five years newer than the newest linked synthesis.
+ * This does not say the older review is wrong; it marks a concrete candidate for
+ * an updated synthesis because the review cannot cover the newer linked trials.
  */
 export function analyzeClaimEvidenceAge(
   analysis: ResearchQualityAnalysis,
@@ -94,15 +115,36 @@ export function analyzeClaimEvidenceAge(
 
   return analysis.claimAnalyses
     .map((claim) => {
-      const years = claim.studyIds
-        .map((studyId) => studyYears.get(studyId))
-        .filter((year): year is number => typeof year === 'number')
+      const datedStudies = claim.studyIds
+        .map((studyId, index) => ({
+          year: studyYears.get(studyId),
+          design: claim.designs[index] ?? 'unclassified',
+        }))
+        .filter((item): item is { year: number; design: (typeof claim.designs)[number] } => typeof item.year === 'number')
+      const years = datedStudies.map((item) => item.year).sort((a, b) => a - b)
+      const primaryHumanYears = datedStudies
+        .filter((item) => PRIMARY_HUMAN_STUDY_CLASSES.has(item.design))
+        .map((item) => item.year)
         .sort((a, b) => a - b)
+      const synthesisYears = datedStudies
+        .filter((item) => SYNTHESIS_STUDY_CLASSES.has(item.design))
+        .map((item) => item.year)
+        .sort((a, b) => a - b)
+
       const oldestYear = years[0] ?? null
       const newestYear = years.at(-1) ?? null
       const medianYear = median(years)
       const knownYearCount = years.length
       const unknownYearCount = Math.max(0, claim.studyCount - knownYearCount)
+      const newestPrimaryHumanYear = primaryHumanYears.at(-1) ?? null
+      const newestSynthesisYear = synthesisYears.at(-1) ?? null
+      const synthesisLagYears = newestPrimaryHumanYear !== null && newestSynthesisYear !== null
+        ? Math.max(0, newestPrimaryHumanYear - newestSynthesisYear)
+        : null
+      const synthesisOutpacedByNewerPrimaryEvidence =
+        synthesisLagYears !== null && synthesisLagYears >= SYNTHESIS_REFRESH_LAG_YEARS
+      const highConfidenceSynthesisRefreshGap =
+        synthesisOutpacedByNewerPrimaryEvidence && claim.confidence >= 0.75
       const allKnownEvidenceOlderThan10Years = knownYearCount > 0 && newestYear !== null && currentYear - newestYear > 10
       const allKnownEvidenceOlderThan15Years = knownYearCount > 0 && newestYear !== null && currentYear - newestYear > 15
       const legacyOnlyOutcomeClaim = claim.outcomeClaim && allKnownEvidenceOlderThan10Years
@@ -121,6 +163,13 @@ export function analyzeClaimEvidenceAge(
         newestYear,
         medianYear,
         newestEvidenceAge: newestYear === null ? null : currentYear - newestYear,
+        primaryHumanKnownYearCount: primaryHumanYears.length,
+        synthesisKnownYearCount: synthesisYears.length,
+        newestPrimaryHumanYear,
+        newestSynthesisYear,
+        synthesisLagYears,
+        synthesisOutpacedByNewerPrimaryEvidence,
+        highConfidenceSynthesisRefreshGap,
         allKnownEvidenceOlderThan10Years,
         allKnownEvidenceOlderThan15Years,
         legacyOnlyOutcomeClaim,
@@ -128,8 +177,11 @@ export function analyzeClaimEvidenceAge(
       }
     })
     .sort((a, b) =>
-      Number(b.highConfidenceLegacyOnlyClaim) - Number(a.highConfidenceLegacyOnlyClaim)
+      Number(b.highConfidenceSynthesisRefreshGap) - Number(a.highConfidenceSynthesisRefreshGap)
+      || Number(b.synthesisOutpacedByNewerPrimaryEvidence) - Number(a.synthesisOutpacedByNewerPrimaryEvidence)
+      || Number(b.highConfidenceLegacyOnlyClaim) - Number(a.highConfidenceLegacyOnlyClaim)
       || Number(b.legacyOnlyOutcomeClaim) - Number(a.legacyOnlyOutcomeClaim)
+      || (b.synthesisLagYears ?? -1) - (a.synthesisLagYears ?? -1)
       || (b.newestEvidenceAge ?? -1) - (a.newestEvidenceAge ?? -1)
       || a.url.localeCompare(b.url)
       || a.claimId.localeCompare(b.claimId),
@@ -142,6 +194,8 @@ export function summarizeEvidenceAge(claims: ClaimEvidenceAge[]): EvidenceAgeSum
     claimsWithKnownStudyYears: claims.filter((claim) => claim.knownYearCount > 0).length,
     claimsWithUnknownStudyYears: claims.filter((claim) => claim.unknownYearCount > 0).length,
     claimsWithOnlyUnknownStudyYears: claims.filter((claim) => claim.studyCount > 0 && claim.knownYearCount === 0).length,
+    synthesisOutpacedClaims: claims.filter((claim) => claim.synthesisOutpacedByNewerPrimaryEvidence).length,
+    highConfidenceSynthesisRefreshGaps: claims.filter((claim) => claim.highConfidenceSynthesisRefreshGap).length,
     legacyOnly10Years: claims.filter((claim) => claim.allKnownEvidenceOlderThan10Years).length,
     legacyOnly15Years: claims.filter((claim) => claim.allKnownEvidenceOlderThan15Years).length,
     legacyOnlyOutcomeClaims: claims.filter((claim) => claim.legacyOnlyOutcomeClaim).length,


### PR DESCRIPTION
Adds design-aware evidence freshness to the canonical claim-age topology. Claims now track newest primary-human and newest synthesis publication years, and flag a synthesis-refresh candidate when linked primary-human evidence is at least five years newer than the newest linked systematic review/meta-analysis. This is advisory refresh priority, not an evidence downgrade. Unknown dates cannot create a gap. Includes focused boundary tests for 5-year, 4-year, and missing-date cases.