### PR TITLE
refactor(research): score canonical underlying-study independence

### DIFF
--- a/lib/__tests__/research-quality-policy-topology-signals.test.ts
+++ b/lib/__tests__/research-quality-policy-topology-signals.test.ts
@@ -35,6 +35,7 @@ function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopol
   return {
     narrowCrossProfileEvidenceBundles: [],
     semanticAlignment: { findings: [], concentrationFindings: [], coverageGapFindings: [] },
+    claimBreadth: { findings: [] },
     claimLanguageCalibration: { directEvidenceFindings: [] },
     claimCitationMetadata: { lowCoverageClaims: [] },
     metadataIntegrity: { profiles: [] },
@@ -42,6 +43,7 @@ function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopol
     edgeCardinality: { pseudoMultiSourceClaims: [] },
     trialRegistrationIndependence: { sameTrialReuseClaims: [] },
     evidenceLineage: { sharedNonRegistryLineageClaims: [] },
+    underlyingStudyIndependence: { reducedClaims: [] },
     evidenceIndependenceCoverage: { unresolvedClaims: [] },
     studyClassConflicts: { conflicts: [], severeConflicts: [] },
     ...overrides,
@@ -62,7 +64,7 @@ describe('aggregated topology gap signals', () => {
     const semantic = signals.filter((signal) => signal.kind === 'semantic-claim-source-mismatch')
     expect(semantic).toHaveLength(1)
     expect(semantic[0]).toMatchObject({ url: '/herbs/a/' })
-    expect(semantic[0].detail).toContain('3 approved claim(s)')
+    expect(semantic[0].detail).toContain('3 explicit alignment mismatch(es)')
     expect(semantic[0].detail).toContain('2 high-confidence')
   })
 
@@ -96,6 +98,40 @@ describe('aggregated topology gap signals', () => {
     expect(pseudo[0].detail).toContain('2 approved claim(s)')
     expect(pseudo[0].detail).toContain('3 redundant source row(s)')
     expect(pseudo[0].detail).toContain('3 source rows')
+  })
+
+  it('scores canonical underlying-study reductions once and prioritizes pseudo-multi-study support', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      underlyingStudyIndependence: {
+        reducedClaims: [
+          {
+            url: '/herbs/a/',
+            apparentStudyCount: 3,
+            underlyingStudyCount: 2,
+            collapsedPublicationCount: 1,
+            pseudoMultiStudySupport: false,
+            highConfidencePseudoMultiStudySupport: false,
+          },
+          {
+            url: '/herbs/a/',
+            apparentStudyCount: 2,
+            underlyingStudyCount: 1,
+            collapsedPublicationCount: 1,
+            pseudoMultiStudySupport: true,
+            highConfidencePseudoMultiStudySupport: true,
+          },
+        ],
+      },
+    }), weights)
+
+    const reuse = signals.filter((signal) => signal.kind === 'underlying-study-publication-reuse')
+    expect(reuse).toHaveLength(1)
+    expect(reuse[0]).toMatchObject({ url: '/herbs/a/', weight: 25 })
+    expect(reuse[0].detail).toContain('2 approved claim(s)')
+    expect(reuse[0].detail).toContain('2 publication(s) collapse')
+    expect(reuse[0].detail).toContain('1 claim(s) reduce to one underlying study')
+    expect(reuse[0].detail).toContain('1 high-confidence pseudo-multi-study')
+    expect(reuse[0].detail).toContain('minimum adjusted count 1')
   })
 
   it('aggregates advisory metadata once while leaving severe class conflicts structural', () => {

--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -200,48 +200,20 @@ export function buildAggregatedTopologyGapSignals(
     })
   }
 
