### PR TITLE
refactor(footer): derive popular goals from canonical taxonomy

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { Brain, Leaf, Newspaper, Search, Shapes } from 'lucide-react'
+import { coreGoals } from '../../lib/core-goals'
 import { Link } from '../lib/router-compat'
 import ConsentManager from './ConsentManager'
 import { onOpenConsent } from '../lib/consentBus'
@@ -19,11 +20,9 @@ const exploreLinks = [
 ]
 
 const priorityGoalLinks = [
+  ...coreGoals.map((goal) => ({ href: goal.href, label: goal.label })),
   { href: '/guides/mental-health/', label: 'Mental Health' },
-  { href: '/guides/sleep/', label: 'Sleep' },
   { href: '/guides/adhd/', label: 'ADHD' },
-  { href: '/guides/anxiety/', label: 'Anxiety' },
-  { href: '/guides/focus/', label: 'Focus & Cognition' },
   { href: '/guides/other/', label: 'More topics' },
 ]
 


### PR DESCRIPTION
## Summary
- Replaces hard-coded Sleep/Anxiety/Focus guide links in the footer with the shared `coreGoals` model.
- Restores Stress to the footer automatically through the canonical goal list.
- Keeps Mental Health, ADHD, and More topics as editorial guide destinations.

## Why
The footer was maintaining a stale copy of the core goal taxonomy, routing core goals back into `/guides/...` and omitting Stress. The header, start flow, and directory already use the canonical goal model.

## Regression contract
- No routes are removed.
- Mental Health and ADHD remain editorial topic links.
- Core goal destinations now stay aligned with `/goals/*`.