### PR TITLE
feat(research): enrich semantic coverage from canonical PubMed context

### DIFF
--- a/lib/__tests__/research-semantic-coverage.test.ts
+++ b/lib/__tests__/research-semantic-coverage.test.ts
@@ -7,7 +7,12 @@ import { describe, expect, it } from 'vitest'
 import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from '@/lib/research-semantic-alignment'
 
-function runWithSources(sources: Array<Record<string, unknown>>, confidence = 0.8) {
+function runWithSources(
+  sources: Array<Record<string, unknown>>,
+  confidence = 0.8,
+  abstracts: Record<string, string> = {},
+  claim = 'Improves sleep symptoms in adults',
+) {
   const root = mkdtempSync(path.join(tmpdir(), 'semantic-coverage-'))
   const dir = path.join(root, 'public', 'data', 'herbs-detail')
   mkdirSync(dir, { recursive: true })
@@ -16,13 +21,18 @@ function runWithSources(sources: Array<Record<string, unknown>>, confidence = 0.
     sources,
     claimMap: [{
       id: 'sleep-outcome',
-      claim: 'Improves sleep symptoms in adults',
+      claim,
       predicate: 'supports_outcome',
       confidence,
       reviewStatus: 'approved',
       sourceRefIds: sources.map((source) => source.id),
     }],
   }))
+  if (Object.keys(abstracts).length) {
+    const cacheDir = path.join(root, 'ops', 'cache')
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(path.join(cacheDir, 'pubmed-abstracts.json'), JSON.stringify({ abstracts }))
+  }
   return { root, report: analyzeResearchSemanticAlignment(analyzeResearchQuality(root)) }
 }
 
@@ -76,6 +86,37 @@ describe('research semantic metadata coverage', () => {
       expect(report.summary.semanticCoverageGapClaims).toBe(0)
       expect(report.summary.fullySemanticallyAssessableClaims).toBe(1)
       expect(report.coverageGapFindings).toHaveLength(0)
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('uses cached abstracts for domain/population context without letting incidental safety text change study role', () => {
+    const { root, report } = runWithSources(
+      [
+        { id: 's1', pmid: '11111111', studyClass: 'rct', title: 'Randomized placebo-controlled trial' },
+        { id: 's2', pmid: '22222222', studyClass: 'rct', title: 'Double-blind clinical trial' },
+      ],
+      0.9,
+      {
+        '11111111': 'Older adults with insomnia were randomized. Sleep outcomes improved. Adverse events were monitored.',
+        '22222222': 'Elderly participants with insomnia completed a placebo-controlled sleep study. Safety and tolerability were also assessed.',
+      },
+      'Improves sleep symptoms in older adults',
+    )
+    try {
+      expect(report.summary).toMatchObject({
+        semanticallyComparableClaims: 1,
+        fullySemanticallyAssessableClaims: 1,
+        semanticCoverageGapClaims: 0,
+        anyMismatch: 0,
+      })
+      expect(report.coverageGapFindings).toHaveLength(0)
+      const finding = report.concentrationFindings[0] ?? report.findings[0]
+      expect(finding).toBeUndefined()
+
+      // Re-run from the report's internally analyzed claim via summary-facing
+      // behavior: both sources were assessable/aligned despite sparse titles.
+      expect(report.summary.semanticSingleSourceClaims).toBe(0)
+      expect(report.summary.semanticSupportConcentratedClaims).toBe(0)
     } finally { rmSync(root, { recursive: true, force: true }) }
   })
 })

--- a/lib/research-semantic-alignment.ts
+++ b/lib/research-semantic-alignment.ts
@@ -5,6 +5,7 @@ import {
   approvedClaims,
   sourceMap,
   uniqueSourceRefs,
+  type PubmedCache,
   type ResearchClaim,
   type ResearchProfileEntry,
 } from './research-coverage'
@@ -123,8 +124,34 @@ function intersects(a: string[], b: string[]): boolean {
   return a.some((value) => right.has(value))
 }
 
