### PR TITLE
feat(atlas): align evidence and human counts with canonical research

### DIFF
--- a/src/lib/__tests__/botanical-atlas-data.test.ts
+++ b/src/lib/__tests__/botanical-atlas-data.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildMappedCompoundsByHerb,
+  enrichAtlasRecordWithCanonicalResearch,
   enrichAtlasRecordWithMappedCompounds,
   toAtlasRecord,
 } from '@/lib/botanical-atlas-data'
@@ -78,6 +79,30 @@ describe('Botanical Activity Atlas runtime fallbacks', () => {
     const result = toAtlasRecord(record({ mechanisms: ['Unmapped experimental pathway XYZ'] }))
     expect(result.effects).toEqual([])
     expect(result.inferredEffects).toEqual([])
+  })
+
+  it('reconciles authored evidence and replaces legacy human counts from canonical topology', () => {
+    const herb = record({
+      evidence_grade: 'A',
+      evidence_tier: 'Limited Evidence',
+      human_trial_count: 7,
+    })
+    const legacy = toAtlasRecord(herb)
+    expect(legacy.humanEvidenceCount).toBe(7)
+
+    const canonical = enrichAtlasRecordWithCanonicalResearch(legacy, herb, {
+      primaryHumanUnderlyingStudyCount: 2,
+    })
+    expect(canonical.evidence).toBe('Preliminary')
+    expect(canonical.humanEvidenceCount).toBe(2)
+  })
+
+  it('uses legacy count only when canonical topology coverage is unavailable', () => {
+    const herb = record({ evidence_tier: 'Moderate Evidence', human_trial_count: 4 })
+    const legacy = toAtlasRecord(herb)
+    const enriched = enrichAtlasRecordWithCanonicalResearch(legacy, herb)
+    expect(enriched.evidence).toBe('Moderate')
+    expect(enriched.humanEvidenceCount).toBe(4)
   })
 
   it('indexes only contains relationships from the canonical herb-compound map', () => {

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -150,6 +150,26 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
   }
 }
 
