### PR TITLE
fix(enrichment): run canonical authoring during rollup refresh

### DIFF
--- a/scripts/report-enrichment-wave-rollup.mjs
+++ b/scripts/report-enrichment-wave-rollup.mjs
@@ -192,7 +192,7 @@ function mapByKey(list) {
 }
 
 function runDeterministicRefresh() {
-  runCommand('npm', ['run', 'report:enrichment-wave-2-authoring'])
+  runCommand('npx', ['tsx', 'scripts/report-enrichment-wave-authoring.ts'])
 
   const promotedEntries = parseNormalizedInput(PATHS.canonicalGovernedInput)
   const { normalizedEntries, issues, sourceById } = validateAndNormalizeEntries(promotedEntries, {


### PR DESCRIPTION
Broad cleanup pass 54.

- fixes runDeterministicRefresh() in the generic wave rollup
- replaces a call to nonexistent npm script report:enrichment-wave-2-authoring with direct execution of scripts/report-enrichment-wave-authoring.ts
- removes dead legacy indirection and ensures rollup refresh can actually reach validation and governed artifact regeneration

This is a functional bug fix exposed by the wave-module genericization.