### PR TITLE
Prioritize underlying-study false diversification

### DIFF
--- a/lib/__tests__/research-underlying-study-profile-policy.test.ts
+++ b/lib/__tests__/research-underlying-study-profile-policy.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeResearchQuality } from '../research-quality-analysis'
+import { buildResearchGapQueue } from '../research-quality-policy'
+import { buildResearchQualityTopology } from '../research-quality-topology'
+
+describe('underlying-study adjusted profile dependency policy', () => {
+  it('routes false publication diversification into the existing high-study-dependency reason', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'underlying-profile-policy-'))
+    try {
+      const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+      mkdirSync(detailDir, { recursive: true })
+      writeFileSync(path.join(detailDir, 'example.json'), JSON.stringify({
+        slug: 'example',
+        sources: [
+          { id: 'a', pmid: '11111111', studyClass: 'rct', trialRegistrationId: 'NCT01234567' },
+          { id: 'b', pmid: '22222222', studyClass: 'rct', trialRegistrationId: 'NCT01234567', cohortId: 'cohort-1' },
+          { id: 'c', pmid: '33333333', studyClass: 'rct', cohortId: 'cohort-1' },
+        ],
+        claimMap: [
+          { id: 'claim-ac', predicate: 'supports_outcome', confidence: 0.9, reviewStatus: 'approved', sourceRefIds: ['a', 'c'] },
+          { id: 'claim-b', predicate: 'supports_outcome', confidence: 0.9, reviewStatus: 'approved', sourceRefIds: ['b'] },
+          { id: 'claim-a', predicate: 'supports_outcome', confidence: 0.9, reviewStatus: 'approved', sourceRefIds: ['a'] },
+        ],
+      }))
+
+      const analysis = analyzeResearchQuality(root)
+      expect(analysis.profileAnalyses[0].overDependentOnSingleStudy).toBe(false)
+
+      const topology = buildResearchQualityTopology(analysis)
+      expect(topology.underlyingStudyIndependence.newlyOverDependentProfiles).toHaveLength(1)
+
+      const gap = buildResearchGapQueue(analysis, topology).find((item) => item.url === '/herbs/example/')
+      expect(gap?.reasonCounts['high-study-dependency']).toBe(1)
+      expect(gap?.reasons.find((reason) => reason.kind === 'high-study-dependency')?.detail)
+        .toContain('underlying study after explicit publication-lineage collapse')
+      expect(gap?.dimensionRawScores.concentration).toBeGreaterThan(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -200,6 +200,21 @@ export function buildAggregatedTopologyGapSignals(
     })
   }
 
+  // Publication-level and underlying-study-level concentration are the same
+  // editorial root cause. Only profiles that were *not* already flagged by the
+  // publication graph appear here, so this reuses the canonical high-study-
+  // dependency reason without double-counting existing profile findings.
+  for (const profile of topology.underlyingStudyIndependence.newlyOverDependentProfiles) {
+    const concentrationBonus = Math.round(Math.min(15, profile.underlyingStudyConcentrationIndex * 20))
+    const weight = Math.round(25 + profile.dominantUnderlyingStudySupportedClaimShare * 30 + concentrationBonus)
+    signals.push({
+      url: profile.url,
+      kind: 'high-study-dependency',
+      weight,
+      detail: `${Math.round(profile.dominantUnderlyingStudySupportedClaimShare * 100)}% of supported approved claims depend on one underlying study after explicit publication-lineage collapse; ${profile.publicationStudyCount} publications resolve to ${profile.underlyingStudyCount} underlying studies; effective underlying-study count ${profile.effectiveUnderlyingStudyCount}`,
+    })
+  }
+
   // One canonical union graph now owns registered-trial + cohort/dataset/parent
   // dependence. Policy only ranks the resulting adjusted underlying-study count.
   for (const [url, items] of groupByUrl(topology.underlyingStudyIndependence.reducedClaims)) {


### PR DESCRIPTION
Routes only profiles newly exposed as overdependent by the profile-wide underlying-study graph into the existing canonical `high-study-dependency` remediation reason. It reuses the same established threshold/weight shape as publication-level concentration, stays in the concentration dimension, and avoids double-counting because already-publication-overdependent profiles are excluded. Adds an end-to-end regression where publication-level metrics appear diversified but explicit NCT+cohort lineage collapse exposes one underlying study supporting the profile.