### PR TITLE
feat(research): expose independence coverage in canonical rollup

### DIFF
--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -76,6 +76,7 @@ const {
   highConfidenceProvenanceNarrowMultiStudyClaims,
   trialRegistrationIndependence,
   evidenceLineage,
+  evidenceIndependenceCoverage,
   studyClassConflicts,
   crossProfileEvidenceBundles,
   narrowCrossProfileEvidenceBundles,
@@ -118,6 +119,7 @@ results.push({
     `pseudoMultiSource=${edgeCardinality.summary.pseudoMultiSourceClaims}`,
     `sameTrialReuse=${trialRegistrationIndependence.summary.sameTrialReuseClaims}`,
     `sharedLineage=${evidenceLineage.summary.sharedNonRegistryLineageClaims}`,
+    `independenceUnresolved=${evidenceIndependenceCoverage.summary.unresolvedClaims}`,
   ].join('; '),
   stderrTail: [
     gate.summary.structuralFailures ? `${gate.summary.structuralFailures} invalid evidence edge(s)` : '',
@@ -182,6 +184,7 @@ const coreSummary = {
   edgeCardinality: edgeCardinality.summary,
   trialRegistrationIndependence: trialRegistrationIndependence.summary,
   evidenceLineage: evidenceLineage.summary,
+  evidenceIndependenceCoverage: evidenceIndependenceCoverage.summary,
   weakApprovedOutcomeClaims: weakApprovedOutcomes.length,
   unsupportedUnapprovedStructuredClaims: unsupportedUnapprovedClaims.length,
   weakUnapprovedOutcomeClaims: weakUnapprovedOutcomes.length,
@@ -216,7 +219,7 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 23,
+  schemaVersion: 24,
   generatedAt: new Date().toISOString(),
   passed: !failed,
   source: {
@@ -228,6 +231,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     edgeCardinality: 'lib/research-edge-cardinality.ts',
     trialRegistrationIndependence: 'lib/research-trial-registration-independence.ts',
     evidenceLineage: 'lib/research-evidence-lineage.ts',
+    evidenceIndependenceCoverage: 'lib/research-evidence-independence-coverage.ts',
   },
   coreSummary,
   structuralFailures: gate.structuralFailures,
@@ -271,6 +275,11 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     sharedNonRegistryLineageClaims: evidenceLineage.sharedNonRegistryLineageClaims.slice(0, 150),
     highConfidenceSharedNonRegistryLineageClaims: evidenceLineage.highConfidenceSharedNonRegistryLineageClaims.slice(0, 100),
   },
+  evidenceIndependenceCoverage: {
+    summary: evidenceIndependenceCoverage.summary,
+    unresolvedClaims: evidenceIndependenceCoverage.unresolvedClaims.slice(0, 150),
+    highConfidenceUnresolvedClaims: evidenceIndependenceCoverage.highConfidenceUnresolvedClaims.slice(0, 100),
+  },
   withdrawnCitedStudies: sourceIntegrity.withdrawn,
   evidenceGradeInvalid: evidenceGradeConsistency.invalid,
   evidenceGradeContradictions: evidenceGradeConsistency.contradictions.slice(0, 100),
@@ -303,6 +312,7 @@ console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explic
 console.log(`Language calibration: ${languageCalibration.summary.causalWithoutControlledSupport} unsupported direct-causal claim(s)`)
 console.log(`Edge cardinality: ${edgeCardinality.summary.pseudoMultiSourceClaims} pseudo-multi-source · ${edgeCardinality.summary.aliasCollapsedClaims} alias-collapsed · ${edgeCardinality.summary.duplicateEdges} duplicate edge(s)`)
 console.log(`Underlying-study reuse: ${trialRegistrationIndependence.summary.sameTrialReuseClaims} same-trial claim(s) · ${evidenceLineage.summary.sharedNonRegistryLineageClaims} shared lineage claim(s)`)
+console.log(`Independence coverage: ${evidenceIndependenceCoverage.summary.unresolvedClaims} unresolved multi-study claim(s) · ${evidenceIndependenceCoverage.summary.highConfidenceUnresolvedClaims} high-confidence · ${Math.round(evidenceIndependenceCoverage.summary.meanCombinedCoverage * 100)}% mean explicit coverage`)
 console.log(`Gap queue: ${researchGapQueue.length} profile(s) prioritized`)
 console.log(`Semantic report: ${path.relative(ROOT, semanticReportPath)}`)
 console.log(`Citation report: ${path.relative(ROOT, citationReportPath)}`)


### PR DESCRIPTION
Adds evidence-independence coverage to the canonical research-quality JSON rollup and CLI summary, including unresolved and high-confidence unresolved multi-study claims. Advances the report schema and records the canonical coverage module as a source.