### PR TITLE
refactor(nav): reduce route metadata to canonical labels

### DIFF
--- a/lib/navigation-config.ts
+++ b/lib/navigation-config.ts
@@ -6,192 +6,54 @@ export interface BreadcrumbItem {
 
 export interface RouteMetadata {
   label: string
-  description?: string
-  isDynamic?: boolean
 }
 
 export const SITE_URL = 'https://thehippiescientist.net'
 
 export const routeLabels: Record<string, RouteMetadata> = {
-  '/': {
-    label: 'Home',
-    description: 'The Hippie Scientist evidence-based supplement research',
-  },
-  '/start': {
-    label: 'Start Here',
-    description: 'Choose between goal research, ingredient lookup, and safety checking',
-  },
-  '/library': {
-    label: 'Explore Everything',
-    description: 'Complete site directory',
-  },
-  '/articles': {
-    label: 'Articles',
-    description: 'Research notes, evidence reviews, and editorial analysis',
-  },
-  '/articles/[slug]': {
-    label: 'Article',
-    description: 'Research article or evidence review',
-    isDynamic: true,
-  },
-  '/herbs': {
-    label: 'Herbs',
-    description: 'Evidence-graded herb profiles',
-  },
-  '/herbs/[slug]': {
-    label: 'Herb Profile',
-    description: 'Detailed herb evidence and safety profile',
-    isDynamic: true,
-  },
-  '/compounds': {
-    label: 'Compounds',
-    description: 'Active compounds, nutrients, and standardized extracts',
-  },
-  '/compounds/[slug]': {
-    label: 'Compound Profile',
-    description: 'Detailed compound evidence and safety profile',
-    isDynamic: true,
-  },
-  '/search': {
-    label: 'Search',
-    description: 'Search the complete site',
-  },
-  '/goals': {
-    label: 'Supplement Goals',
-    description: 'Compare supplement options by the outcome you want to improve',
-  },
-  '/goals/[slug]': {
-    label: 'Goal Guide',
-    description: 'Goal-based supplement comparison by fit, onset, evidence, and risk',
-    isDynamic: true,
-  },
-  '/guides': {
-    label: 'Topics & Guides',
-    description: 'Goal-based and practical evidence guides',
-  },
-  '/guides/mental-health': {
-    label: 'Mental Health',
-    description: 'Conditions, treatment evidence, safety, and stigma-aware explainers',
-  },
-  '/guides/adhd': {
-    label: 'ADHD',
-    description: 'Attention, executive function, nutrients, and treatment context',
-  },
-  '/guides/sleep': {
-    label: 'Sleep',
-    description: 'Sleep aids, alternatives, and sleep-hygiene evidence',
-  },
-  '/guides/stress': {
-    label: 'Stress',
-    description: 'Acute tension, chronic overload, burnout, cortisol concerns, and stress-support evidence',
-  },
-  '/guides/anxiety': {
-    label: 'Anxiety',
-    description: 'Anxiety patterns, calming supports, and evidence-aware safety guidance',
-  },
-  '/guides/focus': {
-    label: 'Focus & Cognition',
-    description: 'Focus support, nootropics, and cognitive performance',
-  },
-  '/guides/metabolic-health': {
-    label: 'Metabolic Health',
-    description: 'Metabolic-health evidence, comparisons, medication context, and practical research paths',
-  },
-  '/guides/herbs': {
-    label: 'Herb Guides',
-    description: 'Long-form practical botanical guides',
-  },
-  '/guides/best': {
-    label: 'Best Supplements',
-    description: 'Evidence-aware roundups organized by need',
-  },
-  '/guides/compare': {
-    label: 'Comparisons',
-    description: 'Side-by-side supplement and compound tradeoffs',
-  },
-  '/guides/other': {
-    label: 'Supplement Topic Guides',
-    description: 'Forms, quality, routines, advanced compounds, and harm reduction',
-  },
-  '/guides/[slug]': {
-    label: 'Guide',
-    description: 'Evidence-informed supplement guide',
-    isDynamic: true,
-  },
-  '/guides/[section]/[slug]': {
-    label: 'Guide',
-    description: 'Evidence-informed topic guide',
-    isDynamic: true,
-  },
-  '/lead-magnets/adhd-supplement-starter-checklist': {
-    label: 'ADHD Supplement Starter Checklist',
-    description: 'Printable baseline, safety, and 28-day tracking worksheet',
-  },
-  '/learn': {
-    label: 'Learning Library',
-    description: 'Neuroscience, evidence literacy, and safety education',
-  },
-  '/learn/[slug]': {
-    label: 'Learning Resource',
-    description: 'Educational research resource',
-    isDynamic: true,
-  },
-  '/novel-psychoactive-substances': {
-    label: 'Novel Psychoactive Substances',
-    description: 'Harm-reduction profiles for emerging substances',
-  },
-  '/safety': {
-    label: 'Safety',
-    description: 'Safety checker redirect',
-  },
-  '/safety-checker': {
-    label: 'Safety Checker',
-    description: 'Interaction and contraindication lookup',
-  },
-  '/evidence/evidence-checker': {
-    label: 'Evidence Lookup',
-    description: 'Search compounds by clinical evidence grade',
-  },
-  '/evidence/evidence-report': {
-    label: 'Evidence Report',
-    description: 'Annual state of supplement evidence review',
-  },
-  '/evidence/evidence-digest': {
-    label: 'Evidence Digest',
-    description: 'Recent human-trial highlights and research summaries',
-  },
-  '/info/methodology': {
-    label: 'Methodology',
-    description: 'Evidence grading and editorial standards',
-  },
-  '/info/dosing': {
-    label: 'Dosing Guide',
-    description: 'Bioavailability, timing, stacking, and dose realism',
-  },
-  '/info/supplement-safety-checklist': {
-    label: 'Supplement Checklist',
-    description: 'What to verify before buying or stacking a supplement',
-  },
-  '/info/infographics': {
-    label: 'Infographics',
-    description: 'Downloadable and embeddable evidence visuals',
-  },
-  '/info/about': {
-    label: 'About',
-    description: 'Project mission and editorial approach',
-  },
-  '/info/author': {
-    label: 'Author',
-    description: 'Author identity and credentials',
-  },
-  '/info/faq': {
-    label: 'FAQ',
-    description: 'Common questions about the site',
-  },
-  '/info/contact': {
-    label: 'Contact',
-    description: 'Corrections, feedback, and contact information',
-  },
+  '/': { label: 'Home' },
+  '/start': { label: 'Start Here' },
+  '/library': { label: 'Explore Everything' },
+  '/articles': { label: 'Articles' },
+  '/articles/[slug]': { label: 'Article' },
+  '/herbs': { label: 'Herbs' },
+  '/herbs/[slug]': { label: 'Herb Profile' },
+  '/compounds': { label: 'Compounds' },
+  '/compounds/[slug]': { label: 'Compound Profile' },
+  '/search': { label: 'Search' },
+  '/goals': { label: 'Supplement Goals' },
+  '/goals/[slug]': { label: 'Goal Guide' },
+  '/guides': { label: 'Topics & Guides' },
+  '/guides/mental-health': { label: 'Mental Health' },
+  '/guides/adhd': { label: 'ADHD' },
+  '/guides/sleep': { label: 'Sleep' },
+  '/guides/stress': { label: 'Stress' },
+  '/guides/anxiety': { label: 'Anxiety' },
+  '/guides/focus': { label: 'Focus & Cognition' },
+  '/guides/metabolic-health': { label: 'Metabolic Health' },
+  '/guides/herbs': { label: 'Herb Guides' },
+  '/guides/best': { label: 'Best Supplements' },
+  '/guides/compare': { label: 'Comparisons' },
+  '/guides/other': { label: 'Supplement Topic Guides' },
+  '/guides/[slug]': { label: 'Guide' },
+  '/guides/[section]/[slug]': { label: 'Guide' },
+  '/lead-magnets/adhd-supplement-starter-checklist': { label: 'ADHD Supplement Starter Checklist' },
+  '/learn': { label: 'Learning Library' },
+  '/learn/[slug]': { label: 'Learning Resource' },
+  '/novel-psychoactive-substances': { label: 'Novel Psychoactive Substances' },
+  '/safety': { label: 'Safety' },
+  '/safety-checker': { label: 'Safety Checker' },
+  '/evidence/evidence-checker': { label: 'Evidence Lookup' },
+  '/evidence/evidence-report': { label: 'Evidence Report' },
+  '/evidence/evidence-digest': { label: 'Evidence Digest' },
+  '/info/methodology': { label: 'Methodology' },
+  '/info/dosing': { label: 'Dosing Guide' },
+  '/info/supplement-safety-checklist': { label: 'Supplement Checklist' },
+  '/info/infographics': { label: 'Infographics' },
+  '/info/about': { label: 'About' },
+  '/info/author': { label: 'Author' },
+  '/info/faq': { label: 'FAQ' },
+  '/info/contact': { label: 'Contact' },
 }
 
 const SEGMENT_LABEL_OVERRIDES: Record<string, string> = {

--- a/tests/goals-route-metadata.test.ts
+++ b/tests/goals-route-metadata.test.ts
@@ -16,7 +16,6 @@ describe('goals route metadata', () => {
     })
     expect(getRouteMetadata('/goals/sleep')).toMatchObject({
       label: 'Goal Guide',
-      isDynamic: true,
     })
   })
 


### PR DESCRIPTION
## Summary
- Reduces `RouteMetadata` to a single `label` field.
- Removes unused route descriptions and `isDynamic` flags.
- Keeps dynamic matching derived from bracketed route patterns, where the behavior already lives.
- Updates the remaining metadata test to assert dynamic recognition behavior instead of a duplicated flag.

## Why
`routeLabels` is only consumed by the breadcrumb/validation module. Descriptions and dynamic flags were not used at runtime and duplicated facts already represented elsewhere.

## Regression contract
- Route validation is unchanged.
- Dynamic matching is unchanged.
- Breadcrumb labels and output remain unchanged.