### PR TITLE
refactor(enrichment): run canonical generic wave phases

### DIFF
--- a/scripts/run-enrichment-wave.mjs
+++ b/scripts/run-enrichment-wave.mjs
@@ -7,10 +7,10 @@ import { normalizeRouteSlug } from '../lib/entity-identity.mjs'
 const ROOT = process.cwd()
 const VALID_MODES = new Set(['full', 'source-review', 'authoring', 'submission-review', 'rollup-refresh'])
 const PHASES = {
-  'source-review': { command: 'npx', args: ['tsx', 'scripts/report-source-wave-2-review.ts'] },
-  authoring: { command: 'npx', args: ['tsx', 'scripts/report-enrichment-wave-2-authoring.ts'] },
+  'source-review': { command: 'npx', args: ['tsx', 'scripts/report-source-wave-review.ts'] },
+  authoring: { command: 'npx', args: ['tsx', 'scripts/report-enrichment-wave-authoring.ts'] },
   'submission-review': { command: 'npx', args: ['tsx', 'scripts/report-enrichment-submission-review.ts'] },
-  'rollup-refresh': { command: process.execPath, args: ['scripts/report-enrichment-wave-2-rollup.mjs'] },
+  'rollup-refresh': { command: process.execPath, args: ['scripts/report-enrichment-wave-rollup.mjs'] },
 }
 
 function safeWaveId(value) {


### PR DESCRIPTION
Broad cleanup pass 53.

- updates scripts/run-enrichment-wave.mjs to execute the canonical generic source-review, authoring, and rollup modules directly
- removes the runner's last dependency on wave-2 compatibility wrappers
- keeps compatibility wrappers available for historical package aliases and direct callers
- no phase behavior, environment variables, staging, preflight, or reporting logic changes

This completes the wave-runner ownership cleanup: generic runner → generic phase implementations.