### PR TITLE
test(research): enforce canonical citation snapshot invariants

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -66,14 +66,30 @@ function fixtures() {
     withdrawn: [],
     studies: [{ studyId: 'pmid:123', pmid: '123', doi: '', pageCount: 1, pages: ['/herbs/example'] }],
   } as unknown as ResearchSourceIntegrity
+  const citationIntegrity = {
+    sources: 1,
+    blockingCount: 0,
+    blocking: [],
+    duplicateProfileSources: [],
+    identifierPairConflicts: [],
+    conflicts: [],
+    passed: true,
+  }
 
-  return { analysis, topology, gate, queue, sourceIntegrity }
+  return { analysis, topology, gate, queue, sourceIntegrity, citationIntegrity }
 }
 
 describe('research quality snapshot invariants', () => {
   it('accepts a self-consistent canonical snapshot', () => {
-    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
-    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    const { analysis, topology, gate, queue, sourceIntegrity, citationIntegrity } = fixtures()
+    const report = validateResearchQualitySnapshotInvariants(
+      analysis,
+      topology,
+      gate,
+      queue,
+      sourceIntegrity,
+      citationIntegrity,
+    )
     expect(report.passed).toBe(true)
     expect(report.summary.failures).toBe(0)
   })
@@ -192,5 +208,50 @@ describe('research quality snapshot invariants', () => {
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(false)
     expect(report.failures.map((failure) => failure.kind)).toContain('source-profile-ownership-mismatch')
+  })
+
+  it('detects citation source cardinality drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity, citationIntegrity } = fixtures()
+    citationIntegrity.sources = 2
+    const report = validateResearchQualitySnapshotInvariants(
+      analysis,
+      topology,
+      gate,
+      queue,
+      sourceIntegrity,
+      citationIntegrity,
+    )
+    expect(report.failures.map((failure) => failure.kind)).toContain('citation-source-count-mismatch')
+    expect(report.summary.citationIntegrityFailures).toBe(1)
+  })
+
+  it('detects citation blocking-count drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity, citationIntegrity } = fixtures()
+    citationIntegrity.blocking.push({ kind: 'invalid-pmid' } as never)
+    const report = validateResearchQualitySnapshotInvariants(
+      analysis,
+      topology,
+      gate,
+      queue,
+      sourceIntegrity,
+      citationIntegrity,
+    )
+    expect(report.failures.map((failure) => failure.kind)).toContain('citation-blocking-count-mismatch')
+  })
+
+  it('detects citation pass-state drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity, citationIntegrity } = fixtures()
+    citationIntegrity.blockingCount = 1
+    citationIntegrity.blocking.push({ kind: 'invalid-pmid' } as never)
+    citationIntegrity.passed = true
+    const report = validateResearchQualitySnapshotInvariants(
+      analysis,
+      topology,
+      gate,
+      queue,
+      sourceIntegrity,
+      citationIntegrity,
+    )
+    expect(report.failures.map((failure) => failure.kind)).toContain('citation-pass-state-mismatch')
   })
 })

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -14,6 +14,16 @@ export type ResearchSnapshotInvariantFailure = {
   detail: string
 }
 
+type CitationIntegritySnapshotView = {
+  sources: number
+  blockingCount: number
+  blocking: unknown[]
+  duplicateProfileSources: unknown[]
+  identifierPairConflicts: unknown[]
+  conflicts: unknown[]
+  passed: boolean
+}
+
 export type ResearchSnapshotInvariantReport = {
   passed: boolean
   failures: ResearchSnapshotInvariantFailure[]
@@ -28,6 +38,7 @@ export type ResearchSnapshotInvariantReport = {
     missingSourceIds: number
     duplicateClaimSourceEdges: number
     sourceIntegrityFailures: number
+    citationIntegrityFailures: number
   }
 }
 
