### PR TITLE
test(research): repair snapshot invariant fixture

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -27,9 +27,18 @@ function fixtures() {
       findings: [],
       concentrationFindings: [],
     },
+    claimBreadth: {
+      summary: { approvedClaimsWithHumanEvidence: 0, overbroadClaims: 0 },
+      claims: [],
+      findings: [],
+    },
     edgeCardinality: {
       summary: { claims: 0 },
       duplicateEdgeClaims: [],
+    },
+    evidenceIndependenceCoverage: {
+      summary: { multiStudyApprovedClaims: 0 },
+      claims: [],
     },
     claimLanguageCalibration: { directEvidenceFindings: [] },
     claimCitationMetadata: { claims: [] },


### PR DESCRIPTION
Repairs the canonical snapshot invariant test fixture after claim-breadth and evidence-independence topology became unconditional invariant inputs. Adds the missing zero-state `claimBreadth` and `evidenceIndependenceCoverage` structures so the baseline self-consistent fixture no longer fails from an incomplete mock. Production code is unchanged.