### PR TITLE
feat(research): derive explicit underlying-study counts

### DIFF
--- a/lib/__tests__/research-underlying-study-independence.test.ts
+++ b/lib/__tests__/research-underlying-study-independence.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeUnderlyingStudyIndependence } from '@/lib/research-underlying-study-independence'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import type { TrialRegistrationIndependenceAnalysis } from '@/lib/research-trial-registration-independence'
+import type { EvidenceLineageAnalysis } from '@/lib/research-evidence-lineage'
+
+function analysis(studyIds: string[], confidence = 0.85): ResearchQualityAnalysis {
+  const claim = {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    reviewStatus: 'approved',
+    approved: true,
+    predicate: 'supports_outcome',
+    confidence,
+    sourceRefCount: studyIds.length,
+    validSourceRefCount: studyIds.length,
+    danglingSourceRefs: [],
+    studyIds,
+    studyCount: studyIds.length,
+    classifiedStudyCount: studyIds.length,
+    primaryHuman: studyIds.length,
+    synthesis: 0,
+    narrative: 0,
+    designs: studyIds.map(() => 'rct' as const),
+    outcomeClaim: true,
+    supportTier: 'human-supported',
+    structuredSupportTier: 'adequate',
+    weakStructuredClaim: false,
+    highConfidenceWeakStructured: false,
+    highConfidenceWeakOutcome: false,
+    singleStudy: false,
+    aliasCollapsed: false,
+  }
+  return {
+    cache: {},
+    profiles: [],
+    profileAnalyses: [],
+    claimAnalyses: [claim],
+    structuredClaimAnalyses: [claim],
+  }
+}
+
+function trialAnalysis(
+  sameRegisteredTrialPairs: Array<{ leftStudyId: string; rightStudyId: string; trialRegistrationId: string }> = [],
+): TrialRegistrationIndependenceAnalysis {
+  return {
+    claims: [{
+      url: '/herbs/example/',
+      claimId: 'claim-1',
+      predicate: 'supports_outcome',
+      confidence: 0.85,
+      apparentStudyCount: 3,
+      registryKnownStudyCount: 0,
+      registryAmbiguousStudyCount: 0,
+      registryCoverage: 0,
+      registryAdjustedStudyCount: 3,
+      duplicatePublicationCount: 0,
+      sameRegisteredTrialPairs,
+      sameRegisteredTrialPublicationReuse: sameRegisteredTrialPairs.length > 0,
+      highConfidenceSameTrialReuse: sameRegisteredTrialPairs.length > 0,
+    }],
+    sameTrialReuseClaims: [],
+    highConfidenceSameTrialReuseClaims: [],
+    summary: {
+      multiStudyApprovedClaims: 1,
+      claimsWithRegistryCoverage: 0,
+      claimsWithAmbiguousRegistryEvidence: 0,
+      sameTrialReuseClaims: 0,
+      highConfidenceSameTrialReuseClaims: 0,
+      duplicatePublicationCount: 0,
+    },
+  }
+}
+
+function lineageAnalysis(
+  lineages: Record<string, string[]> = {},
+): EvidenceLineageAnalysis {
+  const studies = Object.entries(lineages).map(([studyId, lineageIds]) => ({
+    url: '/herbs/example/', studyId, lineageIds, explicitLineage: lineageIds.length > 0,
+  }))
+  return {
+    studies,
+    claims: [],
+    sharedNonRegistryLineageClaims: [],
+    highConfidenceSharedNonRegistryLineageClaims: [],
+    summary: {
+      studies: studies.length,
+      studiesWithExplicitLineage: studies.filter((study) => study.explicitLineage).length,
+      explicitStudyLineageCoverage: 0,
+      multiStudyApprovedClaims: 1,
+      sharedNonRegistryLineageClaims: 0,
+      highConfidenceSharedNonRegistryLineageClaims: 0,
+    },
+  }
+}
+
+describe('underlying study independence', () => {
+  it('combines registered-trial and cohort lineage transitively', () => {
+    const result = analyzeUnderlyingStudyIndependence({
+      analysis: analysis(['a', 'b', 'c']),
+      trialRegistrationIndependence: trialAnalysis([
+        { leftStudyId: 'a', rightStudyId: 'b', trialRegistrationId: 'NCT01234567' },
+      ]),
+      evidenceLineage: lineageAnalysis({
+        b: ['cohort:COHORT-1'],
+        c: ['cohort:COHORT-1'],
+      }),
+    })
+
+    expect(result.claims[0]).toMatchObject({
+      apparentStudyCount: 3,
+      underlyingStudyCount: 1,
+      collapsedPublicationCount: 2,
+      independenceReduced: true,
+      pseudoMultiStudySupport: true,
+      highConfidencePseudoMultiStudySupport: true,
+    })
+    expect(result.claims[0].dependentPublicationGroups).toEqual([['a', 'b', 'c']])
+  })
+
+  it('does not collapse publications when no explicit dependence relation exists', () => {
+    const result = analyzeUnderlyingStudyIndependence({
+      analysis: analysis(['a', 'b', 'c']),
+      trialRegistrationIndependence: trialAnalysis(),
+      evidenceLineage: lineageAnalysis(),
+    })
+
+    expect(result.claims[0]).toMatchObject({
+      apparentStudyCount: 3,
+      underlyingStudyCount: 3,
+      collapsedPublicationCount: 0,
+      independenceReduced: false,
+      pseudoMultiStudySupport: false,
+    })
+  })
+
+  it('can reduce support without collapsing an entire claim to one underlying study', () => {
+    const result = analyzeUnderlyingStudyIndependence({
+      analysis: analysis(['a', 'b', 'c']),
+      trialRegistrationIndependence: trialAnalysis([
+        { leftStudyId: 'a', rightStudyId: 'b', trialRegistrationId: 'NCT01234567' },
+      ]),
+      evidenceLineage: lineageAnalysis(),
+    })
+
+    expect(result.claims[0]).toMatchObject({
+      apparentStudyCount: 3,
+      underlyingStudyCount: 2,
+      collapsedPublicationCount: 1,
+      independenceReduced: true,
+      pseudoMultiStudySupport: false,
+    })
+  })
+})

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -21,6 +21,7 @@ import {
   analyzeEvidenceBundleReuse,
 } from './research-study-load'
 import { analyzeTrialRegistrationIndependence } from './research-trial-registration-independence'
