### PR TITLE
Enforce effect-certainty snapshot invariants

### DIFF
--- a/lib/__tests__/research-effect-certainty-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-effect-certainty-snapshot-invariants.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import type { ResearchQualityTopology } from '@/lib/research-quality-topology'
+import { validateEffectCertaintySnapshotInvariants } from '@/lib/research-effect-certainty-snapshot-invariants'
+
+function fixtures() {
+  const analysis = {
+    claimAnalyses: [{
+      url: '/herbs/example/',
+      claimId: 'claim-1',
+      outcomeClaim: true,
+    }],
+  } as unknown as ResearchQualityAnalysis
+
+  const finding = {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    predicate: 'supports_outcome',
+    confidence: 0.9,
+    claimStrengthLanguage: true,
+    claimClinicalImportanceLanguage: false,
+    claimReliabilityLanguage: false,
+    humanSourceCount: 1,
+    comparableHumanSourceCount: 1,
+    smallOrModestSourceCount: 1,
+    nullSourceCount: 0,
+    mixedSourceCount: 0,
+    clinicallyInsufficientSourceCount: 0,
+    statisticalOnlySourceCount: 0,
+    magnitudeOverstatement: true,
+    clinicalImportanceOverstatement: false,
+    certaintyOverstatement: false,
+    reasons: ['strong magnitude wording exceeds linked evidence'],
+  }
+  const topology = {
+    effectCertainty: {
+      claims: [finding],
+      findings: [finding],
+      highConfidenceFindings: [finding],
+      summary: {
+        approvedOutcomeClaims: 1,
+        assessableClaims: 1,
+        findings: 1,
+        highConfidenceFindings: 1,
+        magnitudeOverstatements: 1,
+        clinicalImportanceOverstatements: 0,
+        certaintyOverstatements: 0,
+      },
+    },
+  } as unknown as ResearchQualityTopology
+
+  return { analysis, topology }
+}
+
+describe('effect-certainty snapshot invariants', () => {
+  it('accepts a self-consistent effect-certainty product', () => {
+    const { analysis, topology } = fixtures()
+    expect(validateEffectCertaintySnapshotInvariants(analysis, topology)).toEqual([])
+  })
+
+  it('rejects summary drift', () => {
+    const { analysis, topology } = fixtures()
+    topology.effectCertainty.summary.findings = 0
+    const kinds = validateEffectCertaintySnapshotInvariants(analysis, topology).map((failure) => failure.kind)
+    expect(kinds).toContain('effect-certainty-finding-count-mismatch')
+  })
+
+  it('rejects impossible source counts', () => {
+    const { analysis, topology } = fixtures()
+    topology.effectCertainty.claims[0].comparableHumanSourceCount = 2
+    const kinds = validateEffectCertaintySnapshotInvariants(analysis, topology).map((failure) => failure.kind)
+    expect(kinds).toContain('effect-certainty-invalid-human-source-count')
+  })
+})

