### PR TITLE
SEO: standardize mental health citation anchors

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'app/articles/**'
+      - 'components/articles/MentalHealthArticlePage.tsx'
       - 'components/References.tsx'
       - 'components/seo/**'
       - 'components/StructuredData.tsx'
@@ -96,6 +97,7 @@ jobs:
         run: >-
           npx eslint
           app/articles/[slug]/page.tsx
+          components/articles/MentalHealthArticlePage.tsx
           components/References.tsx
           components/StructuredData.tsx
           components/compare/CompareSchema.tsx

--- a/components/articles/MentalHealthArticlePage.tsx
+++ b/components/articles/MentalHealthArticlePage.tsx
@@ -18,12 +18,14 @@ import {
   canonicalUrl,
   DEFAULT_OG_IMAGE,
   SITE_NAME,
-  SITE_URL,
 } from '@/src/lib/seo'
+import {
+  AUTHOR_NAME,
+  AUTHOR_SCHEMA_ID,
+  AUTHOR_URL,
+} from '@/src/lib/schema-identities'
 
 const BASE_PATH = '/guides/mental-health'
-const AUTHOR_NAME = 'Willie B. Randolph III'
-const AUTHOR_URL = `${SITE_URL}/info/author/`
 
 function formatReviewDate(date: string): string {
   return new Intl.DateTimeFormat('en-US', {
@@ -70,7 +72,11 @@ function CitedPassage({ passage, article, as = 'p' }: {
     .filter((item): item is { id: string; number: number } => typeof item.number === 'number')
 
   return (
-    <Tag className={as === 'li' ? 'leading-7 text-muted' : 'text-[1.01rem] leading-[1.85] text-muted'}>
+    <Tag
+      className={as === 'li' ? 'leading-7 text-muted' : 'text-[1.01rem] leading-[1.85] text-muted'}
+      data-claim="true"
+      data-citation-sources={refs.length ? refs.map((ref) => `ref-${ref.number}`).join(',') : undefined}
+    >
       {passage.text}{' '}
       {refs.length > 0 && (
         <sup className="ml-0.5 whitespace-nowrap text-[0.72em] font-bold text-brand-700" aria-label="Citations">
@@ -78,7 +84,9 @@ function CitedPassage({ passage, article, as = 'p' }: {
             <React.Fragment key={ref.id}>
               {index > 0 && ','}
               <a
-                href={`#ref-${ref.id}`}
+                href={`#ref-${ref.number}`}
+                data-citation-link="true"
+                data-source-id={ref.id}
                 className="rounded-sm px-0.5 hover:bg-brand-50 hover:text-brand-900"
                 aria-label={`Reference ${ref.number}`}
               >
@@ -168,6 +176,7 @@ export default function MentalHealthArticlePage({ slug }: { slug: string }) {
     mainEntityOfPage: articleUrl,
     author: {
       '@type': 'Person',
+      '@id': AUTHOR_SCHEMA_ID,
       name: AUTHOR_NAME,
       url: AUTHOR_URL,
     },
@@ -180,6 +189,7 @@ export default function MentalHealthArticlePage({ slug }: { slug: string }) {
     articleSection: article.category,
     keywords: keywords.join(', '),
     inLanguage: 'en-US',
+    citation: article.references.map((reference) => reference.url),
     isPartOf: {
       '@type': 'CollectionPage',
       '@id': collectionId,
@@ -325,30 +335,61 @@ export default function MentalHealthArticlePage({ slug }: { slug: string }) {
         </div>
       </section>
 
-      <section id="references" className="mt-7 scroll-mt-24 rounded-2xl border border-brand-900/10 bg-brand-50/40 p-5 sm:p-8" aria-labelledby="references-heading">
+      <section
+        id="references"
+        aria-labelledby="references-heading"
+        data-reference-ledger="true"
+        className="mt-7 scroll-mt-24 rounded-2xl border border-brand-900/10 bg-brand-50/40 p-5 sm:p-8"
+      >
         <h2 id="references-heading" className="text-2xl font-semibold tracking-tight text-ink">References</h2>
         <p className="mt-2 text-sm leading-6 text-muted">
           Reference links point to the publisher, DOI, government agency, or official guideline page. A source tier describes the kind of evidence; it is not a guarantee that every conclusion is certain or applies to every person.
         </p>
         <ol className="mt-5 space-y-4">
-          {article.references.map((reference, index) => (
-            <li key={reference.id} id={`ref-${reference.id}`} className="scroll-mt-24 rounded-xl border border-brand-900/10 bg-white p-4 text-sm leading-6 text-muted">
-              <div className="flex items-start gap-3">
-                <span className="inline-flex min-w-7 justify-center rounded-full bg-brand-100 px-2 py-0.5 font-bold text-brand-900">{index + 1}</span>
-                <div>
-                  <a href={reference.url} target="_blank" rel="noopener noreferrer" className="font-semibold text-brand-800 hover:underline">
-                    {reference.citation}
+          {article.references.map((reference, index) => {
+            const citationNumber = index + 1
+            const citationId = `ref-${citationNumber}`
+            return (
+              <li
+                key={reference.id}
+                id={citationId}
+                data-citation-source="true"
+                data-citation-id={citationId}
+                data-source-id={reference.id}
+                data-source-tier={reference.tier}
+                itemScope
+                itemType="https://schema.org/CreativeWork"
+                className="scroll-mt-24 rounded-xl border border-brand-900/10 bg-white p-4 text-sm leading-6 text-muted"
+              >
+                <div className="flex items-start gap-3">
+                  <a
+                    href={`#${citationId}`}
+                    aria-label={`Permanent link to reference ${citationNumber}`}
+                    className="inline-flex min-w-7 justify-center rounded-full bg-brand-100 px-2 py-0.5 font-bold text-brand-900 hover:underline"
+                  >
+                    {citationNumber}
                   </a>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2 py-0.5 text-[0.7rem] font-bold uppercase tracking-wide text-brand-800">
-                      {reference.tier}
-                    </span>
-                    {reference.note && <span className="text-xs text-muted">{reference.note}</span>}
+                  <div>
+                    <a
+                      href={reference.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      itemProp="url"
+                      className="font-semibold text-brand-800 hover:underline"
+                    >
+                      <cite itemProp="name" className="not-italic">{reference.citation}</cite>
+                    </a>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <span className="rounded-full border border-brand-900/10 bg-brand-50 px-2 py-0.5 text-[0.7rem] font-bold uppercase tracking-wide text-brand-800">
+                        {reference.tier}
+                      </span>
+                      {reference.note && <span className="text-xs text-muted">{reference.note}</span>}
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-          ))}
+              </li>
+            )
+          })}
         </ol>
       </section>
 

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -12,6 +12,7 @@ const ANSWER_TABLE = path.join(ROOT, 'components', 'seo', 'AnswerEngineTable.tsx
 const ARTICLE_EVIDENCE = path.join(ROOT, 'src', 'components', 'evidence', 'WhatEvidenceShows.tsx')
 const ARTICLE_CITATIONS = path.join(ROOT, 'src', 'lib', 'article-citation-metadata.ts')
 const ARTICLE_PAGE = path.join(ROOT, 'app', 'articles', '[slug]', 'page.tsx')
+const MENTAL_HEALTH_ARTICLE = path.join(ROOT, 'components', 'articles', 'MentalHealthArticlePage.tsx')
 const REFERENCES = path.join(ROOT, 'components', 'References.tsx')
 const EVIDENCE_BADGE = path.join(ROOT, 'components', 'ui', 'EvidenceScoreBadge.tsx')
 const SAFETY_GAUGE = path.join(ROOT, 'components', 'ui', 'SafetyGaugeMeter.tsx')
@@ -146,6 +147,25 @@ function auditArticleExtractionPrimitives() {
   }
 }
 
+function auditMentalHealthCitationPrimitives() {
+  requireSignals(MENTAL_HEALTH_ARTICLE, 'mental-health-citations', 'MentalHealthArticlePage', [
+    ['href={`#ref-${ref.number}`}', 'ordinal inline citation targets'],
+    ['data-source-id={ref.id}', 'internal source-id provenance on inline citations'],
+    ['data-reference-ledger="true"', 'reference-ledger marker'],
+    ['id={citationId}', 'ordinal source entry anchors'],
+    ['data-citation-source="true"', 'citation-source marker'],
+    ['data-source-id={reference.id}', 'internal source-id provenance on source entries'],
+    ['itemType="https://schema.org/CreativeWork"', 'CreativeWork source semantics'],
+    ['citation: article.references.map((reference) => reference.url)', 'Article citation URL graph'],
+    ["'@id': AUTHOR_SCHEMA_ID", 'canonical first-party author identity'],
+  ])
+
+  const source = text(MENTAL_HEALTH_ARTICLE)
+  if (/href={`#ref-\$\{ref\.id\}`}/.test(source) || /id={`ref-\$\{reference\.id\}`}/.test(source)) {
+    add('error', 'mental-health-citations', 'mental-health public citation fragments expose internal source IDs instead of ordinal anchors')
+  }
+}
+
 function auditProfilePrimitives() {
   requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
     ['data-evidence="true"', 'evidence marker'],
@@ -223,6 +243,7 @@ auditDiscovery()
 auditMachineReadable()
 auditSharedExtractionPrimitives()
 auditArticleExtractionPrimitives()
+auditMentalHealthCitationPrimitives()
 auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()


### PR DESCRIPTION
Fixes #3449

## Summary
- preserves the mental-health guides' authored inline claim-to-source mapping while separating internal source IDs from public citation fragment IDs
- changes public inline citation links from `#ref-<internal-id>` to stable ordinal `#ref-N` targets that match the visible citation numbers
- changes source ledger entry IDs to the same stable ordinal `#ref-N` convention
- retains internal mental-health reference IDs only as `data-source-id` provenance on inline citation links and source entries
- adds standard claim/source extraction markers to cited passages and the mental-health source ledger
- exposes source entries as conservative `CreativeWork` semantics using only the real citation text and URL already present in the source model
- adds the article's real reference URLs to Article JSON-LD `citation` without inventing missing bibliographic fields
- makes the mental-health Article author explicitly reuse the canonical first-party Person ID
- extends the existing AI answer-engine audit and workflow to own this specialized citation surface instead of creating a second validator

## Relevant URLs
- `/guides/mental-health/<slug>/`
- inline citation targets `/guides/mental-health/<slug>/#ref-N`
- the mental-health source ledger at `#references`

## Acceptance criteria
- Internal source IDs remain available for authored claim mapping but never appear in public `#ref-*` fragments.
- Inline citation numbers target ordinal `#ref-N` anchors matching the displayed citation number.
- Source ledger entries use the same ordinal anchors and expose the internal source ID separately as provenance.
- Cited passages expose claim/source markers for extraction.
- Source entries expose citation-source markers and conservative CreativeWork name/URL semantics.
- Article JSON-LD advertises the real source URLs via `citation` and does not fabricate PMID/DOI/author/journal fields that are absent from the mental-health source model.
- The first-party Article author resolves to the canonical author Person ID.
- The existing AI-search quality workflow triggers and lints this component.

## Validation commands
- `npm run audit:ai-citations`
- `npx eslint components/articles/MentalHealthArticlePage.tsx scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- `npm run build:deploy`
- AI search quality check
- Schema and Media Governance
- Atomic upgrade gate

## Before → after metrics
- Mental-health public reference fragment conventions: internal-ID fragments → 1 stable ordinal `#ref-N` convention.
- Inline citation display/target mismatch: displayed ordinal + internal-ID target → displayed ordinal + matching ordinal target.
- Internal source ID exposure as public URL identity: all cited sources → 0; retained only as `data-source-id` provenance.
- Mental-health cited passages with claim/source extraction markers: 0 → all `CitedPassage` outputs.
- Mental-health source entries with standard citation-source/ledger markers: 0 → all entries.
- Mental-health Article JSON-LD citation URLs: 0 → all modeled reference URLs.
- New citation pipelines introduced: 0; existing specialized renderer and existing answer-engine audit are retained/extended.

## Generator/source-of-truth decision
`MentalHealthArticle.references` remains the authored source registry and its internal `id` remains the claim-mapping key. Public fragment identity is presentation-level ordinal identity derived solely from registry order. `MentalHealthArticlePage` remains the specialized renderer because it preserves claim-level citation mapping that the generic References component does not model. `audit-ai-answer-engine-readiness.mjs` remains the canonical extraction contract; no new citation audit pipeline is introduced.

## Regression contract
- Internal mental-health source IDs must never return to public `#ref-*` fragments.
- The Nth source must remain reachable at `#ref-N` and inline references displaying N must target that anchor.
- Reordering the source registry may change ordinals, but identifier availability or source-ID formatting must never change the anchor convention.
- Internal source IDs must remain available as provenance for debugging/authored claim mapping.
- Source schema must not invent bibliographic properties absent from the source model.
- First-party author identity must remain canonical and must not affect third-party source identity.
- The mental-health surface must remain inside the existing AI-search workflow/audit ownership boundary.

## AI SEO / trust impact
Mental-health guides keep their stronger inline claim-level citation design while gaining the same public citation identity and extraction semantics as the rest of the site: predictable source anchors, explicit claim-to-source markers, real citation URLs, and conservative structured data.