### PR TITLE
feat(research): expose effect certainty in canonical rollup

### DIFF
--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -52,6 +52,7 @@ const aiCitationReadiness = buildAiCitationReadiness(analysis, ROOT)
 const {
   semanticAlignment,
   claimBreadth,
+  effectCertainty,
   claimLanguageCalibration: languageCalibration,
   crossProfileStudyLoad,
   systemicLoadBearingStudies,
@@ -115,6 +116,7 @@ results.push({
     `blocking=${gate.summary.blockingFailures}`,
     `semanticMismatches=${semanticAlignment.summary.anyMismatch}`,
     `claimBreadthOverreach=${claimBreadth.summary.overbroadClaims}`,
+    `effectCertaintyOverreach=${effectCertainty.summary.findings}`,
     `causalWithoutControlled=${languageCalibration.summary.causalWithoutControlledSupport}`,
     `pseudoMultiSource=${edgeCardinality.summary.pseudoMultiSourceClaims}`,
     `sameTrialReuse=${trialRegistrationIndependence.summary.sameTrialReuseClaims}`,
@@ -180,6 +182,7 @@ const coreSummary = {
   citationIntegrityProblems: citationIntegrity.blockingCount,
   semanticAlignment: semanticAlignment.summary,
   claimBreadth: claimBreadth.summary,
+  effectCertainty: effectCertainty.summary,
   claimLanguageCalibration: languageCalibration.summary,
   claimCitationMetadata: claimCitationMetadata.summary,
   edgeCardinality: edgeCardinality.summary,
@@ -220,7 +223,7 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 25,
+  schemaVersion: 26,
   generatedAt: new Date().toISOString(),
   passed: !failed,
   source: {
@@ -234,6 +237,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     evidenceLineage: 'lib/research-evidence-lineage.ts',
     evidenceIndependenceCoverage: 'lib/research-evidence-independence-coverage.ts',
     claimBreadth: 'lib/research-claim-breadth.ts',
+    effectCertainty: 'lib/research-effect-certainty.ts',
   },
   coreSummary,
   structuralFailures: gate.structuralFailures,
@@ -256,6 +260,11 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     summary: claimBreadth.summary,
     findings: claimBreadth.findings.slice(0, 150),
     highConfidenceFindings: claimBreadth.highConfidenceFindings.slice(0, 100),
+  },
+  effectCertainty: {
+    summary: effectCertainty.summary,
+    findings: effectCertainty.findings.slice(0, 150),
+    highConfidenceFindings: effectCertainty.highConfidenceFindings.slice(0, 100),
   },
   claimLanguageCalibration: {
     summary: languageCalibration.summary,
@@ -317,6 +326,7 @@ console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structure
 console.log(`Research gate: ${gate.summary.blockingFailures} blocking · ${gate.summary.structuralFailures} structural · ${gate.summary.severeStudyClassConflicts} severe study-class conflict(s)`)
 console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explicit mismatch(es) · ${semanticAlignment.summary.highConfidenceMismatches} high-confidence`)
 console.log(`Claim breadth: ${claimBreadth.summary.overbroadClaims} overbroad claim(s) · ${claimBreadth.summary.highConfidenceOverbroadClaims} high-confidence · population ${claimBreadth.summary.populationOverbroadClaims} · dose ${claimBreadth.summary.doseOverbroadClaims} · duration ${claimBreadth.summary.durationOverbroadClaims} · formulation ${claimBreadth.summary.formulationOverbroadClaims} · endpoint ${claimBreadth.summary.endpointOverbroadClaims}`)
+console.log(`Effect/certainty: ${effectCertainty.summary.findings} overstatement finding(s) · ${effectCertainty.summary.highConfidenceFindings} high-confidence · magnitude ${effectCertainty.summary.magnitudeOverstatements} · clinical importance ${effectCertainty.summary.clinicalImportanceOverstatements} · certainty ${effectCertainty.summary.certaintyOverstatements}`)
 console.log(`Language calibration: ${languageCalibration.summary.causalWithoutControlledSupport} unsupported direct-causal claim(s)`)
 console.log(`Edge cardinality: ${edgeCardinality.summary.pseudoMultiSourceClaims} pseudo-multi-source · ${edgeCardinality.summary.aliasCollapsedClaims} alias-collapsed · ${edgeCardinality.summary.duplicateEdges} duplicate edge(s)`)
 console.log(`Underlying-study reuse: ${trialRegistrationIndependence.summary.sameTrialReuseClaims} same-trial claim(s) · ${evidenceLineage.summary.sharedNonRegistryLineageClaims} shared lineage claim(s)`)


### PR DESCRIPTION
Adds effect-size/certainty calibration to the canonical research-quality JSON rollup and CLI summary. Reports overall and high-confidence findings split into magnitude, clinical-importance, and certainty overstatement, advances the report schema, and records the canonical analyzer source.