### PR TITLE
refactor(research): aggregate pseudo-multi-source remediation

### DIFF
--- a/lib/__tests__/research-quality-policy-topology-signals.test.ts
+++ b/lib/__tests__/research-quality-policy-topology-signals.test.ts
@@ -20,6 +20,7 @@ const weights = {
   highConfidenceCitationMetadataBonus: 4,
   provenanceNarrowMultiStudySupport: 8,
   highConfidenceProvenanceNarrowBonus: 4,
+  pseudoMultiSourceSupport: 9,
   severeStudyClassConflict: 100,
   studyClassAmbiguity: 5,
 }
@@ -31,6 +32,7 @@ function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopol
     claimLanguageCalibration: { directEvidenceFindings: [] },
     claimCitationMetadata: { lowCoverageClaims: [] },
     provenanceNarrowMultiStudyClaims: [],
+    edgeCardinality: { pseudoMultiSourceClaims: [] },
     studyClassConflicts: { conflicts: [], severeConflicts: [] },
     ...overrides,
   } as unknown as ResearchQualityTopology
@@ -65,6 +67,25 @@ describe('aggregated topology gap signals', () => {
     const provenance = signals.filter((signal) => signal.kind === 'claim-provenance-narrow-multi-study-support')
     expect(provenance).toHaveLength(1)
     expect(provenance[0].detail).toContain('2 multi-study approved claim(s)')
+  })
+
+  it('aggregates pseudo-multi-source claims once per profile', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      edgeCardinality: {
+        pseudoMultiSourceClaims: [
+          { url: '/herbs/a/', approved: true, aliasCollapsedSourceCount: 1, validUniqueSourceRefCount: 2 },
+          { url: '/herbs/a/', approved: true, aliasCollapsedSourceCount: 2, validUniqueSourceRefCount: 3 },
+          { url: '/herbs/a/', approved: false, aliasCollapsedSourceCount: 5, validUniqueSourceRefCount: 6 },
+        ],
+      },
+    }), weights)
+
+    const pseudo = signals.filter((signal) => signal.kind === 'pseudo-multi-source-support')
+    expect(pseudo).toHaveLength(1)
+    expect(pseudo[0]).toMatchObject({ url: '/herbs/a/' })
+    expect(pseudo[0].detail).toContain('2 approved claim(s)')
+    expect(pseudo[0].detail).toContain('3 redundant source row(s)')
+    expect(pseudo[0].detail).toContain('3 source rows')
   })
 
   it('keeps severe and advisory study-class conflicts distinct', () => {

--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -17,6 +17,7 @@ export type AggregatedTopologyGapWeights = {
   highConfidenceCitationMetadataBonus: number
   provenanceNarrowMultiStudySupport: number
   highConfidenceProvenanceNarrowBonus: number
+  pseudoMultiSourceSupport: number
   severeStudyClassConflict: number
   studyClassAmbiguity: number
 }
@@ -144,6 +145,17 @@ export function buildAggregatedTopologyGapSignals(
       kind: 'claim-provenance-narrow-multi-study-support',
       weight: weights.provenanceNarrowMultiStudySupport + Math.min(6, Math.max(0, items.length - 1)) + (highConfidence ? weights.highConfidenceProvenanceNarrowBonus : 0),
       detail: `${items.length} multi-study approved claim(s) have narrow publication provenance; ${sameAuthor} same-first-author lineage; ${sameJournal} same-journal lineage; ${highConfidence} high-confidence`,
+    })
+  }
+
+  for (const [url, items] of groupByUrl(topology.edgeCardinality.pseudoMultiSourceClaims.filter((item) => item.approved))) {
+    const collapsedRows = items.reduce((sum, item) => sum + item.aliasCollapsedSourceCount, 0)
+    const maxNominalSources = Math.max(...items.map((item) => item.validUniqueSourceRefCount))
+    signals.push({
+      url,
+      kind: 'pseudo-multi-source-support',
+      weight: weights.pseudoMultiSourceSupport + Math.min(8, Math.max(0, items.length - 1) * 2 + collapsedRows),
+      detail: `${items.length} approved claim(s) look multi-source but collapse to one canonical study; ${collapsedRows} redundant source row(s); widest nominal support ${maxNominalSources} source rows`,
     })
   }
 

--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -242,16 +242,6 @@ function addTopologyReasons(topology: ResearchQualityTopology, add: AddReason) {
     const bonus = claim.highConfidenceHomogeneousMultiStudySupport ? RESEARCH_GAP_WEIGHTS.highConfidenceHomogeneousMultiStudyBonus : 0
     add(claim.url, 'homogeneous-multi-study-support', RESEARCH_GAP_WEIGHTS.homogeneousMultiStudySupport + bonus, `${claim.claimId} · ${claim.studyCount} studies but one evidence family (${claim.evidenceFamilies.join(', ')})`)
   }
-  for (const claim of topology.edgeCardinality.pseudoMultiSourceClaims) {
-    if (!claim.approved) continue
-    const bonus = Math.min(6, claim.aliasCollapsedSourceCount * 2)
-    add(
-      claim.url,
-      'pseudo-multi-source-support',
-      RESEARCH_GAP_WEIGHTS.pseudoMultiSourceSupport + bonus,
-      `${claim.claimId} · ${claim.validUniqueSourceRefCount} distinct source rows collapse to ${claim.canonicalStudyCount} canonical study`,
-    )
-  }
 
   const overlapByProfile = new Map<string, typeof topology.claimEvidenceOverlap>()
   for (const overlap of topology.claimEvidenceOverlap) {
@@ -329,6 +319,7 @@ function addTopologyReasons(topology: ResearchQualityTopology, add: AddReason) {
     highConfidenceCitationMetadataBonus: RESEARCH_GAP_WEIGHTS.highConfidenceCitationMetadataBonus,
     provenanceNarrowMultiStudySupport: RESEARCH_GAP_WEIGHTS.provenanceNarrowMultiStudySupport,
     highConfidenceProvenanceNarrowBonus: RESEARCH_GAP_WEIGHTS.highConfidenceProvenanceNarrowBonus,
+    pseudoMultiSourceSupport: RESEARCH_GAP_WEIGHTS.pseudoMultiSourceSupport,
     severeStudyClassConflict: RESEARCH_GAP_WEIGHTS.severeStudyClassConflict,
     studyClassAmbiguity: RESEARCH_GAP_WEIGHTS.studyClassAmbiguity,
   }


### PR DESCRIPTION
Moves pseudo-multi-source findings into the shared aggregated topology policy path. Multiple affected claims on one profile now produce one bounded root-cause reason, with regression coverage, instead of repetitive claim-level reasons consuming the concentration cap.