### PR TITLE
refactor(evidence): derive strength tiers from reconciled grades

### DIFF
--- a/lib/evidence.ts
+++ b/lib/evidence.ts
@@ -56,6 +56,12 @@ function evidenceText(record: RuntimeRecord): string {
     .toLowerCase()
 }
 
+function authoredEvidenceSignals(record: RuntimeRecord) {
+  const rawGrade = record?.evidence_grade ?? record?.evidenceGrade
+  const rawTier = record?.evidence_tier ?? record?.evidenceTier ?? record?.evidenceLevel
+  return { rawGrade, rawTier, present: Boolean(text(rawGrade) || text(rawTier)) }
+}
+
 export function hasHumanEvidence(record: RuntimeRecord): boolean {
   const evidence = evidenceText(record)
 
@@ -92,8 +98,23 @@ export function isPreliminaryResearch(record: RuntimeRecord): boolean {
 }
 
 export function getEvidenceTier(record: RuntimeRecord): EvidenceTier {
-  const evidence = evidenceText(record)
+  const authored = authoredEvidenceSignals(record)
+  if (authored.present) {
+    const reconciled = reconcileEvidenceGrade(authored.rawGrade, authored.rawTier)
+    const rawTierText = text(authored.rawTier).toLowerCase()
+    if (reconciled.grade === 'A') return 'strong'
+    if (reconciled.grade === 'B') return 'moderate'
+    if (reconciled.grade === 'C') {
+      return /\b(mixed|conflict|inconsistent|equivocal)\b/.test(rawTierText) ? 'mixed' : 'limited'
+    }
+    if (reconciled.grade === 'D') {
+      return /\b(traditional|ethnobotanical|historical)\b/.test(rawTierText) ? 'traditional' : 'preliminary'
+    }
+    if (reconciled.grade === 'Avoid/Insufficient') return 'insufficient'
+    return 'review'
+  }
 
+  const evidence = evidenceText(record)
   if (/\b(needs? review|unknown|tbd|draft|placeholder|profile pending)\b/.test(evidence)) return 'review'
   if (/\b(none|no evidence|insufficient|minimal|not established)\b/.test(evidence)) return 'insufficient'
   if (/\b(mixed|conflict|inconsistent|equivocal)\b/.test(evidence)) return 'mixed'
@@ -151,13 +172,11 @@ export type EvidenceLetterGrade = CanonicalEvidenceGrade | 'Unassigned'
  * compatibility fallback so older runtime-only content does not disappear.
  */
 export function getEvidenceLetterGrade(record: RuntimeRecord): EvidenceLetterGrade {
-  const rawGrade = record?.evidence_grade ?? record?.evidenceGrade
-  const rawTier = record?.evidence_tier ?? record?.evidenceTier ?? record?.evidenceLevel
-  const reconciled = reconcileEvidenceGrade(rawGrade, rawTier)
-  if (reconciled.grade) return reconciled.grade
-
-  const hasAuthoredSignal = text(rawGrade) || text(rawTier)
-  if (hasAuthoredSignal) return 'Unassigned'
+  const authored = authoredEvidenceSignals(record)
+  if (authored.present) {
+    const reconciled = reconcileEvidenceGrade(authored.rawGrade, authored.rawTier)
+    return reconciled.grade ?? 'Unassigned'
+  }
 
   const tierMap: Record<EvidenceTier, EvidenceLetterGrade> = {
     strong: 'A',

--- a/src/lib/__tests__/evidence.test.ts
+++ b/src/lib/__tests__/evidence.test.ts
@@ -63,8 +63,9 @@ describe('getEvidenceTier', () => {
     expect(getEvidenceTier(record({ evidence_tier: 'Insufficient evidence' }))).toBe('insufficient')
   })
 
-  it('classifies conflicting studies as mixed', () => {
+  it('preserves mixed and traditional nuance inside reconciled C/D bands', () => {
     expect(getEvidenceTier(record({ evidence_tier: 'Mixed / conflicting results' }))).toBe('mixed')
+    expect(getEvidenceTier(record({ evidence_tier: 'Traditional / historical use only' }))).toBe('traditional')
   })
 
   it('classifies robust clinical evidence as strong', () => {
@@ -75,8 +76,19 @@ describe('getEvidenceTier', () => {
     expect(getEvidenceTier(record({ evidence_tier: 'Moderate evidence' }))).toBe('moderate')
   })
 
-  it('classifies ethnobotanical-only records as traditional', () => {
-    expect(getEvidenceTier(record({ evidence_tier: 'Traditional / historical use only' }))).toBe('traditional')
+  it('uses the reconciled weaker band when authored grade and tier disagree', () => {
+    const conflicted = record({ evidence_grade: 'A', evidence_tier: 'Limited Evidence' })
+    expect(getEvidenceLetterGrade(conflicted)).toBe('C')
+    expect(getEvidenceTier(conflicted)).toBe('limited')
+    expect(getEvidenceLabel(conflicted)).toBe('Limited evidence')
+    expect(getEvidenceColor(conflicted)).toBe('slate')
+  })
+
+  it('routes outcome-dependent authored evidence to review instead of a fabricated strong tier', () => {
+    const outcomeDependent = record({ evidence_grade: 'Varies by outcome', evidence_tier: 'Strong Evidence' })
+    expect(getEvidenceLetterGrade(outcomeDependent)).toBe('Unassigned')
+    expect(getEvidenceTier(outcomeDependent)).toBe('review')
+    expect(getEvidenceLabel(outcomeDependent)).toBe('Needs review')
   })
 
   it('falls back to "limited" when nothing else is known', () => {


### PR DESCRIPTION
Removes a second, conflicting evidence-strength classifier. When authored grade/tier fields exist, `getEvidenceTier()` now derives from the same `reconcileEvidenceGrade()` result used by letter grades, while preserving nuanced `mixed` within C and `traditional` within D. Outcome-dependent/unresolved authored evidence maps to `review`, not a fabricated strong/moderate tier. Legacy heuristic classification remains only for records with no authored grade/tier. Tests lock A+Limited => C/limited, outcome-dependent => Unassigned/review, and the existing mixed/traditional nuance.