### PR TITLE
feat(research): expose claim breadth in canonical rollup

### DIFF
--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -53,6 +53,7 @@ const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 
 const {
   semanticAlignment,
+  claimBreadth,
   claimLanguageCalibration: languageCalibration,
   crossProfileStudyLoad,
   systemicLoadBearingStudies,
@@ -115,6 +116,7 @@ results.push({
     `gaps=${researchGapQueue.length}`,
     `blocking=${gate.summary.blockingFailures}`,
     `semanticMismatches=${semanticAlignment.summary.anyMismatch}`,
+    `claimBreadthOverreach=${claimBreadth.summary.overbroadClaims}`,
     `causalWithoutControlled=${languageCalibration.summary.causalWithoutControlledSupport}`,
     `pseudoMultiSource=${edgeCardinality.summary.pseudoMultiSourceClaims}`,
     `sameTrialReuse=${trialRegistrationIndependence.summary.sameTrialReuseClaims}`,
@@ -179,6 +181,7 @@ const coreSummary = {
   withdrawnCitedStudies: sourceIntegrity.summary.withdrawn,
   citationIntegrityProblems: citationIntegrity.blockingCount,
   semanticAlignment: semanticAlignment.summary,
+  claimBreadth: claimBreadth.summary,
   claimLanguageCalibration: languageCalibration.summary,
   claimCitationMetadata: claimCitationMetadata.summary,
   edgeCardinality: edgeCardinality.summary,
@@ -219,7 +222,7 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 24,
+  schemaVersion: 25,
   generatedAt: new Date().toISOString(),
   passed: !failed,
   source: {
@@ -232,6 +235,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     trialRegistrationIndependence: 'lib/research-trial-registration-independence.ts',
     evidenceLineage: 'lib/research-evidence-lineage.ts',
     evidenceIndependenceCoverage: 'lib/research-evidence-independence-coverage.ts',
+    claimBreadth: 'lib/research-claim-breadth.ts',
   },
   coreSummary,
   structuralFailures: gate.structuralFailures,
@@ -249,6 +253,11 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     highConfidenceMismatches: semanticAlignment.highConfidenceMismatches.slice(0, 100),
     highConfidenceConcentration: semanticAlignment.highConfidenceConcentrationFindings.slice(0, 100),
     highConfidenceCoverageGaps: semanticAlignment.highConfidenceCoverageGapFindings.slice(0, 100),
+  },
+  claimBreadth: {
+    summary: claimBreadth.summary,
+    findings: claimBreadth.findings.slice(0, 150),
+    highConfidenceFindings: claimBreadth.highConfidenceFindings.slice(0, 100),
   },
   claimLanguageCalibration: {
     summary: languageCalibration.summary,
@@ -309,6 +318,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
 console.log(`Research gate: ${gate.summary.blockingFailures} blocking · ${gate.summary.structuralFailures} structural · ${gate.summary.severeStudyClassConflicts} severe study-class conflict(s)`)
 console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explicit mismatch(es) · ${semanticAlignment.summary.highConfidenceMismatches} high-confidence`)
+console.log(`Claim breadth: ${claimBreadth.summary.overbroadClaims} overbroad claim(s) · ${claimBreadth.summary.highConfidenceOverbroadClaims} high-confidence · population ${claimBreadth.summary.populationOverbroadClaims} · dose ${claimBreadth.summary.doseOverbroadClaims} · duration ${claimBreadth.summary.durationOverbroadClaims} · formulation ${claimBreadth.summary.formulationOverbroadClaims} · endpoint ${claimBreadth.summary.endpointOverbroadClaims}`)
 console.log(`Language calibration: ${languageCalibration.summary.causalWithoutControlledSupport} unsupported direct-causal claim(s)`)
 console.log(`Edge cardinality: ${edgeCardinality.summary.pseudoMultiSourceClaims} pseudo-multi-source · ${edgeCardinality.summary.aliasCollapsedClaims} alias-collapsed · ${edgeCardinality.summary.duplicateEdges} duplicate edge(s)`)
 console.log(`Underlying-study reuse: ${trialRegistrationIndependence.summary.sameTrialReuseClaims} same-trial claim(s) · ${evidenceLineage.summary.sharedNonRegistryLineageClaims} shared lineage claim(s)`)


### PR DESCRIPTION
Adds claim-breadth calibration to the canonical research-quality CLI and JSON rollup, including summary counts and top/high-confidence findings across population, dose, duration, formulation, and endpoint scope. Advances the report schema and records the canonical analyzer source.