### PR TITLE
feat(research): analyze directional consistency and endpoint multiplicity

### DIFF
--- a/lib/__tests__/research-directional-consistency.test.ts
+++ b/lib/__tests__/research-directional-consistency.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeDirectionalConsistency } from '@/lib/research-directional-consistency'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+function analysis(
+  claimText: string,
+  abstracts: string[],
+  confidence = 0.8,
+): ResearchQualityAnalysis {
+  const sources = abstracts.map((_, index) => ({
+    id: `s${index + 1}`,
+    pmid: String(index + 1),
+    studyClass: 'rct',
+  }))
+  const claimMap = [{
+    id: 'claim-1',
+    claim: claimText,
+    predicate: 'supports_outcome',
+    confidence,
+    reviewStatus: 'approved',
+    qualifiers: { direction: '+' },
+    sourceRefIds: sources.map((source) => source.id),
+  }]
+  const cache = Object.fromEntries(abstracts.map((abstract, index) => [String(index + 1), { abstract }]))
+  return {
+    cache,
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: { slug: 'example', sources, claimMap },
+    }],
+    claimAnalyses: [],
+    structuredClaimAnalyses: [],
+    profileAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+}
+
+describe('directional consistency and endpoint multiplicity', () => {
+  it('flags favorable secondary/subgroup evidence when the primary endpoint is explicitly null', () => {
+    const report = analyzeDirectionalConsistency(analysis(
+      'Improves symptoms',
+      ['The primary outcome showed no significant difference versus placebo. A secondary outcome significantly improved, and a post-hoc subgroup favored treatment.'],
+    ))
+
+    expect(report.summary.endpointCherryPickRisks).toBe(1)
+    expect(report.findings[0]).toMatchObject({
+      endpointCherryPickRisk: true,
+      directionalHeterogeneity: false,
+    })
+  })
+
+  it('flags directional heterogeneity when linked human trials explicitly disagree', () => {
+    const report = analyzeDirectionalConsistency(analysis(
+      'Consistently improves symptoms',
+      [
+        'Symptoms significantly improved compared with placebo.',
+        'There was no significant difference in symptoms compared with placebo.',
+      ],
+    ))
+
+    expect(report.summary.directionalHeterogeneityClaims).toBe(1)
+    expect(report.summary.uniformlyPositiveOverstatements).toBe(1)
+    expect(report.findings[0]).toMatchObject({
+      positiveSourceCount: 1,
+      nullSourceCount: 1,
+      uniformlyPositiveOverstatement: true,
+    })
+  })
+
+  it('does not invent directionality when source text is not explicit', () => {
+    const report = analyzeDirectionalConsistency(analysis(
+      'Supports symptom improvement',
+      ['Participants completed a randomized trial and outcomes were measured after eight weeks.'],
+    ))
+
+    expect(report.summary.findings).toBe(0)
+    expect(report.claims).toHaveLength(0)
+  })
+})

