### PR TITLE
refactor(evidence): preserve unassigned grade state

### DIFF
--- a/components/ui/EvidenceScoreBadge.tsx
+++ b/components/ui/EvidenceScoreBadge.tsx
@@ -61,6 +61,16 @@ const GRADE_CONFIG: Record<EvidenceLetterGrade, {
     ringColor: 'ring-rose-200/40',
     solid: 'bg-rose-700',
   },
+  Unassigned: {
+    badge: '—',
+    label: 'Unassigned',
+    meaning: 'Evidence grade unassigned — A single profile-level grade cannot currently be published from the authored evidence signals.',
+    bg: 'bg-slate-50 dark:bg-slate-300/10',
+    text: 'text-slate-700 dark:text-slate-200',
+    border: 'border-slate-200 dark:border-slate-200/20',
+    ringColor: 'ring-slate-200/40',
+    solid: 'bg-slate-500',
+  },
 }
 
 const GRADE_MEANING_SHORT: Record<EvidenceLetterGrade, string> = {
@@ -69,6 +79,7 @@ const GRADE_MEANING_SHORT: Record<EvidenceLetterGrade, string> = {
   C: 'Limited',
   D: 'Preliminary',
   'Avoid/Insufficient': 'Avoid / Insufficient',
+  Unassigned: 'Unassigned',
 }
 
 const GRADE_TEXT_ADAPTIVE: Record<EvidenceLetterGrade, string> = {
@@ -77,6 +88,7 @@ const GRADE_TEXT_ADAPTIVE: Record<EvidenceLetterGrade, string> = {
   C: 'text-amber-800 dark:text-amber-100',
   D: 'text-stone-700 dark:text-stone-200',
   'Avoid/Insufficient': 'text-rose-800 dark:text-rose-100',
+  Unassigned: 'text-slate-700 dark:text-slate-200',
 }
 
 type EvidenceScoreBadgeProps = {
@@ -94,7 +106,7 @@ export default function EvidenceScoreBadge({
   showLabel = true,
   className = '',
 }: EvidenceScoreBadgeProps) {
-  const canonicalGrade = grade ?? (record ? getEvidenceLetterGrade(record as RuntimeRecord) : 'C')
+  const canonicalGrade = grade ?? (record ? getEvidenceLetterGrade(record as RuntimeRecord) : 'Unassigned')
   const config = GRADE_CONFIG[canonicalGrade]
 
   if (size === 'circle') {
@@ -131,7 +143,7 @@ export default function EvidenceScoreBadge({
       className={`inline-flex items-center rounded-full border font-bold tracking-wide ${config.bg} ${config.text} ${config.border} ${sizeClasses} ${className}`}
     >
       <span className={size === 'sm' ? 'text-[0.8rem]' : 'text-sm'}>{config.label}</span>
-      {showLabel && canonicalGrade !== 'Avoid/Insufficient' && (
+      {showLabel && canonicalGrade !== 'Avoid/Insufficient' && canonicalGrade !== 'Unassigned' && (
         <span className="font-semibold">{' '}{GRADE_MEANING_SHORT[canonicalGrade]}</span>
       )}
     </span>

--- a/lib/evidence.ts
+++ b/lib/evidence.ts
@@ -1,7 +1,6 @@
 import type { RuntimeRecord } from '../src/types/content'
 import {
-  canonicalGradeFromEvidenceTier,
-  normalizeEvidenceGrade,
+  reconcileEvidenceGrade,
   type CanonicalEvidenceGrade,
 } from './evidence-grade'
 
@@ -139,26 +138,26 @@ export function getEvidenceColor(record: RuntimeRecord): EvidenceColor {
   return colors[getEvidenceTier(record)]
 }
 
-/**
- * Compatibility name retained for UI callers. The value now comes from the
- * single canonical evidence-grade contract and may be Avoid/Insufficient.
- */
-export type EvidenceLetterGrade = CanonicalEvidenceGrade
+/** Compatibility name retained for UI/data callers. */
+export type EvidenceLetterGrade = CanonicalEvidenceGrade | 'Unassigned'
 
 /**
- * Resolve a record to the canonical evidence-grade enum.
+ * Resolve a record through the canonical evidence-grade reconciliation contract.
+ * Conflicting grade/tier signals resolve downward. Outcome-dependent,
+ * not-applicable, or otherwise unresolved records remain `Unassigned`; they are
+ * never converted into an invented single grade by heuristic fallback.
  *
- * Explicit grade data wins, but all legacy parsing is delegated to
- * `normalizeEvidenceGrade` so this file cannot drift into a second grading
- * system. Legacy evidence-tier text is only a fallback adapter.
+ * Records with no authored grade/tier at all retain the historical tier-derived
+ * compatibility fallback so older runtime-only content does not disappear.
  */
 export function getEvidenceLetterGrade(record: RuntimeRecord): EvidenceLetterGrade {
-  const normalized = normalizeEvidenceGrade(record?.evidence_grade)
-  if (normalized.grade && !normalized.outcomeDependent) return normalized.grade
+  const rawGrade = record?.evidence_grade ?? record?.evidenceGrade
+  const rawTier = record?.evidence_tier ?? record?.evidenceTier ?? record?.evidenceLevel
+  const reconciled = reconcileEvidenceGrade(rawGrade, rawTier)
+  if (reconciled.grade) return reconciled.grade
 
-  const evidenceTierField = record?.evidence_tier || record?.evidenceTier
-  const gradeFromTier = canonicalGradeFromEvidenceTier(evidenceTierField)
-  if (gradeFromTier) return gradeFromTier
+  const hasAuthoredSignal = text(rawGrade) || text(rawTier)
+  if (hasAuthoredSignal) return 'Unassigned'
 
   const tierMap: Record<EvidenceTier, EvidenceLetterGrade> = {
     strong: 'A',
@@ -168,7 +167,7 @@ export function getEvidenceLetterGrade(record: RuntimeRecord): EvidenceLetterGra
     preliminary: 'D',
     traditional: 'D',
     insufficient: 'Avoid/Insufficient',
-    review: 'Avoid/Insufficient',
+    review: 'Unassigned',
   }
 
   return tierMap[getEvidenceTier(record)]

--- a/src/lib/__tests__/evidence.test.ts
+++ b/src/lib/__tests__/evidence.test.ts
@@ -97,7 +97,7 @@ describe('getEvidenceLabel / getEvidenceColor', () => {
 })
 
 describe('getEvidenceLetterGrade', () => {
-  it('prefers an explicit unambiguous letter grade', () => {
+  it('uses an explicit grade when it is the only authored evidence signal', () => {
     expect(getEvidenceLetterGrade(record({ evidence_grade: 'A' }))).toBe('A')
     expect(getEvidenceLetterGrade(record({ evidence_grade: 'b+' }))).toBe('B')
   })
@@ -107,7 +107,17 @@ describe('getEvidenceLetterGrade', () => {
     expect(getEvidenceLetterGrade(record({ evidence_tier: 'Traditional use' }))).toBe('D')
   })
 
-  it('falls back to the tier map derived from getEvidenceTier', () => {
+  it('resolves conflicting authored grade and tier conservatively', () => {
+    expect(getEvidenceLetterGrade(record({ evidence_grade: 'A', evidence_tier: 'Limited Evidence' }))).toBe('C')
+    expect(getEvidenceLetterGrade(record({ evidence_grade: 'B', evidence_tier: 'Preclinical Evidence' }))).toBe('D')
+  })
+
+  it('preserves outcome-dependent or explicitly unresolved authored grades as unassigned', () => {
+    expect(getEvidenceLetterGrade(record({ evidence_grade: 'Varies by outcome', evidence_tier: 'Strong Evidence' }))).toBe('Unassigned')
+    expect(getEvidenceLetterGrade(record({ evidence_grade: 'Not applicable', evidence_tier: 'Moderate Evidence' }))).toBe('Unassigned')
+  })
+
+  it('keeps the historical compatibility fallback only when no authored grade or tier exists', () => {
     expect(getEvidenceLetterGrade(record())).toBe('C')
   })
 })

--- a/src/lib/canonical-content.ts
+++ b/src/lib/canonical-content.ts
@@ -3,7 +3,7 @@ import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import type { RuntimeRecord } from '../types/content'
 
 export type CanonicalEntityType = 'herb' | 'compound'
-export type CanonicalEvidenceGrade = 'A' | 'B' | 'C' | 'D' | 'Avoid/Insufficient'
+export type CanonicalEvidenceGrade = 'A' | 'B' | 'C' | 'D' | 'Avoid/Insufficient' | 'Unassigned'
 
 export type CanonicalPublicationRecord = {
   id: string
@@ -68,9 +68,7 @@ function stringsFrom(record: RuntimeRecord, keys: string[]): string[] {
 }
 
 function canonicalGrade(record: RuntimeRecord): CanonicalEvidenceGrade {
-  const grade = getEvidenceLetterGrade(record)
-  if (grade === 'A' || grade === 'B' || grade === 'C' || grade === 'D' || grade === 'Avoid/Insufficient') return grade
-  return 'Avoid/Insufficient'
+  return getEvidenceLetterGrade(record)
 }
 
 function resolveName(record: RuntimeRecord, entityType: CanonicalEntityType): string {


### PR DESCRIPTION
Removes a shared grade-fabrication path from `getEvidenceLetterGrade()`. The helper now delegates authored `evidence_grade` + `evidence_tier` signals to `reconcileEvidenceGrade()`, resolving conflicts conservatively and preserving outcome-dependent/not-applicable/unresolved records as a first-class `Unassigned` state instead of inventing a tier-derived grade. Legacy records with no authored grade/tier retain the historical fallback. EvidenceScoreBadge now renders Unassigned explicitly, and canonical publication records preserve it instead of coercing it to Avoid/Insufficient. Tests cover conflicting A→C/B→D reconciliation, outcome-dependent/not-applicable Unassigned behavior, and legacy compatibility.