### PR TITLE
polish(library): show active context in filter summary

### DIFF
--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -73,11 +73,19 @@ export function DecisionFilterGroup({
 }) {
   const itemClass = (active: boolean) =>
     `rounded-full border px-2.5 py-1.5 text-xs font-semibold leading-tight transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
+  const activeContextLabel = activeFilter === 'all'
+    ? null
+    : options.find(option => option.value === activeFilter)?.label
 
   return (
     <details className="group mt-3 rounded-[0.8rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none" open={open || undefined}>
       <summary className="flex min-h-8 cursor-pointer list-none items-center justify-between gap-4 text-sm font-bold text-ink select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/30 focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden">
-        <span>Refine by context</span>
+        <span className="min-w-0">
+          <span>Refine by context</span>
+          {activeContextLabel ? (
+            <span className="ml-2 font-semibold text-brand-800">· {activeContextLabel}</span>
+          ) : null}
+        </span>
         <svg
           aria-hidden="true"
           viewBox="0 0 16 16"


### PR DESCRIPTION
Follow-up library polish: surface the selected context in the collapsed shared filter summary so users can see state without reopening the disclosure. No filtering logic changes.