### PR TITLE
SEO: add shared legacy guide reference primitive

### DIFF
--- a/components/LegacyGuideReference.tsx
+++ b/components/LegacyGuideReference.tsx
@@ -1,0 +1,55 @@
+type LegacyGuideReferenceProps = {
+  n: number
+  text: string
+  url?: string
+}
+
+function sourceLabel(url: string): string {
+  if (url.includes('pubmed.ncbi.nlm.nih.gov')) return 'PubMed →'
+  if (url.includes('doi.org')) return 'DOI →'
+  return 'Source →'
+}
+
+/**
+ * Compatibility reference item for older hand-authored guides that only model
+ * an ordinal, citation text, and optional source URL. Keep this conservative:
+ * do not infer PMID/DOI/authors/journal metadata that the source model does not
+ * explicitly provide.
+ */
+export default function LegacyGuideReference({ n, text, url }: LegacyGuideReferenceProps) {
+  const citationId = `ref-${n}`
+
+  return (
+    <li
+      id={citationId}
+      data-citation-source="true"
+      data-citation-id={citationId}
+      itemScope
+      itemType="https://schema.org/CreativeWork"
+      className="scroll-mt-24 text-xs leading-5 text-muted"
+    >
+      <a
+        href={`#${citationId}`}
+        aria-label={`Permanent link to reference ${n}`}
+        className="font-semibold text-ink underline-offset-4 hover:underline"
+      >
+        [{n}]
+      </a>{' '}
+      <cite itemProp="name" className="not-italic">{text}</cite>
+      {url ? (
+        <>
+          {' '}
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            itemProp="url"
+            className="text-brand-700 underline hover:text-brand-800"
+          >
+            {sourceLabel(url)}
+          </a>
+        </>
+      ) : null}
+    </li>
+  )
+}


### PR DESCRIPTION
Fixes #3610

## Summary
- adds one shared `LegacyGuideReference` compatibility primitive for older hand-authored guides using the existing `{ n, text, url? }` source shape
- standardizes stable ordinal `#ref-N` anchors, permanent self-links, citation-source markers, and conservative `CreativeWork` name/URL semantics
- preserves authored citation text and source URLs exactly
- deliberately does not infer PMID, DOI, author, journal, publication date, or evidence class from free text
- creates the migration target for five currently duplicated local `Ref` implementations

## Relevant URLs
- reference sections on prebiotics, greens powders, bovine colostrum, electrolyte supplements, and collagen supplement guides after the migration wave

## Acceptance criteria
- The shared primitive accepts the existing legacy `{ n, text, url? }` contract.
- It emits stable ordinal `#ref-N` anchors and a durable self-link.
- It exposes citation-source and CreativeWork name/URL semantics.
- It does not parse or infer bibliographic metadata from free-form citation text.
- Existing guide pages are unchanged in this foundation PR; migration is a separate atomic wave.

## Validation commands
- `npx eslint components/LegacyGuideReference.tsx --max-warnings=0`
- `npm run typecheck`
- Atomic upgrade gate

## Before → after metrics
- Shared primitives matching the legacy guide reference contract: 0 → 1.
- Duplicated local guide `Ref` implementations migrated in this foundation: 0 → 0; five remain explicitly queued for the next wave.
- Stable source semantics available to those guides after migration: bespoke minimal anchors → one shared ordinal/citation-source/CreativeWork contract.
- New citation data inference: 0 → 0.

## Generator/source-of-truth decision
The five guide files remain the source of truth for their authored citation text and URLs. `LegacyGuideReference` is presentation/extraction compatibility only; it does not become a bibliographic database and does not parse source strings into invented fields. The richer canonical `References` component remains preferred where structured reference objects already exist.

## Regression contract
- The compatibility primitive must remain conservative and must not infer bibliographic fields from citation prose.
- Public anchors remain ordinal `#ref-N`.
- Existing guide source text and URLs must not be changed by migration unless edited deliberately upstream.
- Richly structured pages should continue using `References`, not be downgraded to this compatibility component.

## AI SEO / trust impact
This establishes one safe migration target for five duplicated legacy reference renderers, allowing their public citation anchors and extraction semantics to be standardized without overstating the metadata those old pages actually contain.