### PR TITLE
test(research): enforce gate-remediation agreement

### DIFF
--- a/lib/__tests__/research-quality-remediation-invariants.test.ts
+++ b/lib/__tests__/research-quality-remediation-invariants.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ResearchQualityGate } from '../research-quality-gate'
+import type { ResearchGapItem } from '../research-quality-policy'
+import { EVIDENCE_GRADE_BLOCKER_REASON } from '../research-quality-remediation'
+import { validateResearchRemediationInvariants } from '../research-quality-remediation-invariants'
+
+function gate(urls: string[]): ResearchQualityGate {
+  return {
+    passed: urls.length === 0,
+    structuralFailures: [],
+    severeStudyClassConflicts: [],
+    evidenceGradeContradictions: urls.map((url) => ({ url }) as never),
+    summary: {
+      structuralFailures: 0,
+      unsupportedApprovedClaims: 0,
+      danglingClaimSourceEdges: 0,
+      severeStudyClassConflicts: 0,
+      evidenceGradeContradictions: urls.length,
+      blockingFailures: urls.length,
+    },
+  }
+}
+
+function queue(urls: string[]): ResearchGapItem[] {
+  return urls.map((url) => ({
+    url,
+    score: 100,
+    rawScore: 100,
+    dimensionScores: { structural: 100 },
+    dimensionRawScores: { structural: 100 },
+    cappedDimensions: [],
+    reasons: [{ kind: EVIDENCE_GRADE_BLOCKER_REASON, dimension: 'structural', weight: 100 }],
+    reasonCounts: { [EVIDENCE_GRADE_BLOCKER_REASON]: 1 },
+  }))
+}
+
+describe('research gate/remediation invariants', () => {
+  it('accepts one remediation target for every grade blocker', () => {
+    expect(validateResearchRemediationInvariants(gate(['/herbs/a/']), queue(['/herbs/a/'])).passed).toBe(true)
+  })
+
+  it('detects a grade blocker with no remediation target', () => {
+    const report = validateResearchRemediationInvariants(gate(['/herbs/a/']), [])
+    expect(report.passed).toBe(false)
+    expect(report.failures).toContainEqual({ kind: 'missing-grade-blocker-remediation', url: '/herbs/a/' })
+  })
+
+  it('detects an orphan remediation blocker with no gate contradiction', () => {
+    const report = validateResearchRemediationInvariants(gate([]), queue(['/herbs/a/']))
+    expect(report.passed).toBe(false)
+    expect(report.failures).toContainEqual({ kind: 'orphan-grade-blocker-remediation', url: '/herbs/a/' })
+  })
+})

--- a/lib/research-quality-remediation-invariants.ts
+++ b/lib/research-quality-remediation-invariants.ts
@@ -1,0 +1,53 @@
+import type { ResearchQualityGate } from './research-quality-gate'
+import type { ResearchGapItem } from './research-quality-policy'
+import { EVIDENCE_GRADE_BLOCKER_REASON } from './research-quality-remediation'
+
+export type ResearchRemediationInvariantFailure = {
+  kind: 'missing-grade-blocker-remediation' | 'orphan-grade-blocker-remediation'
+  url: string
+}
+
+export type ResearchRemediationInvariantReport = {
+  passed: boolean
+  failures: ResearchRemediationInvariantFailure[]
+  summary: {
+    failures: number
+    missingGradeBlockerRemediation: number
+    orphanGradeBlockerRemediation: number
+  }
+}
+
+/**
+ * Cross-check hard evidence-grade blockers against the editorial remediation
+ * queue. A blocker without a remediation target strands the build; a remediation
+ * blocker without a gate contradiction falsely escalates editorial priority.
+ */
+export function validateResearchRemediationInvariants(
+  gate: ResearchQualityGate,
+  researchGapQueue: ResearchGapItem[],
+): ResearchRemediationInvariantReport {
+  const gateUrls = new Set(gate.evidenceGradeContradictions.map((finding) => finding.url))
+  const remediationUrls = new Set(
+    researchGapQueue
+      .filter((item) => item.reasons.some((reason) => reason.kind === EVIDENCE_GRADE_BLOCKER_REASON))
+      .map((item) => item.url),
+  )
+  const failures: ResearchRemediationInvariantFailure[] = []
+
+  for (const url of gateUrls) {
+    if (!remediationUrls.has(url)) failures.push({ kind: 'missing-grade-blocker-remediation', url })
+  }
+  for (const url of remediationUrls) {
+    if (!gateUrls.has(url)) failures.push({ kind: 'orphan-grade-blocker-remediation', url })
+  }
+
+  return {
+    passed: failures.length === 0,
+    failures,
+    summary: {
+      failures: failures.length,
+      missingGradeBlockerRemediation: failures.filter((failure) => failure.kind === 'missing-grade-blocker-remediation').length,
+      orphanGradeBlockerRemediation: failures.filter((failure) => failure.kind === 'orphan-grade-blocker-remediation').length,
+    },
+  }
+}

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -4,6 +4,10 @@ import { analyzeResearchQuality, type ResearchQualityAnalysis } from './research
 import { buildResearchQualityGate, type ResearchQualityGate } from './research-quality-gate'
 import { buildCanonicalResearchGapQueue } from './research-quality-remediation'
 import {
+  validateResearchRemediationInvariants,
+  type ResearchRemediationInvariantReport,
+} from './research-quality-remediation-invariants'
+import {
   validateResearchQualitySnapshotInvariants,
   type ResearchSnapshotInvariantReport,
 } from './research-quality-snapshot-invariants'
@@ -19,6 +23,7 @@ export type ResearchQualitySnapshot = {
   citationIntegrity: ReturnType<typeof analyzeCitationIntegrity>
   evidenceGradeConsistency: ReturnType<typeof analyzeEvidenceGradeConsistency>
   invariants: ResearchSnapshotInvariantReport
+  remediationInvariants: ResearchRemediationInvariantReport
 }
 
 /**
@@ -48,11 +53,18 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
     sourceIntegrity,
     citationIntegrity,
   )
+  const remediationInvariants = validateResearchRemediationInvariants(gate, researchGapQueue)
 
   if (!invariants.passed) {
     const details = invariants.failures.slice(0, 10).map((failure) => `${failure.kind}: ${failure.detail}`).join('; ')
     throw new Error(
       `[research-quality-snapshot] ${invariants.summary.failures} internal invariant failure(s): ${details}`,
+    )
+  }
+  if (!remediationInvariants.passed) {
+    const details = remediationInvariants.failures.slice(0, 10).map((failure) => `${failure.kind}: ${failure.url}`).join('; ')
+    throw new Error(
+      `[research-quality-snapshot] ${remediationInvariants.summary.failures} gate/remediation invariant failure(s): ${details}`,
     )
   }
 
@@ -65,5 +77,6 @@ export function buildResearchQualitySnapshot(root = process.cwd()): ResearchQual
     citationIntegrity,
     evidenceGradeConsistency,
     invariants,
+    remediationInvariants,
   }
 }


### PR DESCRIPTION
Adds first-class snapshot invariants tying evidence-grade hard blockers to editorial remediation. Every topology-backed Grade A contradiction in the gate must have a matching structural `evidence-grade-topology-contradiction` reason in the canonical gap queue, and no orphan blocker reason may exist without a gate contradiction. The snapshot exposes the remediation invariant report and fails immediately on drift. Unit tests cover consistent, missing-remediation, and orphan-remediation cases.