### PR TITLE
Validate claim breadth in canonical snapshot

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -17,7 +17,7 @@ function fixtures() {
       },
     }],
     profileAnalyses: [{ url: '/herbs/example' }],
-    claimAnalyses: [{ url: '/herbs/example', claimId: 'claim-1' }],
+    claimAnalyses: [{ url: '/herbs/example', claimId: 'claim-1', studyCount: 1 }],
     structuredClaimAnalyses: [],
   } as unknown as ResearchQualityAnalysis
 
@@ -27,9 +27,29 @@ function fixtures() {
       findings: [],
       concentrationFindings: [],
     },
+    claimBreadth: {
+      claims: [],
+      findings: [],
+      highConfidenceFindings: [],
+      summary: {
+        approvedClaimsWithHumanEvidence: 0,
+        assessableClaims: 0,
+        overbroadClaims: 0,
+        highConfidenceOverbroadClaims: 0,
+        populationOverbroadClaims: 0,
+        doseOverbroadClaims: 0,
+        durationOverbroadClaims: 0,
+        formulationOverbroadClaims: 0,
+        endpointOverbroadClaims: 0,
+      },
+    },
     edgeCardinality: {
       summary: { claims: 0 },
       duplicateEdgeClaims: [],
+    },
+    evidenceIndependenceCoverage: {
+      claims: [],
+      summary: { multiStudyApprovedClaims: 0 },
     },
     claimLanguageCalibration: { directEvidenceFindings: [] },
     claimCitationMetadata: { claims: [] },
@@ -94,6 +114,24 @@ describe('research quality snapshot invariants', () => {
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(false)
     expect(report.failures.map((failure) => failure.kind)).toContain('semantic-approved-claim-count-mismatch')
+  })
+
+  it('detects claim-breadth rows that reference an unknown approved claim', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    topology.claimBreadth.claims = [
+      { url: '/herbs/example', claimId: 'missing-claim' },
+    ] as typeof topology.claimBreadth.claims
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.passed).toBe(false)
+    expect(report.failures.map((failure) => failure.kind)).toContain('claim-breadth-unknown-claim')
+  })
+
+  it('detects claim-breadth summary drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    topology.claimBreadth.summary.overbroadClaims = 1
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.passed).toBe(false)
+    expect(report.failures.map((failure) => failure.kind)).toContain('claim-breadth-finding-count-mismatch')
   })
 
   it('detects derived findings that reference an unknown approved claim', () => {

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -117,6 +117,24 @@ export function validateResearchQualitySnapshotInvariants(
       `semantic=${topology.semanticAlignment.summary.approvedClaims}; analysis=${analysis.claimAnalyses.length}`,
     )
   }
+  if (topology.claimBreadth.summary.overbroadClaims !== topology.claimBreadth.findings.length) {
+    add(
+      'claim-breadth-finding-count-mismatch',
+      `summary=${topology.claimBreadth.summary.overbroadClaims}; rows=${topology.claimBreadth.findings.length}`,
+    )
+  }
+  if (topology.claimBreadth.summary.highConfidenceOverbroadClaims !== topology.claimBreadth.highConfidenceFindings.length) {
+    add(
+      'claim-breadth-high-confidence-count-mismatch',
+      `summary=${topology.claimBreadth.summary.highConfidenceOverbroadClaims}; rows=${topology.claimBreadth.highConfidenceFindings.length}`,
+    )
+  }
+  if (topology.claimBreadth.findings.length > topology.claimBreadth.claims.length) {
+    add(
+      'claim-breadth-subset-count-mismatch',
+      `findings=${topology.claimBreadth.findings.length}; analyzed=${topology.claimBreadth.claims.length}`,
+    )
+  }
   if (topology.edgeCardinality.summary.claims !== analysis.structuredClaimAnalyses.length) {
     add(
       'edge-cardinality-claim-count-mismatch',
@@ -161,6 +179,10 @@ export function validateResearchQualitySnapshotInvariants(
   }
   for (const finding of topology.semanticAlignment.concentrationFindings) {
     requireApprovedClaim('semantic-concentration-unknown-claim', finding.url, finding.claimId)
+  }
+  for (const claim of topology.claimBreadth.claims) {
+    requireProfile('claim-breadth-unknown-profile', claim.url, claim.claimId)
+    requireApprovedClaim('claim-breadth-unknown-claim', claim.url, claim.claimId)
   }
   for (const finding of topology.claimLanguageCalibration.directEvidenceFindings) {
     requireApprovedClaim('language-calibration-unknown-claim', finding.url, finding.claimId)


### PR DESCRIPTION
Closed as redundant: concurrent main merged #3550 with the canonical claim-breadth snapshot invariant coverage before this PR could merge. Keeping the stale branch out avoids replaying overlapping invariant logic.