### PR TITLE
fix(research): make grade validator topology-aware

### DIFF
--- a/lib/__tests__/evidence-grade-validator-topology-boundary.test.ts
+++ b/lib/__tests__/evidence-grade-validator-topology-boundary.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('evidence-grade standalone validator boundary', () => {
+  it('consumes the canonical snapshot and hard-fails topology-backed Grade A contradictions', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'scripts/ci/validate-evidence-grade-consistency.ts'),
+      'utf8',
+    )
+
+    expect(source).toContain("from '../../lib/research-quality-snapshot'")
+    expect(source).toContain('buildResearchQualitySnapshot(ROOT)')
+    expect(source).not.toContain('analyzeEvidenceGradeConsistency(')
+    expect(source).toContain('report.topologyContradictions.length > 0')
+    expect(source).toContain('Grade A contradiction(s) proven by canonical underlying-study topology')
+  })
+})

--- a/scripts/ci/validate-evidence-grade-consistency.ts
+++ b/scripts/ci/validate-evidence-grade-consistency.ts
@@ -1,14 +1,12 @@
 import path from 'node:path'
 
-import {
-  analyzeEvidenceGradeConsistency,
-  writeEvidenceGradeConsistencyReport,
-} from '../../lib/evidence-grade-consistency'
+import { writeEvidenceGradeConsistencyReport } from '../../lib/evidence-grade-consistency'
+import { buildResearchQualitySnapshot } from '../../lib/research-quality-snapshot'
 
 const ROOT = process.cwd()
 const STRICT = process.argv.slice(2).includes('--strict')
 
-const report = analyzeEvidenceGradeConsistency(ROOT)
+const { evidenceGradeConsistency: report } = buildResearchQualitySnapshot(ROOT)
 const reportPath = writeEvidenceGradeConsistencyReport(report, ROOT)
 
 console.log('\nEvidence grade consistency')
@@ -16,6 +14,8 @@ console.log('='.repeat(66))
 console.log(`Profiles scanned            ${report.totals.profiles}`)
 console.log(`Indexable                   ${report.totals.indexable}`)
 console.log(`Flagged (indexable)         ${report.totals.flaggedIndexable}`)
+console.log(`Topology contradictions     ${report.totals.topologyContradictionsIndexable}`)
+console.log(`Topology warnings           ${report.totals.topologyWarningsIndexable}`)
 console.log(`Rationale cards renderable  ${report.totals.gradeCardRenderable}`)
 for (const [issue, count] of Object.entries(report.issueCounts).sort((a, b) => b[1] - a[1])) {
   console.log(`  ${String(count).padStart(5)}  ${issue}`)
@@ -28,6 +28,14 @@ if (report.invalid.length > 0) {
     console.error(`  ${finding.url}  evidence_grade=${JSON.stringify(finding.rawGrade)}`)
   }
   console.error('\nRun `npm run data:normalize-evidence` to migrate, or fix the workbook value.')
+  process.exit(1)
+}
+
+if (report.topologyContradictions.length > 0) {
+  console.error(`\n[evidence-grade] FAILED — ${report.topologyContradictions.length} indexable Grade A contradiction(s) proven by canonical underlying-study topology.`)
+  for (const finding of report.topologyContradictions.slice(0, 20)) {
+    console.error(`  ${finding.url}  ${finding.issues.join(', ')}`)
+  }
   process.exit(1)
 }
 


### PR DESCRIPTION
Fixes the standalone evidence-grade validator so it no longer analyzes grades without canonical research topology. The validator now consumes `buildResearchQualitySnapshot()`, reports topology contradictions/warnings, and hard-fails topology-backed Grade A contradictions unconditionally because those are production blockers. Legacy grade-vs-tier contradictions remain `--strict` behavior. Adds a boundary regression preventing a return to topology-blind direct analysis.