### PR TITLE
docs(enrichment): align wave runner CLI with canonical entry point

### DIFF
--- a/ops/enrichment-wave-runner.md
+++ b/ops/enrichment-wave-runner.md
@@ -2,13 +2,13 @@
 
 Stable entry point:
 
-- `npm run run:enrichment-wave -- --wave-id <wave-id> --targets <path> --mode <full|source-review|authoring|submission-review|rollup-refresh>`
+- `node scripts/run-enrichment-wave.mjs --wave-id <wave-id> --targets <path> --mode <full|source-review|authoring|submission-review|rollup-refresh>`
 
 Examples:
 
-- `npm run run:enrichment-wave -- --wave-id wave-1 --targets ops/reports/enrichment-wave-1-targets.json --mode full`
-- `npm run run:enrichment-wave -- --wave-id wave-2b --targets ops/reports/enrichment-wave-2b-targets.json --mode source-review`
-- `npm run run:enrichment-wave -- --wave-id wave-3 --targets ops/reports/enrichment-wave-3-targets.json --mode full`
+- `node scripts/run-enrichment-wave.mjs --wave-id wave-1 --targets ops/reports/enrichment-wave-1-targets.json --mode full`
+- `node scripts/run-enrichment-wave.mjs --wave-id wave-2b --targets ops/reports/enrichment-wave-2b-targets.json --mode source-review`
+- `node scripts/run-enrichment-wave.mjs --wave-id wave-3 --targets ops/reports/enrichment-wave-3-targets.json --mode full`
 
 ## Why this exists
 

--- a/ops/governed-enrichment-wave-contractor-note.md
+++ b/ops/governed-enrichment-wave-contractor-note.md
@@ -3,13 +3,13 @@
 Use the single stable CLI:
 
 ```bash
-npm run run:enrichment-wave -- --wave-id <wave-id> --targets <targets-json-path> --mode <full|source-review|authoring|submission-review|rollup-refresh>
+node scripts/run-enrichment-wave.mjs --wave-id <wave-id> --targets <targets-json-path> --mode <full|source-review|authoring|submission-review|rollup-refresh>
 ```
 
 Recommended dry run first:
 
 ```bash
-npm run run:enrichment-wave -- --wave-id wave-3 --targets ops/reports/enrichment-wave-3-targets.json --mode full --dry-run
+node scripts/run-enrichment-wave.mjs --wave-id wave-3 --targets ops/reports/enrichment-wave-3-targets.json --mode full --dry-run
 ```
 
 Then run without `--dry-run` when ready.


### PR DESCRIPTION
Broad cleanup pass 56.

- fixes two operator-facing documents that referenced nonexistent npm script run:enrichment-wave
- documents the actual canonical CLI: node scripts/run-enrichment-wave.mjs
- preserves the runner's explicit design that package.json aliases are not required
- updates both normal and dry-run examples

This removes another stale orchestration layer and keeps documentation aligned with executable reality.