### PR TITLE
feat(research): validate evidence grades against independent support

### DIFF
--- a/lib/__tests__/evidence-grade-independence-consistency.test.ts
+++ b/lib/__tests__/evidence-grade-independence-consistency.test.ts
@@ -1,0 +1,114 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { analyzeEvidenceGradeConsistency } from '@/lib/evidence-grade-consistency'
+import type { ResearchQualityTopology } from '@/lib/research-quality-topology'
+
+function fixtureRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), 'grade-independence-'))
+  const dataDir = path.join(root, 'public', 'data')
+  mkdirSync(dataDir, { recursive: true })
+  writeFileSync(path.join(dataDir, 'herbs.json'), JSON.stringify([
+    { slug: 'grade-a', evidence_grade: 'A', evidence_tier: 'Strong Evidence', indexability_status: 'PUBLISH' },
+    { slug: 'grade-b', evidence_grade: 'B', evidence_tier: 'Moderate Evidence', indexability_status: 'PUBLISH' },
+    { slug: 'grade-c', evidence_grade: 'C', evidence_tier: 'Limited Evidence', indexability_status: 'PUBLISH' },
+  ]))
+  writeFileSync(path.join(dataDir, 'compounds.json'), '[]')
+  return root
+}
+
+function topology(): ResearchQualityTopology {
+  return {
+    underlyingStudyIndependence: {
+      pseudoMultiStudyClaims: [
+        {
+          url: '/herbs/grade-a/',
+          claimId: 'a1',
+          predicate: 'supports_outcome',
+          confidence: 0.9,
+          apparentStudyCount: 2,
+          underlyingStudyCount: 1,
+          collapsedPublicationCount: 1,
+          dependentPublicationGroups: [['pmid:1', 'pmid:2']],
+          independenceReduced: true,
+          pseudoMultiStudySupport: true,
+          highConfidencePseudoMultiStudySupport: true,
+          publicationStructuredSupportTier: 'adequate',
+          independenceAdjustedStructuredSupportTier: 'single-study',
+        },
+        {
+          url: '/herbs/grade-b/',
+          claimId: 'b1',
+          predicate: 'supports_outcome',
+          confidence: 0.6,
+          apparentStudyCount: 2,
+          underlyingStudyCount: 1,
+          collapsedPublicationCount: 1,
+          dependentPublicationGroups: [['pmid:3', 'pmid:4']],
+          independenceReduced: true,
+          pseudoMultiStudySupport: true,
+          highConfidencePseudoMultiStudySupport: false,
+          publicationStructuredSupportTier: 'adequate',
+          independenceAdjustedStructuredSupportTier: 'single-study',
+        },
+        {
+          url: '/herbs/grade-c/',
+          claimId: 'c1',
+          predicate: 'supports_outcome',
+          confidence: 0.9,
+          apparentStudyCount: 2,
+          underlyingStudyCount: 1,
+          collapsedPublicationCount: 1,
+          dependentPublicationGroups: [['pmid:5', 'pmid:6']],
+          independenceReduced: true,
+          pseudoMultiStudySupport: true,
+          highConfidencePseudoMultiStudySupport: true,
+          publicationStructuredSupportTier: 'adequate',
+          independenceAdjustedStructuredSupportTier: 'single-study',
+        },
+      ],
+    },
+  } as unknown as ResearchQualityTopology
+}
+
+describe('evidence grade independence consistency', () => {
+  it('treats Grade A as contradictory, Grade B as advisory, and leaves C unchanged', () => {
+    const root = fixtureRoot()
+    try {
+      const report = analyzeEvidenceGradeConsistency(root, topology())
+      expect(report.totals).toMatchObject({
+        topologyContradictionsIndexable: 1,
+        topologyWarningsIndexable: 1,
+        contradictionsIndexable: 1,
+      })
+      expect(report.topologyContradictions[0]).toMatchObject({
+        url: '/herbs/grade-a/',
+        canonicalGrade: 'A',
+        pseudoMultiStudyClaimCount: 1,
+        highConfidencePseudoMultiStudyClaimCount: 1,
+        collapsedPublicationCount: 1,
+      })
+      expect(report.topologyContradictions[0].issues).toContain('strong-grade-with-pseudo-multi-study-support')
+      expect(report.topologyWarnings[0]).toMatchObject({ url: '/herbs/grade-b/', canonicalGrade: 'B' })
+      expect(report.topologyWarnings[0].issues).toContain('moderate-grade-with-pseudo-multi-study-support')
+      expect(report.findings.some((finding) => finding.url === '/herbs/grade-c/')).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves the legacy consistency behavior when topology is not supplied', () => {
+    const root = fixtureRoot()
+    try {
+      const report = analyzeEvidenceGradeConsistency(root)
+      expect(report.totals.topologyContradictionsIndexable).toBe(0)
+      expect(report.totals.topologyWarningsIndexable).toBe(0)
+      expect(report.findings).toHaveLength(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/lib/evidence-grade-consistency.ts
+++ b/lib/evidence-grade-consistency.ts
@@ -10,6 +10,7 @@ import {
   type CanonicalEvidenceGrade,
   type EvidenceBand,
 } from './evidence-grade'
+import type { ResearchQualityTopology } from './research-quality-topology'
 
 export type EvidenceGradeProfileRecord = {
   slug?: string
@@ -34,6 +35,9 @@ export type EvidenceGradeFinding = {
   gradeBand: EvidenceBand | null
   tierBand: EvidenceBand | null
   distance: number | null
+  pseudoMultiStudyClaimCount: number
+  highConfidencePseudoMultiStudyClaimCount: number
+  collapsedPublicationCount: number
   issues: string[]
 }
 
@@ -46,11 +50,15 @@ export type EvidenceGradeConsistencyReport = {
     flagged: number
     flaggedIndexable: number
     contradictionsIndexable: number
+    topologyContradictionsIndexable: number
+    topologyWarningsIndexable: number
     gradeCardRenderable: number
     invalidPublishedGrades: number
   }
   issueCounts: Record<string, number>
   contradictions: EvidenceGradeFinding[]
+  topologyContradictions: EvidenceGradeFinding[]
+  topologyWarnings: EvidenceGradeFinding[]
   invalid: EvidenceGradeFinding[]
   findings: EvidenceGradeFinding[]
 }
@@ -64,8 +72,19 @@ function readJson(dataDir: string, file: string): EvidenceGradeProfileRecord[] {
   }
 }
 
-/** Analyze published profile evidence grades without owning CLI/report behavior. */
-export function analyzeEvidenceGradeConsistency(root = process.cwd()): EvidenceGradeConsistencyReport {
+/**
+ * Analyze published profile evidence grades. Legacy grade-vs-tier consistency
+ * remains visible, while an optional canonical topology adds one deliberately
+ * narrow independence check: Grade A cannot claim strong evidence when a
+ * high-confidence approved claim only appears multi-study because multiple
+ * publications collapse to one explicitly identified underlying study. Grade B
+ * receives an advisory warning for the same proven dependence rather than a
+ * contradiction. Missing lineage never creates either issue.
+ */
+export function analyzeEvidenceGradeConsistency(
+  root = process.cwd(),
+  topology?: ResearchQualityTopology,
+): EvidenceGradeConsistencyReport {
   const dataDir = path.join(root, 'public', 'data')
   const records: [('herb' | 'compound'), EvidenceGradeProfileRecord[]][] = [
     ['herb', readJson(dataDir, 'herbs.json')],
@@ -73,16 +92,31 @@ export function analyzeEvidenceGradeConsistency(root = process.cwd()): EvidenceG
   ]
   const findings: EvidenceGradeFinding[] = []
 
+  const pseudoByUrl = new Map<string, {
+    claims: number
+    highConfidenceClaims: number
+    collapsedPublications: number
+  }>()
+  for (const claim of topology?.underlyingStudyIndependence.pseudoMultiStudyClaims ?? []) {
+    const item = pseudoByUrl.get(claim.url) ?? { claims: 0, highConfidenceClaims: 0, collapsedPublications: 0 }
+    item.claims += 1
+    if (claim.highConfidencePseudoMultiStudySupport) item.highConfidenceClaims += 1
+    item.collapsedPublications += claim.collapsedPublicationCount
+    pseudoByUrl.set(claim.url, item)
+  }
+
   for (const [kind, rows] of records) {
     for (const record of rows) {
       const slug = String(record.slug ?? '')
       if (!slug) continue
 
+      const url = `/${kind === 'herb' ? 'herbs' : 'compounds'}/${slug}/`
       const published = record.evidence_grade
       const normalized = normalizeEvidenceGrade(published)
       const tierBand = bandFromEvidenceTier(record.evidence_tier)
       const distance = gradeTierDistance(normalized.band, tierBand)
       const indexable = String(record.indexability_status ?? '').toUpperCase() === 'PUBLISH'
+      const independence = pseudoByUrl.get(url) ?? { claims: 0, highConfidenceClaims: 0, collapsedPublications: 0 }
       const issues: string[] = []
 
       const publishedIsValid = published === null || published === undefined || isCanonicalEvidenceGrade(published)
@@ -91,12 +125,18 @@ export function analyzeEvidenceGradeConsistency(root = process.cwd()): EvidenceG
       else if (distance === 1) issues.push('minor-disagreement')
       if (normalized.outcomeDependent) issues.push('outcome-dependent-grade')
       if (published === null && String(record.evidence_grade_reason ?? '') === 'unresolved') issues.push('missing-grade')
+
+      if (normalized.grade === 'A' && independence.highConfidenceClaims > 0) {
+        issues.push('strong-grade-with-pseudo-multi-study-support')
+      } else if (normalized.grade === 'B' && independence.claims > 0) {
+        issues.push('moderate-grade-with-pseudo-multi-study-support')
+      }
       if (!issues.length) continue
 
       findings.push({
         kind,
         slug,
-        url: `/${kind === 'herb' ? 'herbs' : 'compounds'}/${slug}/`,
+        url,
         indexable,
         rawGrade: normalized.raw,
         rawTier: String(record.evidence_tier ?? ''),
@@ -105,15 +145,32 @@ export function analyzeEvidenceGradeConsistency(root = process.cwd()): EvidenceG
         gradeBand: normalized.band,
         tierBand,
         distance,
+        pseudoMultiStudyClaimCount: independence.claims,
+        highConfidencePseudoMultiStudyClaimCount: independence.highConfidenceClaims,
+        collapsedPublicationCount: independence.collapsedPublications,
         issues,
       })
     }
   }
 
   const indexableFindings = findings.filter((finding) => finding.indexable)
+  const topologyContradictions = indexableFindings
+    .filter((finding) => finding.issues.includes('strong-grade-with-pseudo-multi-study-support'))
+    .sort((a, b) => b.highConfidencePseudoMultiStudyClaimCount - a.highConfidencePseudoMultiStudyClaimCount || a.url.localeCompare(b.url))
+  const topologyWarnings = indexableFindings
+    .filter((finding) => finding.issues.includes('moderate-grade-with-pseudo-multi-study-support'))
+    .sort((a, b) => b.pseudoMultiStudyClaimCount - a.pseudoMultiStudyClaimCount || a.url.localeCompare(b.url))
   const contradictions = indexableFindings
-    .filter((finding) => finding.issues.includes('contradicts-evidence-tier'))
-    .sort((a, b) => (b.distance ?? 0) - (a.distance ?? 0) || a.url.localeCompare(b.url))
+    .filter((finding) =>
+      finding.issues.includes('contradicts-evidence-tier')
+      || finding.issues.includes('strong-grade-with-pseudo-multi-study-support'),
+    )
+    .sort((a, b) =>
+      Number(b.issues.includes('strong-grade-with-pseudo-multi-study-support'))
+      - Number(a.issues.includes('strong-grade-with-pseudo-multi-study-support'))
+      || (b.distance ?? 0) - (a.distance ?? 0)
+      || a.url.localeCompare(b.url),
+    )
   const invalid = findings.filter((finding) => finding.issues.includes('invalid-published-grade'))
   const issueCounts: Record<string, number> = {}
   for (const finding of indexableFindings) {
@@ -136,11 +193,15 @@ export function analyzeEvidenceGradeConsistency(root = process.cwd()): EvidenceG
       flagged: findings.length,
       flaggedIndexable: indexableFindings.length,
       contradictionsIndexable: contradictions.length,
+      topologyContradictionsIndexable: topologyContradictions.length,
+      topologyWarningsIndexable: topologyWarnings.length,
       gradeCardRenderable,
       invalidPublishedGrades: invalid.length,
     },
     issueCounts,
     contradictions,
+    topologyContradictions,
+    topologyWarnings,
     invalid,
     findings,
   }

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -38,7 +38,7 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
   const researchGapQueue = buildResearchGapQueue(analysis, topology)
   const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
   const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
-  const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(root)
+  const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(root, topology)
   const invariants = validateResearchQualitySnapshotInvariants(
     analysis,
     topology,


### PR DESCRIPTION
Connects evidence-grade consistency to the canonical research topology instead of comparing only legacy `evidence_grade` vs `evidence_tier`. Grade A now records a contradiction when a high-confidence approved claim appears multi-study only because multiple publications collapse to one explicitly identified underlying trial/cohort/dataset/parent study. Grade B gets an advisory warning for proven pseudo-multi-study support; C/D are not overreached by this rule. Missing lineage never creates a finding. The canonical snapshot passes its existing topology into grade consistency, while direct callers without topology preserve legacy behavior. Adds A/B/C and compatibility regressions.