@@ -55,6 +66,7 @@ export function validateResearchQualitySnapshotInvariants(
   gate: ResearchQualityGate,
   researchGapQueue: ResearchGapItem[],
   sourceIntegrity?: ResearchSourceIntegrity,
+  citationIntegrity?: CitationIntegritySnapshotView,
 ): ResearchSnapshotInvariantReport {
   const failures: ResearchSnapshotInvariantFailure[] = []
   const profileUrls = new Set(analysis.profileAnalyses.map((profile) => profile.url))
@@ -66,6 +78,7 @@ export function validateResearchQualitySnapshotInvariants(
   )
   const canonicalStudyPages = new Map<string, Set<string>>()
   const globalStudyIdentities = crossProfileStudyIdentityMap(analysis.profiles)
+  let rawSourceCount = 0
 
   const add = (kind: string, detail: string) => failures.push({ kind, detail })
   const requireProfile = (kind: string, url: string, detail: string) => {
@@ -89,6 +102,7 @@ export function validateResearchQualitySnapshotInvariants(
     }
 
     const sources = Array.isArray(profile.record.sources) ? profile.record.sources : []
+    rawSourceCount += sources.length
     const seenSources = new Set<string>()
     for (let index = 0; index < sources.length; index += 1) {
       const id = text(sources[index]?.id)
@@ -237,6 +251,25 @@ export function validateResearchQualitySnapshotInvariants(
     }
   }
 
+  if (citationIntegrity) {
+    if (citationIntegrity.sources !== rawSourceCount) {
+      add('citation-source-count-mismatch', `citation=${citationIntegrity.sources}; analysis=${rawSourceCount}`)
+    }
+    const computedBlockingCount = citationIntegrity.blocking.length
+      + citationIntegrity.duplicateProfileSources.length
+      + citationIntegrity.identifierPairConflicts.length
+      + citationIntegrity.conflicts.length
+    if (citationIntegrity.blockingCount !== computedBlockingCount) {
+      add(
+        'citation-blocking-count-mismatch',
+        `summary=${citationIntegrity.blockingCount}; computed=${computedBlockingCount}`,
+      )
+    }
+    if (citationIntegrity.passed !== (citationIntegrity.blockingCount === 0)) {
+      add('citation-pass-state-mismatch', `passed=${citationIntegrity.passed}; blocking=${citationIntegrity.blockingCount}`)
+    }
+  }
+
   const unknownProfileReferences = failures.filter((failure) => failure.kind.includes('unknown-profile')).length
   const unknownClaimReferences = failures.filter((failure) => failure.kind.includes('unknown-claim')).length
   const countMismatches = failures.filter((failure) => failure.kind.includes('mismatch')).length
@@ -246,6 +279,7 @@ export function validateResearchQualitySnapshotInvariants(
   const missingSourceIds = failures.filter((failure) => failure.kind === 'missing-source-id').length
   const duplicateClaimSourceEdges = failures.filter((failure) => failure.kind === 'duplicate-claim-source-edge').length
   const sourceIntegrityFailures = failures.filter((failure) => failure.kind.startsWith('source-')).length
+  const citationIntegrityFailures = failures.filter((failure) => failure.kind.startsWith('citation-')).length
 
   return {
     passed: failures.length === 0,
@@ -261,6 +295,7 @@ export function validateResearchQualitySnapshotInvariants(
       missingSourceIds,
       duplicateClaimSourceEdges,
       sourceIntegrityFailures,
+      citationIntegrityFailures,
     },
   }
 }

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -45,6 +45,7 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
     gate,
     researchGapQueue,
     sourceIntegrity,
+    citationIntegrity,
   )
 
   if (!invariants.passed) {


### PR DESCRIPTION
Extends canonical snapshot invariants to include citation-integrity state now that citation identity is owned by the snapshot. Validates raw source cardinality against the loaded analysis, recomputes citation blocking-count arithmetic, and enforces pass-state consistency. Adds focused regression tests for each drift mode and wires the canonical snapshot's citation result into invariant validation.