### PR TITLE
Enforce directional-consistency snapshot invariants

### DIFF
--- a/lib/__tests__/research-directional-consistency-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-directional-consistency-snapshot-invariants.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateDirectionalConsistencySnapshotInvariants } from '@/lib/research-directional-consistency-snapshot-invariants'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import type { ResearchQualityTopology } from '@/lib/research-quality-topology'
+
+function analysis(): ResearchQualityAnalysis {
+  return {
+    cache: {},
+    profiles: [],
+    profileAnalyses: [],
+    structuredClaimAnalyses: [],
+    claimAnalyses: [{
+      url: '/herbs/example/',
+      claimId: 'claim-1',
+      reviewStatus: 'approved',
+      approved: true,
+      predicate: 'supports_outcome',
+      confidence: 0.8,
+      sourceRefCount: 2,
+      validSourceRefCount: 2,
+      danglingSourceRefs: [],
+      studyIds: ['a', 'b'],
+      studyCount: 2,
+      classifiedStudyCount: 2,
+      primaryHuman: 2,
+      synthesis: 0,
+      narrative: 0,
+      designs: ['rct', 'rct'],
+      outcomeClaim: true,
+      supportTier: 'human-supported',
+      structuredSupportTier: 'adequate',
+      weakStructuredClaim: false,
+      highConfidenceWeakStructured: false,
+      highConfidenceWeakOutcome: false,
+      singleStudy: false,
+      aliasCollapsed: false,
+    }],
+  } as ResearchQualityAnalysis
+}
+
+function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopology {
+  const row = {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    predicate: 'supports_outcome',
+    confidence: 0.8,
+    favorableClaim: true,
+    humanSourceCount: 2,
+    positiveSourceCount: 1,
+    nullSourceCount: 1,
+    negativeSourceCount: 0,
+    mixedSourceCount: 0,
+    primaryNullOrNegativeSourceCount: 0,
+    secondaryOrSubgroupPositiveSourceCount: 0,
+    endpointCherryPickRisk: false,
+    directionalHeterogeneity: true,
+    uniformlyPositiveOverstatement: false,
+    reasons: ['linked human evidence is directionally mixed'],
+    ...overrides,
+  }
+  return {
+    directionalConsistency: {
+      summary: {
+        approvedOutcomeClaims: 1,
+        assessableClaims: 1,
+        findings: 1,
+        highConfidenceFindings: 1,
+        endpointCherryPickRisks: 0,
+        directionalHeterogeneityClaims: 1,
+        uniformlyPositiveOverstatements: 0,
+      },
+      claims: [row],
+      findings: [row],
+      highConfidenceFindings: [row],
+    },
+  } as unknown as ResearchQualityTopology
+}
+
+describe('directional consistency snapshot invariants', () => {
+  it('accepts a self-consistent directional report', () => {
+    expect(validateDirectionalConsistencySnapshotInvariants(analysis(), topology())).toEqual([])
+  })
+
+  it('detects summary drift', () => {
+    const value = topology()
+    value.directionalConsistency.summary.findings = 0
+    expect(validateDirectionalConsistencySnapshotInvariants(analysis(), value)
+      .map((failure) => failure.kind)).toContain('directional-finding-count-mismatch')
+  })
+
+  it('detects impossible source cardinality', () => {
+    expect(validateDirectionalConsistencySnapshotInvariants(analysis(), topology({ positiveSourceCount: 3 }))
+      .map((failure) => failure.kind)).toContain('directional-source-count-invalid')
+  })
+})

