### PR TITLE
refactor(source): unify wave review with shared governance

### DIFF
--- a/scripts/report-source-wave-2-review.ts
+++ b/scripts/report-source-wave-2-review.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import Ajv2020 from 'ajv/dist/2020.js'
 import addFormats from 'ajv-formats'
+import { getSourceClassRule } from './lib/source-class-governance'
 
 type ReviewStatus =
   | 'draft_candidate'
@@ -119,60 +120,6 @@ const WAVE_TARGETS_PATH = process.env.ENRICHMENT_WAVE_TARGETS_PATH || path.join(
 const WAVE_CANDIDATES_PATH = process.env.ENRICHMENT_WAVE_CANDIDATES_PATH || path.join(ROOT, 'ops', 'reports', `source-${SAFE_WAVE_ID}-candidates.json`)
 const OUTPUT_JSON = process.env.ENRICHMENT_WAVE_SOURCE_REVIEW_JSON_PATH || path.join(ROOT, 'ops', 'reports', `source-${SAFE_WAVE_ID}-review.json`)
 const OUTPUT_MD = process.env.ENRICHMENT_WAVE_SOURCE_REVIEW_MD_PATH || path.join(ROOT, 'ops', 'reports', `source-${SAFE_WAVE_ID}-review.md`)
-
-const CLASS_RULES: Record<
-  string,
-  { evidenceClass: string; allowedTypes: Set<string>; pmidApplicable: boolean; preferredStudyDesigns: string[] }
-> = {
-  'randomized-human-trial': {
-    evidenceClass: 'human-clinical',
-    allowedTypes: new Set(['journal-article', 'clinical-trial-registry']),
-    pmidApplicable: true,
-    preferredStudyDesigns: ['randomized-controlled-trial'],
-  },
-  'non-randomized-human-study': {
-    evidenceClass: 'human-clinical',
-    allowedTypes: new Set(['journal-article']),
-    pmidApplicable: true,
-    preferredStudyDesigns: ['non-randomized-trial', 'cohort'],
-  },
-  'observational-human-evidence': {
-    evidenceClass: 'human-observational',
-    allowedTypes: new Set(['journal-article', 'systematic-review']),
-    pmidApplicable: true,
-    preferredStudyDesigns: ['cohort', 'case-control', 'cross-sectional'],
-  },
-  'systematic-review-meta-analysis': {
-    evidenceClass: 'human-clinical',
-    allowedTypes: new Set(['systematic-review', 'meta-analysis', 'journal-article']),
-    pmidApplicable: true,
-    preferredStudyDesigns: ['systematic-review', 'meta-analysis'],
-  },
-  'preclinical-mechanistic-study': {
-    evidenceClass: 'preclinical-mechanistic',
-    allowedTypes: new Set(['journal-article']),
-    pmidApplicable: true,
-    preferredStudyDesigns: ['in-vitro', 'in-vivo-animal'],
-  },
-  'traditional-use-monograph': {
-    evidenceClass: 'traditional-use',
-    allowedTypes: new Set(['monograph', 'book']),
-    pmidApplicable: false,
-    preferredStudyDesigns: ['narrative-monograph'],
-  },
-  'regulatory-agency-monograph-guidance': {
-    evidenceClass: 'regulatory-monograph',
-    allowedTypes: new Set(['regulatory-guidance', 'monograph']),
-    pmidApplicable: false,
-    preferredStudyDesigns: ['regulatory-guidance'],
-  },
-  'reference-database-authority': {
-    evidenceClass: 'regulatory-monograph',
-    allowedTypes: new Set(['reference-database']),
-    pmidApplicable: false,
-    preferredStudyDesigns: ['database-reference'],
-  },
-}
 
 function readJson<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T
@@ -292,7 +239,7 @@ function run() {
     const lowValueFlags: string[] = []
     const duplicateMatches: Array<{ sourceId: string; matchType: 'doi' | 'pmid' | 'canonicalUrl' }> = []
 
-    const classRule = CLASS_RULES[candidate.sourceClass]
+    const classRule = getSourceClassRule(candidate.sourceClass)
     if (!intakeTask) metadataIssues.push(`intakeTaskId=${candidate.intakeTaskId} not found in source-intake queue.`)
 
     if (!classRule) {
@@ -305,7 +252,7 @@ function run() {
       )
       pushIfMissing(
         metadataIssues,
-        classRule.allowedTypes.has(candidate.sourceType),
+        classRule.allowedSourceTypes.includes(candidate.sourceType),
         `sourceType=${candidate.sourceType} is not allowed for sourceClass=${candidate.sourceClass}.`,
       )
       if (!classRule.pmidApplicable && isNonEmpty(candidate.pmid)) {


### PR DESCRIPTION
Broad cleanup pass 39.

- removes the private source-class governance table from report-source-wave-2-review.ts
- migrates wave candidate review to getSourceClassRule() from the shared schema-backed governance loader
- keeps wave-specific duplicate detection, entity coverage accounting, promotion mutation, and unresolved-gap reporting local
- aligns ordinary candidate review, wave candidate review, and registry validation on one class/evidence/type/PMID/design contract

This removes another active governance fork from the source-acquisition pipeline.