### PR TITLE
refactor(nav): trim redundant active-prefix declarations

### DIFF
--- a/lib/primary-navigation.ts
+++ b/lib/primary-navigation.ts
@@ -14,7 +14,6 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     label: 'Goals',
     href: '/goals',
     description: 'Start with what you are researching, then follow the evidence to relevant options',
-    activePrefixes: ['/goals'],
     children: [
       { section: 'Start here', label: 'Goal finder', href: '/goals', description: 'Choose the outcome or question you are actually researching' },
       ...coreGoals.map((goal) => ({
@@ -40,7 +39,6 @@ export const primaryNavigation: PrimaryNavigationItem[] = [
     label: 'Compare',
     href: '/guides/compare',
     description: 'Compare options side by side by evidence, safety, form, dose, and practical tradeoffs',
-    activePrefixes: ['/guides/compare'],
     children: [
       { label: 'Comparison center', href: '/guides/compare', description: 'Browse published side-by-side evidence and safety comparisons' },
       { label: 'Build your own', href: '/guides/compare/dynamic', description: 'Choose two ingredients and inspect the structured research matrix' },


### PR DESCRIPTION
## Summary
- Removes explicit `activePrefixes` from Goals and Compare.
- Lets the navigation component use its existing fallback to each item's own `href`.
- Keeps explicit multi-namespace ownership only for Ingredients, Safety, and Research.

## Why
Goals and Compare each declared a one-item prefix list identical to their own href behavior. Those declarations added maintenance noise without adding information.

## Regression contract
- Active-state behavior is unchanged for Goals and Compare.
- Ingredients, Safety, and Research retain their broader active-prefix ownership.