### PR TITLE
SEO: migrate legacy guide references to shared primitive

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -5,8 +5,14 @@ on:
     paths:
       - 'app/articles/**'
       - 'app/learn/rhabdomyolysis/page.tsx'
+      - 'app/guides/other/prebiotics/page.tsx'
+      - 'app/guides/other/greens-powders/page.tsx'
+      - 'app/guides/other/bovine-colostrum/page.tsx'
+      - 'app/guides/other/electrolyte-supplements/page.tsx'
+      - 'app/guides/other/collagen-supplements/page.tsx'
       - 'components/articles/GoalClusterArticlePage.tsx'
       - 'components/articles/MentalHealthArticlePage.tsx'
+      - 'components/LegacyGuideReference.tsx'
       - 'components/References.tsx'
       - 'components/seo/**'
       - 'components/StructuredData.tsx'
@@ -84,6 +90,27 @@ jobs:
       - name: Install dependencies
         run: npm ci --silent
 
+      - name: Guard legacy guide reference consolidation
+        shell: bash
+        run: |
+          files=(
+            app/guides/other/prebiotics/page.tsx
+            app/guides/other/greens-powders/page.tsx
+            app/guides/other/bovine-colostrum/page.tsx
+            app/guides/other/electrolyte-supplements/page.tsx
+            app/guides/other/collagen-supplements/page.tsx
+          )
+          for file in "${files[@]}"; do
+            grep -Fq "import Ref from '@/components/LegacyGuideReference'" "$file" || {
+              echo "$file must reuse LegacyGuideReference" >&2
+              exit 1
+            }
+            if grep -Eq '^type RefProps|^function Ref\(' "$file"; then
+              echo "$file reintroduced a local legacy reference renderer" >&2
+              exit 1
+            fi
+          done
+
       - name: Run schema, article citation, discovery, and provenance tests
         run: >-
           npx vitest run
@@ -102,6 +129,7 @@ jobs:
           app/learn/rhabdomyolysis/page.tsx
           components/articles/GoalClusterArticlePage.tsx
           components/articles/MentalHealthArticlePage.tsx
+          components/LegacyGuideReference.tsx
           components/References.tsx
           components/StructuredData.tsx
           components/compare/CompareSchema.tsx

--- a/app/guides/other/bovine-colostrum/page.tsx
+++ b/app/guides/other/bovine-colostrum/page.tsx
@@ -5,6 +5,7 @@ import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
+import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -21,9 +22,6 @@ const FAQS = [
   { question: 'Is bovine colostrum safe?', answer: 'Generally well-tolerated at studied doses (10-60 g/day for up to 12 weeks). Common side effects: bloating, nausea, diarrhea [2]. Contraindicated in milk protein allergy. Long-term safety beyond 12 weeks is unknown. The FDA has accepted the safety of hyperimmune milks based on clinical data [2]. Those with hormone-sensitive conditions should consult a clinician.' },
   { question: 'How much colostrum should I take?', answer: 'Clinical studies use 10-60 g/day, with 20 g/day being common. Most commercial products provide 1-2 g per serving — well below studied doses [3]. Look for products standardized to ≥15% IgG from grass-fed, first-milking sources. GI permeability studies used 20 g/day for 14 days or 1.7 g/kg/day pre-exercise [2]. Start low and assess tolerance.' },
 ]
