### PR TITLE
refactor(source): derive source-gap classes from shared governance

### DIFF
--- a/scripts/lib/source-class-governance.ts
+++ b/scripts/lib/source-class-governance.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs'
+
+export type SourceClassGovernanceRule = {
+  evidenceClass: string
+  allowedSourceTypes: string[]
+  pmidApplicable: boolean
+  preferredStudyDesigns: string[]
+}
+
+export type SourceClassGovernance = Record<string, SourceClassGovernanceRule>
+
+const governanceUrl = new URL('../../schemas/source-class-governance.json', import.meta.url)
+
+export const sourceClassGovernance = JSON.parse(
+  fs.readFileSync(governanceUrl, 'utf8'),
+) as SourceClassGovernance
+
+export function sourceClassesForEvidenceClasses(evidenceClasses: Iterable<string>): Set<string> {
+  const allowedEvidenceClasses = new Set(evidenceClasses)
+  return new Set(
+    Object.entries(sourceClassGovernance)
+      .filter(([, rule]) => allowedEvidenceClasses.has(rule.evidenceClass))
+      .map(([sourceClass]) => sourceClass),
+  )
+}
+
+export function getSourceClassRule(sourceClass: string): SourceClassGovernanceRule | null {
+  return sourceClassGovernance[sourceClass] ?? null
+}

--- a/scripts/report-source-gaps.ts
+++ b/scripts/report-source-gaps.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { sourceClassesForEvidenceClasses } from './lib/source-class-governance'
 
 type ItemType = 'herb_page' | 'compound_page' | 'collection_page' | 'comparison_page' | 'discovery_surface' | 'recommendation_surface'
 type PriorityLabel = 'do_now' | 'next_wave' | 're_review_needed' | 'governance_fix_needed' | 'low_priority' | 'defer'
@@ -99,19 +100,14 @@ const OUTPUT_JSON = path.join(ROOT, 'ops', 'reports', 'source-gaps.json')
 const OUTPUT_MD = path.join(ROOT, 'ops', 'reports', 'source-gaps.md')
 
 const HUMAN_EVIDENCE_CLASSES = new Set(['human-clinical', 'human-observational'])
-const HUMAN_SOURCE_CLASSES = new Set([
-  'randomized-human-trial',
-  'non-randomized-human-study',
-  'observational-human-evidence',
-  'systematic-review-meta-analysis',
-])
+const HUMAN_SOURCE_CLASSES = sourceClassesForEvidenceClasses(HUMAN_EVIDENCE_CLASSES)
 const SAFETY_SOURCE_CLASSES = new Set([
   'regulatory-agency-monograph-guidance',
   'reference-database-authority',
   'systematic-review-meta-analysis',
 ])
-const MECHANISM_SOURCE_CLASSES = new Set(['preclinical-mechanistic-study'])
-const TRADITIONAL_SOURCE_CLASSES = new Set(['traditional-use-monograph'])
+const MECHANISM_SOURCE_CLASSES = sourceClassesForEvidenceClasses(['preclinical-mechanistic'])
+const TRADITIONAL_SOURCE_CLASSES = sourceClassesForEvidenceClasses(['traditional-use'])
 
 function readJson<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T


### PR DESCRIPTION
Broad cleanup pass 37.

- adds scripts/lib/source-class-governance.ts as the TypeScript loader for the shared schema-backed source-class contract
- migrates report-source-gaps.ts away from private human/mechanism/traditional source-class sets
- derives those classifications from evidenceClass mappings in schemas/source-class-governance.json
- intentionally leaves safety acquisition preferences and recommended-source ordering local because those are planner policy, not source-class facts

This narrows source-gap ownership to gap detection/prioritization while source-class semantics live in one shared contract.