### PR TITLE
Build profile-wide underlying study independence graph

### DIFF
--- a/lib/__tests__/research-underlying-study-profile-graph.test.ts
+++ b/lib/__tests__/research-underlying-study-profile-graph.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeUnderlyingStudyIndependence } from '../research-underlying-study-independence'
+import type { ResearchQualityAnalysis } from '../research-quality-analysis'
+import type { TrialRegistrationIndependenceAnalysis } from '../research-trial-registration-independence'
+import type { EvidenceLineageAnalysis } from '../research-evidence-lineage'
+
+function claim(claimId: string, studyIds: string[]) {
+  return {
+    url: '/herbs/example/',
+    claimId,
+    reviewStatus: 'approved',
+    approved: true,
+    predicate: 'supports_outcome',
+    confidence: 0.9,
+    sourceRefCount: studyIds.length,
+    validSourceRefCount: studyIds.length,
+    danglingSourceRefs: [],
+    studyIds,
+    studyCount: studyIds.length,
+    classifiedStudyCount: studyIds.length,
+    primaryHuman: studyIds.length,
+    synthesis: 0,
+    narrative: 0,
+    designs: studyIds.map(() => 'rct' as const),
+    outcomeClaim: true,
+    supportTier: 'human-supported' as const,
+    structuredSupportTier: studyIds.length === 1 ? 'single-study' as const : 'adequate' as const,
+    weakStructuredClaim: studyIds.length === 1,
+    highConfidenceWeakStructured: studyIds.length === 1,
+    highConfidenceWeakOutcome: false,
+    singleStudy: studyIds.length === 1,
+    aliasCollapsed: false,
+  }
+}
+
+describe('profile-wide underlying study graph', () => {
+  it('combines registry and cohort relations across claims and exposes false diversification', () => {
+    const claims = [
+      claim('claim-ac', ['a', 'c']),
+      claim('claim-b', ['b']),
+      claim('claim-a', ['a']),
+    ]
+    const analysis = {
+      cache: {},
+      profiles: [],
+      claimAnalyses: claims,
+      structuredClaimAnalyses: claims,
+      profileAnalyses: [{
+        url: '/herbs/example/',
+        overDependentOnSingleStudy: false,
+      }],
+    } as unknown as ResearchQualityAnalysis
+
+    const trialRegistrationIndependence = {
+      studies: [
+        { url: '/herbs/example/', studyId: 'a', registryIds: ['NCT01234567'], stableRegistryId: 'NCT01234567', ambiguous: false },
+        { url: '/herbs/example/', studyId: 'b', registryIds: ['NCT01234567'], stableRegistryId: 'NCT01234567', ambiguous: false },
+        { url: '/herbs/example/', studyId: 'c', registryIds: [], stableRegistryId: null, ambiguous: false },
+      ],
+      claims: [],
+      sameTrialReuseClaims: [],
+      highConfidenceSameTrialReuseClaims: [],
+      summary: {
+        canonicalStudies: 3,
+        studiesWithRegistryCoverage: 2,
+        studiesWithAmbiguousRegistryEvidence: 0,
+        multiStudyApprovedClaims: 1,
+        claimsWithRegistryCoverage: 0,
+        claimsWithAmbiguousRegistryEvidence: 0,
+        sameTrialReuseClaims: 0,
+        highConfidenceSameTrialReuseClaims: 0,
+        duplicatePublicationCount: 0,
+      },
+    } satisfies TrialRegistrationIndependenceAnalysis
+
+    const evidenceLineage = {
+      studies: [
+        { url: '/herbs/example/', studyId: 'b', lineageIds: ['cohort:COHORT-1'], explicitLineage: true },
+        { url: '/herbs/example/', studyId: 'c', lineageIds: ['cohort:COHORT-1'], explicitLineage: true },
+      ],
+      claims: [],
+      sharedNonRegistryLineageClaims: [],
+      highConfidenceSharedNonRegistryLineageClaims: [],
+      summary: {
+        studies: 2,
+        studiesWithExplicitLineage: 2,
+        explicitStudyLineageCoverage: 1,
+        multiStudyApprovedClaims: 1,
+        sharedNonRegistryLineageClaims: 0,
+        highConfidenceSharedNonRegistryLineageClaims: 0,
+      },
+    } satisfies EvidenceLineageAnalysis
+
+    const result = analyzeUnderlyingStudyIndependence({
+      analysis,
+      trialRegistrationIndependence,
+      evidenceLineage,
+    })
+
+    expect(result.claims.find((item) => item.claimId === 'claim-ac')).toMatchObject({
+      apparentStudyCount: 2,
+      underlyingStudyCount: 1,
+      collapsedPublicationCount: 1,
+      pseudoMultiStudySupport: true,
+      independenceAdjustedStructuredSupportTier: 'single-study',
+    })
+    expect(result.profiles[0]).toMatchObject({
+      publicationStudyCount: 3,
+      underlyingStudyCount: 1,
+      collapsedPublicationCount: 2,
+      mostUsedUnderlyingStudyClaimCount: 3,
+      dominantUnderlyingStudySupportedClaimShare: 1,
+      effectiveUnderlyingStudyCount: 1,
+      overDependentOnSingleUnderlyingStudy: true,
+      newlyOverDependentAfterIndependenceAdjustment: true,
+    })
+    expect(result.summary).toMatchObject({
+      profilesWithReducedStudyCount: 1,
+      overDependentProfiles: 1,
+      newlyOverDependentProfiles: 1,
+    })
+  })
+})