-
-type RefProps = { n: number; text: string; url?: string }
-function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 
 export default function BovineColostrumGuidePage() {
   return (

--- a/app/guides/other/collagen-supplements/page.tsx
+++ b/app/guides/other/collagen-supplements/page.tsx
@@ -7,6 +7,7 @@ import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
+import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -23,9 +24,6 @@ const FAQS = [
   { question: 'Is collagen just overpriced protein?', answer: 'Partially. Collagen lacks tryptophan (incomplete protein) and is inferior to whey for muscle protein synthesis [6]. However, its unique amino acid profile (25% glycine, 12% proline) may stimulate fibroblast collagen synthesis in ways general protein does not [1,7]. The skin/joint evidence is specific to collagen, not just protein. Value depends on your goals.' },
   { question: 'Can I get collagen from bone broth?', answer: 'Bone broth collagen content is unpredictable — one study found commercial broths ranged from undetectable to 5 g/serving [8]. Supplements provide standardized doses matching clinical trial protocols. Bone broth is a healthy food but not a reliable substitute for studied collagen doses.' },
 ];
-
-type RefProps = { n: number; text: string; url?: string }
-function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 
 export default function CollagenGuidePage() {
   return (

--- a/app/guides/other/electrolyte-supplements/page.tsx
+++ b/app/guides/other/electrolyte-supplements/page.tsx
@@ -5,6 +5,7 @@ import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
+import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -18,9 +19,6 @@ const FAQS = [
   { question: 'Do I need electrolyte supplements?', answer: 'Most people do not. The AIS (Australian Institute of Sport) classifies electrolyte supplements as a sports food for specific use cases: prolonged exercise &gt;90 min, extreme heat, or documented high sodium losses [1]. For healthy adults with normal diets and moderate activity, kidneys regulate electrolyte balance effectively [2]. Supplementation is primarily indicated for endurance athletes, outdoor laborers in heat, and during illness with vomiting/diarrhea.' },
   { question: 'Is LMNT worth it?', answer: 'For heavy sweaters and endurance athletes — reasonable. LMNT provides 1,000 mg sodium, 200 mg potassium, and 60 mg magnesium at ~$1.50/serving. The 5:1 sodium-to-potassium ratio reflects sweat composition [3]. For everyone else, salt your food and eat potassium-rich foods (bananas, potatoes, spinach) — same electrolytes at 1% of the cost.' },
 ];
-
-type RefProps = { n: number; text: string; url?: string }
-function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 
 export default function ElectrolyteGuidePage() {
   return (

--- a/app/guides/other/greens-powders/page.tsx
+++ b/app/guides/other/greens-powders/page.tsx
@@ -5,6 +5,7 @@ import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
+import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -21,9 +22,6 @@ const FAQS = [
   { question: 'What should I look for in a greens powder?', answer: 'Transparent labeling (no proprietary blends), third-party testing for heavy metals (algae ingredients concentrate contaminants) [7], organic certification, and clear ingredient amounts. Expect $30-50/month for quality. Anything approaching $100/month should be scrutinized carefully.' },
   { question: 'Are greens powders safe?', answer: 'Generally yes, but three concerns: (1) heavy metal contamination in spirulina/chlorella products [7], (2) excessive B6/B12 doses causing neuropathy or acne with long-term use, (3) vitamin K interference with warfarin [8]. The lack of FDA pre-market review means quality varies dramatically.' },
 ]
-
-type RefProps = { n: number; text: string; url?: string }
-function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 
 export default function GreensPowdersPage() {
   return (

--- a/app/guides/other/prebiotics/page.tsx
+++ b/app/guides/other/prebiotics/page.tsx
@@ -5,6 +5,7 @@ import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
+import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
@@ -21,9 +22,6 @@ const FAQS = [
   { question: 'Why do prebiotics cause gas?', answer: 'Fermentation produces gas (hydrogen, methane, CO₂). Start at 1-2 g/day, increase by 1-2 g every 3-4 days over 2-3 weeks. Most adapt within 1-2 weeks [2]. Persistent bloating at low doses may indicate SIBO or IBS — consult a gastroenterologist. PHGG (partially hydrolyzed guar gum) is the best-tolerated prebiotic for sensitive guts [5].' },
   { question: 'Which prebiotic supplement is best?', answer: 'PHGG — best-tolerated, evidence for IBS [5]. Inulin/FOS — most studied for microbiome support, more gas [2]. GOS — gentler, supports immune function [6]. Resistant starch (green banana flour, potato starch) — metabolic health, 15-30 g/day. Start with PHGG if sensitive; inulin if fiber-tolerant. No supplement replicates the diversity of food fiber [4].' },
 ];
-
-type RefProps = { n: number; text: string; url?: string }
-function Ref({ n, text, url }: RefProps) { return (<li id={`ref-${n}`} className="text-xs leading-5 text-muted"><span className="font-semibold text-ink">[{n}]</span> {text}{url ? <> <a href={url} target="_blank" rel="noopener noreferrer" className="text-brand-700 underline hover:text-brand-800">→</a></> : null}</li>) }
 
 export default function PrebioticsGuide() {
   return (


### PR DESCRIPTION
Fixes #3619

## Summary
- removes five duplicated local `RefProps` + `Ref` implementations from prebiotics, greens powders, bovine colostrum, electrolytes, and collagen guides
- imports the already-merged `LegacyGuideReference` compatibility primitive as `Ref`, leaving every existing `<Ref n=… text=… url=… />` call untouched
- preserves all authored citation text, ordinals, and URLs exactly
- standardizes those guide references onto the shared stable `#ref-N`, citation-source, durable self-link, and conservative CreativeWork semantics
- extends the existing AI-search workflow to trigger on all five pages and the shared primitive
- adds one workflow invariant requiring the shared import and forbidding local `RefProps`/`function Ref` copies
- creates no new citation validator or bibliographic inference path

## Acceptance criteria
- All five local reference component implementations are removed.
- All five guides import `@/components/LegacyGuideReference` as `Ref`.
- Existing reference JSX calls, citation prose, ordinals, and URLs are unchanged.
- The existing AI-search workflow fails if any of the five pages stops using the shared primitive or reintroduces the local renderer.
- No PMID/DOI/author/journal/date metadata is inferred from free-form legacy citation text.

## Validation commands
- AI search quality check
- `npx eslint components/LegacyGuideReference.tsx --max-warnings=0`
- `npm run typecheck`
- Atomic upgrade gate

## Before → after metrics
- Duplicated local legacy guide reference renderers: 5 → 0.
- Shared compatibility renderer users in this guide family: 0 → 5.
- Authored reference JSX/citation records rewritten: 0 → 0.
- Existing-governance invariants protecting the migration: 0 → 1.
- New citation pipelines introduced: 0.

## Generator/source-of-truth decision
Each guide file remains the source of truth for its citation text, order, and URL. `LegacyGuideReference` is presentation/extraction compatibility only. Richer structured pages continue using the canonical `References` ledger; these legacy pages are not upgraded by inventing unavailable metadata.

## Regression contract
- These five guides must not redefine `RefProps` or `function Ref` locally.
- Their shared import must remain present while they use the legacy `{n,text,url}` contract.
- Citation prose and URLs must not be altered merely to satisfy structured-data markup.
- The compatibility primitive must remain conservative and must not parse free-form citation text into invented metadata.
- Governance remains inside the existing AI-search workflow; no parallel validator is added.