### PR TITLE
refactor(nav): keep Goals inside the goals namespace

### DIFF
--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -14,7 +14,7 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     label: 'Goals',
     href: '/goals',
     description: 'Start with what you are researching, then follow the evidence to relevant options',
-    activePrefixes: ['/goals', '/guides/mental-health', '/guides/adhd'],
+    activePrefixes: ['/goals'],
     children: [
       { section: 'Start here', label: 'Goal finder', href: '/goals', description: 'Choose the outcome or question you are actually researching' },
       ...coreGoals.map((goal) => ({
@@ -23,8 +23,6 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
         href: goal.href.replace(/\/$/, ''),
         description: goal.description,
       })),
-      { section: 'Health goals', label: 'Mental Health', href: '/guides/mental-health', description: 'Conditions, treatment evidence, safety, and stigma-aware explainers' },
-      { section: 'Health goals', label: 'ADHD', href: '/guides/adhd', description: 'Attention, executive function, nutrients, and treatment context' },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Removes Mental Health and ADHD editorial guide links from the global Goals dropdown.
- Removes their special active-prefix exceptions.
- Keeps the Goals menu focused on the goal finder plus canonical `/goals/*` destinations.

## Why
The site architecture now clearly separates Goals (outcome/decision pages) from Guides (deeper editorial hubs). Mental Health and ADHD were the last `/guides/...` special cases leaking into the Goals namespace.

## Regression contract
- No routes are removed.
- Mental Health and ADHD remain available through the Evidence Library.
- Sleep, Stress, Anxiety, and Focus remain first-class global goal destinations.