### PR TITLE
feat(research): hard-gate topology-backed Grade A contradictions

### DIFF
--- a/lib/__tests__/research-quality-gate-evidence-grade.test.ts
+++ b/lib/__tests__/research-quality-gate-evidence-grade.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import type { EvidenceGradeConsistencyReport, EvidenceGradeFinding } from '@/lib/evidence-grade-consistency'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import { buildResearchQualityGate } from '@/lib/research-quality-gate'
+import type { ResearchQualityTopology } from '@/lib/research-quality-topology'
+
+const analysis = {
+  claimAnalyses: [],
+} as unknown as ResearchQualityAnalysis
+
+const topology = {
+  studyClassConflicts: { severeConflicts: [] },
+} as unknown as ResearchQualityTopology
+
+function finding(grade: 'A' | 'B', issue: string): EvidenceGradeFinding {
+  return {
+    kind: 'herb',
+    slug: grade === 'A' ? 'strong' : 'moderate',
+    url: grade === 'A' ? '/herbs/strong/' : '/herbs/moderate/',
+    indexable: true,
+    rawGrade: grade,
+    rawTier: grade === 'A' ? 'Strong Evidence' : 'Moderate Evidence',
+    canonicalGrade: grade,
+    gradeLetter: grade,
+    gradeBand: grade === 'A' ? 'strong' : 'moderate',
+    tierBand: grade === 'A' ? 'strong' : 'moderate',
+    distance: 0,
+    pseudoMultiStudyClaimCount: 1,
+    highConfidencePseudoMultiStudyClaimCount: grade === 'A' ? 1 : 0,
+    collapsedPublicationCount: 1,
+    overDependentOnSingleUnderlyingStudy: true,
+    newlyOverDependentAfterIndependenceAdjustment: true,
+    dominantUnderlyingStudySupportedClaimShare: 0.75,
+    effectiveUnderlyingStudyCount: 1.6,
+    issues: [issue],
+  }
+}
+
+function gradeReport(options: {
+  contradictions?: EvidenceGradeFinding[]
+  warnings?: EvidenceGradeFinding[]
+} = {}): EvidenceGradeConsistencyReport {
+  const topologyContradictions = options.contradictions ?? []
+  const topologyWarnings = options.warnings ?? []
+  const findings = [...topologyContradictions, ...topologyWarnings]
+  return {
+    generatedAt: new Date(0).toISOString(),
+    canonicalEnum: ['A', 'B', 'C', 'D', 'Avoid/Insufficient'],
+    totals: {
+      profiles: findings.length,
+      indexable: findings.length,
+      flagged: findings.length,
+      flaggedIndexable: findings.length,
+      contradictionsIndexable: topologyContradictions.length,
+      topologyContradictionsIndexable: topologyContradictions.length,
+      topologyWarningsIndexable: topologyWarnings.length,
+      gradeCardRenderable: 0,
+      invalidPublishedGrades: 0,
+    },
+    issueCounts: {},
+    contradictions: topologyContradictions,
+    topologyContradictions,
+    topologyWarnings,
+    invalid: [],
+    findings,
+  }
+}
+
+describe('research quality gate evidence-grade enforcement', () => {
+  it('blocks a topology-backed Grade A contradiction', () => {
+    const contradiction = finding('A', 'strong-grade-with-underlying-study-concentration')
+    const gate = buildResearchQualityGate(
+      analysis,
+      topology,
+      gradeReport({ contradictions: [contradiction] }),
+    )
+
+    expect(gate.passed).toBe(false)
+    expect(gate.evidenceGradeContradictions).toEqual([contradiction])
+    expect(gate.summary).toMatchObject({
+      structuralFailures: 0,
+      severeStudyClassConflicts: 0,
+      evidenceGradeContradictions: 1,
+      blockingFailures: 1,
+    })
+  })
+
+  it('keeps Grade B topology warnings advisory', () => {
+    const warning = finding('B', 'moderate-grade-with-underlying-study-concentration')
+    const gate = buildResearchQualityGate(
+      analysis,
+      topology,
+      gradeReport({ warnings: [warning] }),
+    )
+
+    expect(gate.passed).toBe(true)
+    expect(gate.evidenceGradeContradictions).toEqual([])
+    expect(gate.summary.evidenceGradeContradictions).toBe(0)
+    expect(gate.summary.blockingFailures).toBe(0)
+  })
+
+  it('preserves the low-level gate behavior when grade consistency is omitted', () => {
+    const gate = buildResearchQualityGate(analysis, topology)
+    expect(gate.passed).toBe(true)
+    expect(gate.evidenceGradeContradictions).toEqual([])
+  })
+})

