### PR TITLE
Validate source integrity by canonical study identity

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -18,6 +18,7 @@ function fixtures() {
     }],
     profileAnalyses: [{ url: '/herbs/example' }],
     claimAnalyses: [{ url: '/herbs/example', claimId: 'claim-1' }],
+    structuredClaimAnalyses: [],
   } as unknown as ResearchQualityAnalysis
 
   const topology = {
@@ -25,6 +26,10 @@ function fixtures() {
       summary: { approvedClaims: 1 },
       findings: [],
       concentrationFindings: [],
+    },
+    edgeCardinality: {
+      summary: { claims: 0 },
+      duplicateEdgeClaims: [],
     },
     claimLanguageCalibration: { directEvidenceFindings: [] },
     claimCitationMetadata: { claims: [] },
@@ -50,7 +55,7 @@ function fixtures() {
   const sourceIntegrity = {
     summary: { citedStudies: 1, withdrawn: 0 },
     withdrawn: [],
-    studies: [{ pmid: '123', pageCount: 1, pages: ['/herbs/example'] }],
+    studies: [{ studyId: 'pmid:123', pmid: '123', doi: '', pageCount: 1, pages: ['/herbs/example'] }],
   } as unknown as ResearchSourceIntegrity
 
   return { analysis, topology, gate, queue, sourceIntegrity }
@@ -62,6 +67,25 @@ describe('research quality snapshot invariants', () => {
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(true)
     expect(report.summary.failures).toBe(0)
+  })
+
+  it('accepts DOI-only and profile-local fallback source identities', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    analysis.profiles[0].record.sources = [
+      { id: 'source-1', pmid: '123' },
+      { id: 'doi-only', doi: '10.1000/example' },
+      { id: 'fallback' },
+    ]
+    sourceIntegrity.studies = [
+      sourceIntegrity.studies[0],
+      { studyId: 'doi:10.1000/example', pmid: '', doi: '10.1000/example', pageCount: 1, pages: ['/herbs/example'] },
+      { studyId: '/herbs/example::source-ref:fallback', pmid: '', doi: '', pageCount: 1, pages: ['/herbs/example'] },
+    ] as typeof sourceIntegrity.studies
+    sourceIntegrity.summary.citedStudies = 3
+
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.passed).toBe(true)
+    expect(report.summary.sourceIntegrityFailures).toBe(0)
   })
 
   it('detects semantic approved-claim count drift', () => {
@@ -115,14 +139,14 @@ describe('research quality snapshot invariants', () => {
     expect(report.failures.map((failure) => failure.kind)).toContain('source-unknown-profile')
   })
 
-  it('detects duplicate source identities and page-count drift', () => {
+  it('detects duplicate canonical source identities and page-count drift', () => {
     const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
     sourceIntegrity.studies.push({ ...sourceIntegrity.studies[0] })
     sourceIntegrity.summary.citedStudies = 2
     sourceIntegrity.studies[0].pageCount = 2
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     const kinds = report.failures.map((failure) => failure.kind)
-    expect(kinds).toContain('source-duplicate-pmid')
+    expect(kinds).toContain('source-duplicate-study-id')
     expect(kinds).toContain('source-page-count-mismatch')
   })
 
@@ -139,13 +163,14 @@ describe('research quality snapshot invariants', () => {
     expect(kinds).toContain('missing-source-id')
   })
 
-  it('detects source-integrity studies that do not exist in raw profile sources', () => {
+  it('detects source-integrity studies that do not exist in canonical profile sources', () => {
     const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    sourceIntegrity.studies[0].studyId = 'pmid:999'
     sourceIntegrity.studies[0].pmid = '999'
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     const kinds = report.failures.map((failure) => failure.kind)
-    expect(kinds).toContain('source-unexpected-pmid')
-    expect(kinds).toContain('source-missing-pmid')
+    expect(kinds).toContain('source-unexpected-study-id')
+    expect(kinds).toContain('source-missing-study-id')
   })
 
   it('detects source-integrity ownership drift across profiles', () => {

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -1,3 +1,8 @@
+import {
+  canonicalStudyGroups,
+  crossProfileStudyIdentity,
+  crossProfileStudyIdentityMap,
+} from './research-coverage'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import type { ResearchQualityGate } from './research-quality-gate'
 import type { ResearchGapItem } from './research-quality-policy'
@@ -54,7 +59,8 @@ export function validateResearchQualitySnapshotInvariants(
   const failures: ResearchSnapshotInvariantFailure[] = []
   const profileUrls = new Set(analysis.profileAnalyses.map((profile) => profile.url))
   const approvedClaimKeys = new Set(analysis.claimAnalyses.map((claim) => claimKey(claim.url, claim.claimId)))
-  const citationPages = new Map<string, Set<string>>()
+  const canonicalStudyPages = new Map<string, Set<string>>()
+  const globalStudyIdentities = crossProfileStudyIdentityMap(analysis.profiles)
 
   const add = (kind: string, detail: string) => failures.push({ kind, detail })
   const requireProfile = (kind: string, url: string, detail: string) => {
@@ -82,8 +88,7 @@ export function validateResearchQualitySnapshotInvariants(
     const sources = Array.isArray(profile.record.sources) ? profile.record.sources : []
     const seenSources = new Set<string>()
     for (let index = 0; index < sources.length; index += 1) {
-      const source = sources[index]
-      const id = text(source?.id)
+      const id = text(sources[index]?.id)
       if (!id) {
         add('missing-source-id', `${profile.url} · sources[${index}]`)
       } else if (seenSources.has(id)) {
@@ -91,12 +96,13 @@ export function validateResearchQualitySnapshotInvariants(
       } else {
         seenSources.add(id)
       }
+    }
 
-      const pmid = text(source?.pmid ?? source?.pubmedId)
-      if (!pmid) continue
-      const pages = citationPages.get(pmid) ?? new Set<string>()
+    for (const [localStudyId] of canonicalStudyGroups(profile.record)) {
+      const studyId = crossProfileStudyIdentity(profile.url, localStudyId, globalStudyIdentities)
+      const pages = canonicalStudyPages.get(studyId) ?? new Set<string>()
       pages.add(profile.url)
-      citationPages.set(pmid, pages)
+      canonicalStudyPages.set(studyId, pages)
     }
   }
 
@@ -172,30 +178,30 @@ export function validateResearchQualitySnapshotInvariants(
       add('source-withdrawn-count-mismatch', `summary=${sourceIntegrity.summary.withdrawn}; rows=${sourceIntegrity.withdrawn.length}`)
     }
 
-    const seenPmids = new Set<string>()
+    const seenStudyIds = new Set<string>()
     for (const study of sourceIntegrity.studies) {
-      if (seenPmids.has(study.pmid)) add('source-duplicate-pmid', study.pmid)
-      else seenPmids.add(study.pmid)
+      if (seenStudyIds.has(study.studyId)) add('source-duplicate-study-id', study.studyId)
+      else seenStudyIds.add(study.studyId)
 
       const uniquePages = new Set(study.pages)
       if (study.pageCount !== uniquePages.size) {
-        add('source-page-count-mismatch', `${study.pmid}: pageCount=${study.pageCount}; pages=${uniquePages.size}`)
+        add('source-page-count-mismatch', `${study.studyId}: pageCount=${study.pageCount}; pages=${uniquePages.size}`)
       }
-      for (const url of uniquePages) requireProfile('source-unknown-profile', url, `PMID ${study.pmid}`)
+      for (const url of uniquePages) requireProfile('source-unknown-profile', url, study.studyId)
 
-      const expectedPages = citationPages.get(study.pmid)
+      const expectedPages = canonicalStudyPages.get(study.studyId)
       if (!expectedPages) {
-        add('source-unexpected-pmid', `PMID ${study.pmid} does not exist in canonical profile sources`)
+        add('source-unexpected-study-id', `${study.studyId} does not exist in canonical profile sources`)
       } else if (!sameStrings(uniquePages, expectedPages)) {
         add(
           'source-profile-ownership-mismatch',
-          `PMID ${study.pmid}: sourceIntegrity=${[...uniquePages].sort().join(',')}; analysis=${[...expectedPages].sort().join(',')}`,
+          `${study.studyId}: sourceIntegrity=${[...uniquePages].sort().join(',')}; analysis=${[...expectedPages].sort().join(',')}`,
         )
       }
     }
 
-    for (const pmid of citationPages.keys()) {
-      if (!seenPmids.has(pmid)) add('source-missing-pmid', `PMID ${pmid} missing from source integrity`)
+    for (const studyId of canonicalStudyPages.keys()) {
+      if (!seenStudyIds.has(studyId)) add('source-missing-study-id', `${studyId} missing from source integrity`)
     }
   }
 


### PR DESCRIPTION
Aligns research-quality snapshot invariants with the site-wide canonical study identity model introduced for source integrity. Replaces raw PMID ownership checks with canonical studyId/page checks, so DOI-only and fallback studies no longer trigger false duplicate/unexpected PMID failures. Updates invariant tests for canonical identities and the current edge-cardinality topology shape.