-  // Registration and non-registry lineage are alternate proofs of one root
-  // problem: multiple publications are not independent underlying evidence.
-  const underlyingReuse = new Map<string, {
-    claimKeys: Set<string>
-    highConfidenceClaimKeys: Set<string>
-    registeredTrialClaims: number
-    nonRegistryLineageClaims: number
-    duplicatePublications: number
-  }>()
-  for (const claim of topology.trialRegistrationIndependence.sameTrialReuseClaims) {
-    const item = underlyingReuse.get(claim.url) ?? {
-      claimKeys: new Set<string>(), highConfidenceClaimKeys: new Set<string>(), registeredTrialClaims: 0,
-      nonRegistryLineageClaims: 0, duplicatePublications: 0,
-    }
-    const key = `${claim.url}::${claim.claimId}`
-    item.claimKeys.add(key)
-    if (claim.highConfidenceSameTrialReuse) item.highConfidenceClaimKeys.add(key)
-    item.registeredTrialClaims += 1
-    item.duplicatePublications += claim.duplicatePublicationCount
-    underlyingReuse.set(claim.url, item)
-  }
-  for (const claim of topology.evidenceLineage.sharedNonRegistryLineageClaims) {
-    const item = underlyingReuse.get(claim.url) ?? {
-      claimKeys: new Set<string>(), highConfidenceClaimKeys: new Set<string>(), registeredTrialClaims: 0,
-      nonRegistryLineageClaims: 0, duplicatePublications: 0,
-    }
-    const key = `${claim.url}::${claim.claimId}`
-    item.claimKeys.add(key)
-    if (claim.highConfidenceSharedNonRegistryLineage) item.highConfidenceClaimKeys.add(key)
-    item.nonRegistryLineageClaims += 1
-    underlyingReuse.set(claim.url, item)
-  }
-  for (const [url, item] of underlyingReuse) {
-    const affectedClaims = item.claimKeys.size
-    const highConfidence = item.highConfidenceClaimKeys.size
+  // One canonical union graph now owns registered-trial + cohort/dataset/parent
+  // dependence. Policy only ranks the resulting adjusted underlying-study count.
+  for (const [url, items] of groupByUrl(topology.underlyingStudyIndependence.reducedClaims)) {
+    const collapsedPublications = items.reduce((sum, item) => sum + item.collapsedPublicationCount, 0)
+    const pseudoMultiStudy = items.filter((item) => item.pseudoMultiStudySupport).length
+    const highConfidencePseudo = items.filter((item) => item.highConfidencePseudoMultiStudySupport).length
+    const minimumUnderlyingStudyCount = Math.min(...items.map((item) => item.underlyingStudyCount))
     signals.push({
       url,
       kind: 'underlying-study-publication-reuse',
       weight: weights.underlyingStudyPublicationReuse
-        + Math.min(8, Math.max(0, affectedClaims - 1) * 2 + item.duplicatePublications)
-        + (highConfidence ? weights.highConfidenceUnderlyingStudyPublicationReuseBonus : 0),
-      detail: `${affectedClaims} approved multi-publication claim(s) reuse underlying evidence; ${item.registeredTrialClaims} same registered trial, ${item.nonRegistryLineageClaims} shared cohort/dataset/parent-study lineage; ${highConfidence} high-confidence`,
+        + Math.min(12, Math.max(0, items.length - 1) * 2 + collapsedPublications + pseudoMultiStudy * 3)
+        + (highConfidencePseudo ? weights.highConfidenceUnderlyingStudyPublicationReuseBonus : 0),
+      detail: `${items.length} approved claim(s) lose apparent study independence after explicit lineage collapse; ${collapsedPublications} publication(s) collapse; ${pseudoMultiStudy} claim(s) reduce to one underlying study; ${highConfidencePseudo} high-confidence pseudo-multi-study; minimum adjusted count ${minimumUnderlyingStudyCount}`,
     })
   }
 


### PR DESCRIPTION
Replaces the remediation adapter's duplicated registered-trial + cohort/dataset/parent-study aggregation with the canonical `underlyingStudyIndependence` union graph. The queue now ranks adjusted underlying-study reductions directly, distinguishes partial reductions from pseudo-multi-study support where multiple publications collapse to one evidence unit, and retains one profile-level `underlying-study-publication-reuse` reason. Also repairs stale topology-signal test fixtures from the concurrent claim-breadth refactor and adds a focused partial-vs-pseudo reduction contract.