### PR TITLE
refactor(nav): align route metadata with current architecture

### DIFF
--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -18,6 +18,11 @@ export const routeLabels: Record<string, RouteMetadata> = {
     label: 'Home',
     description: 'The Hippie Scientist evidence-based supplement research',
   },
+  '/start': {
+    label: 'Start Here',
+    description: 'Choose between goal research, ingredient lookup, and safety checking',
+    parent: '/',
+  },
   '/library': {
     label: 'Explore Everything',
     description: 'Complete site directory',
@@ -105,6 +110,11 @@ export const routeLabels: Record<string, RouteMetadata> = {
   '/guides/focus': {
     label: 'Focus & Cognition',
     description: 'Focus support, nootropics, and cognitive performance',
+    parent: '/guides',
+  },
+  '/guides/metabolic-health': {
+    label: 'Metabolic Health',
+    description: 'Metabolic-health evidence, comparisons, medication context, and practical research paths',
     parent: '/guides',
   },
   '/guides/herbs': {

--- a/tests/route-metadata-alignment.test.ts
+++ b/tests/route-metadata-alignment.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  generateDynamicBreadcrumbs,
+  getRouteMetadata,
+  validateRoute,
+} from '@/lib/navigation-config'
+
+describe('route metadata alignment', () => {
+  it('recognizes the start router as a first-class route', () => {
+    expect(validateRoute('/start')).toBe(true)
+    expect(getRouteMetadata('/start')).toMatchObject({
+      label: 'Start Here',
+      parent: '/',
+    })
+    expect(generateDynamicBreadcrumbs('/start')).toEqual([
+      { label: 'Home', href: '/', current: false },
+      { label: 'Start Here', href: '/start', current: true },
+    ])
+  })
+
+  it('recognizes metabolic health as a first-class guide hub', () => {
+    expect(validateRoute('/guides/metabolic-health')).toBe(true)
+    expect(getRouteMetadata('/guides/metabolic-health')).toMatchObject({
+      label: 'Metabolic Health',
+      parent: '/guides',
+    })
+    expect(generateDynamicBreadcrumbs('/guides/metabolic-health')).toEqual([
+      { label: 'Home', href: '/', current: false },
+      { label: 'Topics & Guides', href: '/guides', current: false },
+      { label: 'Metabolic Health', href: '/guides/metabolic-health', current: true },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Registers `/start/` as a first-class route in shared navigation metadata.
- Registers `/guides/metabolic-health/` explicitly instead of relying on the generic dynamic guide fallback.
- Adds focused regression coverage for route validation, metadata, and breadcrumbs.

## Why
Recent navigation cleanup clarified these routes as durable architectural surfaces, but the shared route metadata still lagged behind the actual site structure.

## Regression contract
- No routes are removed.
- Existing breadcrumb generation behavior is preserved.
- New tests cover both newly explicit routes.