### PR TITLE
Fix trial registry test fixture shape

### DIFF
--- a/lib/__tests__/research-underlying-study-independence.test.ts
+++ b/lib/__tests__/research-underlying-study-independence.test.ts
@@ -45,6 +45,7 @@ function trialAnalysis(
   sameRegisteredTrialPairs: Array<{ leftStudyId: string; rightStudyId: string; trialRegistrationId: string }> = [],
 ): TrialRegistrationIndependenceAnalysis {
   return {
+    studies: [],
     claims: [{
       url: '/herbs/example/',
       claimId: 'claim-1',
@@ -63,6 +64,9 @@ function trialAnalysis(
     sameTrialReuseClaims: [],
     highConfidenceSameTrialReuseClaims: [],
     summary: {
+      canonicalStudies: 0,
+      studiesWithRegistryCoverage: 0,
+      studiesWithAmbiguousRegistryEvidence: 0,
       multiStudyApprovedClaims: 1,
       claimsWithRegistryCoverage: 0,
       claimsWithAmbiguousRegistryEvidence: 0,


### PR DESCRIPTION
Updates the typed underlying-study independence fixture for the study-level trial-registration index introduced in #3564. Adds the required `studies` collection and study-level registry summary counters so typechecking remains aligned with the canonical analysis contract. No production behavior change.