### PR TITLE
feat(research): report independence-adjusted claim support tiers

### DIFF
--- a/lib/__tests__/research-underlying-study-independence.test.ts
+++ b/lib/__tests__/research-underlying-study-independence.test.ts
@@ -96,7 +96,7 @@ function lineageAnalysis(
 }
 
 describe('underlying study independence', () => {
-  it('combines registered-trial and cohort lineage transitively', () => {
+  it('combines registered-trial and cohort lineage transitively and downgrades pseudo-multi-study support', () => {
     const result = analyzeUnderlyingStudyIndependence({
       analysis: analysis(['a', 'b', 'c']),
       trialRegistrationIndependence: trialAnalysis([
@@ -112,11 +112,16 @@ describe('underlying study independence', () => {
       apparentStudyCount: 3,
       underlyingStudyCount: 1,
       collapsedPublicationCount: 2,
+      publicationStructuredSupportTier: 'adequate',
+      independenceAdjustedStructuredSupportTier: 'single-study',
+      supportTierDowngradedByDependence: true,
       independenceReduced: true,
       pseudoMultiStudySupport: true,
       highConfidencePseudoMultiStudySupport: true,
     })
     expect(result.claims[0].dependentPublicationGroups).toEqual([['a', 'b', 'c']])
+    expect(result.summary.supportTierDowngrades).toBe(1)
+    expect(result.supportTierDowngrades).toHaveLength(1)
   })
 
   it('does not collapse publications when no explicit dependence relation exists', () => {
@@ -130,12 +135,15 @@ describe('underlying study independence', () => {
       apparentStudyCount: 3,
       underlyingStudyCount: 3,
       collapsedPublicationCount: 0,
+      publicationStructuredSupportTier: 'adequate',
+      independenceAdjustedStructuredSupportTier: 'adequate',
+      supportTierDowngradedByDependence: false,
       independenceReduced: false,
       pseudoMultiStudySupport: false,
     })
   })
 
-  it('can reduce support without collapsing an entire claim to one underlying study', () => {
+  it('can reduce publication count without downgrading multi-study support when two underlying studies remain', () => {
     const result = analyzeUnderlyingStudyIndependence({
       analysis: analysis(['a', 'b', 'c']),
       trialRegistrationIndependence: trialAnalysis([
@@ -148,6 +156,9 @@ describe('underlying study independence', () => {
       apparentStudyCount: 3,
       underlyingStudyCount: 2,
       collapsedPublicationCount: 1,
+      publicationStructuredSupportTier: 'adequate',
+      independenceAdjustedStructuredSupportTier: 'adequate',
+      supportTierDowngradedByDependence: false,
       independenceReduced: true,
       pseudoMultiStudySupport: false,
     })

--- a/lib/research-underlying-study-independence.ts
+++ b/lib/research-underlying-study-independence.ts
@@ -1,5 +1,5 @@
 import type { EvidenceLineageAnalysis } from './research-evidence-lineage'
-import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { ResearchQualityAnalysis, StructuredSupportTier } from './research-quality-analysis'
 import type { TrialRegistrationIndependenceAnalysis } from './research-trial-registration-independence'
 
 export type ClaimUnderlyingStudyIndependence = {
@@ -11,6 +11,9 @@ export type ClaimUnderlyingStudyIndependence = {
   underlyingStudyCount: number
   collapsedPublicationCount: number
   dependentPublicationGroups: string[][]
+  publicationStructuredSupportTier: StructuredSupportTier
+  independenceAdjustedStructuredSupportTier: StructuredSupportTier
+  supportTierDowngradedByDependence: boolean
   independenceReduced: boolean
   pseudoMultiStudySupport: boolean
   highConfidencePseudoMultiStudySupport: boolean
@@ -21,11 +24,13 @@ export type UnderlyingStudyIndependenceAnalysis = {
   reducedClaims: ClaimUnderlyingStudyIndependence[]
   pseudoMultiStudyClaims: ClaimUnderlyingStudyIndependence[]
   highConfidencePseudoMultiStudyClaims: ClaimUnderlyingStudyIndependence[]
+  supportTierDowngrades: ClaimUnderlyingStudyIndependence[]
   summary: {
     multiStudyApprovedClaims: number
     independenceReducedClaims: number
     pseudoMultiStudyClaims: number
     highConfidencePseudoMultiStudyClaims: number
+    supportTierDowngrades: number
     collapsedPublicationCount: number
   }
 }
@@ -65,6 +70,11 @@ function createUnion(studyIds: string[]) {
  * Combining the relation systems here also captures transitive dependence: for
  * example A/B may share a trial registration while B/C share an explicit cohort,
  * proving that all three publications represent one underlying evidence unit.
+ *
+ * Publication-level structured support remains preserved for auditability, while
+ * an independence-adjusted tier prevents an apparently adequate multi-publication
+ * claim from being represented as multi-study support when every publication
+ * collapses to one explicitly identified underlying study.
  */
 export function analyzeUnderlyingStudyIndependence(
   inputs: UnderlyingStudyIndependenceInputs,
@@ -114,6 +124,13 @@ export function analyzeUnderlyingStudyIndependence(
     const collapsedPublicationCount = Math.max(0, claim.studyCount - underlyingStudyCount)
     const independenceReduced = collapsedPublicationCount > 0
     const pseudoMultiStudySupport = claim.studyCount >= 2 && underlyingStudyCount === 1
+    const publicationStructuredSupportTier = claim.structuredSupportTier
+    const independenceAdjustedStructuredSupportTier: StructuredSupportTier =
+      pseudoMultiStudySupport && publicationStructuredSupportTier === 'adequate'
+        ? 'single-study'
+        : publicationStructuredSupportTier
+    const supportTierDowngradedByDependence =
+      independenceAdjustedStructuredSupportTier !== publicationStructuredSupportTier
 
     claims.push({
       url: claim.url,
@@ -124,6 +141,9 @@ export function analyzeUnderlyingStudyIndependence(
       underlyingStudyCount,
       collapsedPublicationCount,
       dependentPublicationGroups,
+      publicationStructuredSupportTier,
+      independenceAdjustedStructuredSupportTier,
+      supportTierDowngradedByDependence,
       independenceReduced,
       pseudoMultiStudySupport,
       highConfidencePseudoMultiStudySupport: pseudoMultiStudySupport && claim.confidence >= 0.75,
@@ -131,7 +151,8 @@ export function analyzeUnderlyingStudyIndependence(
   }
 
   claims.sort((a, b) =>
-    Number(b.highConfidencePseudoMultiStudySupport) - Number(a.highConfidencePseudoMultiStudySupport)
+    Number(b.supportTierDowngradedByDependence) - Number(a.supportTierDowngradedByDependence)
+    || Number(b.highConfidencePseudoMultiStudySupport) - Number(a.highConfidencePseudoMultiStudySupport)
     || Number(b.pseudoMultiStudySupport) - Number(a.pseudoMultiStudySupport)
     || b.collapsedPublicationCount - a.collapsedPublicationCount
     || b.apparentStudyCount - a.apparentStudyCount
@@ -142,17 +163,20 @@ export function analyzeUnderlyingStudyIndependence(
   const reducedClaims = claims.filter((claim) => claim.independenceReduced)
   const pseudoMultiStudyClaims = claims.filter((claim) => claim.pseudoMultiStudySupport)
   const highConfidencePseudoMultiStudyClaims = claims.filter((claim) => claim.highConfidencePseudoMultiStudySupport)
+  const supportTierDowngrades = claims.filter((claim) => claim.supportTierDowngradedByDependence)
 
   return {
     claims,
     reducedClaims,
     pseudoMultiStudyClaims,
     highConfidencePseudoMultiStudyClaims,
+    supportTierDowngrades,
     summary: {
       multiStudyApprovedClaims: claims.length,
       independenceReducedClaims: reducedClaims.length,
       pseudoMultiStudyClaims: pseudoMultiStudyClaims.length,
       highConfidencePseudoMultiStudyClaims: highConfidencePseudoMultiStudyClaims.length,
+      supportTierDowngrades: supportTierDowngrades.length,
       collapsedPublicationCount: reducedClaims.reduce((sum, claim) => sum + claim.collapsedPublicationCount, 0),
     },
   }

--- a/scripts/ci/audit-claim-evidence-strength.ts
+++ b/scripts/ci/audit-claim-evidence-strength.ts
@@ -8,8 +8,9 @@ import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapsho
 
 const ROOT = process.cwd()
 const REPORT_PATH = path.join(ROOT, 'ops', 'reports', 'claim-evidence-strength.json')
-const { analysis } = buildResearchQualitySnapshot(ROOT)
+const { analysis, topology } = buildResearchQualitySnapshot(ROOT)
 const { claimAnalyses: claims, structuredClaimAnalyses } = analysis
+const underlyingStudyIndependence = topology.underlyingStudyIndependence
 
 const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
   counts[claim.supportTier] = (counts[claim.supportTier] ?? 0) + 1
@@ -17,6 +18,17 @@ const tierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
 }, {})
 const structuredTierCounts = structuredClaimAnalyses.reduce<Record<string, number>>((counts, claim) => {
   counts[claim.structuredSupportTier] = (counts[claim.structuredSupportTier] ?? 0) + 1
+  return counts
+}, {})
+const adjustedTierByClaim = new Map(
+  underlyingStudyIndependence.claims.map((claim) => [
+    `${claim.url}::${claim.claimId}`,
+    claim.independenceAdjustedStructuredSupportTier,
+  ]),
+)
+const approvedAdjustedStructuredTierCounts = claims.reduce<Record<string, number>>((counts, claim) => {
+  const tier = adjustedTierByClaim.get(`${claim.url}::${claim.claimId}`) ?? claim.structuredSupportTier
+  counts[tier] = (counts[tier] ?? 0) + 1
   return counts
 }, {})
 const unapproved = structuredClaimAnalyses.filter((claim) => !claim.approved)
@@ -32,6 +44,9 @@ const report = {
     outcomeClaims: claims.filter((claim) => claim.outcomeClaim).length,
     supportTiers: tierCounts,
     structuredSupportTiers: structuredTierCounts,
+    approvedIndependenceAdjustedStructuredSupportTiers: approvedAdjustedStructuredTierCounts,
+    supportTierDowngradesByDependence: underlyingStudyIndependence.summary.supportTierDowngrades,
+    collapsedPublicationsByDependence: underlyingStudyIndependence.summary.collapsedPublicationCount,
     weakApprovedStructuredClaims: claims.filter((claim) => claim.weakStructuredClaim).length,
     highConfidenceWeakStructuredClaims: structuredClaimAnalyses.filter((claim) => claim.highConfidenceWeakStructured).length,
     highConfidenceWeakOutcome: claims.filter((claim) => claim.highConfidenceWeakOutcome).length,
@@ -39,6 +54,11 @@ const report = {
     unapprovedWeakStructuredClaims: unapprovedWeakStructured.length,
   },
   claims,
+  independenceAdjustedSupport: {
+    summary: underlyingStudyIndependence.summary,
+    downgradedClaims: underlyingStudyIndependence.supportTierDowngrades,
+    reducedClaims: underlyingStudyIndependence.reducedClaims,
+  },
   editorialBacklog: {
     unsupportedStructuredClaims: unapprovedUnsupported,
     weakStructuredClaims: unapprovedWeakStructured,
@@ -54,11 +74,15 @@ console.log(`Structured claims                  ${report.summary.structuredClaim
 console.log(`Approved claims                    ${report.summary.approvedClaims}`)
 console.log(`Unapproved claims                  ${report.summary.unapprovedClaims}`)
 console.log(`Outcome claims                     ${report.summary.outcomeClaims}`)
+console.log(`Dependence-adjusted tier downgrades ${report.summary.supportTierDowngradesByDependence}`)
+console.log(`Collapsed dependent publications   ${report.summary.collapsedPublicationsByDependence}`)
 console.log(`Weak approved structured claims    ${report.summary.weakApprovedStructuredClaims}`)
 console.log(`High-confidence weak structured    ${report.summary.highConfidenceWeakStructuredClaims}`)
 console.log(`High-confidence weak outcomes      ${report.summary.highConfidenceWeakOutcome}`)
 console.log(`Unapproved unsupported claims      ${report.summary.unapprovedUnsupportedStructuredClaims}`)
 console.log(`Unapproved weak structured claims  ${report.summary.unapprovedWeakStructuredClaims}`)
-console.log('\nStructured support tiers:')
+console.log('\nPublication-level structured support tiers:')
 for (const [tier, count] of Object.entries(structuredTierCounts).sort((a, b) => b[1] - a[1])) console.log(`  ${tier.padEnd(26)} ${count}`)
+console.log('\nApproved independence-adjusted structured support tiers:')
+for (const [tier, count] of Object.entries(approvedAdjustedStructuredTierCounts).sort((a, b) => b[1] - a[1])) console.log(`  ${tier.padEnd(26)} ${count}`)
 console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`)


### PR DESCRIPTION
Extends canonical underlying-study independence with an auditable support-tier adjustment: publication-level structured support remains preserved, but an `adequate` multi-publication claim is reported as `single-study` when explicit registered-trial/cohort/dataset/parent-study relations collapse all supporting publications to one underlying study. Partial reductions that still leave 2+ underlying studies remain `adequate`. The claim-evidence-strength report now shows publication-level tiers alongside approved independence-adjusted tiers, plus downgraded claims and collapsed-publication counts. Includes regression coverage for downgrade/no-downgrade behavior.