### PR TITLE
fix(source): align intake source-gap sentinel type

### DIFF
--- a/scripts/report-source-intake-queue.ts
+++ b/scripts/report-source-intake-queue.ts
@@ -26,7 +26,7 @@ type SourceGapItem = {
   priorityLabel: PriorityLabel
   topicType: TopicType
   sourceGapType: SourceGapType
-  currentSourceClasses: SourceClass[]
+  currentSourceClasses: Array<SourceClass | 'none_registered_or_active'>
   recommendedSourceClasses: SourceClass[]
   safetyCritical: boolean
   publishBlocking: boolean


### PR DESCRIPTION
Broad cleanup pass 48.

- aligns source-intake's local SourceGapItem type with the source-gap producer
- models currentSourceClasses as SourceClass | none_registered_or_active
- preserves recommendedSourceClasses as strict governed SourceClass[]
- no runtime behavior changes

This closes the producer→consumer type mismatch introduced when the source-gap output was tightened to model its explicit empty-state sentinel honestly.