### PR TITLE
test: refresh stale UI contracts blocking deploy

### DIFF
--- a/app/search/__tests__/SearchClient.test.tsx
+++ b/app/search/__tests__/SearchClient.test.tsx
@@ -68,51 +68,39 @@ vi.mock('../../../src/components/search/DosingSafetyChecker', () => ({
   default: () => <div>Mocked DosingSafetyChecker</div>
 }))
 
+function searchInput() {
+  return screen.getByRole('searchbox', { name: /search herbs and compounds/i })
+}
+
 describe('SearchClient Component', () => {
   it('renders default search interface successfully', () => {
     render(<SearchClient />)
 
-    // Check title and input placeholder
-    expect(screen.getByRole('heading', { name: /Search the library/i })).toBeInTheDocument()
-    expect(screen.getByPlaceholderText(/Try sleep, magnesium, stress/i)).toBeInTheDocument()
-    expect(screen.getByText('2 searchable profiles')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Search ingredients, outcomes, and research context/i })).toBeInTheDocument()
+    expect(searchInput()).toBeInTheDocument()
+    expect(screen.getByText('2 shown')).toBeInTheDocument()
   })
 
-  it('filters and expands search queries using synonyms', async () => {
+  it('filters and expands search queries using synonyms', () => {
     render(<SearchClient />)
 
-    const input = screen.getByPlaceholderText(/Try sleep, magnesium, stress/i)
-
-    // Type layperson term "sleep"
-    fireEvent.change(input, { target: { value: 'sleep' } })
-
-    // Check that Ashwagandha (which matches 'sleep') is rendered
+    fireEvent.change(searchInput(), { target: { value: 'sleep' } })
     expect(screen.getByText('Ashwagandha')).toBeInTheDocument()
   })
 
   it('provides auto-suggestions when typing in the input', () => {
     render(<SearchClient />)
 
-    const input = screen.getByPlaceholderText(/Try sleep, magnesium, stress/i)
-
-    fireEvent.change(input, { target: { value: 'Ash' } })
-
-    // Auto suggestion dropdown should render suggestion
-    expect(screen.getByText('Quick match suggestions')).toBeInTheDocument()
+    fireEvent.change(searchInput(), { target: { value: 'Ash' } })
+    expect(screen.getByText('Quick matches')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Ashwagandha/i })).toBeInTheDocument()
   })
 
   it('excludes restricted substances (e.g. DMT, 5-MeO-DMT, kratom, ibogaine, ketamine, fadogia) from search results and dosing options', () => {
     render(<SearchClient />)
 
-    const input = screen.getByPlaceholderText(/Try sleep, magnesium, stress/i)
-
-    // Query for safe compound to surface results
-    fireEvent.change(input, { target: { value: 'theanine' } })
-
-    // DMT (restricted) should never appear
+    fireEvent.change(searchInput(), { target: { value: 'theanine' } })
     expect(screen.queryByText(/DMT/i)).not.toBeInTheDocument()
-    // L-Theanine (safe, after filter) surfaces in results/suggestions; multiple nodes ok.
     expect(screen.getAllByText(/L-Theanine/i).length).toBeGreaterThan(0)
   })
 })

