### PR TITLE
fix(research): align grade status with canonical hard gate

### DIFF
--- a/lib/__tests__/research-quality-ci-boundary.test.ts
+++ b/lib/__tests__/research-quality-ci-boundary.test.ts
@@ -16,10 +16,6 @@ const OWNED_ANALYSIS_CALLS = [
     call: 'analyzeCitationIntegrity(',
     allowedFiles: new Set(['scripts/ci/validate-citation-identifiers.mjs']),
   },
-  {
-    call: 'analyzeEvidenceGradeConsistency(',
-    allowedFiles: new Set(['scripts/ci/validate-evidence-grade-consistency.ts']),
-  },
 ] as const
 
 function listCodeFiles(dir: string): string[] {
@@ -31,13 +27,13 @@ function listCodeFiles(dir: string): string[] {
   })
 }
 
-describe('research-quality CI boundary', () => {
-  it('keeps scripts/ci consumers on the canonical research-quality snapshot', () => {
+describe('research-quality script boundary', () => {
+  it('keeps every script consumer on the canonical research-quality snapshot', () => {
     const root = process.cwd()
-    const ciDir = path.join(root, 'scripts', 'ci')
+    const scriptsDir = path.join(root, 'scripts')
     const violations: string[] = []
 
-    for (const file of listCodeFiles(ciDir)) {
+    for (const file of listCodeFiles(scriptsDir)) {
       const source = fs.readFileSync(file, 'utf8')
       const relative = path.relative(root, file).replaceAll(path.sep, '/')
 
@@ -54,7 +50,7 @@ describe('research-quality CI boundary', () => {
 
     expect(
       violations,
-      `CI/report scripts must consume buildResearchQualitySnapshot() instead of reconstructing canonical research state; direct specialized analyzers are reserved for their lightweight standalone validators:\n${violations.join('\n')}`,
+      `Scripts must consume buildResearchQualitySnapshot() instead of reconstructing canonical research state; direct specialized analyzers are reserved for explicitly owned lightweight validators:\n${violations.join('\n')}`,
     ).toEqual([])
   })
 
@@ -67,5 +63,16 @@ describe('research-quality CI boundary', () => {
     expect(rollup).toContain('writeContentIntegrityReport(contentIntegrity, ROOT)')
     expect(rollup).not.toContain('spawnSync')
     expect(rollup).not.toContain('audit-content-integrity.mjs')
+  })
+
+  it('keeps the evidence-grade status row aligned with topology-backed hard-gate policy', () => {
+    const root = process.cwd()
+    const rollup = fs.readFileSync(path.join(root, 'scripts', 'ci', 'research-quality.ts'), 'utf8')
+
+    expect(rollup).toContain('evidenceGradeConsistency.topologyContradictions.length === 0')
+    expect(rollup).toContain('topologyContradictions=${evidenceGradeConsistency.totals.topologyContradictionsIndexable}')
+    expect(rollup).toContain('topologyWarnings=${evidenceGradeConsistency.totals.topologyWarningsIndexable}')
+    expect(rollup).toContain('gate.summary.evidenceGradeContradictions')
+    expect(rollup).toContain('topology-backed Grade A contradiction(s)')
   })
 })

--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -130,6 +130,7 @@ results.unshift({
   stderrTail: [
     gate.summary.structuralFailures ? `${gate.summary.structuralFailures} invalid evidence edge(s)` : '',
     gate.summary.severeStudyClassConflicts ? `${gate.summary.severeStudyClassConflicts} severe study-class conflict(s)` : '',
+    gate.summary.evidenceGradeContradictions ? `${gate.summary.evidenceGradeContradictions} topology-backed Grade A contradiction(s)` : '',
     sourceIntegrity.summary.withdrawn ? `${sourceIntegrity.summary.withdrawn} withdrawn/retracted citation(s)` : '',
   ].filter(Boolean).join('; '),
 })
@@ -147,15 +148,30 @@ results.splice(1, 0, {
 })
 if (!citationIntegrity.passed) failed = true
 
-const gradesPassed = evidenceGradeConsistency.invalid.length === 0
+const gradesPassed =
+  evidenceGradeConsistency.invalid.length === 0
+  && evidenceGradeConsistency.topologyContradictions.length === 0
+const gradeErrors = [
+  evidenceGradeConsistency.invalid.length
+    ? `${evidenceGradeConsistency.invalid.length} non-canonical published grade(s)`
+    : '',
+  evidenceGradeConsistency.topologyContradictions.length
+    ? `${evidenceGradeConsistency.topologyContradictions.length} topology-backed Grade A contradiction(s)`
+    : '',
+].filter(Boolean).join('; ')
 results.splice(2, 0, {
   id: 'evidence-grades',
   label: 'Evidence grade consistency',
   passed: gradesPassed,
   exitCode: gradesPassed ? 0 : 1,
   durationMs: 0,
-  stdoutTail: `profiles=${evidenceGradeConsistency.totals.profiles}; contradictions=${evidenceGradeConsistency.totals.contradictionsIndexable}`,
-  stderrTail: gradesPassed ? '' : `${evidenceGradeConsistency.invalid.length} non-canonical published grade(s)`,
+  stdoutTail: [
+    `profiles=${evidenceGradeConsistency.totals.profiles}`,
+    `contradictions=${evidenceGradeConsistency.totals.contradictionsIndexable}`,
+    `topologyContradictions=${evidenceGradeConsistency.totals.topologyContradictionsIndexable}`,
+    `topologyWarnings=${evidenceGradeConsistency.totals.topologyWarningsIndexable}`,
+  ].join('; '),
+  stderrTail: gradeErrors,
 })
 if (!gradesPassed) failed = true
 
@@ -330,7 +346,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
 }, null, 2)}\n`)
 
 console.log(`\nCore: ${coreSummary.profiles} profiles · ${coreSummary.structuredClaims} structured claims · ${coreSummary.approvedClaims} approved`)
-console.log(`Research gate: ${gate.summary.blockingFailures} blocking · ${gate.summary.structuralFailures} structural · ${gate.summary.severeStudyClassConflicts} severe study-class conflict(s)`)
+console.log(`Research gate: ${gate.summary.blockingFailures} blocking · ${gate.summary.structuralFailures} structural · ${gate.summary.severeStudyClassConflicts} severe study-class conflict(s) · ${gate.summary.evidenceGradeContradictions} Grade A contradiction(s)`)
 console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explicit mismatch(es) · ${semanticAlignment.summary.highConfidenceMismatches} high-confidence`)
 console.log(`Claim breadth: ${claimBreadth.summary.overbroadClaims} overbroad claim(s) · ${claimBreadth.summary.highConfidenceOverbroadClaims} high-confidence · population ${claimBreadth.summary.populationOverbroadClaims} · dose ${claimBreadth.summary.doseOverbroadClaims} · duration ${claimBreadth.summary.durationOverbroadClaims} · formulation ${claimBreadth.summary.formulationOverbroadClaims} · endpoint ${claimBreadth.summary.endpointOverbroadClaims}`)
 console.log(`Effect/certainty: ${effectCertainty.summary.findings} overstatement finding(s) · ${effectCertainty.summary.highConfidenceFindings} high-confidence · magnitude ${effectCertainty.summary.magnitudeOverstatements} · clinical importance ${effectCertainty.summary.clinicalImportanceOverstatements} · certainty ${effectCertainty.summary.certaintyOverstatements}`)


### PR DESCRIPTION
Aligns the canonical research-quality rollup with the evidence-grade hard-gate policy already enforced by the snapshot. The dedicated evidence-grade status row now fails on non-canonical published grades or topology-backed Grade A contradictions, reports topology contradictions/warnings explicitly, and the canonical-core failure detail names Grade A blockers. The script boundary regression is broadened from `scripts/ci` to all `scripts/` now that the repo-wide reconstruction sweep is clean, and the obsolete direct grade-analyzer allowlist is removed.