+import { analyzeUnderlyingStudyIndependence } from './research-underlying-study-independence'
 
 export type ResearchQualityTopology = ReturnType<typeof buildResearchQualityTopology>
 
@@ -67,6 +68,11 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     trialRegistrationIndependence,
     evidenceLineage,
   })
+  const underlyingStudyIndependence = analyzeUnderlyingStudyIndependence({
+    analysis,
+    trialRegistrationIndependence,
+    evidenceLineage,
+  })
   const studyClassConflicts = analyzeStudyClassConflicts(analysis)
   const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
   const claimBreadth = analyzeClaimBreadth(analysis)
@@ -109,6 +115,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     trialRegistrationIndependence,
     evidenceLineage,
     evidenceIndependenceCoverage,
+    underlyingStudyIndependence,
     studyClassConflicts,
     semanticAlignment,
     claimBreadth,

--- a/lib/research-underlying-study-independence.ts
+++ b/lib/research-underlying-study-independence.ts
@@ -1,0 +1,159 @@
+import type { EvidenceLineageAnalysis } from './research-evidence-lineage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { TrialRegistrationIndependenceAnalysis } from './research-trial-registration-independence'
+
+export type ClaimUnderlyingStudyIndependence = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  apparentStudyCount: number
+  underlyingStudyCount: number
+  collapsedPublicationCount: number
+  dependentPublicationGroups: string[][]
+  independenceReduced: boolean
+  pseudoMultiStudySupport: boolean
+  highConfidencePseudoMultiStudySupport: boolean
+}
+
+export type UnderlyingStudyIndependenceAnalysis = {
+  claims: ClaimUnderlyingStudyIndependence[]
+  reducedClaims: ClaimUnderlyingStudyIndependence[]
+  pseudoMultiStudyClaims: ClaimUnderlyingStudyIndependence[]
+  highConfidencePseudoMultiStudyClaims: ClaimUnderlyingStudyIndependence[]
+  summary: {
+    multiStudyApprovedClaims: number
+    independenceReducedClaims: number
+    pseudoMultiStudyClaims: number
+    highConfidencePseudoMultiStudyClaims: number
+    collapsedPublicationCount: number
+  }
+}
+
+export type UnderlyingStudyIndependenceInputs = {
+  analysis: ResearchQualityAnalysis
+  trialRegistrationIndependence: TrialRegistrationIndependenceAnalysis
+  evidenceLineage: EvidenceLineageAnalysis
+}
+
+function createUnion(studyIds: string[]) {
+  const parent = new Map(studyIds.map((studyId) => [studyId, studyId]))
+  const find = (value: string): string => {
+    const current = parent.get(value) ?? value
+    if (current === value) return value
+    const root = find(current)
+    parent.set(value, root)
+    return root
+  }
+  const union = (left: string, right: string) => {
+    if (!parent.has(left) || !parent.has(right)) return
+    const leftRoot = find(left)
+    const rightRoot = find(right)
+    if (leftRoot === rightRoot) return
+    const [keep, merge] = [leftRoot, rightRoot].sort()
+    parent.set(merge, keep)
+  }
+  return { find, union }
+}
+
+/**
+ * Collapse publication-level study IDs only when existing canonical lineage
+ * analyzers positively prove that publications belong to the same underlying
+ * trial/cohort/dataset/parent study. Missing independence metadata is never
+ * treated as dependence.
+ *
+ * Combining the relation systems here also captures transitive dependence: for
+ * example A/B may share a trial registration while B/C share an explicit cohort,
+ * proving that all three publications represent one underlying evidence unit.
+ */
+export function analyzeUnderlyingStudyIndependence(
+  inputs: UnderlyingStudyIndependenceInputs,
+): UnderlyingStudyIndependenceAnalysis {
+  const trialByClaim = new Map(
+    inputs.trialRegistrationIndependence.claims.map((claim) => [`${claim.url}::${claim.claimId}`, claim] as const),
+  )
+  const lineageByStudy = new Map(
+    inputs.evidenceLineage.studies.map((study) => [`${study.url}::${study.studyId}`, study.lineageIds] as const),
+  )
+
+  const claims: ClaimUnderlyingStudyIndependence[] = []
+  for (const claim of inputs.analysis.claimAnalyses) {
+    if (claim.studyCount < 2) continue
+    const { find, union } = createUnion(claim.studyIds)
+    const trial = trialByClaim.get(`${claim.url}::${claim.claimId}`)
+
+    for (const pair of trial?.sameRegisteredTrialPairs ?? []) {
+      union(pair.leftStudyId, pair.rightStudyId)
+    }
+
+    const studiesByLineage = new Map<string, string[]>()
+    for (const studyId of claim.studyIds) {
+      for (const lineageId of lineageByStudy.get(`${claim.url}::${studyId}`) ?? []) {
+        const studies = studiesByLineage.get(lineageId) ?? []
+        studies.push(studyId)
+        studiesByLineage.set(lineageId, studies)
+      }
+    }
+    for (const studies of studiesByLineage.values()) {
+      if (studies.length < 2) continue
+      for (let index = 1; index < studies.length; index += 1) union(studies[0], studies[index])
+    }
+
+    const groups = new Map<string, string[]>()
+    for (const studyId of claim.studyIds) {
+      const root = find(studyId)
+      const studies = groups.get(root) ?? []
+      studies.push(studyId)
+      groups.set(root, studies)
+    }
+    const dependentPublicationGroups = [...groups.values()]
+      .filter((studies) => studies.length > 1)
+      .map((studies) => [...studies].sort())
+      .sort((a, b) => b.length - a.length || a[0].localeCompare(b[0]))
+    const underlyingStudyCount = groups.size
+    const collapsedPublicationCount = Math.max(0, claim.studyCount - underlyingStudyCount)
+    const independenceReduced = collapsedPublicationCount > 0
+    const pseudoMultiStudySupport = claim.studyCount >= 2 && underlyingStudyCount === 1
+
+    claims.push({
+      url: claim.url,
+      claimId: claim.claimId,
+      predicate: claim.predicate,
+      confidence: claim.confidence,
+      apparentStudyCount: claim.studyCount,
+      underlyingStudyCount,
+      collapsedPublicationCount,
+      dependentPublicationGroups,
+      independenceReduced,
+      pseudoMultiStudySupport,
+      highConfidencePseudoMultiStudySupport: pseudoMultiStudySupport && claim.confidence >= 0.75,
+    })
+  }
+
+  claims.sort((a, b) =>
+    Number(b.highConfidencePseudoMultiStudySupport) - Number(a.highConfidencePseudoMultiStudySupport)
+    || Number(b.pseudoMultiStudySupport) - Number(a.pseudoMultiStudySupport)
+    || b.collapsedPublicationCount - a.collapsedPublicationCount
+    || b.apparentStudyCount - a.apparentStudyCount
+    || b.confidence - a.confidence
+    || a.url.localeCompare(b.url)
+    || a.claimId.localeCompare(b.claimId),
+  )
+  const reducedClaims = claims.filter((claim) => claim.independenceReduced)
+  const pseudoMultiStudyClaims = claims.filter((claim) => claim.pseudoMultiStudySupport)
+  const highConfidencePseudoMultiStudyClaims = claims.filter((claim) => claim.highConfidencePseudoMultiStudySupport)
+
+  return {
+    claims,
+    reducedClaims,
+    pseudoMultiStudyClaims,
+    highConfidencePseudoMultiStudyClaims,
+    summary: {
+      multiStudyApprovedClaims: claims.length,
+      independenceReducedClaims: reducedClaims.length,
+      pseudoMultiStudyClaims: pseudoMultiStudyClaims.length,
+      highConfidencePseudoMultiStudyClaims: highConfidencePseudoMultiStudyClaims.length,
+      collapsedPublicationCount: reducedClaims.reduce((sum, claim) => sum + claim.collapsedPublicationCount, 0),
+    },
+  }
+}


### PR DESCRIPTION
Adds one canonical underlying-study independence analysis over the existing registered-trial and non-registry lineage systems. Publication-level study IDs are unioned only when explicit NCT/cohort/dataset/parent-study relations prove dependence; missing lineage never implies dependence. The combined graph supports transitive collapse across relation types and reports apparent publication count, adjusted underlying-study count, collapsed-publication count, dependency groups, reduced-independence claims, and pseudo-multi-study support where multiple publications collapse to one evidence unit. Canonical topology now exposes `underlyingStudyIndependence`. Includes focused transitive, no-relation, and partial-collapse tests.