### PR TITLE
test(research): validate source graph ownership in canonical snapshot

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -13,7 +13,7 @@ function fixtures() {
       url: '/herbs/example',
       record: {
         claimMap: [{ id: 'claim-1' }],
-        sources: [{ id: 'source-1' }],
+        sources: [{ id: 'source-1', pmid: '123' }],
       },
     }],
     profileAnalyses: [{ url: '/herbs/example' }],
@@ -105,7 +105,6 @@ describe('research quality snapshot invariants', () => {
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(false)
     expect(report.failures.map((failure) => failure.kind)).toContain('source-study-count-mismatch')
-    expect(report.summary.sourceIntegrityFailures).toBe(1)
   })
 
   it('detects source rows that reference unknown profiles', () => {
@@ -129,10 +128,35 @@ describe('research quality snapshot invariants', () => {
 
   it('detects duplicate and missing source row IDs in raw profiles', () => {
     const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
-    analysis.profiles[0].record.sources = [{ id: 'source-1' }, { id: 'source-1' }, { id: '' }]
+    analysis.profiles[0].record.sources = [
+      { id: 'source-1', pmid: '123' },
+      { id: 'source-1', pmid: '123' },
+      { id: '', pmid: '123' },
+    ]
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     const kinds = report.failures.map((failure) => failure.kind)
     expect(kinds).toContain('duplicate-source-id')
     expect(kinds).toContain('missing-source-id')
+  })
+
+  it('detects source-integrity studies that do not exist in raw profile sources', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    sourceIntegrity.studies[0].pmid = '999'
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    const kinds = report.failures.map((failure) => failure.kind)
+    expect(kinds).toContain('source-unexpected-pmid')
+    expect(kinds).toContain('source-missing-pmid')
+  })
+
+  it('detects source-integrity ownership drift across profiles', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    analysis.profiles.push({
+      url: '/herbs/second',
+      record: { claimMap: [], sources: [{ id: 'source-2', pmid: '123' }] },
+    } as typeof analysis.profiles[number])
+    analysis.profileAnalyses.push({ url: '/herbs/second' } as typeof analysis.profileAnalyses[number])
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.passed).toBe(false)
+    expect(report.failures.map((failure) => failure.kind)).toContain('source-profile-ownership-mismatch')
   })
 })

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -33,6 +33,10 @@ function text(value: unknown): string {
   return String(value ?? '').trim()
 }
 
+function sameStrings(left: Set<string>, right: Set<string>): boolean {
+  return left.size === right.size && [...left].every((value) => right.has(value))
+}
+
 /**
  * Cross-check the canonical research snapshot against itself. These are
  * implementation/data invariants, not scientific judgments: if they fail, two
@@ -49,6 +53,7 @@ export function validateResearchQualitySnapshotInvariants(
   const failures: ResearchSnapshotInvariantFailure[] = []
   const profileUrls = new Set(analysis.profileAnalyses.map((profile) => profile.url))
   const approvedClaimKeys = new Set(analysis.claimAnalyses.map((claim) => claimKey(claim.url, claim.claimId)))
+  const citationPages = new Map<string, Set<string>>()
 
   const add = (kind: string, detail: string) => failures.push({ kind, detail })
   const requireProfile = (kind: string, url: string, detail: string) => {
@@ -76,13 +81,21 @@ export function validateResearchQualitySnapshotInvariants(
     const sources = Array.isArray(profile.record.sources) ? profile.record.sources : []
     const seenSources = new Set<string>()
     for (let index = 0; index < sources.length; index += 1) {
-      const id = text(sources[index]?.id)
+      const source = sources[index]
+      const id = text(source?.id)
       if (!id) {
         add('missing-source-id', `${profile.url} · sources[${index}]`)
-        continue
+      } else if (seenSources.has(id)) {
+        add('duplicate-source-id', `${profile.url}::${id}`)
+      } else {
+        seenSources.add(id)
       }
-      if (seenSources.has(id)) add('duplicate-source-id', `${profile.url}::${id}`)
-      else seenSources.add(id)
+
+      const pmid = text(source?.pmid ?? source?.pubmedId)
+      if (!pmid) continue
+      const pages = citationPages.get(pmid) ?? new Set<string>()
+      pages.add(profile.url)
+      citationPages.set(pmid, pages)
     }
   }
 
@@ -156,6 +169,20 @@ export function validateResearchQualitySnapshotInvariants(
         add('source-page-count-mismatch', `${study.pmid}: pageCount=${study.pageCount}; pages=${uniquePages.size}`)
       }
       for (const url of uniquePages) requireProfile('source-unknown-profile', url, `PMID ${study.pmid}`)
+
+      const expectedPages = citationPages.get(study.pmid)
+      if (!expectedPages) {
+        add('source-unexpected-pmid', `PMID ${study.pmid} does not exist in canonical profile sources`)
+      } else if (!sameStrings(uniquePages, expectedPages)) {
+        add(
+          'source-profile-ownership-mismatch',
+          `PMID ${study.pmid}: sourceIntegrity=${[...uniquePages].sort().join(',')}; analysis=${[...expectedPages].sort().join(',')}`,
+        )
+      }
+    }
+
+    for (const pmid of citationPages.keys()) {
+      if (!seenPmids.has(pmid)) add('source-missing-pmid', `PMID ${pmid} missing from source integrity`)
     }
   }
 


### PR DESCRIPTION
Deepens the research-quality snapshot invariants from self-consistency to graph equivalence. The validator now rebuilds the PMID→profile citation ownership map from canonical raw profile sources and checks that source-integrity studies contain exactly those PMIDs and profile memberships. It detects missing/extra PMIDs and cross-profile ownership drift while preserving the existing ID/count/page invariants. Regression tests cover each failure mode.