### PR TITLE
refactor(routes): remove stale public route aliases

### DIFF
--- a/src/lib/public-routes.ts
+++ b/src/lib/public-routes.ts
@@ -1,15 +1,10 @@
 export const PUBLIC_ROUTES = {
-  home: '/',
+  start: '/start/',
   library: '/library/',
   herbs: '/herbs/',
   compounds: '/compounds/',
-  goals: '/guides/',
-  build: '/build/',
-  blog: '/articles/',
-  researchNotes: '/articles/',
   articles: '/articles/',
   guides: '/guides/',
-  learning: '/learn/',
   about: '/info/about/',
   author: '/info/author/',
   faq: '/info/faq/',
@@ -17,8 +12,6 @@ export const PUBLIC_ROUTES = {
   privacy: '/info/privacy/',
   disclaimer: '/info/disclaimer/',
 } as const
-
-export type PublicRouteKey = keyof typeof PUBLIC_ROUTES
 
 export function herbDetailRoute(slug: string): string {
   return `${PUBLIC_ROUTES.herbs}${slug}/`


### PR DESCRIPTION
## Summary
- Removes unused `home`, `goals`, `build`, `blog`, `researchNotes`, and `learning` aliases from `PUBLIC_ROUTES`.
- Removes the unused `PublicRouteKey` export.
- Adds `/start/` as the canonical beginning route.

## Why
`PUBLIC_ROUTES` had become a stale compatibility map. In particular, `goals` still pointed to `/guides/`, contradicting the cleaned site architecture. Repository search shows only the footer and herb/compound detail helpers consume this module.

## Regression contract
- All currently consumed route constants remain.
- Herb and compound detail route helpers are unchanged.
- No public page is removed.