### PR TITLE
Apply site-wide identity to cross-profile topology

### DIFF
--- a/lib/__tests__/research-cross-profile-alias-topology.test.ts
+++ b/lib/__tests__/research-cross-profile-alias-topology.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeCrossProfileEvidenceBundles } from '@/lib/research-cross-profile-bundles'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import { analyzeCrossProfileStudyLoad } from '@/lib/research-study-load'
+
+function claim(url: string, claimId: string, studyIds: string[]) {
+  return {
+    url,
+    claimId,
+    reviewStatus: 'approved',
+    approved: true,
+    predicate: 'supports_outcome',
+    confidence: 0.9,
+    sourceRefCount: studyIds.length,
+    validSourceRefCount: studyIds.length,
+    danglingSourceRefs: [],
+    studyIds,
+    studyCount: studyIds.length,
+    classifiedStudyCount: studyIds.length,
+    primaryHuman: studyIds.length,
+    synthesis: 0,
+    narrative: 0,
+    designs: studyIds.map(() => 'rct' as const),
+    outcomeClaim: true,
+    supportTier: 'human-supported' as const,
+    structuredSupportTier: 'adequate' as const,
+    weakStructuredClaim: false,
+    highConfidenceWeakStructured: false,
+    highConfidenceWeakOutcome: false,
+    singleStudy: studyIds.length === 1,
+    aliasCollapsed: false,
+  }
+}
+
+describe('cross-profile alias-aware topology', () => {
+  it('aggregates study load and evidence bundles across DOI/PMID representation differences', () => {
+    const profiles = [
+      {
+        kind: 'herbs' as const,
+        url: '/herbs/a/',
+        file: 'a.json',
+        record: {
+          slug: 'a',
+          sources: [
+            { id: 'a1', doi: '10.1234/one', pmid: '12345678' },
+            { id: 'a2', doi: '10.1234/two', pmid: '23456789' },
+          ],
+        },
+      },
+      {
+        kind: 'herbs' as const,
+        url: '/herbs/b/',
+        file: 'b.json',
+        record: {
+          slug: 'b',
+          sources: [
+            { id: 'b1', pmid: '12345678' },
+            { id: 'b2', pmid: '23456789' },
+          ],
+        },
+      },
+    ]
+
+    const analysis = {
+      profiles,
+      claimAnalyses: [
+        claim('/herbs/a/', 'a-outcome', ['doi:10.1234/one', 'doi:10.1234/two']),
+        claim('/herbs/b/', 'b-outcome-1', ['pmid:12345678', 'pmid:23456789']),
+        claim('/herbs/b/', 'b-outcome-2', ['pmid:12345678', 'pmid:23456789']),
+      ],
+    } as unknown as ResearchQualityAnalysis
+
+    const load = analyzeCrossProfileStudyLoad(analysis)
+    const firstStudy = load.find((item) => item.studyId === 'doi:10.1234/one')
+    expect(firstStudy).toMatchObject({ profileCount: 2, approvedClaimCount: 3 })
+
+    const bundles = analyzeCrossProfileEvidenceBundles(analysis)
+    expect(bundles).toHaveLength(1)
+    expect(bundles[0]).toMatchObject({
+      studyIds: ['doi:10.1234/one', 'doi:10.1234/two'],
+      studyCount: 2,
+      profileCount: 2,
+      approvedClaimCount: 3,
+      narrowCrossProfileBundle: true,
+    })
+  })
+})

--- a/lib/research-cross-profile-bundles.ts
+++ b/lib/research-cross-profile-bundles.ts
@@ -1,3 +1,7 @@
+import {
+  crossProfileStudyIdentity,
+  crossProfileStudyIdentityMap,
+} from './research-coverage'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 
 export type CrossProfileEvidenceBundleReuse = {
@@ -14,14 +18,14 @@ export type CrossProfileEvidenceBundleReuse = {
 }
 
 /**
- * Detect the same canonical multi-study evidence bundle being reused across
- * different profiles. Single-study reuse is intentionally left to the existing
- * cross-profile study-load analysis; this focuses on narrow 2-study bundles
- * that can otherwise look diversified while still being copied site-wide.
+ * Detect the same site-wide canonical multi-study evidence bundle being reused
+ * across profiles. DOI/PMID aliases are normalized across pages before bundle
+ * keys are built, preventing identifier-shape differences from hiding reuse.
  */
 export function analyzeCrossProfileEvidenceBundles(
   analysis: ResearchQualityAnalysis,
 ): CrossProfileEvidenceBundleReuse[] {
+  const globalIdentities = crossProfileStudyIdentityMap(analysis.profiles)
   const groups = new Map<string, {
     studyIds: string[]
     profiles: Set<string>
@@ -30,7 +34,10 @@ export function analyzeCrossProfileEvidenceBundles(
 
   for (const claim of analysis.claimAnalyses) {
     if (claim.studyIds.length < 2) continue
-    const studyIds = [...claim.studyIds].sort()
+    const studyIds = [...new Set(
+      claim.studyIds.map((studyId) => crossProfileStudyIdentity(claim.url, studyId, globalIdentities)),
+    )].sort()
+    if (studyIds.length < 2) continue
     const key = studyIds.join('|')
     const item = groups.get(key) ?? { studyIds, profiles: new Set<string>(), claims: [] }
     item.profiles.add(claim.url)

--- a/lib/research-study-load.ts
+++ b/lib/research-study-load.ts
@@ -1,3 +1,7 @@
+import {
+  crossProfileStudyIdentity,
+  crossProfileStudyIdentityMap,
+} from './research-coverage'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 
 export type CrossProfileStudyLoad = {
@@ -44,11 +48,12 @@ function round(value: number, digits = 3): number {
 }
 
 /**
- * Measure how many approved claims and profiles depend on each canonical study.
- * This complements per-profile concentration: a study may look harmless on every
- * individual page while still underwriting a large portion of the site globally.
+ * Measure how many approved claims and profiles depend on each site-wide
+ * canonical study. DOI/PMID aliases are normalized across profiles before load
+ * is counted, so identifier-shape differences cannot split one publication.
  */
 export function analyzeCrossProfileStudyLoad(analysis: ResearchQualityAnalysis): CrossProfileStudyLoad[] {
+  const globalIdentities = crossProfileStudyIdentityMap(analysis.profiles)
   const byStudy = new Map<string, {
     profiles: Set<string>
     claims: Map<string, { url: string; claimId: string; predicate: string; confidence: number }>
@@ -57,7 +62,8 @@ export function analyzeCrossProfileStudyLoad(analysis: ResearchQualityAnalysis):
   }>()
 
   for (const claim of analysis.claimAnalyses) {
-    for (const studyId of claim.studyIds) {
+    for (const localStudyId of claim.studyIds) {
+      const studyId = crossProfileStudyIdentity(claim.url, localStudyId, globalIdentities)
       const item = byStudy.get(studyId) ?? {
         profiles: new Set<string>(),
         claims: new Map<string, { url: string; claimId: string; predicate: string; confidence: number }>(),


### PR DESCRIPTION
Uses the shared cross-profile DOI/PMID canonicalizer in systemic study-load and cross-profile evidence-bundle analysis. Adds an integration regression test proving DOI+PMID and PMID-only representations aggregate into one study/bundle across profiles. Same-profile overlap/bundle logic remains unchanged.