### PR TITLE
cleanup(enrichment): remove obsolete wave-2 wrappers

### DIFF
--- a/scripts/report-enrichment-wave-2-authoring.ts
+++ b/scripts/report-enrichment-wave-2-authoring.ts
@@ -1,2 +1,0 @@
-// Backward-compatible entry point. The implementation is wave-agnostic and lives in the generic module.
-import './report-enrichment-wave-authoring'

--- a/scripts/report-enrichment-wave-2-rollup.mjs
+++ b/scripts/report-enrichment-wave-2-rollup.mjs
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-// Backward-compatible entry point. The implementation is wave-agnostic and lives in the generic module.
-import './report-enrichment-wave-rollup.mjs'

--- a/scripts/report-source-wave-2-review.ts
+++ b/scripts/report-source-wave-2-review.ts
@@ -1,2 +1,0 @@
-// Backward-compatible entry point. The implementation is wave-agnostic and lives in the generic module.
-import './report-source-wave-review'


### PR DESCRIPTION
Broad cleanup pass 55.

- removes the old wave-2 source-review, authoring, and rollup compatibility wrappers
- the canonical wave runner now calls generic modules directly
- package.json contains no wave-2 aliases requiring the wrappers
- the generic rollup no longer invokes the removed legacy authoring alias

This completes the wave-module genericization by eliminating now-unreferenced compatibility entry points.