### PR TITLE
refactor(source): derive source types from governance contract

### DIFF
--- a/scripts/lib/source-class-governance.ts
+++ b/scripts/lib/source-class-governance.ts
@@ -1,29 +1,24 @@
-import fs from 'node:fs'
+import sourceClassGovernanceData from '../../schemas/source-class-governance.json'
 
-export type SourceClassGovernanceRule = {
-  evidenceClass: string
-  allowedSourceTypes: string[]
-  pmidApplicable: boolean
-  preferredStudyDesigns: string[]
-}
+export type SourceClass = keyof typeof sourceClassGovernanceData
+export type SourceClassGovernanceRule = (typeof sourceClassGovernanceData)[SourceClass]
+export type EvidenceClass = SourceClassGovernanceRule['evidenceClass']
+export type SourceType = SourceClassGovernanceRule['allowedSourceTypes'][number]
+export type StudyDesign = SourceClassGovernanceRule['preferredStudyDesigns'][number]
 
-export type SourceClassGovernance = Record<string, SourceClassGovernanceRule>
+export const sourceClassGovernance = sourceClassGovernanceData
 
-const governanceUrl = new URL('../../schemas/source-class-governance.json', import.meta.url)
-
-export const sourceClassGovernance = JSON.parse(
-  fs.readFileSync(governanceUrl, 'utf8'),
-) as SourceClassGovernance
-
-export function sourceClassesForEvidenceClasses(evidenceClasses: Iterable<string>): Set<string> {
+export function sourceClassesForEvidenceClasses(evidenceClasses: Iterable<string>): Set<SourceClass> {
   const allowedEvidenceClasses = new Set(evidenceClasses)
   return new Set(
-    Object.entries(sourceClassGovernance)
+    (Object.entries(sourceClassGovernance) as Array<[SourceClass, SourceClassGovernanceRule]>)
       .filter(([, rule]) => allowedEvidenceClasses.has(rule.evidenceClass))
       .map(([sourceClass]) => sourceClass),
   )
 }
 
 export function getSourceClassRule(sourceClass: string): SourceClassGovernanceRule | null {
-  return sourceClassGovernance[sourceClass] ?? null
+  return sourceClass in sourceClassGovernance
+    ? sourceClassGovernance[sourceClass as SourceClass]
+    : null
 }


### PR DESCRIPTION
Broad cleanup pass 42.

- refactors scripts/lib/source-class-governance.ts to import the shared governance JSON directly
- derives SourceClass from the governance object keys
- derives EvidenceClass, SourceType, and StudyDesign from the same data
- removes filesystem parsing and broad string-based governance types
- keeps schemas/source-registry.schema.json authoritative through the existing schema↔governance parity gate

This establishes one compile-time/runtime source vocabulary for progressive migration of bootstrap, authoring, intake, and submission scripts.