### PR TITLE
polish(profile): restore active TOC styling

### DIFF
--- a/styles/editorial-content-surfaces.css
+++ b/styles/editorial-content-surfaces.css
@@ -106,7 +106,7 @@ html:not(.dark) nav[aria-label="Page sections"] a {
   color: var(--hs-body);
 }
 
-html:not(.dark) nav[aria-label="Page sections"] a[aria-current="true"],
+html:not(.dark) nav[aria-label="Page sections"] a[aria-current="location"],
 html:not(.dark) nav[aria-label="Page sections"] a:hover {
   background: color-mix(in srgb, var(--tone) 7%, var(--hs-surface));
   color: var(--hs-ink);


### PR DESCRIPTION
Fix the light-theme profile TOC selector to match the component's semantic aria-current="location" state. One-line visual-state correction; no markup or navigation behavior changes.