--- a/components/articles/__tests__/EmailCapture.test.tsx
+++ b/components/articles/__tests__/EmailCapture.test.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 import EmailCapture from '../EmailCapture'
 
 describe('article EmailCapture', () => {
-  it('lets readers preview the public checklist before subscribing', () => {
+  it('lets readers preview the public resource before subscribing', () => {
     render(
       <EmailCapture
         title="Get the ADHD Supplement Starter Checklist"
@@ -16,9 +16,9 @@ describe('article EmailCapture', () => {
       />,
     )
 
-    expect(screen.getByRole('link', { name: /preview and print the checklist/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /preview the resource/i })).toHaveAttribute(
       'href',
-      '/lead-magnets/adhd-supplement-starter-checklist',
+      '/lead-magnets/adhd-supplement-starter-checklist/',
     )
     expect(screen.getByRole('button', { name: /send me the checklist/i })).toBeEnabled()
   })

--- a/components/ui/__tests__/EvidenceScoreBadge.test.tsx
+++ b/components/ui/__tests__/EvidenceScoreBadge.test.tsx
@@ -12,13 +12,13 @@ describe('EvidenceScoreBadge', () => {
   it('prefers an explicit grade prop over the record-derived grade', () => {
     render(<EvidenceScoreBadge record={{ evidence_tier: 'Strong evidence' }} grade="D" />)
     expect(screen.getByText('D')).toBeTruthy()
-    expect(screen.getByText('Traditional')).toBeTruthy()
+    expect(screen.getByText('Preliminary')).toBeTruthy()
   })
 
   it('defaults to grade C when neither record nor grade is given', () => {
     render(<EvidenceScoreBadge />)
     expect(screen.getByText('C')).toBeTruthy()
-    expect(screen.getByText('Preliminary')).toBeTruthy()
+    expect(screen.getByText('Limited')).toBeTruthy()
   })
 
   it('hides the label text when showLabel is false', () => {

--- a/components/ui/__tests__/ProfileEvidenceLens.maturity.test.tsx
+++ b/components/ui/__tests__/ProfileEvidenceLens.maturity.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import ProfileEvidenceLens from '../ProfileEvidenceLens'
 
 describe('ProfileEvidenceLens research maturity', () => {
-  it('shows theoretical research distinctly for preclinical-only records', () => {
+  it('shows preliminary research distinctly for preclinical-only records', () => {
     const { container } = render(
       <ProfileEvidenceLens
         record={{
@@ -14,9 +14,9 @@ describe('ProfileEvidenceLens research maturity', () => {
       />,
     )
 
-    expect(screen.getByText('Theoretical / mechanistic research')).toBeTruthy()
-    expect(container.querySelector('[data-research-maturity="theoretical"]')).toBeTruthy()
-    expect(container.querySelector('[data-research-visual-weight="research-only"]')).toBeTruthy()
+    expect(screen.getByText('Preliminary research')).toBeTruthy()
+    expect(container.querySelector('[data-research-maturity="preliminary"]')).toBeTruthy()
+    expect(container.querySelector('[data-research-visual-weight="muted"]')).toBeTruthy()
   })
 
   it('shows established research distinctly for strong human evidence', () => {

--- a/components/ui/__tests__/SafetyGaugeMeter.test.tsx
+++ b/components/ui/__tests__/SafetyGaugeMeter.test.tsx
@@ -21,6 +21,6 @@ describe('SafetyGaugeMeter', () => {
 
   it('exposes an accessible label on the SVG describing the clamped score', () => {
     render(<SafetyGaugeMeter score={45} label="Use caution" />)
-    expect(screen.getByRole('img', { name: 'Safety meter: 45 out of 100 — Use caution' })).toBeTruthy()
+    expect(screen.getByRole('img', { name: 'Safety context: Use caution. Visual gauge position 45 out of 100.' })).toBeTruthy()
   })
 })

--- a/tests/guides-anxiety-stress-routes.test.ts
+++ b/tests/guides-anxiety-stress-routes.test.ts
@@ -12,7 +12,7 @@ describe('Guides hub anxiety and stress routes', () => {
 
     expect(guides).toContain("title: 'Anxiety'")
     expect(guides).toContain("href: '/guides/anxiety/'")
-    expect(guides).toContain("title: 'Stress Decision Hub'")
+    expect(guides).toContain("title: 'Stress'")
     expect(guides).toContain("href: '/guides/stress/'")
     expect(guides).not.toContain("title: 'Anxiety & Stress'")
   })


### PR DESCRIPTION
Fixes the 10 stale test assertions reported by the latest actually-executed failed production deploy (#5918). Aligns SafetyGaugeMeter accessibility text, canonical EvidenceScoreBadge labels, ProfileEvidenceLens maturity semantics, EmailCapture preview copy/URL, SearchClient's current research-search experience, and the guides hub Stress title. Search tests now target the stable accessible searchbox label instead of brittle placeholder copy. Production components are unchanged.