### PR TITLE
Deduplicate effect-certainty invariant ownership

### DIFF
--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -134,15 +134,7 @@ export function validateResearchQualitySnapshotInvariants(
   if (topology.claimBreadth.summary.overbroadClaims !== topology.claimBreadth.findings.length) {
     add('claim-breadth-finding-count-mismatch', `summary=${topology.claimBreadth.summary.overbroadClaims}; rows=${topology.claimBreadth.findings.length}`)
   }
-  if (topology.effectCertainty.summary.findings !== topology.effectCertainty.findings.length) {
-    add('effect-certainty-finding-count-mismatch', `summary=${topology.effectCertainty.summary.findings}; rows=${topology.effectCertainty.findings.length}`)
-  }
-  if (topology.effectCertainty.summary.highConfidenceFindings !== topology.effectCertainty.highConfidenceFindings.length) {
-    add('effect-certainty-high-confidence-count-mismatch', `summary=${topology.effectCertainty.summary.highConfidenceFindings}; rows=${topology.effectCertainty.highConfidenceFindings.length}`)
-  }
-  for (const invariant of validateEffectCertaintySnapshotInvariants(analysis, topology)) {
-    add(invariant.kind, invariant.detail)
-  }
+  for (const invariant of validateEffectCertaintySnapshotInvariants(analysis, topology)) add(invariant.kind, invariant.detail)
   if (topology.edgeCardinality.summary.claims !== analysis.structuredClaimAnalyses.length) {
     add('edge-cardinality-claim-count-mismatch', `edgeCardinality=${topology.edgeCardinality.summary.claims}; analysis=${analysis.structuredClaimAnalyses.length}`)
   }
@@ -167,10 +159,6 @@ export function validateResearchQualitySnapshotInvariants(
   for (const claim of topology.claimBreadth.claims) {
     requireProfile('claim-breadth-unknown-profile', claim.url, claim.claimId)
     requireApprovedClaim('claim-breadth-unknown-claim', claim.url, claim.claimId)
-  }
-  for (const claim of topology.effectCertainty.claims) {
-    requireProfile('effect-certainty-unknown-profile', claim.url, claim.claimId)
-    requireApprovedClaim('effect-certainty-unknown-claim', claim.url, claim.claimId)
   }
   for (const finding of topology.claimLanguageCalibration.directEvidenceFindings) requireApprovedClaim('language-calibration-unknown-claim', finding.url, finding.claimId)
   for (const claim of topology.claimCitationMetadata.claims) requireApprovedClaim('citation-metadata-unknown-claim', claim.url, claim.claimId)


### PR DESCRIPTION
Removes the inline effect-certainty summary/ownership checks that became redundant after the more complete shared `validateEffectCertaintySnapshotInvariants` validator landed. The canonical snapshot now has exactly one effect-certainty invariant owner while preserving stronger coverage for summary arithmetic, ownership, source counts, counterevidence counts, reasons, and subset membership.