### PR TITLE
fix(evidence): keep outcome-dependent grades unassigned

### DIFF
--- a/lib/__tests__/evidence-grade-outcome-dependent.test.ts
+++ b/lib/__tests__/evidence-grade-outcome-dependent.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeEvidenceGrade, reconcileEvidenceGrade } from '../evidence-grade'
+
+describe('outcome-dependent evidence grades', () => {
+  it.each([
+    'Varies by outcome',
+    'Evidence differs by outcome',
+    'Outcome-dependent',
+    'Depends on the outcome',
+    'A for sleep; B for anxiety',
+  ])('keeps %s unresolved', (value) => {
+    expect(normalizeEvidenceGrade(value)).toMatchObject({
+      grade: null,
+      band: null,
+      outcomeDependent: true,
+    })
+    expect(reconcileEvidenceGrade(value, 'Strong Evidence')).toMatchObject({
+      grade: null,
+      band: null,
+      reason: 'unresolved',
+    })
+  })
+})

--- a/lib/evidence-grade.ts
+++ b/lib/evidence-grade.ts
@@ -103,7 +103,7 @@ const EXACT_BAND_VALUES: Record<string, EvidenceBand> = {
  * Values that grade different outcomes differently. Picking one grade from
  * these would misrepresent the record, so they remain explicitly unassigned.
  */
-const OUTCOME_DEPENDENT_RE = /\b[a-df]\s*[+-]?\s+for\s+\w+.*;\s*[a-df]\s*[+-]?\s+for\s+/i
+const OUTCOME_DEPENDENT_RE = /(?:\b[a-df]\s*[+-]?\s+for\s+\w+.*;\s*[a-df]\s*[+-]?\s+for\s+|\b(?:varies?|differs?)\s+by\s+outcome\b|\boutcome[- ]dependent\b|\bdepends?\s+on\s+(?:the\s+)?outcome\b)/i
 
 /**
  * Legacy phrase mappings, ordered from strongest/specific to weakest. Ambiguous


### PR DESCRIPTION
Fixes the production evidence-accounting failure exposed by deploy #6118. Extends the canonical evidence-grade parser so legacy phrases such as `Varies by outcome`, `differs by outcome`, `outcome-dependent`, and `depends on the outcome` remain unresolved even when a separate tier says Strong Evidence. This prevents an invented single public grade and restores complete Unassigned accounting. Adds direct parser/reconciliation regression coverage.