### PR TITLE
Enforce underlying-study snapshot invariants

### DIFF
--- a/lib/__tests__/research-underlying-study-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-underlying-study-snapshot-invariants.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import type { ResearchQualityTopology } from '@/lib/research-quality-topology'
+import { validateUnderlyingStudySnapshotInvariants } from '@/lib/research-underlying-study-snapshot-invariants'
+
+function fixtures() {
+  const analysis = {
+    claimAnalyses: [{
+      url: '/herbs/example/',
+      claimId: 'claim-1',
+      confidence: 0.9,
+      studyIds: ['a', 'b'],
+      studyCount: 2,
+    }],
+    profileAnalyses: [{
+      url: '/herbs/example/',
+      supportedApprovedClaimCount: 1,
+      overDependentOnSingleStudy: false,
+    }],
+  } as unknown as ResearchQualityAnalysis
+
+  const claim = {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    predicate: 'supports_outcome',
+    confidence: 0.9,
+    apparentStudyCount: 2,
+    underlyingStudyCount: 1,
+    collapsedPublicationCount: 1,
+    dependentPublicationGroups: [['a', 'b']],
+    publicationStructuredSupportTier: 'adequate',
+    independenceAdjustedStructuredSupportTier: 'single-study',
+    supportTierDowngradedByDependence: true,
+    independenceReduced: true,
+    pseudoMultiStudySupport: true,
+    highConfidencePseudoMultiStudySupport: true,
+  }
+  const profile = {
+    url: '/herbs/example/',
+    supportedApprovedClaimCount: 1,
+    publicationStudyCount: 2,
+    underlyingStudyCount: 1,
+    collapsedPublicationCount: 1,
+    mostUsedUnderlyingStudyId: 'a',
+    mostUsedUnderlyingStudyClaimCount: 1,
+    dominantUnderlyingStudySupportedClaimShare: 1,
+    underlyingStudyConcentrationIndex: 1,
+    effectiveUnderlyingStudyCount: 1,
+    overDependentOnSingleUnderlyingStudy: false,
+    newlyOverDependentAfterIndependenceAdjustment: false,
+  }
+  const topology = {
+    underlyingStudyIndependence: {
+      claims: [claim],
+      reducedClaims: [claim],
+      pseudoMultiStudyClaims: [claim],
+      highConfidencePseudoMultiStudyClaims: [claim],
+      supportTierDowngrades: [claim],
+      profiles: [profile],
+      newlyOverDependentProfiles: [],
+      summary: {
+        multiStudyApprovedClaims: 1,
+        independenceReducedClaims: 1,
+        pseudoMultiStudyClaims: 1,
+        highConfidencePseudoMultiStudyClaims: 1,
+        supportTierDowngrades: 1,
+        collapsedPublicationCount: 1,
+        profilesWithSupportedClaims: 1,
+        profilesWithReducedStudyCount: 1,
+        overDependentProfiles: 0,
+        newlyOverDependentProfiles: 0,
+      },
+    },
+  } as unknown as ResearchQualityTopology
+
+  return { analysis, topology }
+}
+
+describe('underlying-study snapshot invariants', () => {
+  it('accepts a self-consistent independence product', () => {
+    const { analysis, topology } = fixtures()
+    expect(validateUnderlyingStudySnapshotInvariants(analysis, topology)).toEqual([])
+  })
+
+  it('rejects impossible adjusted study arithmetic', () => {
+    const { analysis, topology } = fixtures()
+    topology.underlyingStudyIndependence.claims[0].underlyingStudyCount = 3
+    const kinds = validateUnderlyingStudySnapshotInvariants(analysis, topology).map((failure) => failure.kind)
+    expect(kinds).toContain('underlying-study-invalid-adjusted-count')
+    expect(kinds).toContain('underlying-study-claim-collapse-mismatch')
+  })
+
+  it('rejects subset and summary count drift', () => {
+    const { analysis, topology } = fixtures()
+    topology.underlyingStudyIndependence.summary.pseudoMultiStudyClaims = 0
+    const kinds = validateUnderlyingStudySnapshotInvariants(analysis, topology).map((failure) => failure.kind)
+    expect(kinds).toContain('underlying-study-pseudo-count-mismatch')
+  })
+})

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -8,6 +8,7 @@ import type { ResearchQualityGate } from './research-quality-gate'
 import type { ResearchGapItem } from './research-quality-policy'
 import type { ResearchQualityTopology } from './research-quality-topology'
 import type { ResearchSourceIntegrity } from './research-source-integrity'