-function sourceText(source: Record<string, unknown>): string {
-  return [source.title, source.studyType, source.studyClass].map(text).filter(Boolean).join(' · ')
+function cachedSource(source: Record<string, unknown>, cache: PubmedCache): Record<string, unknown> {
+  const pmid = text(source.pmid ?? source.pubmedId)
+  return pmid ? (cache[pmid] ?? {}) : {}
+}
+
+/**
+ * Keep role classification anchored to concise bibliographic descriptors. Full
+ * abstracts often mention adverse events or mechanisms incidentally and should
+ * not turn an efficacy trial into a safety/mechanism source.
+ */
+function sourceRoleText(source: Record<string, unknown>, cache: PubmedCache): string {
+  const cached = cachedSource(source, cache)
+  return [source.title, cached.title, source.studyType, source.studyClass]
+    .map(text)
+    .filter(Boolean)
+    .join(' · ')
+}
+
+/**
+ * Domain/population comparability benefits from the richer canonical PubMed
+ * context. Abstracts are descriptive context only; they do not determine role.
+ */
+function sourceSemanticText(source: Record<string, unknown>, cache: PubmedCache): string {
+  const cached = cachedSource(source, cache)
+  return [source.title, cached.title, cached.abstract, source.studyType, source.studyClass]
+    .map(text)
+    .filter(Boolean)
+    .join(' · ')
 }
 
 function detectRole(value: string): EvidenceRole {
@@ -201,7 +228,12 @@ function classifySourceAlignment(
   return 'uncertain'
 }
 
-function analyzeClaim(url: string, claim: ResearchClaim, record: ResearchProfileEntry['record']): SemanticAlignmentFinding | null {
+function analyzeClaim(
+  url: string,
+  claim: ResearchClaim,
+  record: ResearchProfileEntry['record'],
+  cache: PubmedCache,
+): SemanticAlignmentFinding | null {
   const sourcesById = sourceMap(record)
   const refs = uniqueSourceRefs(claim)
   const sources = refs.map((ref) => sourcesById.get(ref)).filter(Boolean) as Array<Record<string, unknown>>
@@ -209,12 +241,13 @@ function analyzeClaim(url: string, claim: ResearchClaim, record: ResearchProfile
 
   const claimText = text(claim.claim)
   const role = claimRole(claim)
-  const sourceTexts = sources.map(sourceText)
-  const sourceRoles = sourceTexts.map(detectRole)
+  const sourceRoleTexts = sources.map((source) => sourceRoleText(source, cache))
+  const sourceSemanticTexts = sources.map((source) => sourceSemanticText(source, cache))
+  const sourceRoles = sourceRoleTexts.map(detectRole)
   const claimDomains = detectTags(claimText, DOMAIN_PATTERNS)
-  const sourceDomains = sourceTexts.map((value) => detectTags(value, DOMAIN_PATTERNS))
+  const sourceDomains = sourceSemanticTexts.map((value) => detectTags(value, DOMAIN_PATTERNS))
   const claimPopulations = detectTags(claimText, POPULATION_PATTERNS)
-  const sourcePopulations = sourceTexts.map((value) => detectTags(value, POPULATION_PATTERNS))
+  const sourcePopulations = sourceSemanticTexts.map((value) => detectTags(value, POPULATION_PATTERNS))
 
   const roleMismatch =
     role !== 'unknown' &&
@@ -289,7 +322,7 @@ export function analyzeResearchSemanticAlignment(analysis: ResearchQualityAnalys
     const claims = approvedClaims(record)
     approvedClaimCount += claims.length
     for (const claim of claims) {
-      const finding = analyzeClaim(url, claim, record)
+      const finding = analyzeClaim(url, claim, record, analysis.cache)
       if (!finding) continue
       analyzedFindings.push(finding)
       if (finding.roleMismatch || finding.domainMismatch || finding.populationMismatch) findings.push(finding)


### PR DESCRIPTION
Improves semantic alignment coverage by consuming the unified PubMed cache already owned by the canonical research analysis. Cached titles and abstracts now enrich source domain/population tagging, reducing false semantic uncertainty for sparse source rows. Study-role classification remains intentionally anchored to concise title/type/class descriptors (including cached title), so incidental adverse-event/mechanism language in abstracts cannot turn an efficacy trial into safety/mechanism evidence. Includes regression coverage showing abstract-derived insomnia/older-adult context closes a coverage gap without creating a false role mismatch.