### PR TITLE
fix(profile): harden compact decision spacing

### DIFF
--- a/components/editorial/ProfileDecisionPanel.tsx
+++ b/components/editorial/ProfileDecisionPanel.tsx
@@ -30,7 +30,7 @@ export function ProfileDecisionPanel({
           evidenceNote={verdict.evidenceNote}
           betterAlternative={verdict.betterAlternative}
           bottomLine={verdict.bottomLine}
-          className="my-0"
+          className="!my-0"
         />
       ) : null}
 
@@ -40,7 +40,7 @@ export function ProfileDecisionPanel({
           whyNotHigher={verdict.evidenceConfidence.whyNotHigher}
           whyNotLower={verdict.evidenceConfidence.whyNotLower}
           practicalTakeaway={verdict.evidenceConfidence.practicalTakeaway}
-          className="my-0"
+          className="!my-0"
         />
       ) : null}
 


### PR DESCRIPTION
Make the profile decision-stack zero-margin overrides deterministic with Tailwind important utilities while preserving the new mobile Next steps label that landed in parallel.