### PR TITLE
refactor(source): add shared source registry record contract

### DIFF
--- a/scripts/lib/source-registry-record.ts
+++ b/scripts/lib/source-registry-record.ts
@@ -1,0 +1,46 @@
+import type {
+  EvidenceClass,
+  SourceClass,
+  SourceType as GovernedSourceType,
+  StudyDesign as GovernedStudyDesign,
+} from './source-class-governance'
+
+export type SourceRegistrySourceType = GovernedSourceType | 'other'
+export type SourceRegistryStudyDesign = GovernedStudyDesign | 'other'
+export type SourcePublicationStatus = 'published' | 'preprint' | 'withdrawn' | 'superseded' | 'archived'
+export type SourceReliabilityTier = 'tier-a' | 'tier-b' | 'tier-c' | 'tier-d'
+
+/**
+ * Script-side representation of one persisted source-registry row.
+ * Runtime validity remains authoritative in schemas/source-registry.schema.json
+ * plus validate-source-registry.mjs; this type exists to keep active TypeScript
+ * consumers from redeclaring incompatible projections of the same record.
+ */
+export type SourceRegistryRecord = {
+  sourceId: string
+  title: string
+  shortTitle?: string
+  sourceType: SourceRegistrySourceType
+  sourceClass: SourceClass
+  organization?: string
+  authors?: string[]
+  publicationYear?: number
+  citationText?: string
+  doi?: string
+  pmid?: string
+  monographId?: string
+  isbn?: string
+  canonicalUrl?: string
+  accessDate?: string
+  language: string
+  jurisdiction?: string
+  region?: string
+  evidenceClass: EvidenceClass
+  studyDesign?: SourceRegistryStudyDesign
+  publicationStatus: SourcePublicationStatus
+  reliabilityTier: SourceReliabilityTier
+  reviewer: string
+  reviewedAt: string
+  notes?: string
+  active: boolean
+}


### PR DESCRIPTION
Broad cleanup pass 49.

- adds scripts/lib/source-registry-record.ts as the shared TypeScript shape for persisted source-registry rows
- reuses governed SourceClass/EvidenceClass vocabulary
- explicitly preserves schema-level sourceType/studyDesign `other` values, which are broader than class-specific governed preferred values
- keeps schemas/source-registry.schema.json + validate-source-registry.mjs as runtime authority

This establishes a compile-time migration target for the many active scripts that currently redeclare SourceRegistryRow independently.