### PR TITLE
Allow unmapped studies to bridge underlying-study identity

### DIFF
--- a/lib/__tests__/research-underlying-study-unmapped-bridge.test.ts
+++ b/lib/__tests__/research-underlying-study-unmapped-bridge.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import type { EvidenceLineageAnalysis } from '@/lib/research-evidence-lineage'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import type { TrialRegistrationIndependenceAnalysis } from '@/lib/research-trial-registration-independence'
+import { analyzeUnderlyingStudyIndependence } from '@/lib/research-underlying-study-independence'
+
+describe('underlying-study inventory bridge nodes', () => {
+  it('uses an unmapped publication to prove transitive dependence without counting it as claim support', () => {
+    const analysis = {
+      profileAnalyses: [{ url: '/herbs/example/', overDependentOnSingleStudy: false }],
+      claimAnalyses: [{
+        url: '/herbs/example/',
+        claimId: 'claim-1',
+        predicate: 'supports_outcome',
+        confidence: 0.9,
+        studyIds: ['a', 'c'],
+        studyCount: 2,
+        structuredSupportTier: 'adequate',
+      }],
+    } as unknown as ResearchQualityAnalysis
+
+    const trialRegistrationIndependence = {
+      studies: [
+        { url: '/herbs/example/', studyId: 'a', registryIds: ['NCT00001234'], stableRegistryId: 'NCT00001234', ambiguous: false },
+        { url: '/herbs/example/', studyId: 'b', registryIds: ['NCT00001234'], stableRegistryId: 'NCT00001234', ambiguous: false },
+        { url: '/herbs/example/', studyId: 'c', registryIds: [], stableRegistryId: null, ambiguous: false },
+      ],
+      claims: [],
+      sameTrialReuseClaims: [],
+      highConfidenceSameTrialReuseClaims: [],
+      summary: {},
+    } as unknown as TrialRegistrationIndependenceAnalysis
+
+    const evidenceLineage = {
+      studies: [
+        { url: '/herbs/example/', studyId: 'a', lineageIds: [], explicitLineage: false },
+        { url: '/herbs/example/', studyId: 'b', lineageIds: ['cohort:bridge'], explicitLineage: true },
+        { url: '/herbs/example/', studyId: 'c', lineageIds: ['cohort:bridge'], explicitLineage: true },
+      ],
+      claims: [],
+      sharedNonRegistryLineageClaims: [],
+      highConfidenceSharedNonRegistryLineageClaims: [],
+      summary: {},
+    } as unknown as EvidenceLineageAnalysis
+
+    const result = analyzeUnderlyingStudyIndependence({
+      analysis,
+      trialRegistrationIndependence,
+      evidenceLineage,
+    })
+
+    expect(result.claims[0]).toMatchObject({
+      apparentStudyCount: 2,
+      underlyingStudyCount: 1,
+      collapsedPublicationCount: 1,
+      pseudoMultiStudySupport: true,
+      independenceAdjustedStructuredSupportTier: 'single-study',
+    })
+    expect(result.claims[0].dependentPublicationGroups).toEqual([['a', 'c']])
+    expect(result.profiles[0]).toMatchObject({
+      publicationStudyCount: 2,
+      underlyingStudyCount: 1,
+      collapsedPublicationCount: 1,
+    })
+  })
+})

--- a/lib/research-underlying-study-independence.ts
+++ b/lib/research-underlying-study-independence.ts
@@ -96,17 +96,32 @@ function unionGroups(union: Union, groups: Iterable<string[]>) {
   }
 }
 
+function addStudy(studyIdsByUrl: Map<string, Set<string>>, url: string, studyId: string) {
+  const studies = studyIdsByUrl.get(url) ?? new Set<string>()
+  studies.add(studyId)
+  studyIdsByUrl.set(url, studies)
+}
+
 /**
  * Build one explicit dependence graph per profile. Registry, cohort, dataset,
  * and parent-study relations are resolved before claims are projected onto the
  * graph, so dependence proven by different claims can combine transitively.
+ *
+ * The graph includes canonical inventory studies even when they are not linked
+ * to approved claims. Such studies may prove a transitive identity bridge, but
+ * they never contribute claim edges or concentration weight unless an approved
+ * claim actually cites them.
  */
 function buildProfileUnions(inputs: UnderlyingStudyIndependenceInputs): Map<string, Union> {
   const studyIdsByUrl = new Map<string, Set<string>>()
   for (const claim of inputs.analysis.claimAnalyses) {
-    const studies = studyIdsByUrl.get(claim.url) ?? new Set<string>()
-    for (const studyId of claim.studyIds) studies.add(studyId)
-    studyIdsByUrl.set(claim.url, studies)
+    for (const studyId of claim.studyIds) addStudy(studyIdsByUrl, claim.url, studyId)
+  }
+  for (const study of inputs.trialRegistrationIndependence.studies ?? []) {
+    addStudy(studyIdsByUrl, study.url, study.studyId)
+  }
+  for (const study of inputs.evidenceLineage.studies) {
+    addStudy(studyIdsByUrl, study.url, study.studyId)
   }
 
   const unions = new Map<string, Union>()


### PR DESCRIPTION
Expands the profile-wide underlying-study union graph so canonical inventory studies from the study-level trial-registry index and evidence-lineage inventory can act as identity bridge nodes even when they are not linked to approved claims. Approved-claim concentration metrics remain based only on approved claim-linked publications, so unmapped evidence can prove transitive dependence without inflating support. Adds a regression where claim-linked A and C collapse through unmapped B because A/B share an NCT and B/C share an explicit cohort.