### PR TITLE
test(research): lock content integrity in-process boundary

### DIFF
--- a/lib/__tests__/research-quality-ci-boundary.test.ts
+++ b/lib/__tests__/research-quality-ci-boundary.test.ts
@@ -57,4 +57,15 @@ describe('research-quality CI boundary', () => {
       `CI/report scripts must consume buildResearchQualitySnapshot() instead of reconstructing canonical research state; direct specialized analyzers are reserved for their lightweight standalone validators:\n${violations.join('\n')}`,
     ).toEqual([])
   })
+
+  it('keeps structured content integrity in-process in the canonical roll-up', () => {
+    const root = process.cwd()
+    const rollup = fs.readFileSync(path.join(root, 'scripts', 'ci', 'research-quality.ts'), 'utf8')
+
+    expect(rollup).toContain("from '../../lib/content-integrity.mjs'")
+    expect(rollup).toContain('analyzeContentIntegrity(ROOT)')
+    expect(rollup).toContain('writeContentIntegrityReport(contentIntegrity, ROOT)')
+    expect(rollup).not.toContain('spawnSync')
+    expect(rollup).not.toContain('audit-content-integrity.mjs')
+  })
 })


### PR DESCRIPTION
Extends the existing research-quality CI boundary test to lock the structured content-integrity refactor in place. The canonical roll-up must import and call the shared content-integrity library directly, and must not reintroduce `spawnSync` or the `audit-content-integrity.mjs` subprocess path.