### PR TITLE
polish(search): keep advanced search visible on mobile

### DIFF
--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -43,8 +43,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
       if (!doc) return
       close()
       router.push(doc.href)
-    },
-    [search.results, close, router],
+    }, [search.results, close, router],
   )
 
   const { activeIndex, setActiveIndex, onKeyDown } = useListKeyboardNav({
@@ -114,8 +113,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
         event.preventDefault()
         first.focus()
       }
-    },
-    [close],
+    }, [close],
   )
 
   const activeOptionId = search.results[activeIndex] ? `${optionPrefix}-${activeIndex}` : undefined
@@ -248,15 +246,17 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
             </ul>
 
             {/* Footer / live region */}
-            <div className="flex shrink-0 items-center justify-between border-t border-brand-900/10 bg-[var(--surface-subtle)] px-4 py-2 text-[11px] text-muted">
-              <span aria-live="polite" aria-atomic="true">
+            <div className="flex shrink-0 items-center justify-between gap-3 border-t border-brand-900/10 bg-[var(--surface-subtle)] px-4 py-2 text-[11px] text-muted">
+              <span aria-live="polite" aria-atomic="true" className="min-w-0">
                 {search.ready
                   ? `${search.results.length} result${search.results.length === 1 ? '' : 's'} shown`
                   : ''}
               </span>
-              <span className="hidden items-center gap-3 sm:flex">
-                <span>↑↓ navigate</span>
-                <span>↵ open</span>
+              <div className="flex shrink-0 items-center gap-3">
+                <span className="hidden items-center gap-3 sm:flex">
+                  <span>↑↓ navigate</span>
+                  <span>↵ open</span>
+                </span>
                 <Link
                   href="/search/"
                   onClick={close}
@@ -264,7 +264,7 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
                 >
                   Advanced search →
                 </Link>
-              </span>
+              </div>
             </div>
           </div>
         </div>

--- a/components/search/GlobalSearchModal.tsx
+++ b/components/search/GlobalSearchModal.tsx
@@ -43,7 +43,8 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
       if (!doc) return
       close()
       router.push(doc.href)
-    }, [search.results, close, router],
+    },
+    [search.results, close, router],
   )
 
   const { activeIndex, setActiveIndex, onKeyDown } = useListKeyboardNav({
@@ -113,7 +114,8 @@ export function GlobalSearchModal({ enableHotkeys = true }: { enableHotkeys?: bo
         event.preventDefault()
         first.focus()
       }
-    }, [close],
+    },
+    [close],
   )
 
   const activeOptionId = search.results[activeIndex] ? `${optionPrefix}-${activeIndex}` : undefined


### PR DESCRIPTION
Keep the Advanced search link visible in the global search footer on phones while leaving keyboard-navigation hints desktop-only. Search behavior and result logic are unchanged.