### PR TITLE
feat(research): route grade blockers into canonical remediation

### DIFF
--- a/lib/__tests__/research-quality-remediation-boundary.test.ts
+++ b/lib/__tests__/research-quality-remediation-boundary.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('canonical research remediation boundary', () => {
+  it('routes snapshot remediation through the canonical grade-aware wrapper', () => {
+    const root = process.cwd()
+    const snapshot = fs.readFileSync(path.join(root, 'lib/research-quality-snapshot.ts'), 'utf8')
+
+    expect(snapshot).toContain("from './research-quality-remediation'")
+    expect(snapshot).toContain('buildCanonicalResearchGapQueue(analysis, topology, evidenceGradeConsistency)')
+    expect(snapshot).not.toContain('buildResearchGapQueue(analysis, topology)')
+  })
+
+  it('injects topology-backed Grade A contradictions as structural remediation blockers', () => {
+    const root = process.cwd()
+    const remediation = fs.readFileSync(path.join(root, 'lib/research-quality-remediation.ts'), 'utf8')
+
+    expect(remediation).toContain("EVIDENCE_GRADE_BLOCKER_REASON = 'evidence-grade-topology-contradiction'")
+    expect(remediation).toContain('EVIDENCE_GRADE_BLOCKER_WEIGHT = 100')
+    expect(remediation).toContain('evidenceGradeConsistency.topologyContradictions')
+    expect(remediation).toContain("dimension: 'structural'")
+    expect(remediation).toContain('item.reasons.some((reason) => reason.kind === EVIDENCE_GRADE_BLOCKER_REASON)')
+  })
+})

--- a/lib/research-quality-remediation.ts
+++ b/lib/research-quality-remediation.ts
@@ -1,0 +1,85 @@
+import type { EvidenceGradeConsistencyReport } from './evidence-grade-consistency'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import {
+  buildResearchGapQueue,
+  RESEARCH_GAP_DIMENSION_CAPS,
+  type ResearchGapDimension,
+  type ResearchGapItem,
+  type ResearchGapReason,
+} from './research-quality-policy'
+import type { ResearchQualityTopology } from './research-quality-topology'
+
+export const EVIDENCE_GRADE_BLOCKER_REASON = 'evidence-grade-topology-contradiction'
+export const EVIDENCE_GRADE_BLOCKER_WEIGHT = 100
+
+function recalculate(item: Pick<ResearchGapItem, 'url' | 'reasons'>): ResearchGapItem {
+  const dimensionRawScores = item.reasons.reduce<Partial<Record<ResearchGapDimension, number>>>((scores, reason) => {
+    scores[reason.dimension] = (scores[reason.dimension] ?? 0) + reason.weight
+    return scores
+  }, {})
+  const dimensionScores = Object.fromEntries(
+    Object.entries(dimensionRawScores).map(([dimension, raw]) => [
+      dimension,
+      Math.min(Number(raw), RESEARCH_GAP_DIMENSION_CAPS[dimension as ResearchGapDimension]),
+    ]),
+  ) as Partial<Record<ResearchGapDimension, number>>
+  const rawScore = Object.values(dimensionRawScores).reduce((sum, value) => sum + Number(value ?? 0), 0)
+  const score = Object.values(dimensionScores).reduce((sum, value) => sum + Number(value ?? 0), 0)
+  const cappedDimensions = Object.entries(dimensionRawScores)
+    .filter(([dimension, raw]) => Number(raw) > RESEARCH_GAP_DIMENSION_CAPS[dimension as ResearchGapDimension])
+    .map(([dimension]) => dimension as ResearchGapDimension)
+  const reasonCounts = item.reasons.reduce<Record<string, number>>((counts, reason) => {
+    counts[reason.kind] = (counts[reason.kind] ?? 0) + 1
+    return counts
+  }, {})
+
+  return {
+    url: item.url,
+    reasons: item.reasons,
+    score: Math.round(score),
+    rawScore: Math.round(rawScore),
+    dimensionScores,
+    dimensionRawScores,
+    cappedDimensions,
+    reasonCounts,
+  }
+}
+
+/**
+ * Production remediation queue for the canonical research-quality snapshot.
+ *
+ * The base policy intentionally remains independent of profile-file grade state.
+ * This wrapper joins the already-computed evidence-grade consistency result to
+ * that queue so every hard Grade A topology contradiction has an explicit,
+ * structural editorial remediation target. No analyzers are rerun here.
+ */
+export function buildCanonicalResearchGapQueue(
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology,
+  evidenceGradeConsistency: EvidenceGradeConsistencyReport,
+): ResearchGapItem[] {
+  const byUrl = new Map<string, Pick<ResearchGapItem, 'url' | 'reasons'>>(
+    buildResearchGapQueue(analysis, topology).map((item) => [
+      item.url,
+      { url: item.url, reasons: [...item.reasons] },
+    ]),
+  )
+
+  for (const finding of evidenceGradeConsistency.topologyContradictions) {
+    const item = byUrl.get(finding.url) ?? { url: finding.url, reasons: [] }
+    if (!item.reasons.some((reason) => reason.kind === EVIDENCE_GRADE_BLOCKER_REASON)) {
+      const reason: ResearchGapReason = {
+        kind: EVIDENCE_GRADE_BLOCKER_REASON,
+        dimension: 'structural',
+        weight: EVIDENCE_GRADE_BLOCKER_WEIGHT,
+        detail: `Published Grade A conflicts with canonical underlying-study independence: ${finding.issues.join(', ')}`,
+      }
+      item.reasons.push(reason)
+      byUrl.set(finding.url, item)
+    }
+  }
+
+  return [...byUrl.values()]
+    .map(recalculate)
+    .sort((a, b) => b.score - a.score || b.rawScore - a.rawScore || b.reasons.length - a.reasons.length || a.url.localeCompare(b.url))
+}

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -2,7 +2,7 @@ import { analyzeCitationIntegrity } from './citation-integrity.mjs'
 import { analyzeEvidenceGradeConsistency } from './evidence-grade-consistency'
 import { analyzeResearchQuality, type ResearchQualityAnalysis } from './research-quality-analysis'
 import { buildResearchQualityGate, type ResearchQualityGate } from './research-quality-gate'