--- a/lib/research-quality-gate.ts
+++ b/lib/research-quality-gate.ts
@@ -1,3 +1,4 @@
+import type { EvidenceGradeConsistencyReport, EvidenceGradeFinding } from './evidence-grade-consistency'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { structuralCoverageFailures, type StructuralCoverageFailure } from './research-quality-policy'
 import { buildResearchQualityTopology, type ResearchQualityTopology } from './research-quality-topology'
@@ -7,44 +8,58 @@ export type ResearchQualityGate = {
   passed: boolean
   structuralFailures: StructuralCoverageFailure[]
   severeStudyClassConflicts: StudyClassConflict[]
+  evidenceGradeContradictions: EvidenceGradeFinding[]
   summary: {
     structuralFailures: number
     unsupportedApprovedClaims: number
     danglingClaimSourceEdges: number
     severeStudyClassConflicts: number
+    evidenceGradeContradictions: number
     blockingFailures: number
   }
 }
 
 /**
  * Canonical hard-gate decision for research coverage. Structural evidence-edge
- * failures and severe cross-family canonical study-class conflicts are the only
- * blockers owned here; softer research-quality signals remain remediation
- * priorities in the gap policy rather than becoming accidental build failures.
+ * failures, severe cross-family canonical study-class conflicts, and published
+ * Grade A contradictions positively proven by the canonical research topology
+ * are blockers. Grade B independence warnings and other softer research-quality
+ * signals remain remediation priorities rather than accidental build failures.
+ *
+ * `evidenceGradeConsistency` stays optional for lightweight/direct callers. The
+ * canonical snapshot always supplies it and therefore owns production grade
+ * enforcement without forcing low-level gate tests to reconstruct profile files.
  */
 export function buildResearchQualityGate(
   analysis: ResearchQualityAnalysis,
   topology: ResearchQualityTopology = buildResearchQualityTopology(analysis),
+  evidenceGradeConsistency?: EvidenceGradeConsistencyReport,
 ): ResearchQualityGate {
   const structuralFailures = structuralCoverageFailures(analysis)
   const severeStudyClassConflicts = topology.studyClassConflicts.severeConflicts
+  const evidenceGradeContradictions = evidenceGradeConsistency?.topologyContradictions ?? []
   const unsupportedApprovedClaims = structuralFailures.filter(
     (failure) => failure.kind === 'unsupported-approved-claim',
   ).length
   const danglingClaimSourceEdges = structuralFailures.filter(
     (failure) => failure.kind === 'dangling-claim-source-edge',
   ).length
-  const blockingFailures = structuralFailures.length + severeStudyClassConflicts.length
+  const blockingFailures =
+    structuralFailures.length
+    + severeStudyClassConflicts.length
+    + evidenceGradeContradictions.length
 
   return {
     passed: blockingFailures === 0,
     structuralFailures,
     severeStudyClassConflicts,
+    evidenceGradeContradictions,
     summary: {
       structuralFailures: structuralFailures.length,
       unsupportedApprovedClaims,
       danglingClaimSourceEdges,
       severeStudyClassConflicts: severeStudyClassConflicts.length,
+      evidenceGradeContradictions: evidenceGradeContradictions.length,
       blockingFailures,
     },
   }

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -34,11 +34,11 @@ export type ResearchQualitySnapshot = {
 export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQualitySnapshot {
   const analysis = analyzeResearchQuality(root)
   const topology = buildResearchQualityTopology(analysis)
-  const gate = buildResearchQualityGate(analysis, topology)
+  const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(root, topology)
+  const gate = buildResearchQualityGate(analysis, topology, evidenceGradeConsistency)
   const researchGapQueue = buildResearchGapQueue(analysis, topology)
   const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
   const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
-  const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(root, topology)
   const invariants = validateResearchQualitySnapshotInvariants(
     analysis,
     topology,


### PR DESCRIPTION
Promotes canonical evidence-grade independence contradictions from report-only findings into the research-quality hard gate. The canonical snapshot now computes evidence-grade consistency before the gate and passes the same topology-backed result into it. Indexable Grade A contradictions proven by underlying-study topology become blocking failures; Grade B topology warnings remain advisory. Low-level callers may omit grade consistency and preserve the prior gate behavior. Adds focused regressions proving A blocks, B does not, and compatibility is retained.