### PR TITLE
fix(research): isolate study years by profile

### DIFF
--- a/lib/__tests__/research-study-year-integrity.test.ts
+++ b/lib/__tests__/research-study-year-integrity.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+import {
+  analyzeClaimEvidenceAge,
+  analyzeStudyYearConflicts,
+  canonicalStudyYearObservations,
+} from '@/lib/research-evidence-age'
+
+const roots: string[] = []
+
+function root(): string {
+  const value = fs.mkdtempSync(path.join(os.tmpdir(), 'research-year-integrity-'))
+  roots.push(value)
+  fs.mkdirSync(path.join(value, 'public', 'data', 'herbs-detail'), { recursive: true })
+  fs.mkdirSync(path.join(value, 'ops', 'cache'), { recursive: true })
+  return value
+}
+
+function writeProfile(rootDir: string, slug: string, year: number, pmid?: string) {
+  fs.writeFileSync(path.join(rootDir, 'public', 'data', 'herbs-detail', `${slug}.json`), JSON.stringify({
+    slug,
+    sources: [{ id: 's1', year, ...(pmid ? { pmid } : {}), studyClass: 'rct', title: `${slug} randomized trial` }],
+    claimMap: [{
+      id: `${slug}-claim`,
+      predicate: 'supports_outcome',
+      claim: 'Improves sleep outcomes in adults.',
+      confidence: 0.8,
+      reviewStatus: 'approved',
+      sourceRefIds: ['s1'],
+    }],
+  }))
+}
+
+afterEach(() => {
+  for (const value of roots.splice(0)) fs.rmSync(value, { recursive: true, force: true })
+})
+
+describe('study publication-year ownership', () => {
+  it('keeps identifier-less fallback study years scoped to their profile', () => {
+    const rootDir = root()
+    writeProfile(rootDir, 'old-example', 2000)
+    writeProfile(rootDir, 'new-example', 2020)
+
+    const analysis = analyzeResearchQuality(rootDir)
+    const ages = analyzeClaimEvidenceAge(analysis, 2026)
+    const byUrl = new Map(ages.map((claim) => [claim.url, claim]))
+
+    expect(byUrl.get('/herbs/old-example/')?.newestYear).toBe(2000)
+    expect(byUrl.get('/herbs/new-example/')?.newestYear).toBe(2020)
+    expect(byUrl.get('/herbs/old-example/')?.allKnownEvidenceOlderThan15Years).toBe(true)
+    expect(byUrl.get('/herbs/new-example/')?.allKnownEvidenceOlderThan10Years).toBe(false)
+
+    const observations = canonicalStudyYearObservations(analysis)
+    expect(observations.size).toBe(2)
+  })
+
+  it('surfaces conflicting source and PubMed years instead of hiding the disagreement', () => {
+    const rootDir = root()
+    writeProfile(rootDir, 'conflicted-example', 2018, '12345')
+    fs.writeFileSync(path.join(rootDir, 'ops', 'cache', 'pubmed-metadata.json'), JSON.stringify({
+      records: { '12345': { year: 2020 } },
+    }))
+
+    const analysis = analyzeResearchQuality(rootDir)
+    const conflicts = analyzeStudyYearConflicts(analysis)
+
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]).toMatchObject({
+      url: '/herbs/conflicted-example/',
+      years: [2018, 2020],
+      minYear: 2018,
+      maxYear: 2020,
+      yearSpread: 2,
+    })
+
+    const [age] = analyzeClaimEvidenceAge(analysis, 2026)
+    expect(age.medianYear).toBe(2019)
+  })
+})

--- a/lib/research-evidence-age.ts
+++ b/lib/research-evidence-age.ts
@@ -47,6 +47,18 @@ export type EvidenceAgeSummary = {
   highConfidenceLegacyOnlyClaims: number
 }
 
