### PR TITLE
Fix directional-consistency assessable claim semantics

### DIFF
--- a/lib/__tests__/research-directional-consistency.test.ts
+++ b/lib/__tests__/research-directional-consistency.test.ts
@@ -69,12 +69,25 @@ describe('directional consistency and endpoint multiplicity', () => {
     })
   })
 
+  it('keeps explicitly directional positive evidence assessable without manufacturing a finding', () => {
+    const report = analyzeDirectionalConsistency(analysis(
+      'Improves symptoms',
+      ['Symptoms significantly improved compared with placebo.'],
+    ))
+
+    expect(report.summary.assessableClaims).toBe(1)
+    expect(report.summary.findings).toBe(0)
+    expect(report.claims).toHaveLength(1)
+    expect(report.findings).toHaveLength(0)
+  })
+
   it('does not invent directionality when source text is not explicit', () => {
     const report = analyzeDirectionalConsistency(analysis(
       'Supports symptom improvement',
       ['Participants completed a randomized trial and outcomes were measured after eight weeks.'],
     ))
 
+    expect(report.summary.assessableClaims).toBe(0)
     expect(report.summary.findings).toBe(0)
     expect(report.claims).toHaveLength(0)
   })

--- a/lib/research-directional-consistency.ts
+++ b/lib/research-directional-consistency.ts
@@ -88,6 +88,15 @@ function uniformlyPositiveLanguage(claim: ResearchClaim): boolean {
   return /\b(consistently|reliably|clear benefit|well[- ]established|proven|robust(?: benefit| effect| evidence)?|strong(?:ly)? (?:improves?|reduces?|benefit))\b/i.test(claimText)
 }
 
+function hasExplicitDirectionalSignal(value: string): boolean {
+  return POSITIVE.test(value)
+    || NULL.test(value)
+    || NEGATIVE.test(value)
+    || MIXED.test(value)
+    || PRIMARY_NULL_OR_NEGATIVE.test(value)
+    || SECONDARY_OR_SUBGROUP_POSITIVE.test(value)
+}
+
 export function analyzeDirectionalConsistency(analysis: ResearchQualityAnalysis): DirectionalConsistencyReport {
   const claims: DirectionalConsistencyFinding[] = []
   let approvedOutcomeClaims = 0
@@ -108,6 +117,8 @@ export function analyzeDirectionalConsistency(analysis: ResearchQualityAnalysis)
 
       const sourceTexts = humanSources.map((source) => sourceEvidenceText(source, analysis.cache)).filter(Boolean)
       if (!sourceTexts.length) continue
+      const explicitDirectionalSourceCount = sourceTexts.filter(hasExplicitDirectionalSignal).length
+      if (!explicitDirectionalSourceCount) continue
 
       const positiveSourceCount = sourceTexts.filter((value) => POSITIVE.test(value)).length
       const nullSourceCount = sourceTexts.filter((value) => NULL.test(value)).length
@@ -118,10 +129,8 @@ export function analyzeDirectionalConsistency(analysis: ResearchQualityAnalysis)
 
       const endpointCherryPickRisk = sourceTexts.some((value) => PRIMARY_NULL_OR_NEGATIVE.test(value) && SECONDARY_OR_SUBGROUP_POSITIVE.test(value))
       const explicitCounterDirection = nullSourceCount + negativeSourceCount + mixedSourceCount
-      const directionalHeterogeneity = humanSources.length >= 2 && positiveSourceCount > 0 && explicitCounterDirection > 0
+      const directionalHeterogeneity = explicitDirectionalSourceCount >= 2 && positiveSourceCount > 0 && explicitCounterDirection > 0
       const uniformlyPositiveOverstatement = directionalHeterogeneity && uniformlyPositiveLanguage(claim)
-
-      if (!endpointCherryPickRisk && !directionalHeterogeneity) continue
 
       const reasons: string[] = []
       if (endpointCherryPickRisk) {
@@ -155,13 +164,14 @@ export function analyzeDirectionalConsistency(analysis: ResearchQualityAnalysis)
     }
   }
 
-  const findings = claims.sort((a, b) =>
+  claims.sort((a, b) =>
     Number(b.uniformlyPositiveOverstatement) - Number(a.uniformlyPositiveOverstatement)
     || Number(b.endpointCherryPickRisk) - Number(a.endpointCherryPickRisk)
     || b.confidence - a.confidence
     || a.url.localeCompare(b.url)
     || a.claimId.localeCompare(b.claimId),
   )
+  const findings = claims.filter((claim) => claim.endpointCherryPickRisk || claim.directionalHeterogeneity)
   const highConfidenceFindings = findings.filter((claim) => claim.confidence >= 0.75)
 
   return {


### PR DESCRIPTION
Repairs the new directional-consistency report contract before downstream policy/reporting depends on it. Explicitly directional favorable claims now remain in the assessable `claims` set even when they do not produce a finding, while ambiguous source text stays unassessable. Heterogeneity now requires at least two source texts with explicit directional signal rather than relying on nominal human-source count. Adds regression coverage for an assessable positive-only claim with zero findings and preserves the conservative ambiguous-text case.