### PR TITLE
test(research): enforce AI citation readiness invariants

### DIFF
--- a/lib/__tests__/ai-citation-readiness-invariants.test.ts
+++ b/lib/__tests__/ai-citation-readiness-invariants.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type AiCitationReadinessReport,
+  validateAiCitationReadinessReport,
+} from '../ai-citation-readiness'
+
+function report(): AiCitationReadinessReport {
+  return {
+    summary: {
+      generatedAt: '2026-08-16T00:00:00.000Z',
+      researchQualitySource: 'lib/research-quality-analysis.ts',
+      profiles: 2,
+      matchedResearchProfiles: 1,
+      averageScore: 60,
+      below50: 1,
+      below70: 1,
+      contradictions: 1,
+      overDependentOnSingleStudy: 1,
+      narrativeDominated: 0,
+    },
+    profiles: [
+      {
+        slug: 'alpha',
+        kind: 'herb',
+        score: 40,
+        researchUrl: '/herbs/alpha/',
+        approvedClaims: 2,
+        canonicalStudies: 2,
+        citationCompleteness: 0.5,
+        primaryHuman: 1,
+        systematicReviews: 0,
+        narrativeReviews: 0,
+        dominantStudySupportedClaimShare: 0.8,
+        effectiveStudyCount: 1.2,
+        contradiction: true,
+        gaps: ['canonical research graph is over-dependent on one study'],
+      },
+      {
+        slug: 'beta',
+        kind: 'compound',
+        score: 80,
+        researchUrl: null,
+        approvedClaims: 0,
+        canonicalStudies: 0,
+        citationCompleteness: 0,
+        primaryHuman: 0,
+        systematicReviews: 0,
+        narrativeReviews: 0,
+        dominantStudySupportedClaimShare: 0,
+        effectiveStudyCount: 0,
+        contradiction: false,
+        gaps: ['no canonical research-quality profile match'],
+      },
+    ],
+  }
+}
+
+describe('AI citation readiness invariants', () => {
+  it('accepts a self-consistent report', () => {
+    expect(validateAiCitationReadinessReport(report())).toEqual({ passed: true, failures: [] })
+  })
+
+  it('detects summary drift', () => {
+    const value = report()
+    value.summary.below70 = 2
+    const result = validateAiCitationReadinessReport(value)
+    expect(result.passed).toBe(false)
+    expect(result.failures).toContain('below70: summary=2; rows=1')
+  })
+
+  it('detects invalid row ranges', () => {
+    const value = report()
+    value.profiles[0].score = 101
+    value.profiles[1].citationCompleteness = -0.1
+    const result = validateAiCitationReadinessReport(value)
+    expect(result.passed).toBe(false)
+    expect(result.failures.some((failure) => failure.includes('score=101 outside 0..100'))).toBe(true)
+    expect(result.failures.some((failure) => failure.includes('citationCompleteness=-0.1 outside 0..1'))).toBe(true)
+  })
+})

--- a/lib/ai-citation-readiness.ts
+++ b/lib/ai-citation-readiness.ts
@@ -54,6 +54,11 @@ export type AiCitationReadinessReport = {
   profiles: AiCitationReadinessRow[]
 }
 
+export type AiCitationReadinessInvariantReport = {
+  passed: boolean
+  failures: string[]
+}
+
 function filesUnder(dir: string, out: string[] = []): string[] {
   if (!fs.existsSync(dir)) return out
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -214,10 +219,46 @@ export function buildAiCitationReadiness(
   }
 }
 
+export function validateAiCitationReadinessReport(report: AiCitationReadinessReport): AiCitationReadinessInvariantReport {
+  const failures: string[] = []
+  const rows = report.profiles
+  const expected = {
+    profiles: rows.length,
+    matchedResearchProfiles: rows.filter((row) => Boolean(row.researchUrl)).length,
+    averageScore: rows.length ? Math.round(rows.reduce((sum, row) => sum + row.score, 0) / rows.length) : 0,
+    below50: rows.filter((row) => row.score < 50).length,
+    below70: rows.filter((row) => row.score < 70).length,
+    contradictions: rows.filter((row) => row.contradiction).length,
+    overDependentOnSingleStudy: rows.filter((row) => row.gaps.includes('canonical research graph is over-dependent on one study')).length,
+    narrativeDominated: rows.filter((row) => row.gaps.includes('narrative-review dominated versus primary human research')).length,
+  }
+
+  for (const [field, value] of Object.entries(expected)) {
+    const actual = report.summary[field as keyof typeof expected]
+    if (actual !== value) failures.push(`${field}: summary=${actual}; rows=${value}`)
+  }
+
+  for (const row of rows) {
+    if (!Number.isFinite(row.score) || row.score < 0 || row.score > 100) {
+      failures.push(`${row.kind}/${row.slug}: score=${row.score} outside 0..100`)
+    }
+    if (!Number.isFinite(row.citationCompleteness) || row.citationCompleteness < 0 || row.citationCompleteness > 1) {
+      failures.push(`${row.kind}/${row.slug}: citationCompleteness=${row.citationCompleteness} outside 0..1`)
+    }
+  }
+
+  return { passed: failures.length === 0, failures }
+}
+
 export function writeAiCitationReadinessReport(
   report: AiCitationReadinessReport,
   root = process.cwd(),
 ): string {
+  const invariants = validateAiCitationReadinessReport(report)
+  if (!invariants.passed) {
+    throw new Error(`[ai-citation-readiness] ${invariants.failures.length} invariant failure(s): ${invariants.failures.slice(0, 10).join('; ')}`)
+  }
+
   const output = path.join(root, 'reports', 'ai-citation-readiness.json')
   fs.mkdirSync(path.dirname(output), { recursive: true })
   fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`)


### PR DESCRIPTION
Replays #3573 cleanly on the current main head. Adds a shared invariant validator for AI citation-readiness derived reports, recomputes summary counts from emitted rows, validates score/completeness ranges, and enforces the contract at the shared report-write boundary used by both the canonical research roll-up and standalone AI topology audit. Includes focused regression tests.