### PR TITLE
feat(research): model non-registry evidence lineage

### DIFF
--- a/lib/research-evidence-lineage.ts
+++ b/lib/research-evidence-lineage.ts
@@ -1,0 +1,165 @@
+import { canonicalStudyGroups, canonicalStudyIdentityMap, type ResearchSource } from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type StudyLineage = {
+  url: string
+  studyId: string
+  lineageIds: string[]
+  explicitLineage: boolean
+}
+
+export type ClaimLineageAnalysis = {
+  url: string
+  claimId: string
+  confidence: number
+  studyCount: number
+  studiesWithExplicitLineage: number
+  explicitLineageCoverage: number
+  explicitLineageCount: number
+  repeatedExplicitLineages: string[]
+  sharedUnderlyingStudy: boolean
+  highConfidenceSharedUnderlyingStudy: boolean
+}
+
+export type EvidenceLineageAnalysis = {
+  studies: StudyLineage[]
+  claims: ClaimLineageAnalysis[]
+  sharedUnderlyingStudyClaims: ClaimLineageAnalysis[]
+  highConfidenceSharedUnderlyingStudyClaims: ClaimLineageAnalysis[]
+  summary: {
+    studies: number
+    studiesWithExplicitLineage: number
+    explicitStudyLineageCoverage: number
+    multiStudyApprovedClaims: number
+    sharedUnderlyingStudyClaims: number
+    highConfidenceSharedUnderlyingStudyClaims: number
+  }
+}
+
+const REGISTRY_KEYS = [
+  'trialRegistrationId', 'trialRegistryId', 'registrationId', 'registryId',
+  'clinicalTrialId', 'clinicalTrialsId', 'nctId', 'isrctnId', 'actrnId',
+] as const
+const COHORT_KEYS = ['cohortId', 'cohortIdentifier', 'studyCohortId'] as const
+const DATASET_KEYS = ['datasetId', 'dataSetId', 'datasetIdentifier'] as const
+const PARENT_KEYS = ['parentStudyId', 'studyGroupId', 'lineageId', 'underlyingStudyId'] as const
+
+function text(value: unknown): string {
+  return String(value ?? '').trim()
+}
+
+function normalizeIdentifier(value: unknown): string {
+  return text(value)
+    .replace(/^https?:\/\/(?:www\.)?clinicaltrials\.gov\/(?:study\/)?/i, '')
+    .replace(/^urn:/i, '')
+    .trim()
+    .toUpperCase()
+}
+
+function values(source: ResearchSource, keys: readonly string[]): string[] {
+  const out: string[] = []
+  for (const key of keys) {
+    const value = source[key]
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const normalized = normalizeIdentifier(item)
+        if (normalized) out.push(normalized)
+      }
+    } else {
+      const normalized = normalizeIdentifier(value)
+      if (normalized) out.push(normalized)
+    }
+  }
+  return out
+}
+
+export function explicitSourceLineageIds(source: ResearchSource): string[] {
+  return [...new Set([
+    ...values(source, REGISTRY_KEYS).map((id) => `registry:${id}`),
+    ...values(source, COHORT_KEYS).map((id) => `cohort:${id}`),
+    ...values(source, DATASET_KEYS).map((id) => `dataset:${id}`),
+    ...values(source, PARENT_KEYS).map((id) => `parent:${id}`),
+  ])].sort()
+}
+
+export function analyzeEvidenceLineage(analysis: ResearchQualityAnalysis): EvidenceLineageAnalysis {
+  const studies: StudyLineage[] = []
+  const claims: ClaimLineageAnalysis[] = []
+
+  for (const profile of analysis.profiles) {
+    const identities = canonicalStudyIdentityMap(profile.record)
+    const groups = canonicalStudyGroups(profile.record)
+    const lineagesByStudy = new Map<string, string[]>()
+
+    for (const [studyId, group] of groups) {
+      const lineageIds = [...new Set(group.flatMap(explicitSourceLineageIds))].sort()
+      lineagesByStudy.set(studyId, lineageIds)
+      studies.push({
+        url: profile.url,
+        studyId,
+        lineageIds,
+        explicitLineage: lineageIds.length > 0,
+      })
+    }
+
+    const rawClaims = Array.isArray(profile.record.claimMap) ? profile.record.claimMap : []
+    for (const claim of rawClaims) {
+      if (text(claim.reviewStatus).toLowerCase() !== 'approved') continue
+      const rawRefs = Array.isArray(claim.sourceRefIds) ? claim.sourceRefIds.map(text).filter(Boolean) : []
+      const studyIds = [...new Set(rawRefs.map((ref) => identities.get(ref)).filter((id): id is string => Boolean(id)))]
+      if (studyIds.length < 2) continue
+
+      const explicit = studyIds
+        .map((studyId) => ({ studyId, lineageIds: lineagesByStudy.get(studyId) ?? [] }))
+        .filter((item) => item.lineageIds.length > 0)
+      const lineageUse = new Map<string, Set<string>>()
+      for (const item of explicit) {
+        for (const lineageId of item.lineageIds) {
+          const studySet = lineageUse.get(lineageId) ?? new Set<string>()
+          studySet.add(item.studyId)
+          lineageUse.set(lineageId, studySet)
+        }
+      }
+      const repeatedExplicitLineages = [...lineageUse.entries()]
+        .filter(([, studySet]) => studySet.size >= 2)
+        .map(([lineageId]) => lineageId)
+        .sort()
+      const sharedUnderlyingStudy = repeatedExplicitLineages.length > 0
+      const confidence = Number(claim.confidence ?? 0)
+      const studiesWithExplicitLineage = explicit.length
+      const explicitLineageCount = new Set(explicit.flatMap((item) => item.lineageIds)).size
+
+      claims.push({
+        url: profile.url,
+        claimId: text(claim.id) || 'unknown-claim',
+        confidence,
+        studyCount: studyIds.length,
+        studiesWithExplicitLineage,
+        explicitLineageCoverage: studyIds.length ? studiesWithExplicitLineage / studyIds.length : 0,
+        explicitLineageCount,
+        repeatedExplicitLineages,
+        sharedUnderlyingStudy,
+        highConfidenceSharedUnderlyingStudy: sharedUnderlyingStudy && confidence >= 0.75,
+      })
+    }
+  }
+
+  const sharedUnderlyingStudyClaims = claims.filter((claim) => claim.sharedUnderlyingStudy)
+  const highConfidenceSharedUnderlyingStudyClaims = claims.filter((claim) => claim.highConfidenceSharedUnderlyingStudy)
+  const studiesWithExplicitLineage = studies.filter((study) => study.explicitLineage).length
+
+  return {
+    studies,
+    claims,
+    sharedUnderlyingStudyClaims,
+    highConfidenceSharedUnderlyingStudyClaims,
+    summary: {
+      studies: studies.length,
+      studiesWithExplicitLineage,
+      explicitStudyLineageCoverage: studies.length ? studiesWithExplicitLineage / studies.length : 1,
+      multiStudyApprovedClaims: claims.length,
+      sharedUnderlyingStudyClaims: sharedUnderlyingStudyClaims.length,
+      highConfidenceSharedUnderlyingStudyClaims: highConfidenceSharedUnderlyingStudyClaims.length,
+    },
+  }
+}