+export type StudyYearObservation = {
+  url: string
+  studyId: string
+  years: number[]
+}
+
+export type StudyYearConflict = StudyYearObservation & {
+  minYear: number
+  maxYear: number
+  yearSpread: number
+}
+
 function numericYear(value: unknown): number | null {
   const year = Number(value)
   const currentYear = new Date().getFullYear()
@@ -70,30 +82,58 @@ function median(values: number[]): number | null {
   return sorted.length % 2 ? sorted[middle] : Math.round((sorted[middle - 1] + sorted[middle]) / 2)
 }
 
-/**
- * Build a canonical study -> publication year map from profile sources and the
- * PubMed metadata cache. Conflicting alias years are reduced by median rather
- * than silently choosing the oldest/newest value.
- */
-export function canonicalStudyYearMap(analysis: ResearchQualityAnalysis): Map<string, number> {
-  const observations = new Map<string, number[]>()
+function scopedStudyKey(url: string, studyId: string): string {
+  return `${url}::${studyId}`
+}
 
-  for (const { record } of analysis.profiles) {
+/**
+ * Preserve every observed publication year for each profile-local canonical
+ * study. The URL namespace matters for identifier-less fallback identities such
+ * as `source-ref:s1`, which may legitimately recur on unrelated profiles.
+ */
+export function canonicalStudyYearObservations(analysis: ResearchQualityAnalysis): Map<string, StudyYearObservation> {
+  const observations = new Map<string, StudyYearObservation>()
+
+  for (const { url, record } of analysis.profiles) {
     for (const [studyId, group] of canonicalStudyGroups(record)) {
-      const years = group.flatMap((source) => sourceYears(source, analysis.cache))
+      const years = [...new Set(group.flatMap((source) => sourceYears(source, analysis.cache)))].sort((a, b) => a - b)
       if (!years.length) continue
-      const existing = observations.get(studyId) ?? []
-      existing.push(...years)
-      observations.set(studyId, existing)
+      observations.set(scopedStudyKey(url, studyId), { url, studyId, years })
     }
   }
 
+  return observations
+}
+
+/**
+ * Build a profile-scoped canonical study -> publication year map. Conflicting
+ * alias years are reduced by median for age calculations, while the raw
+ * observations remain available through `canonicalStudyYearObservations()` so
+ * metadata conflicts are not silently lost.
+ */
+export function canonicalStudyYearMap(analysis: ResearchQualityAnalysis): Map<string, number> {
   const result = new Map<string, number>()
-  for (const [studyId, years] of observations) {
-    const value = median([...new Set(years)])
-    if (value !== null) result.set(studyId, value)
+  for (const [key, observation] of canonicalStudyYearObservations(analysis)) {
+    const value = median(observation.years)
+    if (value !== null) result.set(key, value)
   }
   return result
+}
+
+export function analyzeStudyYearConflicts(analysis: ResearchQualityAnalysis): StudyYearConflict[] {
+  return [...canonicalStudyYearObservations(analysis).values()]
+    .filter((observation) => observation.years.length > 1)
+    .map((observation) => {
+      const minYear = observation.years[0]
+      const maxYear = observation.years.at(-1) ?? minYear
+      return {
+        ...observation,
+        minYear,
+        maxYear,
+        yearSpread: maxYear - minYear,
+      }
+    })
+    .sort((a, b) => b.yearSpread - a.yearSpread || a.url.localeCompare(b.url) || a.studyId.localeCompare(b.studyId))
 }
 
 /**
@@ -117,7 +157,7 @@ export function analyzeClaimEvidenceAge(
     .map((claim) => {
       const datedStudies = claim.studyIds
         .map((studyId, index) => ({
-          year: studyYears.get(studyId),
+          year: studyYears.get(scopedStudyKey(claim.url, studyId)),
           design: claim.designs[index] ?? 'unclassified',
         }))
         .filter((item): item is { year: number; design: (typeof claim.designs)[number] } => typeof item.year === 'number')

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -7,7 +7,7 @@ import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
 import { analyzeResearchEdgeCardinality } from './research-edge-cardinality'
 import { analyzeEvidenceIndependenceCoverage } from './research-evidence-independence-coverage'
 import { analyzeEvidenceLineage } from './research-evidence-lineage'
-import { analyzeClaimEvidenceAge, summarizeEvidenceAge } from './research-evidence-age'
+import { analyzeClaimEvidenceAge, analyzeStudyYearConflicts, summarizeEvidenceAge } from './research-evidence-age'
 import { analyzeProvenanceConcentration } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
@@ -38,6 +38,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const crossPredicateEvidenceOverlap = claimEvidenceOverlap.filter((item) => item.differentPredicates)
   const claimEvidenceAge = analyzeClaimEvidenceAge(analysis)
   const evidenceAgeSummary = summarizeEvidenceAge(claimEvidenceAge)
+  const studyYearConflicts = analyzeStudyYearConflicts(analysis)
   const legacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.allKnownEvidenceOlderThan10Years)
   const highConfidenceLegacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.highConfidenceLegacyOnlyClaim)
   const studyIdentityCoverage = analyzeStudyIdentityCoverage(analysis)
@@ -80,6 +81,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     crossPredicateEvidenceOverlap,
     claimEvidenceAge,
     evidenceAgeSummary,
+    studyYearConflicts,
     legacyOnlyClaims,
     highConfidenceLegacyOnlyClaims,
     studyIdentityCoverage,


### PR DESCRIPTION
Fixes a freshness-integrity bug where identifier-less fallback study IDs such as `source-ref:s1` could collide across unrelated profiles inside the global publication-year map. Publication-year observations and lookups are now profile-scoped (`url::studyId`), preventing cross-profile year contamination. Also exposes conflicting source/PubMed year observations through canonical topology instead of silently hiding them behind the median fallback. Adds regressions for cross-profile fallback-ID isolation and explicit year-conflict detection.