+export type AtlasCanonicalResearchProfile = {
+  primaryHumanUnderlyingStudyCount: number
+}
+
+/**
+ * Apply canonical grade reconciliation and independence-adjusted human-study
+ * counts after the broad runtime adapter has done its compatibility work.
+ */
+export function enrichAtlasRecordWithCanonicalResearch(
+  record: BotanicalAtlasRecord,
+  herb: RuntimeRecord,
+  profile?: AtlasCanonicalResearchProfile,
+): BotanicalAtlasRecord {
+  return {
+    ...record,
+    evidence: atlasEvidenceFromGrade(getEvidenceLetterGrade(herb)),
+    humanEvidenceCount: profile?.primaryHumanUnderlyingStudyCount ?? record.humanEvidenceCount,
+  }
+}
+
 export interface AtlasCompoundRelationship {
   compound: string
   relationship: string
@@ -211,15 +231,11 @@ export const getBotanicalAtlasRecords = cache(async (): Promise<BotanicalAtlasRe
 
   return herbRecords
     .filter((herb: RuntimeRecord) => getRuntimeVisibility(herb).canRender)
-    .map((herb: RuntimeRecord) => {
-      const record = toAtlasRecord(herb)
-      const profile = canonicalHumanByUrl.get(`/herbs/${herb.slug}/`)
-      return {
-        ...record,
-        evidence: atlasEvidenceFromGrade(getEvidenceLetterGrade(herb)),
-        humanEvidenceCount: profile?.primaryHumanUnderlyingStudyCount ?? record.humanEvidenceCount,
-      }
-    })
+    .map((herb: RuntimeRecord) => enrichAtlasRecordWithCanonicalResearch(
+      toAtlasRecord(herb),
+      herb,
+      canonicalHumanByUrl.get(`/herbs/${herb.slug}/`),
+    ))
     .map((record: BotanicalAtlasRecord) => enrichAtlasRecordWithMappedCompounds(record, mappedCompoundsByHerb.get(record.slug)))
     .filter((herb: BotanicalAtlasRecord) => herb.effects.length || herb.compounds.length || herb.safety.length)
     .sort((a: BotanicalAtlasRecord, b: BotanicalAtlasRecord) => a.name.localeCompare(b.name))

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -1,5 +1,7 @@
 import { getHerbCompoundMap, getHerbs } from '@/lib/runtime-data'
 import { cache } from '@/lib/react-cache'
+import { getEvidenceLetterGrade, type EvidenceLetterGrade } from '../../lib/evidence'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 import { getRuntimeVisibility } from '../../lib/runtime-visibility'
 import {
   inferAtlasEffectsFromMechanisms,
@@ -52,6 +54,14 @@ const KNOWN_COMPOUND_CLASSES = new Set([
 
 const inferCompoundClasses = (compounds: string[]): string[] =>
   uniqueNormalized(compounds, normalizeCompoundClass).filter((value) => KNOWN_COMPOUND_CLASSES.has(value))
+
+const atlasEvidenceFromGrade = (grade: EvidenceLetterGrade): string => {
+  if (grade === 'A') return 'Strong'
+  if (grade === 'B') return 'Moderate'
+  if (grade === 'C') return 'Preliminary'
+  if (grade === 'D') return 'Traditional / preclinical'
+  return 'Unclassified'
+}
 
 export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
   const explicitEffects = uniqueNormalized(
@@ -121,6 +131,20 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
       herb.clinical_trials,
       herb.clinicalTrials,
     ),
+    humanPublicationCount: positiveInteger(
+      herb.human_trial_count,
+      herb.humanTrialCount,
+      herb.human_study_count,
+      herb.humanStudyCount,
+      herb.clinical_study_count,
+      herb.clinicalStudyCount,
+      herb.human_trials,
+      herb.humanTrials,
+      herb.clinical_trials,
+      herb.clinicalTrials,
+    ),
+    collapsedHumanPublicationCount: 0,
+    humanEvidenceCountCanonical: false,
     intensity: normalizeIntensity(
       text(
         herb.intensityLabel,
@@ -194,10 +218,25 @@ export const getBotanicalAtlasRecords = cache(async (): Promise<BotanicalAtlasRe
   const herbRecords = rawHerbs as RuntimeRecord[]
   const compoundMapRows = herbCompoundMap as RuntimeRecord[]
   const mappedCompoundsByHerb = buildMappedCompoundsByHerb(compoundMapRows)
+  const { topology } = buildResearchQualitySnapshot(process.cwd())
+  const canonicalHumanByUrl = new Map(
+    topology.underlyingStudyIndependence.profiles.map((profile) => [profile.url, profile] as const),
+  )
 
   return herbRecords
     .filter((herb: RuntimeRecord) => getRuntimeVisibility(herb).canRender)
-    .map(toAtlasRecord)
+    .map((herb: RuntimeRecord) => {
+      const record = toAtlasRecord(herb)
+      const profile = canonicalHumanByUrl.get(`/herbs/${herb.slug}/`)
+      return {
+        ...record,
+        evidence: atlasEvidenceFromGrade(getEvidenceLetterGrade(herb)),
+        humanEvidenceCount: profile?.primaryHumanUnderlyingStudyCount ?? record.humanEvidenceCount,
+        humanPublicationCount: profile?.primaryHumanPublicationCount ?? record.humanPublicationCount,
+        collapsedHumanPublicationCount: profile?.collapsedPrimaryHumanPublicationCount ?? 0,
+        humanEvidenceCountCanonical: Boolean(profile),
+      }
+    })
     .map((record: BotanicalAtlasRecord) => enrichAtlasRecordWithMappedCompounds(record, mappedCompoundsByHerb.get(record.slug)))
     .filter((herb: BotanicalAtlasRecord) => herb.effects.length || herb.compounds.length || herb.safety.length)
     .sort((a: BotanicalAtlasRecord, b: BotanicalAtlasRecord) => a.name.localeCompare(b.name))

--- a/src/lib/botanical-atlas-data.ts
+++ b/src/lib/botanical-atlas-data.ts
@@ -131,20 +131,6 @@ export const toAtlasRecord = (herb: RuntimeRecord): BotanicalAtlasRecord => {
       herb.clinical_trials,
       herb.clinicalTrials,
     ),
-    humanPublicationCount: positiveInteger(
-      herb.human_trial_count,
-      herb.humanTrialCount,
-      herb.human_study_count,
-      herb.humanStudyCount,
-      herb.clinical_study_count,
-      herb.clinicalStudyCount,
-      herb.human_trials,
-      herb.humanTrials,
-      herb.clinical_trials,
-      herb.clinicalTrials,
-    ),
-    collapsedHumanPublicationCount: 0,
-    humanEvidenceCountCanonical: false,
     intensity: normalizeIntensity(
       text(
         herb.intensityLabel,
@@ -232,9 +218,6 @@ export const getBotanicalAtlasRecords = cache(async (): Promise<BotanicalAtlasRe
         ...record,
         evidence: atlasEvidenceFromGrade(getEvidenceLetterGrade(herb)),
         humanEvidenceCount: profile?.primaryHumanUnderlyingStudyCount ?? record.humanEvidenceCount,
-        humanPublicationCount: profile?.primaryHumanPublicationCount ?? record.humanPublicationCount,
-        collapsedHumanPublicationCount: profile?.collapsedPrimaryHumanPublicationCount ?? 0,
-        humanEvidenceCountCanonical: Boolean(profile),
       }
     })
     .map((record: BotanicalAtlasRecord) => enrichAtlasRecordWithMappedCompounds(record, mappedCompoundsByHerb.get(record.slug)))


### PR DESCRIPTION
Aligns the Botanical Activity Atlas with the canonical research-quality system. The broad runtime adapter remains intact for compatibility, but server-loaded Atlas records are now enriched with reconciled evidence grades and independence-adjusted primary-human study counts from the canonical snapshot. Legacy human-study counters remain fallback-only when a profile lacks topology coverage. A pure enrichment function keeps this testable without mocking the full snapshot. Regressions prove A+Limited renders at the weaker Atlas evidence level and a legacy count of 7 is replaced by a canonical underlying-human count of 2.