### PR TITLE
feat(research): show canonical underlying human-study counts

### DIFF
--- a/app/tools/evidence-matrices/page.tsx
+++ b/app/tools/evidence-matrices/page.tsx
@@ -6,7 +6,7 @@ import { buildPageMetadata } from '@/lib/seo'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Supplement Evidence & Safety Matrices',
-  description: 'Compare supplements across structured outcome mappings, evidence grades, human-study counts, and normalized safety signals.',
+  description: 'Compare supplements across structured outcome mappings, evidence grades, independence-adjusted human-study counts, and normalized safety signals.',
   path: '/tools/evidence-matrices',
 })
 
@@ -18,12 +18,12 @@ export default async function EvidenceMatricesPage() {
       <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8'>
         <p className='eyebrow-label'>Research comparison tool</p>
         <h1 className='mt-2 text-3xl font-bold tracking-tight text-ink sm:text-5xl'>Supplement Evidence & Safety Matrices</h1>
-        <p className='mt-4 max-w-4xl text-base leading-7 text-muted sm:text-lg'>One evidence matrix and eight safety-focused screening views built from the same canonical ingredient records. Use them to compare what is mapped, where evidence is stronger, and which safety signals deserve deeper review—without converting a database flag into medical advice.</p>
+        <p className='mt-4 max-w-4xl text-base leading-7 text-muted sm:text-lg'>One evidence matrix and eight safety-focused screening views built from the same canonical ingredient records and research-quality topology. Compare what is mapped, how many underlying human studies are represented, where evidence is stronger, and which safety signals deserve deeper review—without converting a database flag into medical advice.</p>
         <div className='mt-5 flex flex-wrap gap-3 text-sm'><Link href='/tools/botanical-activity-atlas/' className='font-semibold text-indigo-800 hover:underline'>Open the Botanical Activity Atlas →</Link><Link href='/safety-checker/' className='font-semibold text-indigo-800 hover:underline'>Screen a combination →</Link></div>
       </section>
 
       <section className='grid gap-4 md:grid-cols-3'>
-        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'><h2 className='font-bold text-ink'>Evidence stays separate</h2><p className='mt-2 text-sm leading-6 text-muted'>The profile grade and human-study count are displayed independently from outcome mappings and safety flags.</p></article>
+        <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'><h2 className='font-bold text-ink'>Evidence stays separate</h2><p className='mt-2 text-sm leading-6 text-muted'>The profile grade and underlying human-study count are displayed independently from outcome mappings and safety flags. Multiple publications are collapsed only when explicit trial, cohort, dataset, or parent-study identity proves they are not independent evidence.</p></article>
         <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'><h2 className='font-bold text-ink'>Flags are screening signals</h2><p className='mt-2 text-sm leading-6 text-muted'>A structured caution does not by itself establish severity, dose dependence, or a documented clinical interaction.</p></article>
         <article className='rounded-2xl border border-brand-900/10 bg-white/85 p-5 shadow-sm'><h2 className='font-bold text-ink'>Missing is not safe</h2><p className='mt-2 text-sm leading-6 text-muted'>An empty field means the dataset does not currently contain that signal. It is never translated into a claim of no risk.</p></article>
       </section>

--- a/src/components/matrices/ResearchMatricesClient.tsx
+++ b/src/components/matrices/ResearchMatricesClient.tsx
@@ -38,6 +38,22 @@ function OutcomeCell({ mapped }: { mapped: boolean }) {
     : <span className='text-muted'>—</span>
 }
 
+function HumanStudyCount({ row }: { row: ResearchMatrixRow }) {
+  if (!row.humanEvidenceCount) return <span className='text-muted'>—</span>
+  const title = row.humanEvidenceCountCanonical
+    ? row.collapsedHumanPublicationCount > 0
+      ? `${row.humanPublicationCount} primary-human publications collapse to ${row.humanEvidenceCount} underlying human studies because explicit trial/cohort identity proves publication reuse.`
+      : `${row.humanEvidenceCount} canonical primary-human studies; no explicit publication reuse was collapsed.`
+    : `${row.humanEvidenceCount} human studies from legacy runtime count data; this record does not yet have canonical research-topology coverage.`
+
+  return (
+    <span className='font-semibold text-ink' title={title}>
+      {row.humanEvidenceCount}
+      {row.collapsedHumanPublicationCount > 0 ? <span className='ml-1 text-xs font-normal text-muted'>({row.humanPublicationCount} pubs)</span> : null}
+    </span>
+  )
+}
+
 export default function ResearchMatricesClient({ rows }: { rows: ResearchMatrixRow[] }) {
   const [view, setView] = useState<MatrixView>('evidence')
   const [query, setQuery] = useState('')
@@ -60,7 +76,7 @@ export default function ResearchMatricesClient({ rows }: { rows: ResearchMatrixR
           <div>
             <p className='eyebrow-label'>Matrix explorer</p>
             <h2 className='mt-1 text-2xl font-bold text-ink'>Choose a comparison lens</h2>
-            <p className='mt-2 max-w-3xl text-sm leading-6 text-muted'>Each matrix is generated from the same canonical runtime records so evidence, outcome, and safety labels do not drift between tools.</p>
+            <p className='mt-2 max-w-3xl text-sm leading-6 text-muted'>Each matrix is generated from the same canonical runtime records and research-quality topology so evidence, study counts, outcome mappings, and safety labels do not drift between tools.</p>
           </div>
           <label className='w-full sm:w-72'>
             <span className='mb-1 block text-xs font-bold uppercase tracking-wide text-muted'>Search matrices</span>
@@ -86,11 +102,11 @@ export default function ResearchMatricesClient({ rows }: { rows: ResearchMatrixR
           <div className='overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm'>
             <table className='min-w-[1100px] w-full border-collapse text-left text-sm'>
               <caption className='sr-only'>Popular supplements compared across structured outcome mappings and profile-level evidence</caption>
-              <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Ingredient</th><th className='p-4'>Profile evidence</th><th className='p-4'>Mapped human studies</th>{OUTCOME_COLUMNS.map((column) => <th key={column.id} className='p-4'>{column.label}</th>)}</tr></thead>
-              <tbody>{evidenceRows.map((row) => <tr key={`${row.entityType}:${row.slug}`} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={row.href} className='font-bold text-indigo-900 hover:underline'>{row.name}</Link><p className='mt-1 text-xs uppercase tracking-wide text-muted'>{row.entityType}</p></td><td className='p-4'><GradeBadge grade={row.evidenceGrade} /></td><td className='p-4 font-semibold text-ink'>{row.humanEvidenceCount || '—'}</td>{OUTCOME_COLUMNS.map((column) => <td key={column.id} className='p-4'><OutcomeCell mapped={column.matches(row)} /></td>)}</tr>)}</tbody>
+              <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Ingredient</th><th className='p-4'>Profile evidence</th><th className='p-4'>Underlying human studies</th>{OUTCOME_COLUMNS.map((column) => <th key={column.id} className='p-4'>{column.label}</th>)}</tr></thead>
+              <tbody>{evidenceRows.map((row) => <tr key={`${row.entityType}:${row.slug}`} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={row.href} className='font-bold text-indigo-900 hover:underline'>{row.name}</Link><p className='mt-1 text-xs uppercase tracking-wide text-muted'>{row.entityType}</p></td><td className='p-4'><GradeBadge grade={row.evidenceGrade} /></td><td className='p-4'><HumanStudyCount row={row} /></td>{OUTCOME_COLUMNS.map((column) => <td key={column.id} className='p-4'><OutcomeCell mapped={column.matches(row)} /></td>)}</tr>)}</tbody>
             </table>
           </div>
-          <p className='text-xs leading-5 text-muted'>A blank cell means that outcome is not mapped in this dataset—not that the ingredient has been proven ineffective for that outcome. Human-study counts are shown only when structured count data is available.</p>
+          <p className='text-xs leading-5 text-muted'>A blank outcome cell means that outcome is not mapped in this dataset—not that the ingredient has been proven ineffective. Human-study counts use canonical primary-human studies when available; publications explicitly proven to come from the same underlying trial or cohort are counted once. Missing lineage is never assumed to mean duplicate evidence.</p>
         </section>
       ) : (
         <section className='space-y-4'>
@@ -99,8 +115,8 @@ export default function ResearchMatricesClient({ rows }: { rows: ResearchMatrixR
           <div className='overflow-x-auto rounded-2xl border border-brand-900/10 bg-white/90 shadow-sm'>
             <table className='min-w-[1050px] w-full border-collapse text-left text-sm'>
               <caption className='sr-only'>{definition?.title} generated from normalized structured safety signals</caption>
-              <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Ingredient</th><th className='p-4'>Profile evidence</th><th className='p-4'>Human studies</th><th className='p-4'>Why included</th><th className='p-4'>Other structured safety signals</th></tr></thead>
-              <tbody>{safetyRows.map((row) => <tr key={`${row.entityType}:${row.slug}`} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={row.href} className='font-bold text-indigo-900 hover:underline'>{row.name}</Link></td><td className='p-4'><GradeBadge grade={row.evidenceGrade} /></td><td className='p-4 font-semibold text-ink'>{row.humanEvidenceCount || '—'}</td><td className='p-4 text-ink'>{definition?.signal ? `Structured ${definition.signal} signal` : 'One or more structured safety / interaction signals'}</td><td className='p-4 text-muted'>{row.safetySignals.join(' · ') || 'No structured signal'}</td></tr>)}</tbody>
+              <thead className='bg-brand-50/80 text-xs uppercase tracking-wide text-muted'><tr><th className='p-4'>Ingredient</th><th className='p-4'>Profile evidence</th><th className='p-4'>Underlying human studies</th><th className='p-4'>Why included</th><th className='p-4'>Other structured safety signals</th></tr></thead>
+              <tbody>{safetyRows.map((row) => <tr key={`${row.entityType}:${row.slug}`} className='border-t border-brand-900/10 align-top'><td className='p-4'><Link href={row.href} className='font-bold text-indigo-900 hover:underline'>{row.name}</Link></td><td className='p-4'><GradeBadge grade={row.evidenceGrade} /></td><td className='p-4'><HumanStudyCount row={row} /></td><td className='p-4 text-ink'>{definition?.signal ? `Structured ${definition.signal} signal` : 'One or more structured safety / interaction signals'}</td><td className='p-4 text-muted'>{row.safetySignals.join(' · ') || 'No structured signal'}</td></tr>)}</tbody>
             </table>
           </div>
           {!safetyRows.length ? <p className='rounded-xl border border-brand-900/10 bg-white p-5 text-sm text-muted'>No records match this matrix and search term.</p> : null}

--- a/src/lib/__tests__/research-matrices-client-boundary.test.ts
+++ b/src/lib/__tests__/research-matrices-client-boundary.test.ts
@@ -11,9 +11,12 @@ describe('research matrix client boundary', () => {
 
     expect(client).toContain("from '@/lib/research-matrices.shared'")
     expect(client).not.toContain("from '@/lib/research-matrices'")
+    expect(client).not.toContain('research-quality-snapshot')
+    expect(client).not.toContain('node:fs')
+    expect(client).toContain('Underlying human studies')
   })
 
-  it('keeps filesystem-backed runtime loading out of the shared contract', () => {
+  it('keeps filesystem-backed research topology on the server contract', () => {
     const shared = fs.readFileSync(
       path.join(process.cwd(), 'src/lib/research-matrices.shared.ts'),
       'utf8',
@@ -24,9 +27,15 @@ describe('research matrix client boundary', () => {
     )
 
     expect(shared).not.toContain('runtime-record-index')
+    expect(shared).not.toContain('research-quality-snapshot')
     expect(shared).not.toContain('node:fs')
     expect(shared).not.toContain('node:path')
+    expect(server).toContain("import 'server-only'")
     expect(server).toContain("from '@/lib/runtime-record-index'")
+    expect(server).toContain("from '../../lib/research-quality-snapshot'")
+    expect(server).toContain('profile.primaryHumanUnderlyingStudyCount')
+    expect(server).toContain('profile.primaryHumanPublicationCount')
+    expect(server).toContain('profile.collapsedPrimaryHumanPublicationCount')
     expect(server).toContain("from './research-matrices.shared'")
   })
 })

--- a/src/lib/research-matrices.shared.ts
+++ b/src/lib/research-matrices.shared.ts
@@ -19,7 +19,13 @@ export interface ResearchMatrixRow {
   entityType: 'herb' | 'compound'
   href: string
   evidenceGrade: CanonicalEvidenceGrade | 'Unassigned'
+  /** Independence-adjusted primary-human study count when canonical topology is available. */
   humanEvidenceCount: number
+  /** Canonical primary-human publication count before proven same-study collapse. */
+  humanPublicationCount: number
+  collapsedHumanPublicationCount: number
+  /** False only for runtime records that do not yet have a canonical research profile. */
+  humanEvidenceCountCanonical: boolean
   outcomes: string[]
   mechanisms: string[]
   safetySignals: string[]

--- a/src/lib/research-matrices.ts
+++ b/src/lib/research-matrices.ts
@@ -1,5 +1,8 @@
+import 'server-only'
+
 import { cache } from '@/lib/react-cache'
 import { normalizeEvidenceGrade, canonicalGradeFromEvidenceTier, type CanonicalEvidenceGrade } from '../../lib/evidence-grade'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { getUnifiedRuntimeRecords } from '@/lib/runtime-record-index'
 import { normalizeEffect, normalizeSafetySignals, uniqueNormalized } from '@/lib/botanical-atlas-taxonomy'
@@ -51,7 +54,16 @@ const canonicalEvidence = (record: RuntimeRecord): CanonicalEvidenceGrade | 'Una
   return canonicalGradeFromEvidenceTier(record.evidence_tier ?? record.evidenceTier ?? record.evidenceLevel) ?? 'Unassigned'
 }
 
-const toMatrixRow = (record: RuntimeRecord): ResearchMatrixRow => {
+type CanonicalHumanCount = {
+  publicationCount: number
+  underlyingStudyCount: number
+  collapsedPublicationCount: number
+}
+
+const toMatrixRow = (
+  record: RuntimeRecord,
+  canonicalHumanByUrl: ReadonlyMap<string, CanonicalHumanCount>,
+): ResearchMatrixRow => {
   const entityType = record.entityType === 'compound' ? 'compound' : 'herb'
   const outcomes = uniqueNormalized(
     collect(record.primary_effects, record.effects, record.primaryActions, record.benefits, record.conditions),
@@ -76,25 +88,31 @@ const toMatrixRow = (record: RuntimeRecord): ResearchMatrixRow => {
   const safetySignals = Array.from(new Set(safetyRaw.flatMap(normalizeSafetySignals)))
   const name = text(record.displayName, record.name, record.compoundName, record.commonName, record.slug)
   const slug = String(record.slug ?? '')
+  const href = entityType === 'compound' ? `/compounds/${slug}/` : `/herbs/${slug}/`
+  const legacyHumanCount = positiveInteger(
+    record.human_trial_count,
+    record.humanTrialCount,
+    record.human_study_count,
+    record.humanStudyCount,
+    record.clinical_study_count,
+    record.clinicalStudyCount,
+    record.human_trials,
+    record.humanTrials,
+    record.clinical_trials,
+    record.clinicalTrials,
+  )
+  const canonicalHuman = canonicalHumanByUrl.get(href)
 
   return {
     slug,
     name,
     entityType,
-    href: entityType === 'compound' ? `/compounds/${slug}/` : `/herbs/${slug}/`,
+    href,
     evidenceGrade: canonicalEvidence(record),
-    humanEvidenceCount: positiveInteger(
-      record.human_trial_count,
-      record.humanTrialCount,
-      record.human_study_count,
-      record.humanStudyCount,
-      record.clinical_study_count,
-      record.clinicalStudyCount,
-      record.human_trials,
-      record.humanTrials,
-      record.clinical_trials,
-      record.clinicalTrials,
-    ),
+    humanEvidenceCount: canonicalHuman?.underlyingStudyCount ?? legacyHumanCount,
+    humanPublicationCount: canonicalHuman?.publicationCount ?? legacyHumanCount,
+    collapsedHumanPublicationCount: canonicalHuman?.collapsedPublicationCount ?? 0,
+    humanEvidenceCountCanonical: Boolean(canonicalHuman),
     outcomes,
     mechanisms,
     safetySignals,
@@ -117,10 +135,21 @@ const evidenceRank: Record<ResearchMatrixRow['evidenceGrade'], number> = {
 
 export const getResearchMatrixRows = cache(async (): Promise<ResearchMatrixRow[]> => {
   const { allRecords } = await getUnifiedRuntimeRecords()
+  const { topology } = buildResearchQualitySnapshot(process.cwd())
+  const canonicalHumanByUrl = new Map<string, CanonicalHumanCount>(
+    topology.underlyingStudyIndependence.profiles.map((profile) => [
+      profile.url,
+      {
+        publicationCount: profile.primaryHumanPublicationCount,
+        underlyingStudyCount: profile.primaryHumanUnderlyingStudyCount,
+        collapsedPublicationCount: profile.collapsedPrimaryHumanPublicationCount,
+      },
+    ]),
+  )
 
   return (allRecords as RuntimeRecord[])
     .filter((record) => Boolean(record.slug) && getRuntimeVisibility(record).canRender)
-    .map(toMatrixRow)
+    .map((record) => toMatrixRow(record, canonicalHumanByUrl))
     .filter((row) => row.outcomes.length || row.safetySignals.length || row.humanEvidenceCount > 0)
     .sort((a, b) => {
       const priorityDelta = priorityIndex(a.slug) - priorityIndex(b.slug)


### PR DESCRIPTION
Replaces the Research Matrix's legacy runtime human-study counters with the canonical research-quality topology on the server. Rows now carry independence-adjusted primary-human study count, publication count, collapsed-publication count, and whether the number came from canonical topology. The client labels the column `Underlying human studies`, shows publication count when explicit same-trial/cohort reuse was collapsed, and explains that missing lineage is never assumed duplicate. The server module is explicitly `server-only`; the browser-safe shared contract stays free of filesystem/topology imports. Page metadata/copy and the client/server boundary regression are updated accordingly.