### PR TITLE
refactor(report): separate primary human and synthesis evidence

### DIFF
--- a/app/evidence/evidence-report/CategoryEvidenceMixPanel.tsx
+++ b/app/evidence/evidence-report/CategoryEvidenceMixPanel.tsx
@@ -16,25 +16,26 @@ export default function CategoryEvidenceMixPanel({ dataset }: Props) {
   return (
     <section className="mx-auto mb-10 max-w-6xl px-4 sm:px-6 lg:px-8" aria-labelledby="category-evidence-mix-title">
       <div className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
-        <p className="eyebrow-label">Human vs preclinical evidence mix</p>
+        <p className="eyebrow-label">Evidence-design mix</p>
         <h2 id="category-evidence-mix-title" className="mt-2 text-2xl font-semibold text-ink">
-          Which categories currently rely most on mechanism, animal, or in-vitro evidence?
+          Which categories rely on direct human research, synthesis, or preclinical evidence?
         </h2>
         <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
-          This compares structured study-to-ingredient relationships by evidence class. “Preclinical” here means
-          mechanistic, animal, or in-vitro evidence. A high share is a research-maturity signal, not a statement that
-          the category is ineffective or unsafe. Categories with fewer than three structured relationships are omitted
-          from this ranking to reduce tiny-sample noise.
+          Primary human evidence includes trials, observational studies, and case reports. Evidence synthesis includes
+          systematic reviews and meta-analyses and is shown separately so review-heavy categories are not mistaken for
+          categories with a deep primary-human study base. “Preclinical” means mechanistic, animal, or in-vitro evidence.
+          Categories with fewer than three structured relationships are omitted to reduce tiny-sample noise.
         </p>
 
         <div className="mt-6 overflow-x-auto">
-          <table className="w-full min-w-[720px] border-collapse text-left text-sm">
+          <table className="w-full min-w-[900px] border-collapse text-left text-sm">
             <thead>
               <tr className="border-b border-brand-900/10 text-xs uppercase tracking-wider text-muted">
                 <th className="py-3 pr-4">Category</th>
                 <th className="py-3 pr-4">Evidence relationships</th>
+                <th className="py-3 pr-4">Primary human</th>
+                <th className="py-3 pr-4">Synthesis</th>
                 <th className="py-3 pr-4">Preclinical</th>
-                <th className="py-3 pr-4">Human</th>
                 <th className="py-3">Other / unclear</th>
               </tr>
             </thead>
@@ -44,10 +45,13 @@ export default function CategoryEvidenceMixPanel({ dataset }: Props) {
                   <td className="py-3 pr-4 font-semibold text-ink">{category.category}</td>
                   <td className="py-3 pr-4 text-muted">{category.evidenceRelationships}</td>
                   <td className="py-3 pr-4 text-muted">
-                    {category.preclinicalRelationships} · {formatPct(category.preclinicalShare)}
+                    {category.primaryHumanRelationships} · {formatPct(category.primaryHumanShare)}
                   </td>
                   <td className="py-3 pr-4 text-muted">
-                    {category.humanRelationships} · {formatPct(category.humanShare)}
+                    {category.synthesisRelationships} · {formatPct(category.synthesisShare)}
+                  </td>
+                  <td className="py-3 pr-4 text-muted">
+                    {category.preclinicalRelationships} · {formatPct(category.preclinicalShare)}
                   </td>
                   <td className="py-3 text-muted">{category.otherRelationships}</td>
                 </tr>

--- a/lib/__tests__/evidence-report-primary-human-split.test.ts
+++ b/lib/__tests__/evidence-report-primary-human-split.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { summarizeCategoryEvidenceMix } from '../evidence-report-insights'
+import type { PublicEvidenceDataset, PublicStudyEntity } from '../public-evidence-dataset'
+
+const study = (id: string, evidenceClass: PublicStudyEntity['evidenceClass']): PublicStudyEntity => ({
+  id,
+  title: id,
+  evidenceClass,
+  confidence: 'unknown',
+  conditions: [],
+  relationships: [{
+    ingredientSlug: 'example',
+    ingredientName: 'Example',
+    ingredientType: 'herb',
+    ingredientPath: '/herbs/example/',
+    evidenceGrade: 'B',
+    relationship: 'supports',
+  }],
+  relationshipSummary: 'supports',
+})
+
+describe('evidence report category design mix', () => {
+  it('separates primary human studies from synthesis and preclinical evidence', () => {
+    const dataset = {
+      ingredients: [{
+        slug: 'example',
+        name: 'Example',
+        type: 'herb',
+        path: '/herbs/example/',
+        evidenceGrade: 'B',
+        category: 'Test category',
+        safetyCaution: false,
+      }],
+      studies: [
+        study('rct', 'randomized_controlled_trial'),
+        study('review', 'systematic_review'),
+        study('animal', 'animal'),
+        study('narrative', 'narrative_review'),
+      ],
+    } as PublicEvidenceDataset
+
+    const [result] = summarizeCategoryEvidenceMix(dataset)
+
+    expect(result).toMatchObject({
+      category: 'Test category',
+      evidenceRelationships: 4,
+      humanRelationships: 2,
+      primaryHumanRelationships: 1,
+      synthesisRelationships: 1,
+      preclinicalRelationships: 1,
+      otherRelationships: 1,
+      humanShare: 0.5,
+      primaryHumanShare: 0.25,
+      synthesisShare: 0.25,
+      preclinicalShare: 0.25,
+    })
+  })
+})

--- a/lib/evidence-report-insights.ts
+++ b/lib/evidence-report-insights.ts
@@ -1,28 +1,31 @@
 import type { PublicEvidenceDataset } from '@/lib/public-evidence-dataset'
 
 const PRECLINICAL_CLASSES = new Set(['mechanistic', 'animal', 'in_vitro'])
-const HUMAN_CLASSES = new Set([
-  'meta_analysis',
-  'systematic_review',
+const PRIMARY_HUMAN_CLASSES = new Set([
   'randomized_controlled_trial',
   'controlled_trial',
   'observational',
   'case_report',
 ])
+const SYNTHESIS_CLASSES = new Set(['meta_analysis', 'systematic_review'])
 
 export type CategoryEvidenceMix = {
   category: string
   evidenceRelationships: number
   humanRelationships: number
+  primaryHumanRelationships: number
+  synthesisRelationships: number
   preclinicalRelationships: number
   otherRelationships: number
   preclinicalShare: number
   humanShare: number
+  primaryHumanShare: number
+  synthesisShare: number
 }
 
 export function summarizeCategoryEvidenceMix(dataset: PublicEvidenceDataset): CategoryEvidenceMix[] {
   const categoryBySlug = new Map(dataset.ingredients.map(ingredient => [ingredient.slug, ingredient.category]))
-  const buckets = new Map<string, Omit<CategoryEvidenceMix, 'preclinicalShare' | 'humanShare'>>()
+  const buckets = new Map<string, Omit<CategoryEvidenceMix, 'preclinicalShare' | 'humanShare' | 'primaryHumanShare' | 'synthesisShare'>>()
 
   for (const study of dataset.studies) {
     for (const relationship of study.relationships) {
@@ -31,14 +34,21 @@ export function summarizeCategoryEvidenceMix(dataset: PublicEvidenceDataset): Ca
         category,
         evidenceRelationships: 0,
         humanRelationships: 0,
+        primaryHumanRelationships: 0,
+        synthesisRelationships: 0,
         preclinicalRelationships: 0,
         otherRelationships: 0,
       }
 
       bucket.evidenceRelationships += 1
       if (PRECLINICAL_CLASSES.has(study.evidenceClass)) bucket.preclinicalRelationships += 1
-      else if (HUMAN_CLASSES.has(study.evidenceClass)) bucket.humanRelationships += 1
-      else bucket.otherRelationships += 1
+      else if (PRIMARY_HUMAN_CLASSES.has(study.evidenceClass)) {
+        bucket.primaryHumanRelationships += 1
+        bucket.humanRelationships += 1
+      } else if (SYNTHESIS_CLASSES.has(study.evidenceClass)) {
+        bucket.synthesisRelationships += 1
+        bucket.humanRelationships += 1
+      } else bucket.otherRelationships += 1
       buckets.set(category, bucket)
     }
   }
@@ -51,6 +61,12 @@ export function summarizeCategoryEvidenceMix(dataset: PublicEvidenceDataset): Ca
         : 0,
       humanShare: bucket.evidenceRelationships
         ? bucket.humanRelationships / bucket.evidenceRelationships
+        : 0,
+      primaryHumanShare: bucket.evidenceRelationships
+        ? bucket.primaryHumanRelationships / bucket.evidenceRelationships
+        : 0,
+      synthesisShare: bucket.evidenceRelationships
+        ? bucket.synthesisRelationships / bucket.evidenceRelationships
         : 0,
     }))
     .sort((a, b) =>


### PR DESCRIPTION
Refines the public Evidence Report category design mix so systematic reviews/meta-analyses are no longer merged into the same visible bucket as primary human studies. Category analysis now reports primary-human, synthesis, preclinical, and other/unclear relationships separately while retaining aggregate human counts/shares for compatibility. The panel copy explains the distinction so review-heavy categories are not mistaken for categories with a deep direct-human evidence base. Adds a focused four-class regression.