### PR TITLE
refactor(research): centralize metadata integrity rollup

### DIFF
--- a/lib/__tests__/research-metadata-integrity.test.ts
+++ b/lib/__tests__/research-metadata-integrity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildResearchMetadataIntegrity } from '@/lib/research-metadata-integrity'
+
+describe('research metadata integrity rollup', () => {
+  it('groups specialized metadata findings once per profile without redefining detection', () => {
+    const inputs = {
+      studyYearConflicts: [
+        { url: '/herbs/a/', studyId: 'study-a', years: [2018, 2020], minYear: 2018, maxYear: 2020, yearSpread: 2 },
+      ],
+      provenanceConflicts: [
+        {
+          url: '/herbs/a/',
+          studyId: 'study-a',
+          firstAuthorCandidates: ['alpha', 'beta'],
+          journalCandidates: [],
+          firstAuthorConflict: true,
+          journalConflict: false,
+        },
+      ],
+      studyClassConflicts: {
+        conflicts: [
+          { url: '/herbs/a/', studyId: 'study-a', sourceIds: ['s1', 's2'], classes: ['rct', 'animal'], families: ['primary-human', 'preclinical'], severe: true },
+          { url: '/herbs/b/', studyId: 'study-b', sourceIds: ['s1', 's2'], classes: ['rct', 'controlled-trial'], families: ['primary-human'], severe: false },
+        ],
+        severeConflicts: [
+          { url: '/herbs/a/', studyId: 'study-a', sourceIds: ['s1', 's2'], classes: ['rct', 'animal'], families: ['primary-human', 'preclinical'], severe: true },
+        ],
+        summary: { canonicalStudiesChecked: 2, studiesWithClassConflict: 2, severeClassConflicts: 1 },
+      },
+      claimCitationMetadata: {
+        claims: [],
+        lowCoverageClaims: [
+          { url: '/herbs/a/', claimId: 'a', predicate: 'supports_outcome', confidence: 0.9, studyCount: 2, completeStudyCount: 0, metadataCoverage: 0, fieldMetadataCoverage: 0.5, missingFieldCounts: {}, lowMetadataCoverage: true, highConfidenceLowMetadataCoverage: true },
+          { url: '/herbs/b/', claimId: 'b', predicate: 'supports_outcome', confidence: 0.5, studyCount: 2, completeStudyCount: 0, metadataCoverage: 0, fieldMetadataCoverage: 0.5, missingFieldCounts: {}, lowMetadataCoverage: true, highConfidenceLowMetadataCoverage: false },
+        ],
+        highConfidenceLowCoverageClaims: [
+          { url: '/herbs/a/', claimId: 'a', predicate: 'supports_outcome', confidence: 0.9, studyCount: 2, completeStudyCount: 0, metadataCoverage: 0, fieldMetadataCoverage: 0.5, missingFieldCounts: {}, lowMetadataCoverage: true, highConfidenceLowMetadataCoverage: true },
+        ],
+        summary: {
+          approvedClaimsWithStudies: 2,
+          lowMetadataCoverageClaims: 2,
+          highConfidenceLowMetadataCoverageClaims: 1,
+          averageMetadataCoverage: 0,
+          averageFieldMetadataCoverage: 0.5,
+        },
+      },
+    } as Parameters<typeof buildResearchMetadataIntegrity>[0]
+
+    const result = buildResearchMetadataIntegrity(inputs)
+
+    expect(result.profiles[0]).toMatchObject({
+      url: '/herbs/a/',
+      yearConflicts: 1,
+      provenanceConflicts: 1,
+      studyClassConflicts: 1,
+      severeStudyClassConflicts: 1,
+      lowCitationMetadataClaims: 1,
+      highConfidenceLowCitationMetadataClaims: 1,
+      issueCount: 4,
+      severeIssueCount: 2,
+    })
+    expect(result.profiles[1]).toMatchObject({
+      url: '/herbs/b/',
+      issueCount: 2,
+      severeIssueCount: 0,
+    })
+    expect(result.summary).toMatchObject({
+      profilesWithIssues: 2,
+      profilesWithSevereIssues: 1,
+      yearConflicts: 1,
+      provenanceConflicts: 1,
+      studyClassConflicts: 2,
+      severeStudyClassConflicts: 1,
+      lowCitationMetadataClaims: 2,
+      highConfidenceLowCitationMetadataClaims: 1,
+    })
+  })
+})

