### PR TITLE
refactor(source): derive authoring source types from governance

### DIFF
--- a/scripts/report-enrichment-authoring-packs.ts
+++ b/scripts/report-enrichment-authoring-packs.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import type { EvidenceClass, SourceClass } from './lib/source-class-governance'
 
 type EntityType = 'herb' | 'compound' | 'surface'
 type TopicType =
@@ -39,23 +40,6 @@ type ClaimType =
   | 'research_gap'
   | 'relationship_signal'
   | 'origin_note'
-
-type SourceClass =
-  | 'randomized-human-trial'
-  | 'non-randomized-human-study'
-  | 'observational-human-evidence'
-  | 'systematic-review-meta-analysis'
-  | 'preclinical-mechanistic-study'
-  | 'traditional-use-monograph'
-  | 'regulatory-agency-monograph-guidance'
-  | 'reference-database-authority'
-
-type EvidenceClass =
-  | 'human-clinical'
-  | 'human-observational'
-  | 'preclinical-mechanistic'
-  | 'traditional-use'
-  | 'regulatory-monograph'
 
 type BootstrapPack = {
   bootstrapPackId: string


### PR DESCRIPTION
Broad cleanup pass 44.

- migrates enrichment authoring packs to shared SourceClass and EvidenceClass types
- removes local hard-coded source/evidence unions
- preserves authoring-specific framing restrictions, required entry fields, and review/handoff policy
- keeps bootstrap topic eligibility upstream instead of duplicating it in authoring

This tightens the live bootstrap→authoring contract while preserving clear stage ownership.