### PR TITLE
SEO: guard rhabdomyolysis citation-pipeline reuse

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'app/articles/**'
+      - 'app/learn/rhabdomyolysis/page.tsx'
       - 'components/articles/GoalClusterArticlePage.tsx'
       - 'components/articles/MentalHealthArticlePage.tsx'
       - 'components/References.tsx'
@@ -98,6 +99,7 @@ jobs:
         run: >-
           npx eslint
           app/articles/[slug]/page.tsx
+          app/learn/rhabdomyolysis/page.tsx
           components/articles/GoalClusterArticlePage.tsx
           components/articles/MentalHealthArticlePage.tsx
           components/References.tsx

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -14,6 +14,7 @@ const ARTICLE_CITATIONS = path.join(ROOT, 'src', 'lib', 'article-citation-metada
 const ARTICLE_PAGE = path.join(ROOT, 'app', 'articles', '[slug]', 'page.tsx')
 const MENTAL_HEALTH_ARTICLE = path.join(ROOT, 'components', 'articles', 'MentalHealthArticlePage.tsx')
 const GOAL_CLUSTER_ARTICLE = path.join(ROOT, 'components', 'articles', 'GoalClusterArticlePage.tsx')
+const RHABDO_PAGE = path.join(ROOT, 'app', 'learn', 'rhabdomyolysis', 'page.tsx')
 const REFERENCES = path.join(ROOT, 'components', 'References.tsx')
 const EVIDENCE_BADGE = path.join(ROOT, 'components', 'ui', 'EvidenceScoreBadge.tsx')
 const SAFETY_GAUGE = path.join(ROOT, 'components', 'ui', 'SafetyGaugeMeter.tsx')
@@ -184,6 +185,25 @@ function auditGoalClusterCitationPrimitives() {
   }
 }
 
+function auditRhabdoCitationPrimitives() {
+  requireSignals(RHABDO_PAGE, 'safety-citations', 'rhabdomyolysis page', [
+    ['normalizeArticleReferences(page.references)', 'canonical article reference normalization'],
+    ['articleReferences.map(buildArticleReferenceSchema)', 'canonical conservative citation schema'],
+    ['<References refs={articleReferences}', 'shared durable source ledger'],
+    ["'@id': AUTHOR_SCHEMA_ID", 'canonical first-party author identity'],
+    ["'@id': ORGANIZATION_SCHEMA_ID", 'canonical publisher identity'],
+    ['data-citation-sources="true"', 'source-ledger verification marker'],
+  ])
+
+  const source = text(RHABDO_PAGE)
+  if (source.includes("reference.pmid ? `https://pubmed.ncbi.nlm.nih.gov/${reference.pmid}/`")) {
+    add('error', 'safety-citations', 'rhabdomyolysis page reintroduced page-local PubMed URL derivation')
+  }
+  if (/citation:\s*page\.references\.map/.test(source)) {
+    add('error', 'safety-citations', 'rhabdomyolysis page reintroduced page-local scholarly citation construction')
+  }
+}
+
 function auditProfilePrimitives() {
   requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
     ['data-evidence="true"', 'evidence marker'],
@@ -263,6 +283,7 @@ auditSharedExtractionPrimitives()
 auditArticleExtractionPrimitives()
 auditMentalHealthCitationPrimitives()
 auditGoalClusterCitationPrimitives()
+auditRhabdoCitationPrimitives()
 auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()


### PR DESCRIPTION
Fixes #3605

Parent cleanup: #3591

## Summary
- extends the existing `audit-ai-answer-engine-readiness.mjs` with a rhabdomyolysis citation-pipeline contract
- requires canonical article reference normalization, canonical conservative citation schema, shared `References` rendering, canonical first-party author/publisher IDs, and source-ledger verification markers
- blocks reintroduced page-local PubMed URL derivation and page-local `page.references.map(...)` scholarly citation construction
- adds `/learn/rhabdomyolysis/` to the existing AI-search workflow path trigger and lint command
- creates no new validator, workflow, or parallel citation pipeline

## Relevant URLs
- `/learn/rhabdomyolysis/`
- existing AI-search quality workflow and answer-engine audit

## Acceptance criteria
- The existing answer-engine audit fails if rhabdomyolysis stops using `normalizeArticleReferences()`.
- The audit fails if the page stops using `buildArticleReferenceSchema()` or the shared `References` ledger.
- The audit fails if page-local PubMed URL derivation or local scholarly citation construction returns.
- Canonical first-party author/publisher identity signals remain required.
- The existing AI-search workflow triggers and lints changes to the rhabdomyolysis page.
- No new audit script or workflow is introduced.

## Validation commands
- `npm run audit:ai-citations`
- `npx eslint app/learn/rhabdomyolysis/page.tsx scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- AI search quality check
- Atomic upgrade gate

## Before → after metrics
- Rhabdomyolysis-specific citation regression checks in the canonical answer-engine audit: 0 → 1 contract covering 6 required signals + 2 forbidden anti-patterns.
- AI-search workflow path triggers for the rhabdomyolysis page: 0 → 1.
- AI-search workflow lint coverage for the rhabdomyolysis page: 0 → 1.
- New validators/workflows introduced: 0 → 0.

## Generator/source-of-truth decision
`src/lib/article-citation-metadata.ts` and `components/References.tsx` remain the implementation authorities. `audit-ai-answer-engine-readiness.mjs` remains the existing extraction/citation contract, and `.github/workflows/ai-entity-enrichment-check.yml` remains the existing execution boundary. This PR only extends those authorities; it does not duplicate them.

## Regression contract
- Rhabdomyolysis must remain on the canonical article citation pipeline.
- Page-local PubMed URL derivation must remain absent.
- Page-local scholarly citation construction must remain absent.
- Shared source-ledger usage and canonical first-party identities remain required.
- The page must remain in the existing AI-search workflow trigger/lint surface.
- A separate rhabdomyolysis citation validator/workflow must not be added.

## AI SEO / trust impact
The safety-sensitive rhabdomyolysis page now has explicit regression ownership inside the site's existing AI-search quality system, making its citation refactor durable without adding more governance duplication.