--- a/lib/research-effect-certainty-snapshot-invariants.ts
+++ b/lib/research-effect-certainty-snapshot-invariants.ts
@@ -1,0 +1,88 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { ResearchQualityTopology } from './research-quality-topology'
+
+export type EffectCertaintySnapshotInvariantFailure = {
+  kind: string
+  detail: string
+}
+
+function claimKey(url: string, claimId: string): string {
+  return `${url}::${claimId}`
+}
+
+/** Validate self-consistency for the canonical effect-size/certainty product. */
+export function validateEffectCertaintySnapshotInvariants(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology,
+): EffectCertaintySnapshotInvariantFailure[] {
+  const failures: EffectCertaintySnapshotInvariantFailure[] = []
+  const add = (kind: string, detail: string) => failures.push({ kind, detail })
+  const product = topology.effectCertainty
+  const outcomeClaims = new Set(
+    analysis.claimAnalyses
+      .filter((claim) => claim.outcomeClaim)
+      .map((claim) => claimKey(claim.url, claim.claimId)),
+  )
+
+  if (product.summary.approvedOutcomeClaims !== outcomeClaims.size) {
+    add('effect-certainty-approved-outcome-count-mismatch', `summary=${product.summary.approvedOutcomeClaims}; analysis=${outcomeClaims.size}`)
+  }
+  if (product.summary.assessableClaims !== product.claims.length) {
+    add('effect-certainty-assessable-count-mismatch', `summary=${product.summary.assessableClaims}; rows=${product.claims.length}`)
+  }
+  if (product.summary.findings !== product.findings.length) {
+    add('effect-certainty-finding-count-mismatch', `summary=${product.summary.findings}; rows=${product.findings.length}`)
+  }
+  if (product.summary.highConfidenceFindings !== product.highConfidenceFindings.length) {
+    add('effect-certainty-high-confidence-count-mismatch', `summary=${product.summary.highConfidenceFindings}; rows=${product.highConfidenceFindings.length}`)
+  }
+  if (product.summary.magnitudeOverstatements !== product.findings.filter((claim) => claim.magnitudeOverstatement).length) {
+    add('effect-certainty-magnitude-count-mismatch', `summary=${product.summary.magnitudeOverstatements}`)
+  }
+  if (product.summary.clinicalImportanceOverstatements !== product.findings.filter((claim) => claim.clinicalImportanceOverstatement).length) {
+    add('effect-certainty-clinical-count-mismatch', `summary=${product.summary.clinicalImportanceOverstatements}`)
+  }
+  if (product.summary.certaintyOverstatements !== product.findings.filter((claim) => claim.certaintyOverstatement).length) {
+    add('effect-certainty-reliability-count-mismatch', `summary=${product.summary.certaintyOverstatements}`)
+  }
+
+  const claimKeys = new Set<string>()
+  for (const claim of product.claims) {
+    const key = claimKey(claim.url, claim.claimId)
+    if (claimKeys.has(key)) add('effect-certainty-duplicate-claim', key)
+    claimKeys.add(key)
+    if (!outcomeClaims.has(key)) add('effect-certainty-unknown-outcome-claim', key)
+    if (claim.comparableHumanSourceCount < 1 || claim.comparableHumanSourceCount > claim.humanSourceCount) {
+      add('effect-certainty-invalid-human-source-count', `${key}: human=${claim.humanSourceCount}; comparable=${claim.comparableHumanSourceCount}`)
+    }
+    for (const [label, count] of [
+      ['small-or-modest', claim.smallOrModestSourceCount],
+      ['null', claim.nullSourceCount],
+      ['mixed', claim.mixedSourceCount],
+      ['clinically-insufficient', claim.clinicallyInsufficientSourceCount],
+      ['statistical-only', claim.statisticalOnlySourceCount],
+    ] as const) {
+      if (count < 0 || count > claim.comparableHumanSourceCount) {
+        add('effect-certainty-invalid-counterevidence-count', `${key}: ${label}=${count}; comparable=${claim.comparableHumanSourceCount}`)
+      }
+    }
+    const finding = claim.magnitudeOverstatement || claim.clinicalImportanceOverstatement || claim.certaintyOverstatement
+    if (finding && claim.reasons.length === 0) add('effect-certainty-finding-without-reason', key)
+  }
+
+  const findingKeys = new Set(product.findings.map((claim) => claimKey(claim.url, claim.claimId)))
+  for (const finding of product.findings) {
+    const key = claimKey(finding.url, finding.claimId)
+    if (!claimKeys.has(key)) add('effect-certainty-orphan-finding', key)
+    if (!finding.magnitudeOverstatement && !finding.clinicalImportanceOverstatement && !finding.certaintyOverstatement) {
+      add('effect-certainty-nonfinding-in-findings', key)
+    }
+  }
+  for (const finding of product.highConfidenceFindings) {
+    const key = claimKey(finding.url, finding.claimId)
+    if (!findingKeys.has(key)) add('effect-certainty-orphan-high-confidence-finding', key)
+    if (finding.confidence < 0.75) add('effect-certainty-invalid-high-confidence-finding', `${key}: confidence=${finding.confidence}`)
+  }
+
+  return failures
+}

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -3,6 +3,7 @@ import {
   crossProfileStudyIdentity,
   crossProfileStudyIdentityMap,
 } from './research-coverage'
+import { validateEffectCertaintySnapshotInvariants } from './research-effect-certainty-snapshot-invariants'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import type { ResearchQualityGate } from './research-quality-gate'
 import type { ResearchGapItem } from './research-quality-policy'
@@ -141,6 +142,9 @@ export function validateResearchQualitySnapshotInvariants(
       'claim-breadth-finding-count-mismatch',
       `summary=${topology.claimBreadth.summary.overbroadClaims}; rows=${topology.claimBreadth.findings.length}`,
     )
+  }
+  for (const invariant of validateEffectCertaintySnapshotInvariants(analysis, topology)) {
+    add(invariant.kind, invariant.detail)
   }
   if (topology.edgeCardinality.summary.claims !== analysis.structuredClaimAnalyses.length) {
     add(


### PR DESCRIPTION
Adds canonical self-consistency checks for the effect magnitude/clinical-importance/reliability calibration product and wires them into the existing research-quality snapshot invariant engine. Validates approved-outcome ownership, assessable/finding/high-confidence counts, overstatement subtype totals, human-source cardinality, counterevidence counts, finding reasons, and subset membership. Includes focused regressions for summary drift and impossible source counts.