--- a/lib/research-directional-consistency-snapshot-invariants.ts
+++ b/lib/research-directional-consistency-snapshot-invariants.ts
@@ -1,0 +1,116 @@
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { ResearchQualityTopology } from './research-quality-topology'
+
+export type DirectionalConsistencyInvariantFailure = {
+  kind: string
+  detail: string
+}
+
+function claimKey(url: string, claimId: string): string {
+  return `${url}::${claimId}`
+}
+
+/** Validate self-consistency of the canonical directional-consistency product. */
+export function validateDirectionalConsistencySnapshotInvariants(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology,
+): DirectionalConsistencyInvariantFailure[] {
+  const failures: DirectionalConsistencyInvariantFailure[] = []
+  const report = topology.directionalConsistency
+  const approvedOutcomeClaimKeys = new Set(
+    analysis.claimAnalyses
+      .filter((claim) => claim.outcomeClaim)
+      .map((claim) => claimKey(claim.url, claim.claimId)),
+  )
+  const add = (kind: string, detail: string) => failures.push({ kind, detail })
+
+  if (report.summary.approvedOutcomeClaims !== approvedOutcomeClaimKeys.size) {
+    add(
+      'directional-approved-outcome-count-mismatch',
+      `summary=${report.summary.approvedOutcomeClaims}; analysis=${approvedOutcomeClaimKeys.size}`,
+    )
+  }
+  if (report.summary.assessableClaims !== report.claims.length) {
+    add('directional-assessable-count-mismatch', `summary=${report.summary.assessableClaims}; rows=${report.claims.length}`)
+  }
+  if (report.summary.findings !== report.findings.length) {
+    add('directional-finding-count-mismatch', `summary=${report.summary.findings}; rows=${report.findings.length}`)
+  }
+  if (report.summary.highConfidenceFindings !== report.highConfidenceFindings.length) {
+    add(
+      'directional-high-confidence-count-mismatch',
+      `summary=${report.summary.highConfidenceFindings}; rows=${report.highConfidenceFindings.length}`,
+    )
+  }
+
+  const endpointFindings = report.findings.filter((claim) => claim.endpointCherryPickRisk).length
+  const heterogeneityFindings = report.findings.filter((claim) => claim.directionalHeterogeneity).length
+  const uniformlyPositiveFindings = report.findings.filter((claim) => claim.uniformlyPositiveOverstatement).length
+  if (report.summary.endpointCherryPickRisks !== endpointFindings) {
+    add('directional-endpoint-count-mismatch', `summary=${report.summary.endpointCherryPickRisks}; rows=${endpointFindings}`)
+  }
+  if (report.summary.directionalHeterogeneityClaims !== heterogeneityFindings) {
+    add(
+      'directional-heterogeneity-count-mismatch',
+      `summary=${report.summary.directionalHeterogeneityClaims}; rows=${heterogeneityFindings}`,
+    )
+  }
+  if (report.summary.uniformlyPositiveOverstatements !== uniformlyPositiveFindings) {
+    add(
+      'directional-uniform-overstatement-count-mismatch',
+      `summary=${report.summary.uniformlyPositiveOverstatements}; rows=${uniformlyPositiveFindings}`,
+    )
+  }
+
+  const claimKeys = new Set<string>()
+  for (const claim of report.claims) {
+    const key = claimKey(claim.url, claim.claimId)
+    claimKeys.add(key)
+    if (!approvedOutcomeClaimKeys.has(key)) add('directional-unknown-approved-outcome-claim', key)
+    if (!claim.favorableClaim) add('directional-nonfavorable-assessable-claim', key)
+
+    for (const [label, count] of Object.entries({
+      positive: claim.positiveSourceCount,
+      null: claim.nullSourceCount,
+      negative: claim.negativeSourceCount,
+      mixed: claim.mixedSourceCount,
+      primaryNullOrNegative: claim.primaryNullOrNegativeSourceCount,
+      secondaryOrSubgroupPositive: claim.secondaryOrSubgroupPositiveSourceCount,
+    })) {
+      if (count < 0 || count > claim.humanSourceCount) {
+        add('directional-source-count-invalid', `${key} · ${label}=${count}; human=${claim.humanSourceCount}`)
+      }
+    }
+
+    if (claim.endpointCherryPickRisk
+      && (claim.primaryNullOrNegativeSourceCount === 0 || claim.secondaryOrSubgroupPositiveSourceCount === 0)) {
+      add('directional-endpoint-state-invalid', key)
+    }
+    if (claim.directionalHeterogeneity
+      && (claim.positiveSourceCount === 0 || claim.nullSourceCount + claim.negativeSourceCount + claim.mixedSourceCount === 0)) {
+      add('directional-heterogeneity-state-invalid', key)
+    }
+    if (claim.uniformlyPositiveOverstatement && !claim.directionalHeterogeneity) {
+      add('directional-uniform-state-invalid', key)
+    }
+
+    const isFinding = claim.endpointCherryPickRisk || claim.directionalHeterogeneity
+    if (isFinding && claim.reasons.length === 0) add('directional-finding-without-reason', key)
+    if (!isFinding && claim.reasons.length > 0) add('directional-nonfinding-with-reason', key)
+  }
+
+  for (const finding of report.findings) {
+    const key = claimKey(finding.url, finding.claimId)
+    if (!claimKeys.has(key)) add('directional-finding-not-assessable', key)
+    if (!finding.endpointCherryPickRisk && !finding.directionalHeterogeneity) add('directional-finding-state-invalid', key)
+  }
+
+  const findingKeys = new Set(report.findings.map((claim) => claimKey(claim.url, claim.claimId)))
+  for (const finding of report.highConfidenceFindings) {
+    const key = claimKey(finding.url, finding.claimId)
+    if (!findingKeys.has(key)) add('directional-high-confidence-not-finding', key)
+    if (finding.confidence < 0.75) add('directional-high-confidence-threshold-invalid', `${key} · confidence=${finding.confidence}`)
+  }
+
+  return failures
+}

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -3,6 +3,7 @@ import {
   crossProfileStudyIdentity,
   crossProfileStudyIdentityMap,
 } from './research-coverage'
+import { validateDirectionalConsistencySnapshotInvariants } from './research-directional-consistency-snapshot-invariants'
 import { validateEffectCertaintySnapshotInvariants } from './research-effect-certainty-snapshot-invariants'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import type { ResearchQualityGate } from './research-quality-gate'
@@ -135,6 +136,7 @@ export function validateResearchQualitySnapshotInvariants(
     add('claim-breadth-finding-count-mismatch', `summary=${topology.claimBreadth.summary.overbroadClaims}; rows=${topology.claimBreadth.findings.length}`)
   }
   for (const invariant of validateEffectCertaintySnapshotInvariants(analysis, topology)) add(invariant.kind, invariant.detail)
+  for (const invariant of validateDirectionalConsistencySnapshotInvariants(analysis, topology)) add(invariant.kind, invariant.detail)
   if (topology.edgeCardinality.summary.claims !== analysis.structuredClaimAnalyses.length) {
     add('edge-cardinality-claim-count-mismatch', `edgeCardinality=${topology.edgeCardinality.summary.claims}; analysis=${analysis.structuredClaimAnalyses.length}`)
   }


### PR DESCRIPTION
Adds a shared invariant validator for the canonical directional-consistency/endpoint-multiplicity product and invokes it from the existing research-quality snapshot invariant engine. It validates approved-outcome ownership, assessable/finding/high-confidence counts, subtype totals, source-count bounds, cherry-pick/heterogeneity state, reasons, and subset membership. Includes focused regressions for summary drift and impossible source cardinality. No parallel validator or scoring path is introduced.