### PR TITLE
refactor(research): unify PubMed metadata and abstract cache

### DIFF
--- a/lib/__tests__/research-pubmed-cache-enrichment.test.ts
+++ b/lib/__tests__/research-pubmed-cache-enrichment.test.ts
@@ -1,0 +1,54 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { loadPubmedCache } from '@/lib/research-coverage'
+
+describe('canonical PubMed cache enrichment', () => {
+  it('merges abstracts onto metadata records and retains abstract-only PMIDs', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pubmed-cache-'))
+    const cacheDir = path.join(root, 'ops', 'cache')
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(path.join(cacheDir, 'pubmed-metadata.json'), JSON.stringify({
+      records: {
+        '111': { title: 'Study one', year: 2024 },
+      },
+    }))
+    writeFileSync(path.join(cacheDir, 'pubmed-abstracts.json'), JSON.stringify({
+      abstracts: {
+        '111': '  Abstract for study one.  ',
+        '222': 'Abstract-only study with NCT01234567.',
+      },
+    }))
+
+    try {
+      const cache = loadPubmedCache(root)
+      expect(cache['111']).toMatchObject({
+        title: 'Study one',
+        year: 2024,
+        abstract: 'Abstract for study one.',
+      })
+      expect(cache['222']).toEqual({ abstract: 'Abstract-only study with NCT01234567.' })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not discard valid metadata when the abstract cache is malformed', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pubmed-cache-'))
+    const cacheDir = path.join(root, 'ops', 'cache')
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(path.join(cacheDir, 'pubmed-metadata.json'), JSON.stringify({
+      records: { '111': { title: 'Study one' } },
+    }))
+    writeFileSync(path.join(cacheDir, 'pubmed-abstracts.json'), '{not-json')
+
+    try {
+      expect(loadPubmedCache(root)['111']).toEqual({ title: 'Study one' })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/lib/research-coverage.ts
+++ b/lib/research-coverage.ts
@@ -40,14 +40,47 @@ export const PRIMARY_HUMAN_STUDY_CLASSES = new Set<StudyClass>(['rct', 'controll
 export const SYNTHESIS_STUDY_CLASSES = new Set<StudyClass>(['meta-analysis', 'systematic-review'])
 export const NARRATIVE_STUDY_CLASSES = new Set<StudyClass>(['narrative-review'])
 
+/**
+ * Load one canonical PubMed cache view. Structured metadata remains the base
+ * record, while the already-fetched abstract corpus is merged onto the same PMID
+ * under `abstract`. Consumers therefore do not need a second loader or a second
+ * source of truth when an analysis needs both metadata and publication text.
+ */
 export function loadPubmedCache(root = process.cwd()): PubmedCache {
-  const cachePath = path.join(root, 'ops', 'cache', 'pubmed-metadata.json')
-  if (!fs.existsSync(cachePath)) return {}
-  try {
-    return JSON.parse(fs.readFileSync(cachePath, 'utf8')).records ?? {}
-  } catch {
-    return {}
+  const cacheDir = path.join(root, 'ops', 'cache')
+  const metadataPath = path.join(cacheDir, 'pubmed-metadata.json')
+  const abstractsPath = path.join(cacheDir, 'pubmed-abstracts.json')
+  const records: PubmedCache = {}
+
+  if (fs.existsSync(metadataPath)) {
+    try {
+      const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8')).records ?? {}
+      for (const [pmid, record] of Object.entries(metadata)) {
+        records[String(pmid)] = record && typeof record === 'object'
+          ? { ...(record as Record<string, unknown>) }
+          : {}
+      }
+    } catch {
+      // Metadata coverage is allowed to be partial; downstream audits expose it.
+    }
   }
+
+  if (fs.existsSync(abstractsPath)) {
+    try {
+      const abstracts = JSON.parse(fs.readFileSync(abstractsPath, 'utf8')).abstracts ?? {}
+      for (const [pmid, abstract] of Object.entries(abstracts)) {
+        if (typeof abstract !== 'string' || !abstract.trim()) continue
+        records[String(pmid)] = {
+          ...(records[String(pmid)] ?? {}),
+          abstract: abstract.trim(),
+        }
+      }
+    } catch {
+      // Abstract coverage is optional; malformed cache data must not erase metadata.
+    }
+  }
+
+  return records
 }
 
 export function designFromPublicationTypes(publicationTypes: string[] = []): StudyClass {


### PR DESCRIPTION
Enriches the canonical `loadPubmedCache()` view by merging the existing PubMed abstract corpus onto structured metadata records by PMID. Abstract-only PMIDs are retained, structured metadata remains intact, and malformed abstract cache data cannot erase valid metadata. This eliminates the need for downstream research analyzers to create a second abstract loader and provides one canonical evidence context for trial-registration and other text-derived topology. Includes focused cache merge/failure tests.