-import { buildResearchGapQueue } from './research-quality-policy'
+import { buildCanonicalResearchGapQueue } from './research-quality-remediation'
 import {
   validateResearchQualitySnapshotInvariants,
   type ResearchSnapshotInvariantReport,
@@ -14,7 +14,7 @@ export type ResearchQualitySnapshot = {
   analysis: ResearchQualityAnalysis
   topology: ResearchQualityTopology
   gate: ResearchQualityGate
-  researchGapQueue: ReturnType<typeof buildResearchGapQueue>
+  researchGapQueue: ReturnType<typeof buildCanonicalResearchGapQueue>
   sourceIntegrity: ReturnType<typeof analyzeResearchSourceIntegrity>
   citationIntegrity: ReturnType<typeof analyzeCitationIntegrity>
   evidenceGradeConsistency: ReturnType<typeof analyzeEvidenceGradeConsistency>
@@ -26,17 +26,18 @@ export type ResearchQualitySnapshot = {
  *
  * Specialized reporters may format different views, but they should consume
  * this snapshot instead of independently rebuilding analysis/topology/gate/policy,
- * citation/source-integrity, or evidence-grade consistency state. The hard gate
- * and softer remediation queue remain separate by design. Snapshot invariants
- * are implementation contracts: contradictory derived views invalidate the
- * snapshot itself and therefore fail every canonical consumer.
+ * citation/source-integrity, evidence-grade consistency, or remediation state.
+ * The hard gate and remediation queue remain distinct views, but every hard
+ * blocker must have an explicit remediation target. Snapshot invariants are
+ * implementation contracts: contradictory derived views invalidate the snapshot
+ * itself and therefore fail every canonical consumer.
  */
 export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQualitySnapshot {
   const analysis = analyzeResearchQuality(root)
   const topology = buildResearchQualityTopology(analysis)
   const evidenceGradeConsistency = analyzeEvidenceGradeConsistency(root, topology)
   const gate = buildResearchQualityGate(analysis, topology, evidenceGradeConsistency)
-  const researchGapQueue = buildResearchGapQueue(analysis, topology)
+  const researchGapQueue = buildCanonicalResearchGapQueue(analysis, topology, evidenceGradeConsistency)
   const sourceIntegrity = analyzeResearchSourceIntegrity(analysis)
   const citationIntegrity = analyzeCitationIntegrity(analysis.profiles)
   const invariants = validateResearchQualitySnapshotInvariants(


### PR DESCRIPTION
Adds a canonical remediation wrapper around the base research-gap policy so topology-backed Grade A contradictions are not only hard-gate failures but explicit editorial remediation targets. The snapshot now builds evidence-grade consistency once, passes it to both the gate and remediation queue, and injects one 100-point structural `evidence-grade-topology-contradiction` reason per affected profile while preserving the existing dimension-cap scoring model. No analyzers are rerun. Boundary regressions lock the snapshot onto the grade-aware queue.