### PR TITLE
refactor(research): canonicalize citation integrity in snapshot

### DIFF
--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -1,3 +1,4 @@
+import { analyzeCitationIntegrity } from './citation-integrity.mjs'
 import { analyzeResearchQuality, type ResearchQualityAnalysis } from './research-quality-analysis'
 import { buildResearchQualityGate, type ResearchQualityGate } from './research-quality-gate'
 import { buildResearchGapQueue } from './research-quality-policy'
@@ -14,6 +15,7 @@ export type ResearchQualitySnapshot = {
   gate: ResearchQualityGate
   researchGapQueue: ReturnType<typeof buildResearchGapQueue>
   sourceIntegrity: ReturnType<typeof analyzeResearchSourceIntegrity>
+  citationIntegrity: ReturnType<typeof analyzeCitationIntegrity>
   invariants: ResearchSnapshotInvariantReport
 }
 
@@ -22,9 +24,10 @@ export type ResearchQualitySnapshot = {
  *
  * Specialized reporters may format different views, but they should consume
  * this snapshot instead of independently rebuilding analysis/topology/gate/policy
- * state. The hard gate and softer remediation queue remain separate by design.
- * Snapshot invariants are implementation contracts: contradictory derived views
- * invalidate the snapshot itself and therefore fail every canonical consumer.
+ * or citation/source-integrity state. The hard gate and softer remediation queue
+ * remain separate by design. Snapshot invariants are implementation contracts:
+ * contradictory derived views invalidate the snapshot itself and therefore fail
+ * every canonical consumer.
  */
 export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQualitySnapshot {
   const analysis = analyzeResearchQuality(root)
@@ -32,6 +35,7 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
   const gate = buildResearchQualityGate(analysis, topology)
   const researchGapQueue = buildResearchGapQueue(analysis, topology)
   const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
+  const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
   const invariants = validateResearchQualitySnapshotInvariants(
     analysis,
     topology,
@@ -53,6 +57,7 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
     gate,
     researchGapQueue,
     sourceIntegrity,
+    citationIntegrity,
     invariants,
   }
 }

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { buildAiCitationReadiness, writeAiCitationReadinessReport } from '../../lib/ai-citation-readiness'
-import { analyzeCitationIntegrity, writeCitationIntegrityReport } from '../../lib/citation-integrity.mjs'
+import { writeCitationIntegrityReport } from '../../lib/citation-integrity.mjs'
 import { analyzeEvidenceGradeConsistency, writeEvidenceGradeConsistencyReport } from '../../lib/evidence-grade-consistency'
 import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 import { writeResearchSemanticAlignmentReport } from '../../lib/research-semantic-alignment'
@@ -46,8 +46,7 @@ console.log('='.repeat(76))
 
 const coreStarted = Date.now()
 const snapshot = buildResearchQualitySnapshot(ROOT)
-const { analysis, topology, gate, researchGapQueue, sourceIntegrity } = snapshot
-const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
+const { analysis, topology, gate, researchGapQueue, sourceIntegrity, citationIntegrity } = snapshot
 const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(ROOT)
 const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 


### PR DESCRIPTION
Moves citation identity integrity into `buildResearchQualitySnapshot()` and makes the canonical `scripts/ci/research-quality.ts` roll-up consume that snapshot result instead of independently recomputing citation integrity. Keeps the standalone citation validator lightweight. No report schema or public behavior changes; this removes one duplicate citation scan from the canonical research-quality execution path.