### PR TITLE
refactor(qa): align contrast audit with current IA

### DIFF
--- a/scripts/dev/contrast-audit.mjs
+++ b/scripts/dev/contrast-audit.mjs
@@ -12,8 +12,12 @@
  *   npm i --no-save playwright && node scripts/dev/contrast-audit.mjs
  */
 import { chromium } from 'playwright'
-const ROUTES = ['/', '/herbs/ashwagandha/', '/compounds/l-theanine/', '/guides/', '/guides/compare/',
-  '/library/', '/goals/sleep/', '/articles/', '/safety-checker/', '/info/about/', '/learn/', '/evidence/evidence-report/']
+const ROUTES = [
+  '/', '/start/', '/library/', '/goals/',
+  '/goals/sleep/', '/goals/stress/', '/goals/anxiety/', '/goals/focus/',
+  '/herbs/ashwagandha/', '/compounds/l-theanine/', '/guides/', '/guides/compare/',
+  '/articles/', '/safety-checker/', '/info/about/', '/learn/', '/evidence/evidence-report/',
+]
 const browser = await chromium.launch({ ...(process.env.CHROMIUM_PATH ? { executablePath: process.env.CHROMIUM_PATH } : {}) })
 const rows = []
 for (const theme of ['light', 'dark']) {


### PR DESCRIPTION
Updates the manual contrast-audit sample to cover Start, the Goals index, and all four canonical goal decision pages instead of only Sleep. Keeps representative ingredient, guide, article, safety, learn, and evidence surfaces. No production behavior changes.