--- a/lib/research-underlying-study-independence.ts
+++ b/lib/research-underlying-study-independence.ts
@@ -19,12 +19,29 @@ export type ClaimUnderlyingStudyIndependence = {
   highConfidencePseudoMultiStudySupport: boolean
 }
 
+export type ProfileUnderlyingStudyIndependence = {
+  url: string
+  supportedApprovedClaimCount: number
+  publicationStudyCount: number
+  underlyingStudyCount: number
+  collapsedPublicationCount: number
+  mostUsedUnderlyingStudyId: string | null
+  mostUsedUnderlyingStudyClaimCount: number
+  dominantUnderlyingStudySupportedClaimShare: number
+  underlyingStudyConcentrationIndex: number
+  effectiveUnderlyingStudyCount: number
+  overDependentOnSingleUnderlyingStudy: boolean
+  newlyOverDependentAfterIndependenceAdjustment: boolean
+}
+
 export type UnderlyingStudyIndependenceAnalysis = {
   claims: ClaimUnderlyingStudyIndependence[]
   reducedClaims: ClaimUnderlyingStudyIndependence[]
   pseudoMultiStudyClaims: ClaimUnderlyingStudyIndependence[]
   highConfidencePseudoMultiStudyClaims: ClaimUnderlyingStudyIndependence[]
   supportTierDowngrades: ClaimUnderlyingStudyIndependence[]
+  profiles: ProfileUnderlyingStudyIndependence[]
+  newlyOverDependentProfiles: ProfileUnderlyingStudyIndependence[]
   summary: {
     multiStudyApprovedClaims: number
     independenceReducedClaims: number
@@ -32,6 +49,10 @@ export type UnderlyingStudyIndependenceAnalysis = {
     highConfidencePseudoMultiStudyClaims: number
     supportTierDowngrades: number
     collapsedPublicationCount: number
+    profilesWithSupportedClaims: number
+    profilesWithReducedStudyCount: number
+    overDependentProfiles: number
+    newlyOverDependentProfiles: number
   }
 }
 
@@ -39,6 +60,13 @@ export type UnderlyingStudyIndependenceInputs = {
   analysis: ResearchQualityAnalysis
   trialRegistrationIndependence: TrialRegistrationIndependenceAnalysis
   evidenceLineage: EvidenceLineageAnalysis
+}
+
+type Union = ReturnType<typeof createUnion>
+
+function round(value: number, digits = 3): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
 }
 
 function createUnion(studyIds: string[]) {
@@ -61,61 +89,103 @@ function createUnion(studyIds: string[]) {
   return { find, union }
 }
 
+function unionGroups(union: Union, groups: Iterable<string[]>) {
+  for (const studies of groups) {
+    if (studies.length < 2) continue
+    for (let index = 1; index < studies.length; index += 1) union.union(studies[0], studies[index])
+  }
+}
+
 /**
- * Collapse publication-level study IDs only when existing canonical lineage
- * analyzers positively prove that publications belong to the same underlying
+ * Build one explicit dependence graph per profile. Registry, cohort, dataset,
+ * and parent-study relations are resolved before claims are projected onto the
+ * graph, so dependence proven by different claims can combine transitively.
+ */
+function buildProfileUnions(inputs: UnderlyingStudyIndependenceInputs): Map<string, Union> {
+  const studyIdsByUrl = new Map<string, Set<string>>()
+  for (const claim of inputs.analysis.claimAnalyses) {
+    const studies = studyIdsByUrl.get(claim.url) ?? new Set<string>()
+    for (const studyId of claim.studyIds) studies.add(studyId)
+    studyIdsByUrl.set(claim.url, studies)
+  }
+
+  const unions = new Map<string, Union>()
+  for (const [url, studyIds] of studyIdsByUrl) unions.set(url, createUnion([...studyIds]))
+
+  const registryGroups = new Map<string, string[]>()
+  for (const study of inputs.trialRegistrationIndependence.studies ?? []) {
+    if (!study.stableRegistryId) continue
+    const key = `${study.url}::${study.stableRegistryId}`
+    const group = registryGroups.get(key) ?? []
+    group.push(study.studyId)
+    registryGroups.set(key, group)
+  }
+  for (const [key, studies] of registryGroups) {
+    const separator = key.lastIndexOf('::')
+    const url = key.slice(0, separator)
+    const union = unions.get(url)
+    if (union) unionGroups(union, [studies])
+  }
+
+  // Preserve explicit same-trial claim relations as a compatibility/fallback
+  // path for synthetic callers that supply claim diagnostics without the study
+  // registry index. Production analysis supplies both and the union is idempotent.
+  for (const claim of inputs.trialRegistrationIndependence.claims) {
+    const union = unions.get(claim.url)
+    if (!union) continue
+    for (const pair of claim.sameRegisteredTrialPairs) union.union(pair.leftStudyId, pair.rightStudyId)
+  }
+
+  const lineageGroups = new Map<string, string[]>()
+  for (const study of inputs.evidenceLineage.studies) {
+    for (const lineageId of study.lineageIds) {
+      const key = `${study.url}::${lineageId}`
+      const group = lineageGroups.get(key) ?? []
+      group.push(study.studyId)
+      lineageGroups.set(key, group)
+    }
+  }
+  for (const [key, studies] of lineageGroups) {
+    const separator = key.indexOf('::')
+    const url = key.slice(0, separator)
+    const union = unions.get(url)
+    if (union) unionGroups(union, [studies])
+  }
+
+  return unions
+}
+
+function claimGroups(studyIds: string[], union: Union): Map<string, string[]> {
+  const groups = new Map<string, string[]>()
+  for (const studyId of studyIds) {
+    const root = union.find(studyId)
+    const studies = groups.get(root) ?? []
+    studies.push(studyId)
+    groups.set(root, studies)
+  }
+  return groups
+}
+
+/**
+ * Collapse publication-level study IDs only when canonical lineage analyzers
+ * positively prove that publications belong to the same underlying
  * trial/cohort/dataset/parent study. Missing independence metadata is never
  * treated as dependence.
  *
- * Combining the relation systems here also captures transitive dependence: for
- * example A/B may share a trial registration while B/C share an explicit cohort,
- * proving that all three publications represent one underlying evidence unit.
- *
- * Publication-level structured support remains preserved for auditability, while
- * an independence-adjusted tier prevents an apparently adequate multi-publication
- * claim from being represented as multi-study support when every publication
- * collapses to one explicitly identified underlying study.
+ * Dependence is resolved once per profile, then projected onto each claim. This
+ * captures transitive evidence relationships even when the publications proving
+ * the chain never all co-occur on the same claim.
  */
 export function analyzeUnderlyingStudyIndependence(
   inputs: UnderlyingStudyIndependenceInputs,
 ): UnderlyingStudyIndependenceAnalysis {
-  const trialByClaim = new Map(
-    inputs.trialRegistrationIndependence.claims.map((claim) => [`${claim.url}::${claim.claimId}`, claim] as const),
-  )
-  const lineageByStudy = new Map(
-    inputs.evidenceLineage.studies.map((study) => [`${study.url}::${study.studyId}`, study.lineageIds] as const),
-  )
-
+  const unions = buildProfileUnions(inputs)
   const claims: ClaimUnderlyingStudyIndependence[] = []
+
   for (const claim of inputs.analysis.claimAnalyses) {
     if (claim.studyCount < 2) continue
-    const { find, union } = createUnion(claim.studyIds)
-    const trial = trialByClaim.get(`${claim.url}::${claim.claimId}`)
-
-    for (const pair of trial?.sameRegisteredTrialPairs ?? []) {
-      union(pair.leftStudyId, pair.rightStudyId)
-    }
-
-    const studiesByLineage = new Map<string, string[]>()
-    for (const studyId of claim.studyIds) {
-      for (const lineageId of lineageByStudy.get(`${claim.url}::${studyId}`) ?? []) {
-        const studies = studiesByLineage.get(lineageId) ?? []
-        studies.push(studyId)
-        studiesByLineage.set(lineageId, studies)
-      }
-    }
-    for (const studies of studiesByLineage.values()) {
-      if (studies.length < 2) continue
-      for (let index = 1; index < studies.length; index += 1) union(studies[0], studies[index])
-    }
-
-    const groups = new Map<string, string[]>()
-    for (const studyId of claim.studyIds) {
-      const root = find(studyId)
-      const studies = groups.get(root) ?? []
-      studies.push(studyId)
-      groups.set(root, studies)
-    }
+    const union = unions.get(claim.url) ?? createUnion(claim.studyIds)
+    const groups = claimGroups(claim.studyIds, union)
     const dependentPublicationGroups = [...groups.values()]
       .filter((studies) => studies.length > 1)
       .map((studies) => [...studies].sort())
@@ -165,12 +235,78 @@ export function analyzeUnderlyingStudyIndependence(
   const highConfidencePseudoMultiStudyClaims = claims.filter((claim) => claim.highConfidencePseudoMultiStudySupport)
   const supportTierDowngrades = claims.filter((claim) => claim.supportTierDowngradedByDependence)
 
+  const rawProfileByUrl = new Map(inputs.analysis.profileAnalyses.map((profile) => [profile.url, profile] as const))
+  const claimsByUrl = new Map<string, typeof inputs.analysis.claimAnalyses>()
+  for (const claim of inputs.analysis.claimAnalyses) {
+    if (!claim.studyIds.length) continue
+    const values = claimsByUrl.get(claim.url) ?? []
+    values.push(claim)
+    claimsByUrl.set(claim.url, values)
+  }
+
+  const profiles: ProfileUnderlyingStudyIndependence[] = []
+  for (const [url, profileClaims] of claimsByUrl) {
+    const union = unions.get(url) ?? createUnion([...new Set(profileClaims.flatMap((claim) => claim.studyIds))])
+    const publicationStudyIds = [...new Set(profileClaims.flatMap((claim) => claim.studyIds))]
+    const underlyingStudyIds = [...new Set(publicationStudyIds.map((studyId) => union.find(studyId)))]
+    const use = new Map<string, number>()
+    let claimUnderlyingEdges = 0
+
+    for (const claim of profileClaims) {
+      const roots = new Set(claim.studyIds.map((studyId) => union.find(studyId)))
+      claimUnderlyingEdges += roots.size
+      for (const root of roots) use.set(root, (use.get(root) ?? 0) + 1)
+    }
+
+    const ranked = [...use.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    const mostUsed = ranked[0] ?? null
+    const mostUsedUnderlyingStudyClaimCount = mostUsed?.[1] ?? 0
+    const supportedApprovedClaimCount = profileClaims.length
+    const dominantUnderlyingStudySupportedClaimShare = supportedApprovedClaimCount
+      ? mostUsedUnderlyingStudyClaimCount / supportedApprovedClaimCount
+      : 0
+    const edgeShares = claimUnderlyingEdges ? ranked.map(([, count]) => count / claimUnderlyingEdges) : []
+    const underlyingStudyConcentrationIndex = edgeShares.reduce((sum, share) => sum + share * share, 0)
+    const effectiveUnderlyingStudyCount = underlyingStudyConcentrationIndex > 0 ? 1 / underlyingStudyConcentrationIndex : 0
+    const overDependentOnSingleUnderlyingStudy =
+      supportedApprovedClaimCount >= 3
+      && dominantUnderlyingStudySupportedClaimShare >= 0.5
+      && effectiveUnderlyingStudyCount < 2.5
+    const rawProfile = rawProfileByUrl.get(url)
+
+    profiles.push({
+      url,
+      supportedApprovedClaimCount,
+      publicationStudyCount: publicationStudyIds.length,
+      underlyingStudyCount: underlyingStudyIds.length,
+      collapsedPublicationCount: Math.max(0, publicationStudyIds.length - underlyingStudyIds.length),
+      mostUsedUnderlyingStudyId: mostUsed?.[0] ?? null,
+      mostUsedUnderlyingStudyClaimCount,
+      dominantUnderlyingStudySupportedClaimShare: round(dominantUnderlyingStudySupportedClaimShare),
+      underlyingStudyConcentrationIndex: round(underlyingStudyConcentrationIndex),
+      effectiveUnderlyingStudyCount: round(effectiveUnderlyingStudyCount),
+      overDependentOnSingleUnderlyingStudy,
+      newlyOverDependentAfterIndependenceAdjustment:
+        overDependentOnSingleUnderlyingStudy && !Boolean(rawProfile?.overDependentOnSingleStudy),
+    })
+  }
+  profiles.sort((a, b) =>
+    Number(b.newlyOverDependentAfterIndependenceAdjustment) - Number(a.newlyOverDependentAfterIndependenceAdjustment)
+    || Number(b.overDependentOnSingleUnderlyingStudy) - Number(a.overDependentOnSingleUnderlyingStudy)
+    || b.dominantUnderlyingStudySupportedClaimShare - a.dominantUnderlyingStudySupportedClaimShare
+    || a.effectiveUnderlyingStudyCount - b.effectiveUnderlyingStudyCount
+    || a.url.localeCompare(b.url),
+  )
+  const newlyOverDependentProfiles = profiles.filter((profile) => profile.newlyOverDependentAfterIndependenceAdjustment)
+
   return {
     claims,
     reducedClaims,
     pseudoMultiStudyClaims,
     highConfidencePseudoMultiStudyClaims,
     supportTierDowngrades,
+    profiles,
+    newlyOverDependentProfiles,
     summary: {
       multiStudyApprovedClaims: claims.length,
       independenceReducedClaims: reducedClaims.length,
@@ -178,6 +314,10 @@ export function analyzeUnderlyingStudyIndependence(
       highConfidencePseudoMultiStudyClaims: highConfidencePseudoMultiStudyClaims.length,
       supportTierDowngrades: supportTierDowngrades.length,
       collapsedPublicationCount: reducedClaims.reduce((sum, claim) => sum + claim.collapsedPublicationCount, 0),
+      profilesWithSupportedClaims: profiles.length,
+      profilesWithReducedStudyCount: profiles.filter((profile) => profile.collapsedPublicationCount > 0).length,
+      overDependentProfiles: profiles.filter((profile) => profile.overDependentOnSingleUnderlyingStudy).length,
+      newlyOverDependentProfiles: newlyOverDependentProfiles.length,
     },
   }
 }


### PR DESCRIPTION
Refactors underlying-study independence from claim-local unions to one explicit dependence graph per profile, built from canonical study-level trial registrations plus cohort/dataset/parent-study lineage. Claims are projected onto that shared graph, enabling mixed-relation transitive collapse even when the publications proving dependence occur on different claims. Adds profile-level publication-vs-underlying-study counts, concentration/effective-study metrics using the existing overdependence threshold, and a `newlyOverDependentAfterIndependenceAdjustment` signal for false diversification. Includes a regression where A/B share an NCT, B/C share a cohort, and an A+C claim/profile is correctly collapsed despite no claim-local A/B pair.