+import { validateUnderlyingStudySnapshotInvariants } from './research-underlying-study-snapshot-invariants'
 
 export type ResearchSnapshotInvariantFailure = {
   kind: string
@@ -152,6 +153,9 @@ export function validateResearchQualitySnapshotInvariants(
       'independence-coverage-claim-count-mismatch',
       `coverage=${topology.evidenceIndependenceCoverage.summary.multiStudyApprovedClaims}; analysis=${approvedMultiStudyClaimKeys.size}`,
     )
+  }
+  for (const invariant of validateUnderlyingStudySnapshotInvariants(analysis, topology)) {
+    add(invariant.kind, invariant.detail)
   }
   for (const claim of topology.edgeCardinality.duplicateEdgeClaims) {
     add(

--- a/lib/research-underlying-study-snapshot-invariants.ts
+++ b/lib/research-underlying-study-snapshot-invariants.ts
@@ -1,0 +1,158 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { ResearchQualityTopology } from './research-quality-topology'
+
+export type UnderlyingStudySnapshotInvariantFailure = {
+  kind: string
+  detail: string
+}
+
+function claimKey(url: string, claimId: string): string {
+  return `${url}::${claimId}`
+}
+
+/**
+ * Validate arithmetic and ownership for the canonical underlying-study graph.
+ * These checks are implementation invariants, not scientific judgments.
+ */
+export function validateUnderlyingStudySnapshotInvariants(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology,
+): UnderlyingStudySnapshotInvariantFailure[] {
+  const failures: UnderlyingStudySnapshotInvariantFailure[] = []
+  const add = (kind: string, detail: string) => failures.push({ kind, detail })
+  const product = topology.underlyingStudyIndependence
+  const analysisClaims = new Map(
+    analysis.claimAnalyses.map((claim) => [claimKey(claim.url, claim.claimId), claim] as const),
+  )
+  const multiStudyClaimKeys = new Set(
+    analysis.claimAnalyses
+      .filter((claim) => claim.studyCount >= 2)
+      .map((claim) => claimKey(claim.url, claim.claimId)),
+  )
+  const profileByUrl = new Map(analysis.profileAnalyses.map((profile) => [profile.url, profile] as const))
+
+  const claimSubsets: Array<[string, typeof product.claims]> = [
+    ['reduced', product.reducedClaims],
+    ['pseudo', product.pseudoMultiStudyClaims],
+    ['high-confidence-pseudo', product.highConfidencePseudoMultiStudyClaims],
+    ['support-tier-downgrade', product.supportTierDowngrades],
+  ]
+
+  if (product.summary.multiStudyApprovedClaims !== product.claims.length) {
+    add('underlying-study-claim-count-mismatch', `summary=${product.summary.multiStudyApprovedClaims}; rows=${product.claims.length}`)
+  }
+  if (product.claims.length !== multiStudyClaimKeys.size) {
+    add('underlying-study-analysis-claim-count-mismatch', `rows=${product.claims.length}; analysis=${multiStudyClaimKeys.size}`)
+  }
+  if (product.summary.independenceReducedClaims !== product.reducedClaims.length) {
+    add('underlying-study-reduced-count-mismatch', `summary=${product.summary.independenceReducedClaims}; rows=${product.reducedClaims.length}`)
+  }
+  if (product.summary.pseudoMultiStudyClaims !== product.pseudoMultiStudyClaims.length) {
+    add('underlying-study-pseudo-count-mismatch', `summary=${product.summary.pseudoMultiStudyClaims}; rows=${product.pseudoMultiStudyClaims.length}`)
+  }
+  if (product.summary.highConfidencePseudoMultiStudyClaims !== product.highConfidencePseudoMultiStudyClaims.length) {
+    add('underlying-study-high-confidence-pseudo-count-mismatch', `summary=${product.summary.highConfidencePseudoMultiStudyClaims}; rows=${product.highConfidencePseudoMultiStudyClaims.length}`)
+  }
+  if (product.summary.supportTierDowngrades !== product.supportTierDowngrades.length) {
+    add('underlying-study-tier-downgrade-count-mismatch', `summary=${product.summary.supportTierDowngrades}; rows=${product.supportTierDowngrades.length}`)
+  }
+  const collapsedClaimPublications = product.reducedClaims.reduce((sum, claim) => sum + claim.collapsedPublicationCount, 0)
+  if (product.summary.collapsedPublicationCount !== collapsedClaimPublications) {
+    add('underlying-study-collapsed-publication-count-mismatch', `summary=${product.summary.collapsedPublicationCount}; computed=${collapsedClaimPublications}`)
+  }
+
+  const claimKeys = new Set<string>()
+  for (const claim of product.claims) {
+    const key = claimKey(claim.url, claim.claimId)
+    if (claimKeys.has(key)) add('underlying-study-duplicate-claim', key)
+    claimKeys.add(key)
+    const source = analysisClaims.get(key)
+    if (!source) {
+      add('underlying-study-unknown-claim', key)
+      continue
+    }
+    if (!multiStudyClaimKeys.has(key)) add('underlying-study-non-multistudy-claim', key)
+    if (claim.apparentStudyCount !== source.studyCount) {
+      add('underlying-study-apparent-count-mismatch', `${key}: product=${claim.apparentStudyCount}; analysis=${source.studyCount}`)
+    }
+    if (claim.underlyingStudyCount < 1 || claim.underlyingStudyCount > claim.apparentStudyCount) {
+      add('underlying-study-invalid-adjusted-count', `${key}: apparent=${claim.apparentStudyCount}; underlying=${claim.underlyingStudyCount}`)
+    }
+    const expectedCollapsed = Math.max(0, claim.apparentStudyCount - claim.underlyingStudyCount)
+    if (claim.collapsedPublicationCount !== expectedCollapsed) {
+      add('underlying-study-claim-collapse-mismatch', `${key}: rows=${claim.collapsedPublicationCount}; expected=${expectedCollapsed}`)
+    }
+    if (claim.independenceReduced !== (expectedCollapsed > 0)) {
+      add('underlying-study-reduced-state-mismatch', `${key}: reduced=${claim.independenceReduced}; collapsed=${expectedCollapsed}`)
+    }
+    const expectedPseudo = claim.apparentStudyCount >= 2 && claim.underlyingStudyCount === 1
+    if (claim.pseudoMultiStudySupport !== expectedPseudo) {
+      add('underlying-study-pseudo-state-mismatch', `${key}: pseudo=${claim.pseudoMultiStudySupport}; underlying=${claim.underlyingStudyCount}`)
+    }
+    if (claim.highConfidencePseudoMultiStudySupport !== (expectedPseudo && claim.confidence >= 0.75)) {
+      add('underlying-study-high-confidence-pseudo-state-mismatch', key)
+    }
+    if (claim.supportTierDowngradedByDependence !== (claim.publicationStructuredSupportTier !== claim.independenceAdjustedStructuredSupportTier)) {
+      add('underlying-study-tier-downgrade-state-mismatch', key)
+    }
+    const sourceStudyIds = new Set(source.studyIds)
+    for (const group of claim.dependentPublicationGroups) {
+      if (group.length < 2 || group.some((studyId) => !sourceStudyIds.has(studyId))) {
+        add('underlying-study-invalid-dependent-group', `${key}: ${group.join(',')}`)
+      }
+    }
+  }
+
+  for (const [label, subset] of claimSubsets) {
+    for (const claim of subset) {
+      if (!claimKeys.has(claimKey(claim.url, claim.claimId))) {
+        add('underlying-study-orphan-subset-claim', `${label}: ${claim.url}::${claim.claimId}`)
+      }
+    }
+  }
+
+  if (product.summary.profilesWithSupportedClaims !== product.profiles.length) {
+    add('underlying-study-profile-count-mismatch', `summary=${product.summary.profilesWithSupportedClaims}; rows=${product.profiles.length}`)
+  }
+  if (product.summary.profilesWithReducedStudyCount !== product.profiles.filter((profile) => profile.collapsedPublicationCount > 0).length) {
+    add('underlying-study-reduced-profile-count-mismatch', `summary=${product.summary.profilesWithReducedStudyCount}`)
+  }
+  if (product.summary.overDependentProfiles !== product.profiles.filter((profile) => profile.overDependentOnSingleUnderlyingStudy).length) {
+    add('underlying-study-overdependent-profile-count-mismatch', `summary=${product.summary.overDependentProfiles}`)
+  }
+  if (product.summary.newlyOverDependentProfiles !== product.newlyOverDependentProfiles.length) {
+    add('underlying-study-new-overdependent-count-mismatch', `summary=${product.summary.newlyOverDependentProfiles}; rows=${product.newlyOverDependentProfiles.length}`)
+  }
+
+  const profileUrls = new Set<string>()
+  for (const profile of product.profiles) {
+    if (profileUrls.has(profile.url)) add('underlying-study-duplicate-profile', profile.url)
+    profileUrls.add(profile.url)
+    const source = profileByUrl.get(profile.url)
+    if (!source) {
+      add('underlying-study-unknown-profile', profile.url)
+      continue
+    }
+    if (profile.supportedApprovedClaimCount !== source.supportedApprovedClaimCount) {
+      add('underlying-study-profile-supported-claim-count-mismatch', `${profile.url}: product=${profile.supportedApprovedClaimCount}; analysis=${source.supportedApprovedClaimCount}`)
+    }
+    if (profile.underlyingStudyCount < 1 || profile.underlyingStudyCount > profile.publicationStudyCount) {
+      add('underlying-study-invalid-profile-adjusted-count', `${profile.url}: publication=${profile.publicationStudyCount}; underlying=${profile.underlyingStudyCount}`)
+    }
+    const expectedCollapsed = Math.max(0, profile.publicationStudyCount - profile.underlyingStudyCount)
+    if (profile.collapsedPublicationCount !== expectedCollapsed) {
+      add('underlying-study-profile-collapse-mismatch', `${profile.url}: rows=${profile.collapsedPublicationCount}; expected=${expectedCollapsed}`)
+    }
+    if (profile.newlyOverDependentAfterIndependenceAdjustment !== (profile.overDependentOnSingleUnderlyingStudy && !source.overDependentOnSingleStudy)) {
+      add('underlying-study-new-overdependent-state-mismatch', profile.url)
+    }
+  }
+
+  for (const profile of product.newlyOverDependentProfiles) {
+    if (!profileUrls.has(profile.url) || !profile.newlyOverDependentAfterIndependenceAdjustment) {
+      add('underlying-study-invalid-new-overdependent-profile', profile.url)
+    }
+  }
+
+  return failures
+}


### PR DESCRIPTION
Adds canonical self-consistency checks for `underlyingStudyIndependence` and wires them into the existing research-quality snapshot invariant engine. Validates claim/profile ownership, apparent-vs-adjusted counts, collapsed-publication arithmetic, subset/summary cardinality, pseudo-multi-study and support-tier downgrade states, dependent-publication group membership, and newly-overdependent profile state. Includes focused regression coverage for impossible adjusted counts and summary drift. This stays inside the canonical invariant boundary rather than creating a parallel validator.