--- a/lib/research-metadata-integrity.ts
+++ b/lib/research-metadata-integrity.ts
@@ -1,0 +1,107 @@
+import type { ClaimCitationMetadataAnalysis } from './research-claim-citation-metadata'
+import type { StudyYearConflict } from './research-evidence-age'
+import type { StudyProvenanceConflict } from './research-provenance-concentration'
+import type { StudyClassConflictAnalysis } from './research-study-class-conflicts'
+
+export type ResearchMetadataIntegrityProfile = {
+  url: string
+  yearConflicts: number
+  provenanceConflicts: number
+  studyClassConflicts: number
+  severeStudyClassConflicts: number
+  lowCitationMetadataClaims: number
+  highConfidenceLowCitationMetadataClaims: number
+  issueCount: number
+  severeIssueCount: number
+}
+
+export type ResearchMetadataIntegrity = {
+  profiles: ResearchMetadataIntegrityProfile[]
+  summary: {
+    profilesWithIssues: number
+    profilesWithSevereIssues: number
+    yearConflicts: number
+    provenanceConflicts: number
+    studyClassConflicts: number
+    severeStudyClassConflicts: number
+    lowCitationMetadataClaims: number
+    highConfidenceLowCitationMetadataClaims: number
+  }
+}
+
+type MetadataIntegrityInputs = {
+  studyYearConflicts: readonly StudyYearConflict[]
+  provenanceConflicts: readonly StudyProvenanceConflict[]
+  studyClassConflicts: StudyClassConflictAnalysis
+  claimCitationMetadata: ClaimCitationMetadataAnalysis
+}
+
+type MutableProfile = Omit<ResearchMetadataIntegrityProfile, 'issueCount' | 'severeIssueCount'>
+
+function emptyProfile(url: string): MutableProfile {
+  return {
+    url,
+    yearConflicts: 0,
+    provenanceConflicts: 0,
+    studyClassConflicts: 0,
+    severeStudyClassConflicts: 0,
+    lowCitationMetadataClaims: 0,
+    highConfidenceLowCitationMetadataClaims: 0,
+  }
+}
+
+/**
+ * Canonical roll-up for metadata-integrity findings. Specialized analyzers own
+ * detection; this layer only groups their outputs by profile so reporting and
+ * remediation consumers do not rebuild overlapping metadata summaries.
+ */
+export function buildResearchMetadataIntegrity(inputs: MetadataIntegrityInputs): ResearchMetadataIntegrity {
+  const byUrl = new Map<string, MutableProfile>()
+  const profile = (url: string) => {
+    const value = byUrl.get(url) ?? emptyProfile(url)
+    byUrl.set(url, value)
+    return value
+  }
+
+  for (const conflict of inputs.studyYearConflicts) profile(conflict.url).yearConflicts += 1
+  for (const conflict of inputs.provenanceConflicts) profile(conflict.url).provenanceConflicts += 1
+  for (const conflict of inputs.studyClassConflicts.conflicts) {
+    const value = profile(conflict.url)
+    value.studyClassConflicts += 1
+    if (conflict.severe) value.severeStudyClassConflicts += 1
+  }
+  for (const claim of inputs.claimCitationMetadata.lowCoverageClaims) profile(claim.url).lowCitationMetadataClaims += 1
+  for (const claim of inputs.claimCitationMetadata.highConfidenceLowCoverageClaims) {
+    profile(claim.url).highConfidenceLowCitationMetadataClaims += 1
+  }
+
+  const profiles = [...byUrl.values()]
+    .map((value): ResearchMetadataIntegrityProfile => {
+      const issueCount = value.yearConflicts
+        + value.provenanceConflicts
+        + value.studyClassConflicts
+        + value.lowCitationMetadataClaims
+      const severeIssueCount = value.severeStudyClassConflicts + value.highConfidenceLowCitationMetadataClaims
+      return { ...value, issueCount, severeIssueCount }
+    })
+    .filter((value) => value.issueCount > 0)
+    .sort((a, b) =>
+      b.severeIssueCount - a.severeIssueCount
+      || b.issueCount - a.issueCount
+      || a.url.localeCompare(b.url),
+    )
+
+  return {
+    profiles,
+    summary: {
+      profilesWithIssues: profiles.length,
+      profilesWithSevereIssues: profiles.filter((value) => value.severeIssueCount > 0).length,
+      yearConflicts: inputs.studyYearConflicts.length,
+      provenanceConflicts: inputs.provenanceConflicts.length,
+      studyClassConflicts: inputs.studyClassConflicts.conflicts.length,
+      severeStudyClassConflicts: inputs.studyClassConflicts.severeConflicts.length,
+      lowCitationMetadataClaims: inputs.claimCitationMetadata.lowCoverageClaims.length,
+      highConfidenceLowCitationMetadataClaims: inputs.claimCitationMetadata.highConfidenceLowCoverageClaims.length,
+    },
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -8,6 +8,7 @@ import { analyzeResearchEdgeCardinality } from './research-edge-cardinality'
 import { analyzeEvidenceIndependenceCoverage } from './research-evidence-independence-coverage'
 import { analyzeEvidenceLineage } from './research-evidence-lineage'
 import { analyzeClaimEvidenceAge, analyzeStudyYearConflicts, summarizeEvidenceAge } from './research-evidence-age'
+import { buildResearchMetadataIntegrity } from './research-metadata-integrity'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
@@ -69,6 +70,12 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
+  const metadataIntegrity = buildResearchMetadataIntegrity({
+    studyYearConflicts,
+    provenanceConflicts,
+    studyClassConflicts,
+    claimCitationMetadata,
+  })
   const edgeCardinality = analyzeResearchEdgeCardinality(analysis)
 
   return {
@@ -104,6 +111,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     semanticAlignment,
     claimLanguageCalibration,
     claimCitationMetadata,
+    metadataIntegrity,
     edgeCardinality,
   }
 }


### PR DESCRIPTION
Adds one canonical profile-level metadata-integrity rollup over the existing specialist analyzers for publication-year conflicts, provenance alias conflicts, study-class conflicts, and claim citation-metadata gaps. Detection rules remain owned by their existing modules; the rollup only groups their outputs so snapshot/reporting consumers do not rebuild overlapping metadata summaries. Canonical topology now exposes `metadataIntegrity`. Includes a focused contract test for issue/severity aggregation.