--- a/lib/research-directional-consistency.ts
+++ b/lib/research-directional-consistency.ts
@@ -1,0 +1,181 @@
+import {
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  approvedClaims,
+  sourceMap,
+  sourceStudyClass,
+  uniqueSourceRefs,
+  type ResearchClaim,
+} from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type DirectionalConsistencyFinding = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  favorableClaim: boolean
+  humanSourceCount: number
+  positiveSourceCount: number
+  nullSourceCount: number
+  negativeSourceCount: number
+  mixedSourceCount: number
+  primaryNullOrNegativeSourceCount: number
+  secondaryOrSubgroupPositiveSourceCount: number
+  endpointCherryPickRisk: boolean
+  directionalHeterogeneity: boolean
+  uniformlyPositiveOverstatement: boolean
+  reasons: string[]
+}
+
+export type DirectionalConsistencyReport = {
+  summary: {
+    approvedOutcomeClaims: number
+    assessableClaims: number
+    findings: number
+    highConfidenceFindings: number
+    endpointCherryPickRisks: number
+    directionalHeterogeneityClaims: number
+    uniformlyPositiveOverstatements: number
+  }
+  claims: DirectionalConsistencyFinding[]
+  findings: DirectionalConsistencyFinding[]
+  highConfidenceFindings: DirectionalConsistencyFinding[]
+}
+
+const POSITIVE = /\b(significantly (?:improved|reduced|increased|decreased)|significant (?:improvement|reduction|benefit|difference)|improved significantly|reduced significantly|beneficial effect|favou?r(?:ed|s) (?:the )?(?:treatment|intervention)|superior to placebo)\b/i
+const NULL = /\b(no significant (?:difference|effect|benefit|improvement|reduction)|not statistically significant|non[- ]significant|did not (?:differ|improve|reduce)|no (?:difference|effect|benefit)|failed to (?:improve|reduce)|similar to placebo|comparable to placebo)\b/i
+const NEGATIVE = /\b(significantly worsened|worsened significantly|worse than placebo|inferior to placebo|significant (?:worsening|harm)|increased adverse|favou?red placebo)\b/i
+const MIXED = /\b(mixed results?|inconsistent results?|inconsistent findings?|conflicting results?|not consistent across|heterogeneous results?)\b/i
+
+const PRIMARY_NULL_OR_NEGATIVE = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:no significant|not statistically significant|non[- ]significant|did not|failed to|worsen|worse|inferior|favou?red placebo)\b/i
+const SECONDARY_OR_SUBGROUP_POSITIVE = /\b(?:secondary (?:outcome|endpoint)|subgroup|sub-group|post[- ]hoc|exploratory (?:outcome|endpoint|analysis))[^.]{0,180}(?:significant|improv|reduc|benefit|favou?r|superior)\b/i
+
+function text(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function sourceEvidenceText(source: Record<string, unknown>, cache: ResearchQualityAnalysis['cache']): string {
+  const pmid = text(source.pmid ?? source.pubmedId)
+  const meta = pmid ? cache[pmid] ?? {} : {}
+  return [
+    source.title,
+    source.note,
+    source.citation,
+    source.result,
+    source.results,
+    source.effect,
+    meta.title,
+    meta.abstract,
+  ].map(text).filter(Boolean).join(' · ')
+}
+
+function isOutcomeClaim(claim: ResearchClaim): boolean {
+  return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
+}
+
+function favorableClaimDirection(claim: ResearchClaim): boolean {
+  const qualifiers = claim.qualifiers && typeof claim.qualifiers === 'object'
+    ? claim.qualifiers as Record<string, unknown>
+    : {}
+  const direction = text(qualifiers.direction).toLowerCase()
+  if (['+', 'positive', 'benefit', 'beneficial', 'improves', 'reduces'].includes(direction)) return true
+  const claimText = [claim.claim, claim.notes].map(text).filter(Boolean).join(' · ')
+  return /\b(improv|reduc|benefit|help|support|increase|decrease|better|relief|protect)\w*\b/i.test(claimText)
+}
+
+function uniformlyPositiveLanguage(claim: ResearchClaim): boolean {
+  const claimText = [claim.claim, claim.notes].map(text).filter(Boolean).join(' · ')
+  return /\b(consistently|reliably|clear benefit|well[- ]established|proven|robust(?: benefit| effect| evidence)?|strong(?:ly)? (?:improves?|reduces?|benefit))\b/i.test(claimText)
+}
+
+export function analyzeDirectionalConsistency(analysis: ResearchQualityAnalysis): DirectionalConsistencyReport {
+  const claims: DirectionalConsistencyFinding[] = []
+  let approvedOutcomeClaims = 0
+
+  for (const { url, record } of analysis.profiles) {
+    const sourcesById = sourceMap(record)
+    for (const claim of approvedClaims(record)) {
+      if (!isOutcomeClaim(claim)) continue
+      approvedOutcomeClaims += 1
+      const favorableClaim = favorableClaimDirection(claim)
+      if (!favorableClaim) continue
+
+      const humanSources = uniqueSourceRefs(claim)
+        .map((id) => sourcesById.get(id))
+        .filter((source): source is Record<string, unknown> => Boolean(source))
+        .filter((source) => PRIMARY_HUMAN_STUDY_CLASSES.has(sourceStudyClass(source, analysis.cache)))
+      if (!humanSources.length) continue
+
+      const sourceTexts = humanSources.map((source) => sourceEvidenceText(source, analysis.cache)).filter(Boolean)
+      if (!sourceTexts.length) continue
+
+      const positiveSourceCount = sourceTexts.filter((value) => POSITIVE.test(value)).length
+      const nullSourceCount = sourceTexts.filter((value) => NULL.test(value)).length
+      const negativeSourceCount = sourceTexts.filter((value) => NEGATIVE.test(value)).length
+      const mixedSourceCount = sourceTexts.filter((value) => MIXED.test(value)).length
+      const primaryNullOrNegativeSourceCount = sourceTexts.filter((value) => PRIMARY_NULL_OR_NEGATIVE.test(value)).length
+      const secondaryOrSubgroupPositiveSourceCount = sourceTexts.filter((value) => SECONDARY_OR_SUBGROUP_POSITIVE.test(value)).length
+
+      const endpointCherryPickRisk = sourceTexts.some((value) => PRIMARY_NULL_OR_NEGATIVE.test(value) && SECONDARY_OR_SUBGROUP_POSITIVE.test(value))
+      const explicitCounterDirection = nullSourceCount + negativeSourceCount + mixedSourceCount
+      const directionalHeterogeneity = humanSources.length >= 2 && positiveSourceCount > 0 && explicitCounterDirection > 0
+      const uniformlyPositiveOverstatement = directionalHeterogeneity && uniformlyPositiveLanguage(claim)
+
+      if (!endpointCherryPickRisk && !directionalHeterogeneity) continue
+
+      const reasons: string[] = []
+      if (endpointCherryPickRisk) {
+        reasons.push(`${primaryNullOrNegativeSourceCount} linked human source(s) explicitly report a null/negative primary endpoint while a secondary, subgroup, post-hoc, or exploratory result is favorable`)
+      }
+      if (directionalHeterogeneity) {
+        reasons.push(`linked human evidence is directionally mixed: ${positiveSourceCount} positive, ${nullSourceCount} null, ${negativeSourceCount} negative, ${mixedSourceCount} explicitly mixed source(s)`)
+      }
+      if (uniformlyPositiveOverstatement) {
+        reasons.push('claim uses uniformly positive/reliable wording despite explicit directional heterogeneity in linked human evidence')
+      }
+
+      claims.push({
+        url,
+        claimId: text(claim.id) || 'unknown-claim',
+        predicate: text(claim.predicate),
+        confidence: Number(claim.confidence ?? 0),
+        favorableClaim,
+        humanSourceCount: humanSources.length,
+        positiveSourceCount,
+        nullSourceCount,
+        negativeSourceCount,
+        mixedSourceCount,
+        primaryNullOrNegativeSourceCount,
+        secondaryOrSubgroupPositiveSourceCount,
+        endpointCherryPickRisk,
+        directionalHeterogeneity,
+        uniformlyPositiveOverstatement,
+        reasons,
+      })
+    }
+  }
+
+  const findings = claims.sort((a, b) =>
+    Number(b.uniformlyPositiveOverstatement) - Number(a.uniformlyPositiveOverstatement)
+    || Number(b.endpointCherryPickRisk) - Number(a.endpointCherryPickRisk)
+    || b.confidence - a.confidence
+    || a.url.localeCompare(b.url)
+    || a.claimId.localeCompare(b.claimId),
+  )
+  const highConfidenceFindings = findings.filter((claim) => claim.confidence >= 0.75)
+
+  return {
+    summary: {
+      approvedOutcomeClaims,
+      assessableClaims: claims.length,
+      findings: findings.length,
+      highConfidenceFindings: highConfidenceFindings.length,
+      endpointCherryPickRisks: findings.filter((claim) => claim.endpointCherryPickRisk).length,
+      directionalHeterogeneityClaims: findings.filter((claim) => claim.directionalHeterogeneity).length,
+      uniformlyPositiveOverstatements: findings.filter((claim) => claim.uniformlyPositiveOverstatement).length,
+    },
+    claims,
+    findings,
+    highConfidenceFindings,
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -5,6 +5,7 @@ import { analyzeClaimLanguageCalibration } from './research-claim-language-calib
 import { analyzeClaimProvenanceIndependence } from './research-claim-provenance-independence'
 import { analyzeCrossProfileEvidenceBundles } from './research-cross-profile-bundles'
 import { analyzeEdgeWeightedDesignUsage } from './research-design-usage'
+import { analyzeDirectionalConsistency } from './research-directional-consistency'
 import { analyzeEffectCertainty } from './research-effect-certainty'
 import { analyzeResearchEdgeCardinality } from './research-edge-cardinality'
 import { analyzeEvidenceIndependenceCoverage } from './research-evidence-independence-coverage'
@@ -78,6 +79,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const semanticAlignment = analyzeResearchSemanticAlignment(analysis)
   const claimBreadth = analyzeClaimBreadth(analysis)
   const effectCertainty = analyzeEffectCertainty(analysis)
+  const directionalConsistency = analyzeDirectionalConsistency(analysis)
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
   const metadataIntegrity = buildResearchMetadataIntegrity({
@@ -122,6 +124,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     semanticAlignment,
     claimBreadth,
     effectCertainty,
+    directionalConsistency,
     claimLanguageCalibration,
     claimCitationMetadata,
     metadataIntegrity,


### PR DESCRIPTION
Adds conservative directional-consistency analysis for approved outcome claims. It flags explicit primary-null/negative with favorable secondary/subgroup/post-hoc results, plus multi-study bundles with explicit positive and null/negative human evidence. Sparse or ambiguous source text remains unassessable. Adds the product to the canonical topology with regression coverage.