### PR TITLE
feat(research): prioritize syntheses outpaced by newer trials

### DIFF
--- a/lib/__tests__/research-synthesis-refresh-policy.test.ts
+++ b/lib/__tests__/research-synthesis-refresh-policy.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+import { buildResearchGapQueue } from '@/lib/research-quality-policy'
+
+function queueForYears(synthesisYear: number, primaryYear: number) {
+  const root = mkdtempSync(path.join(tmpdir(), 'synthesis-refresh-policy-'))
+  const dir = path.join(root, 'public', 'data', 'herbs-detail')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, 'example.json'), JSON.stringify({
+    slug: 'example',
+    sources: [
+      {
+        id: 'review',
+        title: 'Systematic review of sleep outcomes',
+        year: synthesisYear,
+        studyClass: 'systematic-review',
+      },
+      {
+        id: 'trial',
+        title: 'Randomized controlled trial of sleep outcomes',
+        year: primaryYear,
+        studyClass: 'rct',
+      },
+    ],
+    claimMap: [{
+      id: 'sleep-outcome',
+      claim: 'May improve sleep outcomes.',
+      predicate: 'supports_outcome',
+      confidence: 0.8,
+      reviewStatus: 'approved',
+      sourceRefIds: ['review', 'trial'],
+    }],
+  }))
+
+  try {
+    return buildResearchGapQueue(analyzeResearchQuality(root))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+describe('synthesis refresh remediation policy', () => {
+  it('adds a freshness reason when newer primary-human evidence outpaces synthesis by five years', () => {
+    const item = queueForYears(2018, 2023).find((row) => row.url === '/herbs/example/')
+    expect(item?.reasonCounts['synthesis-outpaced-by-newer-primary-evidence']).toBe(1)
+    expect(item?.dimensionScores.freshness).toBeGreaterThanOrEqual(15)
+  })
+
+  it('does not add the synthesis refresh reason below the five-year threshold', () => {
+    const item = queueForYears(2019, 2023).find((row) => row.url === '/herbs/example/')
+    expect(item?.reasonCounts['synthesis-outpaced-by-newer-primary-evidence'] ?? 0).toBe(0)
+  })
+})

--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -93,6 +93,8 @@ export const RESEARCH_GAP_WEIGHTS = {
   weakIdentityCoverageBonus: 6,
   severeStudyClassConflict: 100,
   studyClassAmbiguity: 5,
+  synthesisRefreshGap: 10,
+  highConfidenceSynthesisRefreshBonus: 5,
   legacyOnlyOutcomeClaim: 8,
   highConfidenceLegacyOnlyBonus: 4,
   unknownEvidenceYearMetadata: 4,
@@ -135,6 +137,7 @@ const DIMENSION_BY_KIND: Record<string, ResearchGapDimension> = {
   'claim-citation-metadata-gap': 'metadata',
   'canonical-study-class-ambiguity': 'metadata',
   'unknown-evidence-year-metadata': 'metadata',
+  'synthesis-outpaced-by-newer-primary-evidence': 'freshness',
   'legacy-only-outcome-evidence': 'freshness',
 }
 
@@ -280,6 +283,15 @@ function addTopologyReasons(topology: ResearchQualityTopology, add: AddReason) {
   }
 
   for (const freshness of topology.claimEvidenceAge) {
+    if (freshness.synthesisOutpacedByNewerPrimaryEvidence) {
+      const bonus = freshness.highConfidenceSynthesisRefreshGap ? RESEARCH_GAP_WEIGHTS.highConfidenceSynthesisRefreshBonus : 0
+      add(
+        freshness.url,
+        'synthesis-outpaced-by-newer-primary-evidence',
+        RESEARCH_GAP_WEIGHTS.synthesisRefreshGap + bonus,
+        `${freshness.claimId} · newest synthesis ${freshness.newestSynthesisYear ?? 'unknown'} trails primary-human evidence ${freshness.newestPrimaryHumanYear ?? 'unknown'} by ${freshness.synthesisLagYears ?? '?'} years${bonus ? ' · high confidence' : ''}`,
+      )
+    }
     if (freshness.studyCount > 0 && freshness.knownYearCount === 0) {
       add(freshness.url, 'unknown-evidence-year-metadata', RESEARCH_GAP_WEIGHTS.unknownEvidenceYearMetadata, `${freshness.claimId} · publication year unknown for all ${freshness.studyCount} studies`)
     } else if (freshness.legacyOnlyOutcomeClaim) {


### PR DESCRIPTION
Routes the new design-aware synthesis refresh signal into the canonical remediation queue. A linked systematic review/meta-analysis that trails linked primary-human evidence by at least five years adds a freshness reason (10 points, +5 for high-confidence claims) under the existing freshness dimension cap. This complements rather than replaces legacy-age scoring. Includes an end-to-end policy fixture verifying the five-year threshold and freshness routing.