### PR TITLE
fix(research): normalize source identity at profile ingestion

### DIFF
--- a/lib/__tests__/research-profile-source-identity.test.ts
+++ b/lib/__tests__/research-profile-source-identity.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { listResearchProfiles } from '../research-coverage'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+})
+
+function fixture(sources: Array<Record<string, unknown>>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'research-source-id-'))
+  roots.push(root)
+  const dir = path.join(root, 'public', 'data', 'herbs-detail')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'example.json'), JSON.stringify({ slug: 'example', sources }))
+  return root
+}
+
+describe('research profile source identity ingestion', () => {
+  it('derives stable IDs for legacy DOI/PubMed rows before analysis', () => {
+    const root = fixture([
+      { pubmedId: '31627309', doi: '10.3390/nu11102494', title: 'Example study' },
+      { pmid: '38396766', title: 'PMID-only study' },
+    ])
+
+    const [profile] = listResearchProfiles(root)
+
+    expect(profile.record.sources).toEqual([
+      expect.objectContaining({ id: 'doi:10.3390/nu11102494', pubmedId: '31627309' }),
+      expect.objectContaining({ id: 'pmid:38396766', pmid: '38396766' }),
+    ])
+  })
+
+  it('does not invent identity for a truly anonymous source row', () => {
+    const root = fixture([{ title: 'Unidentified source' }])
+    const [profile] = listResearchProfiles(root)
+
+    expect(profile.record.sources?.[0]).not.toHaveProperty('id')
+  })
+})

--- a/lib/research-coverage.ts
+++ b/lib/research-coverage.ts
@@ -99,6 +99,21 @@ export function sourceStudyClass(source: ResearchSource, cache: PubmedCache): St
   return designFromPublicationTypes(meta.publicationTypes ?? [])
 }
 
+function normalizeResearchSourceIdentity(source: ResearchSource): ResearchSource {
+  const explicitId = String(source.id ?? '').trim()
+  if (explicitId) return source
+  const [canonicalId] = citationIdentifiers(source)
+  return canonicalId ? { ...source, id: canonicalId } : source
+}
+
+function normalizeResearchProfileSources(record: ResearchProfile): ResearchProfile {
+  if (!Array.isArray(record.sources)) return record
+  return {
+    ...record,
+    sources: record.sources.map(normalizeResearchSourceIdentity),
+  }
+}
+
 export function listResearchProfiles(root = process.cwd()): ResearchProfileEntry[] {
   const dataDir = path.join(root, 'public', 'data')
   const profiles: ResearchProfileEntry[] = []
@@ -114,7 +129,8 @@ export function listResearchProfiles(root = process.cwd()): ResearchProfileEntry
       if (!name.endsWith('.json')) continue
       const file = path.join(full, name)
       try {
-        const record = JSON.parse(fs.readFileSync(file, 'utf8')) as ResearchProfile
+        const rawRecord = JSON.parse(fs.readFileSync(file, 'utf8')) as ResearchProfile
+        const record = normalizeResearchProfileSources(rawRecord)
         const slug = String(record.slug ?? name.replace(/\.json$/, ''))
         profiles.push({ kind, url: `/${kind}/${slug}/`, file, record })
       } catch {


### PR DESCRIPTION
Fixes the production test-suite blocker where 1,609 valid citation rows with DOI/PubMed identity but no redundant synthetic `source.id` invalidated the canonical research snapshot. `listResearchProfiles()` now derives an in-memory ID from the canonical citation identity before analysis, so valid legacy citations participate in source maps and study grouping while truly anonymous rows remain blockable. Adds focused regression coverage; committed runtime JSON is not mutated.