### PR TITLE
SEO: unify sleep goal-cluster source ledger

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'app/articles/**'
+      - 'components/articles/GoalClusterArticlePage.tsx'
       - 'components/articles/MentalHealthArticlePage.tsx'
       - 'components/References.tsx'
       - 'components/seo/**'
@@ -97,6 +98,7 @@ jobs:
         run: >-
           npx eslint
           app/articles/[slug]/page.tsx
+          components/articles/GoalClusterArticlePage.tsx
           components/articles/MentalHealthArticlePage.tsx
           components/References.tsx
           components/StructuredData.tsx

--- a/components/articles/GoalClusterArticlePage.tsx
+++ b/components/articles/GoalClusterArticlePage.tsx
@@ -11,6 +11,7 @@ import {
   isCalibratedSleepArticleSlug,
   SLEEP_CLUSTER_EVIDENCE_REVIEW_DATE,
 } from '@/lib/sleep-cluster-public-copy'
+import References from '@/components/References'
 import SchemaGraphScript from '@/components/seo/SchemaGraphScript'
 import EvidenceMeter from '../EvidenceMeter'
 import EvidenceLegend from '../EvidenceLegend'
@@ -71,8 +72,14 @@ export default function GoalClusterArticlePage({ slug, canonicalPath }: GoalClus
   const articlePath = canonicalPath ?? `/articles/${article.slug}/`
   const canonicalUrl = `${SITE_URL}${articlePath}`
   const faqSchema = faqPageJsonLd({ pagePath: articlePath, questions: content.faq })
-  const schemas = [
-    blogJsonLd(
+  const sourceRefs = content.references.map((reference, index) => ({
+    n: index + 1,
+    title: reference.label,
+    text: '',
+    url: reference.href,
+  }))
+  const articleSchema = {
+    ...blogJsonLd(
       {
         title: publicMetadata.title,
         slug: article.slug,
@@ -81,6 +88,10 @@ export default function GoalClusterArticlePage({ slug, canonicalPath }: GoalClus
       },
       articlePath,
     ),
+    citation: content.references.map((reference) => reference.href),
+  }
+  const schemas = [
+    articleSchema,
     breadcrumbJsonLd([
       { name: 'Home', url: `${SITE_URL}/` },
       { name: 'Guides', url: `${SITE_URL}/guides/` },
@@ -135,11 +146,18 @@ export default function GoalClusterArticlePage({ slug, canonicalPath }: GoalClus
           )}
         </header>
 
-        <section className="card-premium p-6 sm:p-8">
-          <h2 className="text-xl font-semibold text-ink">TL;DR</h2>
+        <section className="card-premium p-6 sm:p-8" data-answer-engine-summary="true" data-evidence="true">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-xl font-semibold text-ink">TL;DR</h2>
+            {sourceRefs.length > 0 ? (
+              <a href="#references" data-citation-sources="true" className="text-xs font-bold text-brand-800 hover:underline">
+                Verify {sourceRefs.length} source{sourceRefs.length === 1 ? '' : 's'} ↓
+              </a>
+            ) : null}
+          </div>
           <ul className="mt-4 space-y-3 text-sm leading-7 text-muted">
             {content.tlDr.map((item) => (
-              <li key={item} className="flex gap-3">
+              <li key={item} className="flex gap-3" data-claim="true">
                 <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-700" />
                 <span>{item}</span>
               </li>
@@ -290,23 +308,7 @@ export default function GoalClusterArticlePage({ slug, canonicalPath }: GoalClus
           </div>
         </section>
 
-        <section className="rounded-2xl border border-brand-900/10 bg-white/70 p-5">
-          <h2 className="text-base font-semibold text-ink">References</h2>
-          <ul className="mt-3 space-y-2 text-sm leading-6">
-            {content.references.map((reference) => (
-              <li key={reference.href}>
-                <a
-                  href={reference.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-brand-800 hover:text-brand-700 hover:underline"
-                >
-                  {reference.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
+        {sourceRefs.length > 0 ? <References refs={sourceRefs} /> : null}
       </article>
     </div>
   )

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -13,6 +13,7 @@ const ARTICLE_EVIDENCE = path.join(ROOT, 'src', 'components', 'evidence', 'WhatE
 const ARTICLE_CITATIONS = path.join(ROOT, 'src', 'lib', 'article-citation-metadata.ts')
 const ARTICLE_PAGE = path.join(ROOT, 'app', 'articles', '[slug]', 'page.tsx')
 const MENTAL_HEALTH_ARTICLE = path.join(ROOT, 'components', 'articles', 'MentalHealthArticlePage.tsx')
+const GOAL_CLUSTER_ARTICLE = path.join(ROOT, 'components', 'articles', 'GoalClusterArticlePage.tsx')
 const REFERENCES = path.join(ROOT, 'components', 'References.tsx')
 const EVIDENCE_BADGE = path.join(ROOT, 'components', 'ui', 'EvidenceScoreBadge.tsx')
 const SAFETY_GAUGE = path.join(ROOT, 'components', 'ui', 'SafetyGaugeMeter.tsx')
@@ -166,6 +167,23 @@ function auditMentalHealthCitationPrimitives() {
   }
 }
 
+function auditGoalClusterCitationPrimitives() {
+  requireSignals(GOAL_CLUSTER_ARTICLE, 'goal-cluster-citations', 'GoalClusterArticlePage', [
+    ["import References from '@/components/References'", 'shared References ledger import'],
+    ['const sourceRefs = content.references.map', 'sleep source adapter'],
+    ['<References refs={sourceRefs}', 'shared durable source ledger'],
+    ['citation: content.references.map((reference) => reference.href)', 'Article citation URL graph'],
+    ['href="#references"', 'source-ledger verification target'],
+    ['data-answer-engine-summary="true"', 'answer-engine summary marker'],
+    ['data-claim="true"', 'TLDR claim markers'],
+  ])
+
+  const source = text(GOAL_CLUSTER_ARTICLE)
+  if (source.includes('<h2 className="text-base font-semibold text-ink">References</h2>') && source.includes('content.references.map((reference) =>')) {
+    add('error', 'goal-cluster-citations', 'sleep goal-cluster page reintroduced a page-local references renderer instead of the shared ledger')
+  }
+}
+
 function auditProfilePrimitives() {
   requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
     ['data-evidence="true"', 'evidence marker'],
@@ -244,6 +262,7 @@ auditMachineReadable()
 auditSharedExtractionPrimitives()
 auditArticleExtractionPrimitives()
 auditMentalHealthCitationPrimitives()
+auditGoalClusterCitationPrimitives()
 auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()


### PR DESCRIPTION
Fixes #3578

## Summary
- removes the page-local sleep references `<ul>` from `GoalClusterArticlePage`
- adapts the existing `{ label, href }` sleep reference model into the shared `References` ledger
- preserves authored labels and URLs exactly and does not infer PMID, DOI, authors, journal, year, or study type
- gives sleep references the same stable ordinal `#ref-N` anchors, citation-source markers, and CreativeWork semantics as other article sources
- adds the real sleep reference URLs to the Article/BlogPosting JSON-LD `citation` graph
- gives the TL;DR answer surface explicit answer/evidence/claim markers and a direct source-ledger verification link without pretending bullets have per-claim citations
- extends the existing answer-engine audit so the sleep page must continue using the shared ledger and real citation URLs
- adds the sleep article component to the existing AI-search workflow trigger/lint surface

## Relevant URLs
- sleep goal-cluster article routes rendered by `GoalClusterArticlePage`
- source ledger `#references`
- individual source anchors `#ref-N`

## Acceptance criteria
- Sleep goal-cluster pages no longer maintain a custom references renderer.
- Existing authored source labels and URLs are preserved without inferred bibliographic metadata.
- The shared `References` component is the visible source-ledger authority.
- Source anchors follow the canonical ordinal `#ref-N` convention.
- Article JSON-LD exposes only the real authored source URLs via `citation`.
- The TL;DR links to the source ledger when sources exist but does not claim unsupported per-bullet citation relationships.
- The existing AI-search audit fails if a page-local sleep references renderer returns or the shared ledger/citation graph disappears.
- The existing AI-search workflow triggers and lints `GoalClusterArticlePage`.

## Validation commands
- `npm run audit:ai-citations`
- `npx eslint components/articles/GoalClusterArticlePage.tsx scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- `npm run build:deploy`
- AI search quality check
- Schema and Media Governance
- Atomic upgrade gate

## Before → after metrics
- Sleep goal-cluster reference renderers: 1 page-local bare list + shared ledger elsewhere → 1 shared `References` ledger.
- Sleep source anchors: 0 durable source anchors → all sources at ordinal `#ref-N` anchors.
- Sleep source entries with standard citation-source/CreativeWork semantics: 0 → all rendered sources.
- Sleep Article JSON-LD citation URLs: 0 → all authored sleep source URLs.
- Sleep TL;DR surfaces with direct source-ledger verification link: 0 → all pages with modeled references.
- Independently inferred bibliographic fields added: 0 → 0.
- New citation pipelines introduced: 0; existing shared ledger and AI-search audit are reused.

## Generator/source-of-truth decision
`lib/sleep-cluster-content.ts` remains the source of truth for sleep article references and continues to model only `label` and `href`. `GoalClusterArticlePage` is only an adapter into the canonical `References` view. `components/References.tsx` remains the visible ledger authority, and `audit-ai-answer-engine-readiness.mjs` remains the AI extraction/citation contract. No source metadata is invented or migrated into a parallel registry.

## Regression contract
- Sleep references must not regain a separate page-local renderer.
- Authored source labels/URLs must remain unchanged unless their source data changes.
- The adapter must not fabricate PMID, DOI, authors, journals, dates, evidence classes, or study types.
- Source anchors must remain ordinal and independent of external URL format.
- Article citation schema must contain real authored source URLs only.
- TL;DR verification may link to the ledger, but per-claim source relationships must not be asserted unless the source model gains explicit claim mapping.
- The sleep source surface must remain under the existing AI-search workflow/audit rather than a new pipeline.

## AI SEO / trust impact
Sleep goal-cluster pages now use the same durable source anatomy as generic articles: one shared ledger, predictable source anchors, real citation URLs in structured data, and a direct verification path from the answer surface—without overstating bibliographic detail the source model does not contain.