### PR TITLE
Expose canonical research-gap drivers

### DIFF
--- a/scripts/ci/build-research-gap-priorities.ts
+++ b/scripts/ci/build-research-gap-priorities.ts
@@ -4,7 +4,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { RESEARCH_GAP_DIMENSION_CAPS, RESEARCH_GAP_WEIGHTS } from '../../lib/research-quality-policy'
+import {
+  RESEARCH_GAP_DIMENSION_CAPS,
+  RESEARCH_GAP_WEIGHTS,
+  type ResearchGapDimension,
+} from '../../lib/research-quality-policy'
 import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
@@ -12,8 +16,40 @@ const REPORT_DIR = path.join(ROOT, 'ops', 'reports')
 const OUTPUT = path.join(REPORT_DIR, 'research-gaps.json')
 const { researchGapQueue: ranked } = buildResearchQualitySnapshot(ROOT)
 
+const dimensions = Object.keys(RESEARCH_GAP_DIMENSION_CAPS) as ResearchGapDimension[]
+const dimensionRollup = Object.fromEntries(dimensions.map((dimension) => {
+  const affected = ranked.filter((item) => Number(item.dimensionRawScores[dimension] ?? 0) > 0)
+  const rawScore = affected.reduce((sum, item) => sum + Number(item.dimensionRawScores[dimension] ?? 0), 0)
+  const cappedScore = affected.reduce((sum, item) => sum + Number(item.dimensionScores[dimension] ?? 0), 0)
+  return [dimension, {
+    profiles: affected.length,
+    rawScore,
+    cappedScore,
+    cappedProfiles: affected.filter((item) => item.cappedDimensions.includes(dimension)).length,
+  }]
+}))
+
+const reasonCounts = new Map<string, { profiles: Set<string>; findings: number; totalWeight: number }>()
+for (const item of ranked) {
+  for (const reason of item.reasons) {
+    const aggregate = reasonCounts.get(reason.kind) ?? { profiles: new Set<string>(), findings: 0, totalWeight: 0 }
+    aggregate.profiles.add(item.url)
+    aggregate.findings += 1
+    aggregate.totalWeight += reason.weight
+    reasonCounts.set(reason.kind, aggregate)
+  }
+}
+const topReasonKinds = [...reasonCounts.entries()]
+  .map(([kind, aggregate]) => ({
+    kind,
+    profiles: aggregate.profiles.size,
+    findings: aggregate.findings,
+    totalWeight: aggregate.totalWeight,
+  }))
+  .sort((a, b) => b.profiles - a.profiles || b.totalWeight - a.totalWeight || b.findings - a.findings || a.kind.localeCompare(b.kind))
+
 const report = {
-  schemaVersion: 3,
+  schemaVersion: 4,
   generatedAt: new Date().toISOString(),
   source: 'lib/research-quality-snapshot.ts -> lib/research-quality-policy.ts',
   scoring: {
@@ -31,7 +67,11 @@ const report = {
     medium: ranked.filter((item) => item.score >= 25 && item.score < 60).length,
     low: ranked.filter((item) => item.score < 25).length,
     profilesWithCappedDimensions: ranked.filter((item) => item.cappedDimensions.length > 0).length,
+    totalRawScore: ranked.reduce((sum, item) => sum + item.rawScore, 0),
+    totalCappedScore: ranked.reduce((sum, item) => sum + item.score, 0),
   },
+  dimensionRollup,
+  topReasonKinds,
   queue: ranked,
 }
 
@@ -46,6 +86,18 @@ console.log(`High                        ${report.summary.high}`)
 console.log(`Medium                      ${report.summary.medium}`)
 console.log(`Low                         ${report.summary.low}`)
 console.log(`Dimension-capped profiles   ${report.summary.profilesWithCappedDimensions}`)
+console.log(`Queue score                 ${report.summary.totalCappedScore} capped / ${report.summary.totalRawScore} raw`)
+console.log('\nTop dimensions by affected profiles:')
+for (const [dimension, values] of Object.entries(dimensionRollup)
+  .sort((a, b) => b[1].profiles - a[1].profiles || b[1].rawScore - a[1].rawScore)
+  .slice(0, 6)) {
+  console.log(`  ${dimension.padEnd(20)} ${String(values.profiles).padStart(4)} profiles · ${String(values.cappedScore).padStart(5)} capped / ${String(values.rawScore).padStart(5)} raw`)
+}
+console.log('\nTop root causes:')
+for (const reason of topReasonKinds.slice(0, 8)) {
+  console.log(`  ${reason.kind.padEnd(42)} ${String(reason.profiles).padStart(4)} profiles · ${String(reason.findings).padStart(4)} finding(s)`)
+}
+console.log('\nHighest-priority profiles:')
 for (const item of ranked.slice(0, 10)) {
   const capNote = item.cappedDimensions.length ? ` · capped: ${item.cappedDimensions.join(',')}` : ''
   console.log(`  ${String(item.score).padStart(3)} (${String(item.rawScore).padStart(3)} raw) · ${item.url} · ${item.reasons.length} finding(s)${capNote}`)


### PR DESCRIPTION
Adds site-wide observability to the existing canonical remediation queue without changing scoring policy. `research-gaps.json` schema 4 now includes dimension rollups (affected profiles, raw/capped score, capped profiles), top root-cause reason kinds, and total raw-vs-capped queue pressure. The CLI prints dominant dimensions/root causes before the highest-priority profiles. All metrics are projections of the already-built canonical snapshot queue, so no parallel analysis or scoring path is introduced.