### PR TITLE
fix(research): include grade blockers in snapshot invariants

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -51,11 +51,13 @@ function fixtures() {
     passed: true,
     structuralFailures: [],
     severeStudyClassConflicts: [],
+    evidenceGradeContradictions: [],
     summary: {
       structuralFailures: 0,
       unsupportedApprovedClaims: 0,
       danglingClaimSourceEdges: 0,
       severeStudyClassConflicts: 0,
+      evidenceGradeContradictions: 0,
       blockingFailures: 0,
     },
   } as ResearchQualityGate
@@ -92,6 +94,25 @@ describe('research quality snapshot invariants', () => {
     )
     expect(report.passed).toBe(true)
     expect(report.summary.failures).toBe(0)
+  })
+
+  it('accepts a legitimate Grade A gate blocker as normal gate state', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity, citationIntegrity } = fixtures()
+    gate.passed = false
+    gate.evidenceGradeContradictions = [{ url: '/herbs/example' }] as never
+    gate.summary.evidenceGradeContradictions = 1
+    gate.summary.blockingFailures = 1
+
+    const report = validateResearchQualitySnapshotInvariants(
+      analysis,
+      topology,
+      gate,
+      queue,
+      sourceIntegrity,
+      citationIntegrity,
+    )
+    expect(report.passed).toBe(true)
+    expect(report.failures).toEqual([])
   })
 
   it('accepts DOI-only and profile-local fallback source identities', () => {
@@ -146,6 +167,13 @@ describe('research quality snapshot invariants', () => {
     const kinds = report.failures.map((failure) => failure.kind)
     expect(kinds).toContain('gate-blocking-count-mismatch')
     expect(kinds).toContain('gate-pass-state-mismatch')
+  })
+
+  it('detects evidence-grade blocker count drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    gate.summary.evidenceGradeContradictions = 1
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.failures.map((failure) => failure.kind)).toContain('gate-evidence-grade-count-mismatch')
   })
 
   it('detects source-integrity count drift', () => {

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -148,7 +148,11 @@ export function validateResearchQualitySnapshotInvariants(
 
   if (gate.summary.structuralFailures !== gate.structuralFailures.length) add('gate-structural-count-mismatch', `summary=${gate.summary.structuralFailures}; rows=${gate.structuralFailures.length}`)
   if (gate.summary.severeStudyClassConflicts !== gate.severeStudyClassConflicts.length) add('gate-study-class-count-mismatch', `summary=${gate.summary.severeStudyClassConflicts}; rows=${gate.severeStudyClassConflicts.length}`)
-  if (gate.summary.blockingFailures !== gate.structuralFailures.length + gate.severeStudyClassConflicts.length) add('gate-blocking-count-mismatch', `summary=${gate.summary.blockingFailures}; computed=${gate.structuralFailures.length + gate.severeStudyClassConflicts.length}`)
+  if (gate.summary.evidenceGradeContradictions !== gate.evidenceGradeContradictions.length) add('gate-evidence-grade-count-mismatch', `summary=${gate.summary.evidenceGradeContradictions}; rows=${gate.evidenceGradeContradictions.length}`)
+  const computedGateBlockingFailures = gate.structuralFailures.length
+    + gate.severeStudyClassConflicts.length
+    + gate.evidenceGradeContradictions.length
+  if (gate.summary.blockingFailures !== computedGateBlockingFailures) add('gate-blocking-count-mismatch', `summary=${gate.summary.blockingFailures}; computed=${computedGateBlockingFailures}`)
   if (gate.passed !== (gate.summary.blockingFailures === 0)) add('gate-pass-state-mismatch', `passed=${gate.passed}; blocking=${gate.summary.blockingFailures}`)
 
   for (const finding of topology.semanticAlignment.findings) {


### PR DESCRIPTION
Fixes a follow-on invariant bug from topology-backed Grade A hard gating. Snapshot invariants still computed `blockingFailures` as structural failures + severe study-class conflicts only, so a legitimate evidence-grade contradiction was misclassified as internal snapshot corruption. The invariant now validates the evidence-grade contradiction count explicitly and includes it in canonical blocking-count arithmetic. The test fixture is updated for the expanded gate contract, with regressions proving a legitimate Grade A blocker is internally consistent and a mismatched grade-blocker count is detected.