--- a/lib/research-evidence-lineage.ts
+++ b/lib/research-evidence-lineage.ts
@@ -1,59 +1,53 @@
-import { canonicalStudyGroups, canonicalStudyIdentityMap, type ResearchSource } from './research-coverage'
+import { canonicalStudyGroups, type ResearchSource } from './research-coverage'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 
-export type StudyLineage = {
+export type StudyEvidenceLineage = {
   url: string
   studyId: string
   lineageIds: string[]
   explicitLineage: boolean
 }
 
-export type ClaimLineageAnalysis = {
+export type ClaimEvidenceLineage = {
   url: string
   claimId: string
   confidence: number
   studyCount: number
   studiesWithExplicitLineage: number
   explicitLineageCoverage: number
-  explicitLineageCount: number
   repeatedExplicitLineages: string[]
-  sharedUnderlyingStudy: boolean
-  highConfidenceSharedUnderlyingStudy: boolean
+  sharedNonRegistryLineage: boolean
+  highConfidenceSharedNonRegistryLineage: boolean
 }
 
 export type EvidenceLineageAnalysis = {
-  studies: StudyLineage[]
-  claims: ClaimLineageAnalysis[]
-  sharedUnderlyingStudyClaims: ClaimLineageAnalysis[]
-  highConfidenceSharedUnderlyingStudyClaims: ClaimLineageAnalysis[]
+  studies: StudyEvidenceLineage[]
+  claims: ClaimEvidenceLineage[]
+  sharedNonRegistryLineageClaims: ClaimEvidenceLineage[]
+  highConfidenceSharedNonRegistryLineageClaims: ClaimEvidenceLineage[]
   summary: {
     studies: number
     studiesWithExplicitLineage: number
     explicitStudyLineageCoverage: number
     multiStudyApprovedClaims: number
-    sharedUnderlyingStudyClaims: number
-    highConfidenceSharedUnderlyingStudyClaims: number
+    sharedNonRegistryLineageClaims: number
+    highConfidenceSharedNonRegistryLineageClaims: number
   }
 }
 
-const REGISTRY_KEYS = [
-  'trialRegistrationId', 'trialRegistryId', 'registrationId', 'registryId',
-  'clinicalTrialId', 'clinicalTrialsId', 'nctId', 'isrctnId', 'actrnId',
-] as const
+// Clinical-trial registration is owned by research-trial-registration-independence.
+// This module covers explicit non-registry lineage that can still make separate
+// publications dependent: cohort, dataset, parent-study, or analysis-family IDs.
 const COHORT_KEYS = ['cohortId', 'cohortIdentifier', 'studyCohortId'] as const
-const DATASET_KEYS = ['datasetId', 'dataSetId', 'datasetIdentifier'] as const
-const PARENT_KEYS = ['parentStudyId', 'studyGroupId', 'lineageId', 'underlyingStudyId'] as const
+const DATASET_KEYS = ['datasetId', 'dataSetId', 'datasetIdentifier', 'dataSourceId'] as const
+const PARENT_KEYS = ['parentStudyId', 'studyGroupId', 'lineageId', 'underlyingStudyId', 'analysisFamilyId'] as const
 
 function text(value: unknown): string {
   return String(value ?? '').trim()
 }
 
 function normalizeIdentifier(value: unknown): string {
-  return text(value)
-    .replace(/^https?:\/\/(?:www\.)?clinicaltrials\.gov\/(?:study\/)?/i, '')
-    .replace(/^urn:/i, '')
-    .trim()
-    .toUpperCase()
+  return text(value).replace(/^urn:/i, '').trim().toUpperCase()
 }
 
 function values(source: ResearchSource, keys: readonly string[]): string[] {
@@ -73,9 +67,8 @@ function values(source: ResearchSource, keys: readonly string[]): string[] {
   return out
 }
 
-export function explicitSourceLineageIds(source: ResearchSource): string[] {
+export function explicitNonRegistryLineageIds(source: ResearchSource): string[] {
   return [...new Set([
-    ...values(source, REGISTRY_KEYS).map((id) => `registry:${id}`),
     ...values(source, COHORT_KEYS).map((id) => `cohort:${id}`),
     ...values(source, DATASET_KEYS).map((id) => `dataset:${id}`),
     ...values(source, PARENT_KEYS).map((id) => `parent:${id}`),
@@ -83,83 +76,70 @@ export function explicitSourceLineageIds(source: ResearchSource): string[] {
 }
 
 export function analyzeEvidenceLineage(analysis: ResearchQualityAnalysis): EvidenceLineageAnalysis {
-  const studies: StudyLineage[] = []
-  const claims: ClaimLineageAnalysis[] = []
+  const studies: StudyEvidenceLineage[] = []
+  const claims: ClaimEvidenceLineage[] = []
+  const lineagesByUrl = new Map<string, Map<string, string[]>>()
 
   for (const profile of analysis.profiles) {
-    const identities = canonicalStudyIdentityMap(profile.record)
-    const groups = canonicalStudyGroups(profile.record)
-    const lineagesByStudy = new Map<string, string[]>()
-
-    for (const [studyId, group] of groups) {
-      const lineageIds = [...new Set(group.flatMap(explicitSourceLineageIds))].sort()
-      lineagesByStudy.set(studyId, lineageIds)
-      studies.push({
-        url: profile.url,
-        studyId,
-        lineageIds,
-        explicitLineage: lineageIds.length > 0,
-      })
+    const byStudy = new Map<string, string[]>()
+    for (const [studyId, group] of canonicalStudyGroups(profile.record)) {
+      const lineageIds = [...new Set(group.flatMap(explicitNonRegistryLineageIds))].sort()
+      byStudy.set(studyId, lineageIds)
+      studies.push({ url: profile.url, studyId, lineageIds, explicitLineage: lineageIds.length > 0 })
     }
-
-    const rawClaims = Array.isArray(profile.record.claimMap) ? profile.record.claimMap : []
-    for (const claim of rawClaims) {
-      if (text(claim.reviewStatus).toLowerCase() !== 'approved') continue
-      const rawRefs = Array.isArray(claim.sourceRefIds) ? claim.sourceRefIds.map(text).filter(Boolean) : []
-      const studyIds = [...new Set(rawRefs.map((ref) => identities.get(ref)).filter((id): id is string => Boolean(id)))]
-      if (studyIds.length < 2) continue
-
-      const explicit = studyIds
-        .map((studyId) => ({ studyId, lineageIds: lineagesByStudy.get(studyId) ?? [] }))
-        .filter((item) => item.lineageIds.length > 0)
-      const lineageUse = new Map<string, Set<string>>()
-      for (const item of explicit) {
-        for (const lineageId of item.lineageIds) {
-          const studySet = lineageUse.get(lineageId) ?? new Set<string>()
-          studySet.add(item.studyId)
-          lineageUse.set(lineageId, studySet)
-        }
-      }
-      const repeatedExplicitLineages = [...lineageUse.entries()]
-        .filter(([, studySet]) => studySet.size >= 2)
-        .map(([lineageId]) => lineageId)
-        .sort()
-      const sharedUnderlyingStudy = repeatedExplicitLineages.length > 0
-      const confidence = Number(claim.confidence ?? 0)
-      const studiesWithExplicitLineage = explicit.length
-      const explicitLineageCount = new Set(explicit.flatMap((item) => item.lineageIds)).size
-
-      claims.push({
-        url: profile.url,
-        claimId: text(claim.id) || 'unknown-claim',
-        confidence,
-        studyCount: studyIds.length,
-        studiesWithExplicitLineage,
-        explicitLineageCoverage: studyIds.length ? studiesWithExplicitLineage / studyIds.length : 0,
-        explicitLineageCount,
-        repeatedExplicitLineages,
-        sharedUnderlyingStudy,
-        highConfidenceSharedUnderlyingStudy: sharedUnderlyingStudy && confidence >= 0.75,
-      })
-    }
+    lineagesByUrl.set(profile.url, byStudy)
   }
 
-  const sharedUnderlyingStudyClaims = claims.filter((claim) => claim.sharedUnderlyingStudy)
-  const highConfidenceSharedUnderlyingStudyClaims = claims.filter((claim) => claim.highConfidenceSharedUnderlyingStudy)
+  for (const claim of analysis.claimAnalyses) {
+    if (claim.studyCount < 2) continue
+    const byStudy = lineagesByUrl.get(claim.url) ?? new Map<string, string[]>()
+    const explicit = claim.studyIds
+      .map((studyId) => ({ studyId, lineageIds: byStudy.get(studyId) ?? [] }))
+      .filter((item) => item.lineageIds.length > 0)
+    const lineageUse = new Map<string, Set<string>>()
+    for (const item of explicit) {
+      for (const lineageId of item.lineageIds) {
+        const studiesForLineage = lineageUse.get(lineageId) ?? new Set<string>()
+        studiesForLineage.add(item.studyId)
+        lineageUse.set(lineageId, studiesForLineage)
+      }
+    }
+    const repeatedExplicitLineages = [...lineageUse.entries()]
+      .filter(([, studyIds]) => studyIds.size >= 2)
+      .map(([lineageId]) => lineageId)
+      .sort()
+    const sharedNonRegistryLineage = repeatedExplicitLineages.length > 0
+    const studiesWithExplicitLineage = explicit.length
+
+    claims.push({
+      url: claim.url,
+      claimId: claim.claimId,
+      confidence: claim.confidence,
+      studyCount: claim.studyCount,
+      studiesWithExplicitLineage,
+      explicitLineageCoverage: claim.studyCount ? studiesWithExplicitLineage / claim.studyCount : 0,
+      repeatedExplicitLineages,
+      sharedNonRegistryLineage,
+      highConfidenceSharedNonRegistryLineage: sharedNonRegistryLineage && claim.confidence >= 0.75,
+    })
+  }
+
+  const sharedNonRegistryLineageClaims = claims.filter((claim) => claim.sharedNonRegistryLineage)
+  const highConfidenceSharedNonRegistryLineageClaims = claims.filter((claim) => claim.highConfidenceSharedNonRegistryLineage)
   const studiesWithExplicitLineage = studies.filter((study) => study.explicitLineage).length
 
   return {
     studies,
     claims,
-    sharedUnderlyingStudyClaims,
-    highConfidenceSharedUnderlyingStudyClaims,
+    sharedNonRegistryLineageClaims,
+    highConfidenceSharedNonRegistryLineageClaims,
     summary: {
       studies: studies.length,
       studiesWithExplicitLineage,
       explicitStudyLineageCoverage: studies.length ? studiesWithExplicitLineage / studies.length : 1,
       multiStudyApprovedClaims: claims.length,
-      sharedUnderlyingStudyClaims: sharedUnderlyingStudyClaims.length,
-      highConfidenceSharedUnderlyingStudyClaims: highConfidenceSharedUnderlyingStudyClaims.length,
+      sharedNonRegistryLineageClaims: sharedNonRegistryLineageClaims.length,
+      highConfidenceSharedNonRegistryLineageClaims: highConfidenceSharedNonRegistryLineageClaims.length,
     },
   }
 }

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -5,6 +5,7 @@ import { analyzeClaimProvenanceIndependence } from './research-claim-provenance-
 import { analyzeCrossProfileEvidenceBundles } from './research-cross-profile-bundles'
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeResearchEdgeCardinality } from './research-edge-cardinality'
+import { analyzeEvidenceLineage } from './research-evidence-lineage'
 import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
 import { analyzeProvenanceConcentration } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
@@ -56,6 +57,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     (claim) => claim.highConfidenceProvenanceNarrowMultiStudySupport,
   )
   const trialRegistrationIndependence = analyzeTrialRegistrationIndependence(analysis)
+  const evidenceLineage = analyzeEvidenceLineage(analysis)
   const studyClassConflicts = analyzeStudyClassConflicts(analysis)
   const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
@@ -87,6 +89,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     provenanceNarrowMultiStudyClaims,
     highConfidenceProvenanceNarrowMultiStudyClaims,
     trialRegistrationIndependence,
+    evidenceLineage,
     studyClassConflicts,
     semanticAlignment,
     claimLanguageCalibration,


### PR DESCRIPTION
Adds explicit cohort/dataset/parent-study lineage analysis alongside the existing trial-registration independence analyzer. Multi-publication claims can now surface shared underlying non-registry provenance without guessing from author/year metadata. Missing lineage remains unknown, not contradictory.