### PR TITLE
polish(library): refine filter disclosure

### DIFF
--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -75,10 +75,19 @@ export function DecisionFilterGroup({
     `rounded-full border px-2.5 py-1.5 text-xs font-semibold leading-tight transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
 
   return (
-    <details className="mt-3 rounded-[0.8rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none" open={open || undefined}>
-      <summary className="flex min-h-8 items-center justify-between gap-4 text-sm font-bold text-ink">
+    <details className="group mt-3 rounded-[0.8rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none" open={open || undefined}>
+      <summary className="flex min-h-8 cursor-pointer list-none items-center justify-between gap-4 text-sm font-bold text-ink select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/30 focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden">
         <span>Refine by context</span>
-        <span className="text-brand-800" aria-hidden="true">↓</span>
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          className="size-4 shrink-0 text-brand-800 transition-transform group-open:rotate-180"
+        >
+          <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
       </summary>
       <div className="mt-3 flex flex-wrap gap-2">
         <Link href={buildHref('all', query)} className={itemClass(activeFilter === 'all')}>


### PR DESCRIPTION
Shared visual polish for herb/compound library filters: make the context filter disclosure read and behave like a proper expandable control with a rotating chevron, hidden native marker, pointer affordance, and focus treatment. No filtering logic changes.