### PR TITLE
feat(research): detect same registered-trial publication reuse

### DIFF
--- a/lib/__tests__/research-trial-registration-independence.test.ts
+++ b/lib/__tests__/research-trial-registration-independence.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import { canonicalStudyIdentityMap, type ResearchProfile } from '@/lib/research-coverage'
+import type { ClaimQualityAnalysis, ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import {
+  analyzeTrialRegistrationIndependence,
+  extractTrialRegistryIds,
+} from '@/lib/research-trial-registration-independence'
+
+function qualityClaim(studyIds: string[]): ClaimQualityAnalysis {
+  return {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    reviewStatus: 'approved',
+    approved: true,
+    predicate: 'supports_outcome',
+    confidence: 0.85,
+    sourceRefCount: studyIds.length,
+    validSourceRefCount: studyIds.length,
+    danglingSourceRefs: [],
+    studyIds,
+    studyCount: studyIds.length,
+    classifiedStudyCount: studyIds.length,
+    primaryHuman: studyIds.length,
+    synthesis: 0,
+    narrative: 0,
+    designs: studyIds.map(() => 'rct' as const),
+    outcomeClaim: true,
+    supportTier: 'human-supported',
+    structuredSupportTier: 'adequate',
+    weakStructuredClaim: false,
+    highConfidenceWeakStructured: false,
+    highConfidenceWeakOutcome: false,
+    singleStudy: false,
+    aliasCollapsed: false,
+  }
+}
+
+function analysis(
+  sources: Array<Record<string, unknown>>,
+  abstracts: Record<string, string> = {},
+): ResearchQualityAnalysis {
+  const record: ResearchProfile = { slug: 'example', sources, claimMap: [] }
+  const identities = canonicalStudyIdentityMap(record)
+  const studyIds = sources.map((source) => identities.get(String(source.id))!).filter(Boolean)
+  const claim = qualityClaim(studyIds)
+  const cache = Object.fromEntries(Object.entries(abstracts).map(([pmid, abstract]) => [pmid, { abstract }]))
+  return {
+    cache,
+    profiles: [{ kind: 'herbs', url: '/herbs/example/', file: 'example.json', record }],
+    claimAnalyses: [claim],
+    structuredClaimAnalyses: [claim],
+    profileAnalyses: [],
+  }
+}
+
+describe('registered-trial publication independence', () => {
+  it('normalizes common registry identifiers from text', () => {
+    expect(extractTrialRegistryIds('NCT 01234567; ISRCTN 12345678; ACTRN12612345678901')).toEqual([
+      'ACTRN12612345678901', 'ISRCTN12345678', 'NCT01234567',
+    ])
+  })
+
+  it('collapses two publications carrying the same stable NCT registration', () => {
+    const result = analyzeTrialRegistrationIndependence(analysis([
+      { id: 's1', pmid: '111', studyClass: 'rct' },
+      { id: 's2', pmid: '222', studyClass: 'rct' },
+    ], {
+      '111': 'Randomized trial. ClinicalTrials.gov NCT01234567.',
+      '222': 'Follow-up publication from NCT01234567.',
+    }))
+    expect(result.claims[0]).toMatchObject({
+      apparentStudyCount: 2,
+      registryKnownStudyCount: 2,
+      registryAdjustedStudyCount: 1,
+      duplicatePublicationCount: 1,
+      sameRegisteredTrialPublicationReuse: true,
+      highConfidenceSameTrialReuse: true,
+    })
+    expect(result.claims[0].sameRegisteredTrialPairs[0].trialRegistrationId).toBe('NCT01234567')
+  })
+
+  it('keeps publications from different registered trials separate', () => {
+    const result = analyzeTrialRegistrationIndependence(analysis([
+      { id: 's1', pmid: '111', studyClass: 'rct' },
+      { id: 's2', pmid: '222', studyClass: 'rct' },
+    ], {
+      '111': 'ClinicalTrials.gov NCT01234567.',
+      '222': 'ClinicalTrials.gov NCT07654321.',
+    }))
+    expect(result.claims[0]).toMatchObject({ registryAdjustedStudyCount: 2, duplicatePublicationCount: 0, sameRegisteredTrialPublicationReuse: false })
+  })
+
+  it('does not collapse a publication that mentions multiple registry IDs', () => {
+    const result = analyzeTrialRegistrationIndependence(analysis([
+      { id: 's1', pmid: '111', studyClass: 'rct' },
+      { id: 's2', pmid: '222', studyClass: 'rct' },
+    ], {
+      '111': 'Pooled report of NCT01234567 and NCT07654321.',
+      '222': 'ClinicalTrials.gov NCT01234567.',
+    }))
+    expect(result.claims[0]).toMatchObject({
+      registryKnownStudyCount: 1,
+      registryAmbiguousStudyCount: 1,
+      registryAdjustedStudyCount: 2,
+      sameRegisteredTrialPublicationReuse: false,
+    })
+  })
+
+  it('uses structured registration fields when abstract text is unavailable', () => {
+    const result = analyzeTrialRegistrationIndependence(analysis([
+      { id: 's1', pmid: '111', studyClass: 'rct', trialRegistrationId: 'NCT01234567' },
+      { id: 's2', pmid: '222', studyClass: 'rct', registrationId: 'NCT01234567' },
+    ]))
+    expect(result.claims[0].sameRegisteredTrialPublicationReuse).toBe(true)
+    expect(result.claims[0].registryAdjustedStudyCount).toBe(1)
+  })
+})

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -16,6 +16,7 @@ import {
   analyzeCrossProfileStudyLoad,
   analyzeEvidenceBundleReuse,
 } from './research-study-load'
+import { analyzeTrialRegistrationIndependence } from './research-trial-registration-independence'
 
 export type ResearchQualityTopology = ReturnType<typeof buildResearchQualityTopology>
 
@@ -54,6 +55,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const highConfidenceProvenanceNarrowMultiStudyClaims = claimProvenanceIndependence.filter(
     (claim) => claim.highConfidenceProvenanceNarrowMultiStudySupport,
   )
+  const trialRegistrationIndependence = analyzeTrialRegistrationIndependence(analysis)
   const studyClassConflicts = analyzeStudyClassConflicts(analysis)
   const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
@@ -84,6 +86,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     claimProvenanceIndependence,
     provenanceNarrowMultiStudyClaims,
     highConfidenceProvenanceNarrowMultiStudyClaims,
+    trialRegistrationIndependence,
     studyClassConflicts,
     semanticAlignment,
     claimLanguageCalibration,

--- a/lib/research-trial-registration-independence.ts
+++ b/lib/research-trial-registration-independence.ts
@@ -1,0 +1,229 @@
+import { detectStudyIndependence, type StudyIdentity } from './evidence/study-quality'
+import { canonicalStudyGroups, type PubmedCache, type ResearchSource } from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type TrialRegistryResolution = {
+  registryIds: string[]
+  stableRegistryId: string | null
+  ambiguous: boolean
+}
+
+export type SameRegisteredTrialPair = {
+  leftStudyId: string
+  rightStudyId: string
+  trialRegistrationId: string
+}
+
+export type ClaimTrialRegistrationIndependence = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  apparentStudyCount: number
+  registryKnownStudyCount: number
+  registryAmbiguousStudyCount: number
+  registryCoverage: number
+  registryAdjustedStudyCount: number
+  duplicatePublicationCount: number
+  sameRegisteredTrialPairs: SameRegisteredTrialPair[]
+  sameRegisteredTrialPublicationReuse: boolean
+  highConfidenceSameTrialReuse: boolean
+}
+
+export type TrialRegistrationIndependenceAnalysis = {
+  claims: ClaimTrialRegistrationIndependence[]
+  sameTrialReuseClaims: ClaimTrialRegistrationIndependence[]
+  highConfidenceSameTrialReuseClaims: ClaimTrialRegistrationIndependence[]
+  summary: {
+    multiStudyApprovedClaims: number
+    claimsWithRegistryCoverage: number
+    claimsWithAmbiguousRegistryEvidence: number
+    sameTrialReuseClaims: number
+    highConfidenceSameTrialReuseClaims: number
+    duplicatePublicationCount: number
+  }
+}
+
+const EXPLICIT_REGISTRY_FIELDS = [
+  'trialRegistrationId',
+  'trialRegistrationIds',
+  'trialRegistration',
+  'registrationId',
+  'registrationIds',
+  'registryId',
+  'registryIds',
+  'clinicalTrialsGovId',
+  'clinicalTrialId',
+] as const
+
+function round(value: number, digits = 3): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) return value.flatMap(stringValues)
+  return []
+}
+
+/** Extract well-formed clinical-trial registry identifiers from free text. */
+export function extractTrialRegistryIds(value: unknown): string[] {
+  const text = stringValues(value).join(' ')
+  if (!text) return []
+  const ids = new Set<string>()
+  const patterns: Array<[RegExp, (match: RegExpExecArray) => string]> = [
+    [/\bNCT[-\s]?(\d{8})\b/gi, (match) => `NCT${match[1]}`],
+    [/\bISRCTN[-\s]?(\d{8})\b/gi, (match) => `ISRCTN${match[1]}`],
+    [/\bACTRN[-\s]?(\d{14})\b/gi, (match) => `ACTRN${match[1]}`],
+    [/\bUMIN[-\s]?(?:CTR[-\s]?)?(\d{9})\b/gi, (match) => `UMIN${match[1]}`],
+    [/\bDRKS[-\s]?(\d{8})\b/gi, (match) => `DRKS${match[1]}`],
+    [/\bEUDRACT[-\s]?(\d{4}-\d{6}-\d{2})\b/gi, (match) => `EUDRACT${match[1]}`],
+  ]
+
+  for (const [pattern, normalize] of patterns) {
+    pattern.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = pattern.exec(text))) ids.add(normalize(match).toUpperCase())
+  }
+  return [...ids].sort()
+}
+
+function sourceRegistryIds(source: ResearchSource, cache: PubmedCache): string[] {
+  const values: unknown[] = []
+  for (const field of EXPLICIT_REGISTRY_FIELDS) values.push(source[field])
+  values.push(source.title, source.abstract)
+
+  const pmid = String(source.pmid ?? source.pubmedId ?? '').trim()
+  if (pmid) {
+    const cached = cache[pmid] ?? {}
+    for (const field of EXPLICIT_REGISTRY_FIELDS) values.push(cached[field])
+    values.push(cached.title, cached.abstract)
+  }
+  return extractTrialRegistryIds(values.flatMap(stringValues))
+}
+
+export function resolveCanonicalStudyTrialRegistry(
+  group: ResearchSource[],
+  cache: PubmedCache,
+): TrialRegistryResolution {
+  const registryIds = [...new Set(group.flatMap((source) => sourceRegistryIds(source, cache)))].sort()
+  return {
+    registryIds,
+    stableRegistryId: registryIds.length === 1 ? registryIds[0] : null,
+    ambiguous: registryIds.length > 1,
+  }
+}
+
+function adjustedStudyCount(
+  studyIds: string[],
+  relations: ReturnType<typeof detectStudyIndependence>,
+): number {
+  const parent = new Map(studyIds.map((studyId) => [studyId, studyId]))
+  const find = (value: string): string => {
+    const current = parent.get(value) ?? value
+    if (current === value) return value
+    const root = find(current)
+    parent.set(value, root)
+    return root
+  }
+  const union = (left: string, right: string) => {
+    const rootLeft = find(left)
+    const rootRight = find(right)
+    if (rootLeft !== rootRight) parent.set(rootRight, rootLeft)
+  }
+
+  for (const relation of relations) {
+    if (relation.reason === 'same-trial-registration') union(relation.leftStudyId, relation.rightStudyId)
+  }
+  return new Set(studyIds.map(find)).size
+}
+
+/**
+ * Detect when multiple canonical publications supporting one approved claim are
+ * actually outputs from the same registered clinical trial. The existing study
+ * independence engine owns the relation rule; this adapter resolves canonical
+ * research studies onto registry IDs from structured fields and PubMed text.
+ *
+ * Publications mentioning multiple registry IDs are deliberately ambiguous and
+ * never collapsed automatically.
+ */
+export function analyzeTrialRegistrationIndependence(
+  analysis: ResearchQualityAnalysis,
+): TrialRegistrationIndependenceAnalysis {
+  const registryByUrl = new Map<string, Map<string, TrialRegistryResolution>>()
+  for (const { url, record } of analysis.profiles) {
+    const registry = new Map<string, TrialRegistryResolution>()
+    for (const [studyId, group] of canonicalStudyGroups(record)) {
+      registry.set(studyId, resolveCanonicalStudyTrialRegistry(group, analysis.cache))
+    }
+    registryByUrl.set(url, registry)
+  }
+
+  const claims: ClaimTrialRegistrationIndependence[] = []
+  for (const claim of analysis.claimAnalyses) {
+    if (claim.studyCount < 2) continue
+    const registry = registryByUrl.get(claim.url) ?? new Map()
+    const identities: StudyIdentity[] = claim.studyIds.map((studyId) => ({
+      studyId,
+      publicationId: studyId,
+      trialRegistrationId: registry.get(studyId)?.stableRegistryId ?? undefined,
+    }))
+    const relations = detectStudyIndependence(identities)
+    const sameTrialRelations = relations.filter((relation) => relation.reason === 'same-trial-registration')
+    const sameRegisteredTrialPairs = sameTrialRelations.map((relation): SameRegisteredTrialPair => ({
+      leftStudyId: relation.leftStudyId,
+      rightStudyId: relation.rightStudyId,
+      trialRegistrationId: registry.get(relation.leftStudyId)?.stableRegistryId
+        ?? registry.get(relation.rightStudyId)?.stableRegistryId
+        ?? 'unknown',
+    }))
+    const registryKnownStudyCount = claim.studyIds.filter((studyId) => Boolean(registry.get(studyId)?.stableRegistryId)).length
+    const registryAmbiguousStudyCount = claim.studyIds.filter((studyId) => registry.get(studyId)?.ambiguous).length
+    const registryAdjustedStudyCount = adjustedStudyCount(claim.studyIds, relations)
+    const duplicatePublicationCount = Math.max(0, claim.studyCount - registryAdjustedStudyCount)
+    const sameRegisteredTrialPublicationReuse = sameRegisteredTrialPairs.length > 0
+
+    claims.push({
+      url: claim.url,
+      claimId: claim.claimId,
+      predicate: claim.predicate,
+      confidence: claim.confidence,
+      apparentStudyCount: claim.studyCount,
+      registryKnownStudyCount,
+      registryAmbiguousStudyCount,
+      registryCoverage: round(claim.studyCount ? registryKnownStudyCount / claim.studyCount : 0),
+      registryAdjustedStudyCount,
+      duplicatePublicationCount,
+      sameRegisteredTrialPairs,
+      sameRegisteredTrialPublicationReuse,
+      highConfidenceSameTrialReuse: sameRegisteredTrialPublicationReuse && claim.confidence >= 0.75,
+    })
+  }
+
+  claims.sort((a, b) =>
+    Number(b.highConfidenceSameTrialReuse) - Number(a.highConfidenceSameTrialReuse)
+    || Number(b.sameRegisteredTrialPublicationReuse) - Number(a.sameRegisteredTrialPublicationReuse)
+    || b.duplicatePublicationCount - a.duplicatePublicationCount
+    || b.registryCoverage - a.registryCoverage
+    || b.confidence - a.confidence
+    || a.url.localeCompare(b.url)
+    || a.claimId.localeCompare(b.claimId),
+  )
+  const sameTrialReuseClaims = claims.filter((claim) => claim.sameRegisteredTrialPublicationReuse)
+  const highConfidenceSameTrialReuseClaims = claims.filter((claim) => claim.highConfidenceSameTrialReuse)
+
+  return {
+    claims,
+    sameTrialReuseClaims,
+    highConfidenceSameTrialReuseClaims,
+    summary: {
+      multiStudyApprovedClaims: claims.length,
+      claimsWithRegistryCoverage: claims.filter((claim) => claim.registryKnownStudyCount > 0).length,
+      claimsWithAmbiguousRegistryEvidence: claims.filter((claim) => claim.registryAmbiguousStudyCount > 0).length,
+      sameTrialReuseClaims: sameTrialReuseClaims.length,
+      highConfidenceSameTrialReuseClaims: highConfidenceSameTrialReuseClaims.length,
+      duplicatePublicationCount: sameTrialReuseClaims.reduce((sum, claim) => sum + claim.duplicatePublicationCount, 0),
+    },
+  }
+}


### PR DESCRIPTION
Latest-main replacement for superseded #3505. Bridges canonical research topology to the existing `detectStudyIndependence()` engine by resolving trial registry IDs from structured source/cache fields or the unified PubMed abstract cache. Publications auto-resolve only when exactly one registry ID is present; multi-registry papers remain ambiguous and are never collapsed. Approved multi-study claims report registry coverage, same-trial publication pairs, registry-adjusted study count, and duplicate-publication count. Includes focused parsing, same-trial, distinct-trial, ambiguous, and structured-field tests.