### PR TITLE
feat(research): analyze selective outcome reporting

### DIFF
--- a/lib/__tests__/research-selective-outcome-reporting.test.ts
+++ b/lib/__tests__/research-selective-outcome-reporting.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeSelectiveOutcomeReporting } from '@/lib/research-selective-outcome-reporting'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+function analysis(abstracts: string[], confidence = 0.8): ResearchQualityAnalysis {
+  const sources = abstracts.map((_, index) => ({
+    id: `s${index + 1}`,
+    pmid: String(index + 1),
+    studyClass: 'rct',
+  }))
+  const claimMap = [{
+    id: 'claim-1',
+    claim: 'Improves symptoms',
+    predicate: 'supports_outcome',
+    confidence,
+    reviewStatus: 'approved',
+    qualifiers: { direction: '+' },
+    sourceRefIds: sources.map((source) => source.id),
+  }]
+  const cache = Object.fromEntries(abstracts.map((abstract, index) => [String(index + 1), { abstract }]))
+  return {
+    cache,
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: { slug: 'example', sources, claimMap },
+    }],
+    claimAnalyses: [],
+    structuredClaimAnalyses: [],
+    profileAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+}
+
+describe('selective outcome reporting', () => {
+  it('flags favorable secondary evidence when a prespecified primary outcome is explicitly null', () => {
+    const report = analyzeSelectiveOutcomeReporting(analysis([
+      'The prespecified primary outcome showed no significant difference. A secondary endpoint significantly improved versus placebo.',
+    ]))
+
+    expect(report.summary.selectiveOutcomeRisks).toBe(1)
+    expect(report.findings[0]).toMatchObject({
+      selectiveOutcomeRisk: true,
+      explicitOutcomeSwitchRisk: false,
+    })
+  })
+
+  it('flags explicit outcome switching or non-reporting of registered outcomes', () => {
+    const report = analyzeSelectiveOutcomeReporting(analysis([
+      'The primary outcome was changed after trial registration and the registered outcome was not reported.',
+    ]))
+
+    expect(report.summary.explicitOutcomeSwitchRisks).toBe(1)
+    expect(report.findings[0].explicitOutcomeSwitchRisk).toBe(true)
+  })
+
+  it('does not call a clean prespecified positive primary outcome selective reporting', () => {
+    const report = analyzeSelectiveOutcomeReporting(analysis([
+      'The prespecified primary endpoint significantly improved compared with placebo.',
+    ]))
+
+    expect(report.summary.assessableClaims).toBe(1)
+    expect(report.summary.findings).toBe(0)
+  })
+
+  it('leaves studies without explicit registration or outcome-hierarchy language unassessable', () => {
+    const report = analyzeSelectiveOutcomeReporting(analysis([
+      'Symptoms improved during the eight-week randomized trial.',
+    ]))
+
+    expect(report.summary.assessableClaims).toBe(0)
+    expect(report.summary.findings).toBe(0)
+  })
+})

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -15,6 +15,7 @@ import { buildResearchMetadataIntegrity } from './research-metadata-integrity'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
+import { analyzeSelectiveOutcomeReporting } from './research-selective-outcome-reporting'
 import { analyzeStudyClassConflicts } from './research-study-class-conflicts'
 import { analyzeStudyIdentityCoverage } from './research-study-identity-coverage'
 import {
@@ -80,6 +81,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const claimBreadth = analyzeClaimBreadth(analysis)
   const effectCertainty = analyzeEffectCertainty(analysis)
   const directionalConsistency = analyzeDirectionalConsistency(analysis)
+  const selectiveOutcomeReporting = analyzeSelectiveOutcomeReporting(analysis)
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
   const metadataIntegrity = buildResearchMetadataIntegrity({
@@ -125,6 +127,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     claimBreadth,
     effectCertainty,
     directionalConsistency,
+    selectiveOutcomeReporting,
     claimLanguageCalibration,
     claimCitationMetadata,
     metadataIntegrity,

--- a/lib/research-selective-outcome-reporting.ts
+++ b/lib/research-selective-outcome-reporting.ts
@@ -1,0 +1,163 @@
+import {
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  approvedClaims,
+  sourceMap,
+  sourceStudyClass,
+  uniqueSourceRefs,
+  type ResearchClaim,
+} from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type SelectiveOutcomeReportingFinding = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  humanSourceCount: number
+  assessableSourceCount: number
+  registeredOrPrespecifiedPrimaryNullCount: number
+  favorableSecondaryOrExploratoryCount: number
+  explicitOutcomeSwitchCount: number
+  primaryOutcomeNotMetCount: number
+  selectiveOutcomeRisk: boolean
+  explicitOutcomeSwitchRisk: boolean
+  reasons: string[]
+}
+
+export type SelectiveOutcomeReportingReport = {
+  summary: {
+    approvedOutcomeClaims: number
+    assessableClaims: number
+    findings: number
+    highConfidenceFindings: number
+    selectiveOutcomeRisks: number
+    explicitOutcomeSwitchRisks: number
+  }
+  claims: SelectiveOutcomeReportingFinding[]
+  findings: SelectiveOutcomeReportingFinding[]
+  highConfidenceFindings: SelectiveOutcomeReportingFinding[]
+}
+
+const REGISTERED_PRIMARY_NULL = /\b(?:registered|prespecified|pre[- ]specified|protocol[- ]specified) (?:primary )?(?:outcome|endpoint)[^.]{0,220}(?:no significant|not statistically significant|non[- ]significant|did not|failed to|not met|was not met|null)\b/i
+const PRIMARY_NOT_MET = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was not met|not met|failed to meet|did not meet|no significant|not statistically significant|non[- ]significant)\b/i
+const FAVORABLE_SECONDARY = /\b(?:secondary (?:outcome|endpoint)|subgroup|sub-group|post[- ]hoc|exploratory (?:outcome|endpoint|analysis))[^.]{0,220}(?:significant|improv|reduc|benefit|favou?r|superior|positive)\b/i
+const OUTCOME_SWITCH = /\b(outcome switch(?:ing|ed)?|switched (?:the )?(?:primary )?(?:outcome|endpoint)|changed (?:the )?(?:primary )?(?:outcome|endpoint)|primary outcome (?:was )?changed|deviation from (?:the )?(?:registered|prespecified|protocol[- ]specified) outcome|registered outcome[^.]{0,120}not reported|prespecified outcome[^.]{0,120}not reported)\b/i
+const REGISTERED_LANGUAGE = /\b(registered|prespecified|pre[- ]specified|protocol[- ]specified|trial registration|registry)\b/i
+
+function text(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function sourceEvidenceText(source: Record<string, unknown>, cache: ResearchQualityAnalysis['cache']): string {
+  const pmid = text(source.pmid ?? source.pubmedId)
+  const meta = pmid ? cache[pmid] ?? {} : {}
+  return [
+    source.title,
+    source.note,
+    source.citation,
+    source.result,
+    source.results,
+    source.effect,
+    source.primaryOutcome,
+    source.secondaryOutcome,
+    source.outcomeRegistration,
+    meta.title,
+    meta.abstract,
+    meta.primaryOutcome,
+    meta.secondaryOutcome,
+    meta.outcomeRegistration,
+  ].map(text).filter(Boolean).join(' · ')
+}
+
+function isOutcomeClaim(claim: ResearchClaim): boolean {
+  return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
+}
+
+export function analyzeSelectiveOutcomeReporting(
+  analysis: ResearchQualityAnalysis,
+): SelectiveOutcomeReportingReport {
+  const claims: SelectiveOutcomeReportingFinding[] = []
+  let approvedOutcomeClaims = 0
+
+  for (const { url, record } of analysis.profiles) {
+    const sourcesById = sourceMap(record)
+    for (const claim of approvedClaims(record)) {
+      if (!isOutcomeClaim(claim)) continue
+      approvedOutcomeClaims += 1
+
+      const humanSources = uniqueSourceRefs(claim)
+        .map((id) => sourcesById.get(id))
+        .filter((source): source is Record<string, unknown> => Boolean(source))
+        .filter((source) => PRIMARY_HUMAN_STUDY_CLASSES.has(sourceStudyClass(source, analysis.cache)))
+      if (!humanSources.length) continue
+
+      const sourceTexts = humanSources.map((source) => sourceEvidenceText(source, analysis.cache)).filter(Boolean)
+      const assessable = sourceTexts.filter((value) =>
+        REGISTERED_PRIMARY_NULL.test(value)
+        || PRIMARY_NOT_MET.test(value)
+        || FAVORABLE_SECONDARY.test(value)
+        || OUTCOME_SWITCH.test(value)
+        || REGISTERED_LANGUAGE.test(value),
+      )
+      if (!assessable.length) continue
+
+      const registeredOrPrespecifiedPrimaryNullCount = assessable.filter((value) => REGISTERED_PRIMARY_NULL.test(value)).length
+      const primaryOutcomeNotMetCount = assessable.filter((value) => PRIMARY_NOT_MET.test(value)).length
+      const favorableSecondaryOrExploratoryCount = assessable.filter((value) => FAVORABLE_SECONDARY.test(value)).length
+      const explicitOutcomeSwitchCount = assessable.filter((value) => OUTCOME_SWITCH.test(value)).length
+
+      const selectiveOutcomeRisk = assessable.some((value) =>
+        (REGISTERED_PRIMARY_NULL.test(value) || PRIMARY_NOT_MET.test(value)) && FAVORABLE_SECONDARY.test(value),
+      )
+      const explicitOutcomeSwitchRisk = explicitOutcomeSwitchCount > 0
+
+      const reasons: string[] = []
+      if (selectiveOutcomeRisk) {
+        reasons.push('linked human evidence explicitly pairs a null/not-met primary outcome with a favorable secondary, subgroup, post-hoc, or exploratory result')
+      }
+      if (explicitOutcomeSwitchRisk) {
+        reasons.push(`${explicitOutcomeSwitchCount} linked human source(s) explicitly describe outcome switching, changed primary outcomes, or unreported registered/prespecified outcomes`)
+      }
+
+      claims.push({
+        url,
+        claimId: text(claim.id) || 'unknown-claim',
+        predicate: text(claim.predicate),
+        confidence: Number(claim.confidence ?? 0),
+        humanSourceCount: humanSources.length,
+        assessableSourceCount: assessable.length,
+        registeredOrPrespecifiedPrimaryNullCount,
+        favorableSecondaryOrExploratoryCount,
+        explicitOutcomeSwitchCount,
+        primaryOutcomeNotMetCount,
+        selectiveOutcomeRisk,
+        explicitOutcomeSwitchRisk,
+        reasons,
+      })
+    }
+  }
+
+  claims.sort((a, b) =>
+    Number(b.explicitOutcomeSwitchRisk) - Number(a.explicitOutcomeSwitchRisk)
+    || Number(b.selectiveOutcomeRisk) - Number(a.selectiveOutcomeRisk)
+    || b.confidence - a.confidence
+    || a.url.localeCompare(b.url)
+    || a.claimId.localeCompare(b.claimId),
+  )
+  const findings = claims.filter((claim) => claim.selectiveOutcomeRisk || claim.explicitOutcomeSwitchRisk)
+  const highConfidenceFindings = findings.filter((claim) => claim.confidence >= 0.75)
+
+  return {
+    summary: {
+      approvedOutcomeClaims,
+      assessableClaims: claims.length,
+      findings: findings.length,
+      highConfidenceFindings: highConfidenceFindings.length,
+      selectiveOutcomeRisks: findings.filter((claim) => claim.selectiveOutcomeRisk).length,
+      explicitOutcomeSwitchRisks: findings.filter((claim) => claim.explicitOutcomeSwitchRisk).length,
+    },
+    claims,
+    findings,
+    highConfidenceFindings,
+  }
+}


### PR DESCRIPTION
Adds a conservative selective-outcome/reporting-bias analyzer for approved outcome claims. It requires explicit prespecified/registered primary-outcome language, favorable secondary/subgroup/post-hoc/exploratory results, or explicit outcome switching/non-reporting language. Sparse registry/outcome metadata remains unassessable. Adds the product to the canonical research topology with focused regression coverage.