### PR TITLE
refactor(research): score single-study claims after independence adjustment

### DIFF
--- a/lib/__tests__/research-quality-remediation-boundary.test.ts
+++ b/lib/__tests__/research-quality-remediation-boundary.test.ts
@@ -35,4 +35,17 @@ describe('canonical research remediation boundary', () => {
     expect(remediation).toContain('profile.effectiveUnderlyingStudyCount')
     expect(remediation).toContain('publications resolve to ${profile.underlyingStudyCount} underlying studies')
   })
+
+  it('rebuilds single-study support depth from adjusted claim cardinality', () => {
+    const root = process.cwd()
+    const remediation = fs.readFileSync(path.join(root, 'lib/research-quality-remediation.ts'), 'utf8')
+
+    expect(remediation).toContain("SINGLE_STUDY_REASON = 'single-study-approved-claim'")
+    expect(remediation).toContain('item.reasons.filter((reason) => reason.kind !== SINGLE_STUDY_REASON)')
+    expect(remediation).toContain('topology.underlyingStudyIndependence.claims')
+    expect(remediation).toContain('const underlyingStudyCount = adjusted?.underlyingStudyCount ?? claim.studyCount')
+    expect(remediation).toContain('if (underlyingStudyCount !== 1) continue')
+    expect(remediation).toContain('publications collapse to 1 underlying study')
+    expect(remediation).toContain('RESEARCH_GAP_WEIGHTS.highConfidenceSingleStudyBonus')
+  })
 })

--- a/lib/research-quality-remediation.ts
+++ b/lib/research-quality-remediation.ts
@@ -3,6 +3,7 @@ import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import {
   buildResearchGapQueue,
   RESEARCH_GAP_DIMENSION_CAPS,
+  RESEARCH_GAP_WEIGHTS,
   type ResearchGapDimension,
   type ResearchGapItem,
   type ResearchGapReason,
@@ -12,6 +13,7 @@ import type { ResearchQualityTopology } from './research-quality-topology'
 export const EVIDENCE_GRADE_BLOCKER_REASON = 'evidence-grade-topology-contradiction'
 export const EVIDENCE_GRADE_BLOCKER_WEIGHT = 100
 export const STUDY_DEPENDENCY_REASON = 'high-study-dependency'
+export const SINGLE_STUDY_REASON = 'single-study-approved-claim'
 
 function recalculate(item: Pick<ResearchGapItem, 'url' | 'reasons'>): ResearchGapItem {
   const dimensionRawScores = item.reasons.reduce<Partial<Record<ResearchGapDimension, number>>>((scores, reason) => {
@@ -46,6 +48,10 @@ function recalculate(item: Pick<ResearchGapItem, 'url' | 'reasons'>): ResearchGa
   }
 }
 
+function claimKey(url: string, claimId: string) {
+  return `${url}::${claimId}`
+}
+
 /**
  * Replace every publication-level or transition-only study-dependency reason
  * inherited from the base policy with exactly one current underlying-study
@@ -76,14 +82,54 @@ function canonicalizeStudyDependencyReasons(
 }
 
 /**
+ * Rebuild single-study support-depth reasons from independence-adjusted claim
+ * cardinality. Claims that were already single-study remain flagged, while
+ * nominally multi-publication claims that collapse to one underlying study gain
+ * the same remediation signal instead of escaping through publication count.
+ */
+function canonicalizeSingleStudyReasons(
+  byUrl: Map<string, Pick<ResearchGapItem, 'url' | 'reasons'>>,
+  analysis: ResearchQualityAnalysis,
+  topology: ResearchQualityTopology,
+) {
+  for (const item of byUrl.values()) {
+    item.reasons = item.reasons.filter((reason) => reason.kind !== SINGLE_STUDY_REASON)
+  }
+
+  const adjustedByClaim = new Map(
+    topology.underlyingStudyIndependence.claims.map((claim) => [claimKey(claim.url, claim.claimId), claim] as const),
+  )
+
+  for (const claim of analysis.claimAnalyses) {
+    const adjusted = adjustedByClaim.get(claimKey(claim.url, claim.claimId))
+    const underlyingStudyCount = adjusted?.underlyingStudyCount ?? claim.studyCount
+    if (underlyingStudyCount !== 1) continue
+
+    const high = claim.confidence >= 0.75 ? RESEARCH_GAP_WEIGHTS.highConfidenceSingleStudyBonus : 0
+    const veryHigh = claim.confidence >= 0.9 ? RESEARCH_GAP_WEIGHTS.veryHighConfidenceSingleStudyBonus : 0
+    const item = byUrl.get(claim.url) ?? { url: claim.url, reasons: [] }
+    const reason: ResearchGapReason = {
+      kind: SINGLE_STUDY_REASON,
+      dimension: 'concentration',
+      weight: RESEARCH_GAP_WEIGHTS.singleStudyApprovedClaim + high + veryHigh,
+      detail: adjusted?.independenceReduced
+        ? `${claim.claimId} · ${adjusted.apparentStudyCount} publications collapse to 1 underlying study · confidence ${claim.confidence}`
+        : `${claim.claimId} · 1 underlying study · confidence ${claim.confidence}`,
+    }
+    item.reasons.push(reason)
+    byUrl.set(claim.url, item)
+  }
+}
+
+/**
  * Production remediation queue for the canonical research-quality snapshot.
  *
  * The base policy intentionally remains independent of profile-file grade state.
  * This wrapper joins the already-computed evidence-grade consistency result to
  * that queue so every hard Grade A topology contradiction has an explicit,
  * structural editorial remediation target. It also canonicalizes study
- * dependency remediation onto the underlying-study graph, replacing raw
- * publication-level and transition-only dependency reasons. No analyzers are
+ * dependency and single-study remediation onto the underlying-study graph,
+ * replacing raw publication-level and transition-only reasons. No analyzers are
  * rerun here.
  */
 export function buildCanonicalResearchGapQueue(
@@ -99,6 +145,7 @@ export function buildCanonicalResearchGapQueue(
   )
 
   canonicalizeStudyDependencyReasons(byUrl, topology)
+  canonicalizeSingleStudyReasons(byUrl, analysis, topology)
 
   for (const finding of evidenceGradeConsistency.topologyContradictions) {
     const item = byUrl.get(finding.url) ?? { url: finding.url, reasons: [] }


### PR DESCRIPTION
Canonicalizes single-study remediation on underlying-study cardinality. The snapshot remediation wrapper removes inherited publication-level `single-study-approved-claim` reasons and rebuilds them from the canonical independence graph: genuinely single-study claims remain flagged, while nominally multi-publication claims that collapse to one underlying trial/cohort/dataset now receive the same support-depth warning. Existing confidence bonuses are preserved and adjusted cases include explicit publication→underlying-study detail. Regression locks this ownership.