### PR TITLE
Preserve study-level trial registration identity

### DIFF
--- a/lib/__tests__/research-trial-registration-study-index.test.ts
+++ b/lib/__tests__/research-trial-registration-study-index.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeTrialRegistrationIndependence } from '../research-trial-registration-independence'
+import type { ResearchQualityAnalysis } from '../research-quality-analysis'
+
+describe('study-level trial registration index', () => {
+  it('preserves canonical registry resolution even when publications do not co-occur on a claim', () => {
+    const analysis = {
+      profiles: [{
+        url: '/herbs/example/',
+        record: {
+          sources: [
+            { id: 'publication-a', pmid: '11111111', trialRegistrationId: 'NCT00001234' },
+            { id: 'publication-b', pmid: '22222222', trialRegistrationId: 'NCT00001234' },
+            { id: 'ambiguous', pmid: '33333333', trialRegistrationIds: ['NCT00005678', 'NCT00009999'] },
+          ],
+        },
+      }],
+      claimAnalyses: [
+        { url: '/herbs/example/', claimId: 'claim-a', predicate: 'supports_outcome', confidence: 0.8, studyCount: 1, studyIds: ['pmid:11111111'] },
+        { url: '/herbs/example/', claimId: 'claim-b', predicate: 'supports_outcome', confidence: 0.8, studyCount: 1, studyIds: ['pmid:22222222'] },
+      ],
+      cache: {},
+    } as unknown as ResearchQualityAnalysis
+
+    const result = analyzeTrialRegistrationIndependence(analysis)
+
+    expect(result.claims).toHaveLength(0)
+    expect(result.studies).toEqual([
+      {
+        url: '/herbs/example/',
+        studyId: 'pmid:11111111',
+        registryIds: ['NCT00001234'],
+        stableRegistryId: 'NCT00001234',
+        ambiguous: false,
+      },
+      {
+        url: '/herbs/example/',
+        studyId: 'pmid:22222222',
+        registryIds: ['NCT00001234'],
+        stableRegistryId: 'NCT00001234',
+        ambiguous: false,
+      },
+      {
+        url: '/herbs/example/',
+        studyId: 'pmid:33333333',
+        registryIds: ['NCT00005678', 'NCT00009999'],
+        stableRegistryId: null,
+        ambiguous: true,
+      },
+    ])
+    expect(result.summary).toMatchObject({
+      canonicalStudies: 3,
+      studiesWithRegistryCoverage: 2,
+      studiesWithAmbiguousRegistryEvidence: 1,
+      multiStudyApprovedClaims: 0,
+    })
+  })
+})

--- a/lib/research-trial-registration-independence.ts
+++ b/lib/research-trial-registration-independence.ts
@@ -8,6 +8,11 @@ export type TrialRegistryResolution = {
   ambiguous: boolean
 }
 
+export type StudyTrialRegistration = TrialRegistryResolution & {
+  url: string
+  studyId: string
+}
+
 export type SameRegisteredTrialPair = {
   leftStudyId: string
   rightStudyId: string
@@ -31,10 +36,14 @@ export type ClaimTrialRegistrationIndependence = {
 }
 
 export type TrialRegistrationIndependenceAnalysis = {
+  studies: StudyTrialRegistration[]
   claims: ClaimTrialRegistrationIndependence[]
   sameTrialReuseClaims: ClaimTrialRegistrationIndependence[]
   highConfidenceSameTrialReuseClaims: ClaimTrialRegistrationIndependence[]
   summary: {
+    canonicalStudies: number
+    studiesWithRegistryCoverage: number
+    studiesWithAmbiguousRegistryEvidence: number
     multiStudyApprovedClaims: number
     claimsWithRegistryCoverage: number
     claimsWithAmbiguousRegistryEvidence: number
@@ -140,10 +149,10 @@ function adjustedStudyCount(
 }
 
 /**
- * Detect when multiple canonical publications supporting one approved claim are
- * actually outputs from the same registered clinical trial. The existing study
- * independence engine owns the relation rule; this adapter resolves canonical
- * research studies onto registry IDs from structured fields and PubMed text.
+ * Detect when canonical publications are outputs from the same registered
+ * clinical trial. Study-level registry resolution is preserved in the result so
+ * downstream independence analysis can reason across a whole profile instead of
+ * only publications that happen to co-occur on one approved claim.
  *
  * Publications mentioning multiple registry IDs are deliberately ambiguous and
  * never collapsed automatically.
@@ -152,13 +161,17 @@ export function analyzeTrialRegistrationIndependence(
   analysis: ResearchQualityAnalysis,
 ): TrialRegistrationIndependenceAnalysis {
   const registryByUrl = new Map<string, Map<string, TrialRegistryResolution>>()
+  const studies: StudyTrialRegistration[] = []
   for (const { url, record } of analysis.profiles) {
     const registry = new Map<string, TrialRegistryResolution>()
     for (const [studyId, group] of canonicalStudyGroups(record)) {
-      registry.set(studyId, resolveCanonicalStudyTrialRegistry(group, analysis.cache))
+      const resolution = resolveCanonicalStudyTrialRegistry(group, analysis.cache)
+      registry.set(studyId, resolution)
+      studies.push({ url, studyId, ...resolution })
     }
     registryByUrl.set(url, registry)
   }
+  studies.sort((a, b) => a.url.localeCompare(b.url) || a.studyId.localeCompare(b.studyId))
 
   const claims: ClaimTrialRegistrationIndependence[] = []
   for (const claim of analysis.claimAnalyses) {
@@ -214,10 +227,14 @@ export function analyzeTrialRegistrationIndependence(
   const highConfidenceSameTrialReuseClaims = claims.filter((claim) => claim.highConfidenceSameTrialReuse)
 
   return {
+    studies,
     claims,
     sameTrialReuseClaims,
     highConfidenceSameTrialReuseClaims,
     summary: {
+      canonicalStudies: studies.length,
+      studiesWithRegistryCoverage: studies.filter((study) => Boolean(study.stableRegistryId)).length,
+      studiesWithAmbiguousRegistryEvidence: studies.filter((study) => study.ambiguous).length,
       multiStudyApprovedClaims: claims.length,
       claimsWithRegistryCoverage: claims.filter((claim) => claim.registryKnownStudyCount > 0).length,
       claimsWithAmbiguousRegistryEvidence: claims.filter((claim) => claim.registryAmbiguousStudyCount > 0).length,


### PR DESCRIPTION
Extends the canonical trial-registration independence product with a study-level registry index instead of discarding the already-resolved per-study registry map. This does not change scoring or claim-level collapse yet; it preserves stable/ambiguous registry resolution for every canonical study so downstream underlying-study analysis can identify same-trial publications across an entire profile even when they never co-occur on one claim. Adds a regression covering two same-NCT publications on separate single-study claims plus ambiguous registry metadata.