### PR TITLE
fix(research): reconcile public matrix evidence grades

### DIFF
--- a/src/lib/__tests__/research-matrices-client-boundary.test.ts
+++ b/src/lib/__tests__/research-matrices-client-boundary.test.ts
@@ -16,7 +16,7 @@ describe('research matrix client boundary', () => {
     expect(client).toContain('Underlying human studies')
   })
 
-  it('keeps filesystem-backed research topology on the server contract', () => {
+  it('keeps filesystem-backed research topology and grade reconciliation on the server contract', () => {
     const shared = fs.readFileSync(
       path.join(process.cwd(), 'src/lib/research-matrices.shared.ts'),
       'utf8',
@@ -33,6 +33,9 @@ describe('research matrix client boundary', () => {
     expect(server).toContain("import 'server-only'")
     expect(server).toContain("from '@/lib/runtime-record-index'")
     expect(server).toContain("from '../../lib/research-quality-snapshot'")
+    expect(server).toContain('reconcileEvidenceGrade')
+    expect(server).not.toContain('canonicalGradeFromEvidenceTier')
+    expect(server).not.toContain('normalizeEvidenceGrade')
     expect(server).toContain('profile.primaryHumanUnderlyingStudyCount')
     expect(server).toContain('profile.primaryHumanPublicationCount')
     expect(server).toContain('profile.collapsedPrimaryHumanPublicationCount')

--- a/src/lib/research-matrices.ts
+++ b/src/lib/research-matrices.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { cache } from '@/lib/react-cache'
-import { normalizeEvidenceGrade, canonicalGradeFromEvidenceTier, type CanonicalEvidenceGrade } from '../../lib/evidence-grade'
+import { reconcileEvidenceGrade, type CanonicalEvidenceGrade } from '../../lib/evidence-grade'
 import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import { getUnifiedRuntimeRecords } from '@/lib/runtime-record-index'
@@ -49,9 +49,11 @@ const positiveInteger = (...values: unknown[]): number => {
 }
 
 const canonicalEvidence = (record: RuntimeRecord): CanonicalEvidenceGrade | 'Unassigned' => {
-  const normalized = normalizeEvidenceGrade(record.evidence_grade ?? record.evidenceGrade)
-  if (normalized.grade) return normalized.grade
-  return canonicalGradeFromEvidenceTier(record.evidence_tier ?? record.evidenceTier ?? record.evidenceLevel) ?? 'Unassigned'
+  const reconciled = reconcileEvidenceGrade(
+    record.evidence_grade ?? record.evidenceGrade,
+    record.evidence_tier ?? record.evidenceTier ?? record.evidenceLevel,
+  )
+  return reconciled.grade ?? 'Unassigned'
 }
 
 type CanonicalHumanCount = {


### PR DESCRIPTION
Fixes a public grade drift in the Research Matrix. The server loader previously preferred raw `evidence_grade` and only fell back to the tier, so a raw Grade A could render even when the canonical grade reconciliation would cap it because `evidence_tier` was weaker. Matrix rows now use `reconcileEvidenceGrade()` directly and publish `Unassigned` when the canonical contract cannot honestly resolve one grade. The existing browser/server boundary test now also locks the canonical grade resolver dependency and forbids the old raw normalization/tier fallback path.