### PR TITLE
fix(research): align underlying-study invariants with full inventory

### DIFF
--- a/lib/__tests__/research-underlying-study-full-inventory-invariants.test.ts
+++ b/lib/__tests__/research-underlying-study-full-inventory-invariants.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ResearchQualityAnalysis } from '../research-quality-analysis'
+import { validateUnderlyingStudySnapshotInvariants } from '../research-underlying-study-snapshot-invariants'
+import type { ResearchQualityTopology } from '../research-quality-topology'
+
+function fixture() {
+  const analysis = {
+    claimAnalyses: [],
+    profileAnalyses: [{
+      url: '/herbs/example/',
+      supportedApprovedClaimCount: 0,
+      overDependentOnSingleStudy: false,
+    }],
+  } as unknown as ResearchQualityAnalysis
+
+  const profile = {
+    url: '/herbs/example/',
+    supportedApprovedClaimCount: 0,
+    publicationStudyCount: 0,
+    underlyingStudyCount: 0,
+    collapsedPublicationCount: 0,
+    inventoryPublicationStudyCount: 2,
+    inventoryUnderlyingStudyCount: 1,
+    inventoryCollapsedPublicationCount: 1,
+    primaryHumanPublicationCount: 2,
+    primaryHumanUnderlyingStudyCount: 1,
+    collapsedPrimaryHumanPublicationCount: 1,
+    mostUsedUnderlyingStudyId: null,
+    mostUsedUnderlyingStudyClaimCount: 0,
+    dominantUnderlyingStudySupportedClaimShare: 0,
+    underlyingStudyConcentrationIndex: 0,
+    effectiveUnderlyingStudyCount: 0,
+    overDependentOnSingleUnderlyingStudy: false,
+    newlyOverDependentAfterIndependenceAdjustment: false,
+  }
+
+  const topology = {
+    underlyingStudyIndependence: {
+      claims: [],
+      reducedClaims: [],
+      pseudoMultiStudyClaims: [],
+      highConfidencePseudoMultiStudyClaims: [],
+      supportTierDowngrades: [],
+      profiles: [profile],
+      newlyOverDependentProfiles: [],
+      summary: {
+        multiStudyApprovedClaims: 0,
+        independenceReducedClaims: 0,
+        pseudoMultiStudyClaims: 0,
+        highConfidencePseudoMultiStudyClaims: 0,
+        supportTierDowngrades: 0,
+        collapsedPublicationCount: 0,
+        profilesAnalyzed: 1,
+        profilesWithSupportedClaims: 0,
+        profilesWithReducedStudyCount: 1,
+        profilesWithReducedHumanStudyCount: 1,
+        primaryHumanPublicationCount: 2,
+        primaryHumanUnderlyingStudyCount: 1,
+        collapsedPrimaryHumanPublicationCount: 1,
+        overDependentProfiles: 0,
+        newlyOverDependentProfiles: 0,
+      },
+    },
+  } as unknown as ResearchQualityTopology
+
+  return { analysis, topology }
+}
+
+describe('underlying-study full-inventory snapshot invariants', () => {
+  it('accepts inventory evidence for a profile with zero approved claim edges', () => {
+    const { analysis, topology } = fixture()
+    expect(validateUnderlyingStudySnapshotInvariants(analysis, topology)).toEqual([])
+  })
+
+  it('detects inventory-vs-summary reduction drift independently of claim-linked counts', () => {
+    const { analysis, topology } = fixture()
+    topology.underlyingStudyIndependence.summary.profilesWithReducedStudyCount = 0
+    const failures = validateUnderlyingStudySnapshotInvariants(analysis, topology)
+    expect(failures.map((failure) => failure.kind)).toContain('underlying-study-reduced-profile-count-mismatch')
+  })
+
+  it('detects invalid primary-human collapse arithmetic', () => {
+    const { analysis, topology } = fixture()
+    topology.underlyingStudyIndependence.profiles[0].collapsedPrimaryHumanPublicationCount = 0
+    const failures = validateUnderlyingStudySnapshotInvariants(analysis, topology)
+    expect(failures.map((failure) => failure.kind)).toContain('underlying-study-primary-human-collapse-mismatch')
+  })
+})

--- a/lib/research-underlying-study-snapshot-invariants.ts
+++ b/lib/research-underlying-study-snapshot-invariants.ts
@@ -10,6 +10,11 @@ function claimKey(url: string, claimId: string): string {
   return `${url}::${claimId}`
 }
 
+function validAdjustedCount(publicationCount: number, underlyingCount: number): boolean {
+  if (publicationCount === 0) return underlyingCount === 0
+  return underlyingCount >= 1 && underlyingCount <= publicationCount
+}
+
 /**
  * Validate arithmetic and ownership for the canonical underlying-study graph.
  * These checks are implementation invariants, not scientific judgments.
@@ -75,7 +80,7 @@ export function validateUnderlyingStudySnapshotInvariants(
     if (claim.apparentStudyCount !== source.studyCount) {
       add('underlying-study-apparent-count-mismatch', `${key}: product=${claim.apparentStudyCount}; analysis=${source.studyCount}`)
     }
-    if (claim.underlyingStudyCount < 1 || claim.underlyingStudyCount > claim.apparentStudyCount) {
+    if (!validAdjustedCount(claim.apparentStudyCount, claim.underlyingStudyCount)) {
       add('underlying-study-invalid-adjusted-count', `${key}: apparent=${claim.apparentStudyCount}; underlying=${claim.underlyingStudyCount}`)
     }
     const expectedCollapsed = Math.max(0, claim.apparentStudyCount - claim.underlyingStudyCount)
@@ -111,11 +116,32 @@ export function validateUnderlyingStudySnapshotInvariants(
     }
   }
 
-  if (product.summary.profilesWithSupportedClaims !== product.profiles.length) {
-    add('underlying-study-profile-count-mismatch', `summary=${product.summary.profilesWithSupportedClaims}; rows=${product.profiles.length}`)
+  if (product.summary.profilesAnalyzed !== product.profiles.length) {
+    add('underlying-study-profile-count-mismatch', `summary=${product.summary.profilesAnalyzed}; rows=${product.profiles.length}`)
   }
-  if (product.summary.profilesWithReducedStudyCount !== product.profiles.filter((profile) => profile.collapsedPublicationCount > 0).length) {
-    add('underlying-study-reduced-profile-count-mismatch', `summary=${product.summary.profilesWithReducedStudyCount}`)
+  const supportedProfileCount = product.profiles.filter((profile) => profile.supportedApprovedClaimCount > 0).length
+  if (product.summary.profilesWithSupportedClaims !== supportedProfileCount) {
+    add('underlying-study-supported-profile-count-mismatch', `summary=${product.summary.profilesWithSupportedClaims}; computed=${supportedProfileCount}`)
+  }
+  const reducedInventoryProfiles = product.profiles.filter((profile) => profile.inventoryCollapsedPublicationCount > 0).length
+  if (product.summary.profilesWithReducedStudyCount !== reducedInventoryProfiles) {
+    add('underlying-study-reduced-profile-count-mismatch', `summary=${product.summary.profilesWithReducedStudyCount}; computed=${reducedInventoryProfiles}`)
+  }
+  const reducedHumanProfiles = product.profiles.filter((profile) => profile.collapsedPrimaryHumanPublicationCount > 0).length
+  if (product.summary.profilesWithReducedHumanStudyCount !== reducedHumanProfiles) {
+    add('underlying-study-reduced-human-profile-count-mismatch', `summary=${product.summary.profilesWithReducedHumanStudyCount}; computed=${reducedHumanProfiles}`)
+  }
+  const primaryHumanPublicationCount = product.profiles.reduce((sum, profile) => sum + profile.primaryHumanPublicationCount, 0)
+  if (product.summary.primaryHumanPublicationCount !== primaryHumanPublicationCount) {
+    add('underlying-study-primary-human-publication-count-mismatch', `summary=${product.summary.primaryHumanPublicationCount}; computed=${primaryHumanPublicationCount}`)
+  }
+  const primaryHumanUnderlyingStudyCount = product.profiles.reduce((sum, profile) => sum + profile.primaryHumanUnderlyingStudyCount, 0)
+  if (product.summary.primaryHumanUnderlyingStudyCount !== primaryHumanUnderlyingStudyCount) {
+    add('underlying-study-primary-human-adjusted-count-mismatch', `summary=${product.summary.primaryHumanUnderlyingStudyCount}; computed=${primaryHumanUnderlyingStudyCount}`)
+  }
+  const collapsedPrimaryHumanPublicationCount = product.profiles.reduce((sum, profile) => sum + profile.collapsedPrimaryHumanPublicationCount, 0)
+  if (product.summary.collapsedPrimaryHumanPublicationCount !== collapsedPrimaryHumanPublicationCount) {
+    add('underlying-study-primary-human-collapse-count-mismatch', `summary=${product.summary.collapsedPrimaryHumanPublicationCount}; computed=${collapsedPrimaryHumanPublicationCount}`)
   }
   if (product.summary.overDependentProfiles !== product.profiles.filter((profile) => profile.overDependentOnSingleUnderlyingStudy).length) {
     add('underlying-study-overdependent-profile-count-mismatch', `summary=${product.summary.overDependentProfiles}`)
@@ -136,13 +162,31 @@ export function validateUnderlyingStudySnapshotInvariants(
     if (profile.supportedApprovedClaimCount !== source.supportedApprovedClaimCount) {
       add('underlying-study-profile-supported-claim-count-mismatch', `${profile.url}: product=${profile.supportedApprovedClaimCount}; analysis=${source.supportedApprovedClaimCount}`)
     }
-    if (profile.underlyingStudyCount < 1 || profile.underlyingStudyCount > profile.publicationStudyCount) {
+
+    if (!validAdjustedCount(profile.publicationStudyCount, profile.underlyingStudyCount)) {
       add('underlying-study-invalid-profile-adjusted-count', `${profile.url}: publication=${profile.publicationStudyCount}; underlying=${profile.underlyingStudyCount}`)
     }
-    const expectedCollapsed = Math.max(0, profile.publicationStudyCount - profile.underlyingStudyCount)
-    if (profile.collapsedPublicationCount !== expectedCollapsed) {
-      add('underlying-study-profile-collapse-mismatch', `${profile.url}: rows=${profile.collapsedPublicationCount}; expected=${expectedCollapsed}`)
+    const expectedClaimCollapsed = Math.max(0, profile.publicationStudyCount - profile.underlyingStudyCount)
+    if (profile.collapsedPublicationCount !== expectedClaimCollapsed) {
+      add('underlying-study-profile-collapse-mismatch', `${profile.url}: rows=${profile.collapsedPublicationCount}; expected=${expectedClaimCollapsed}`)
     }
+
+    if (!validAdjustedCount(profile.inventoryPublicationStudyCount, profile.inventoryUnderlyingStudyCount)) {
+      add('underlying-study-invalid-inventory-adjusted-count', `${profile.url}: publication=${profile.inventoryPublicationStudyCount}; underlying=${profile.inventoryUnderlyingStudyCount}`)
+    }
+    const expectedInventoryCollapsed = Math.max(0, profile.inventoryPublicationStudyCount - profile.inventoryUnderlyingStudyCount)
+    if (profile.inventoryCollapsedPublicationCount !== expectedInventoryCollapsed) {
+      add('underlying-study-inventory-collapse-mismatch', `${profile.url}: rows=${profile.inventoryCollapsedPublicationCount}; expected=${expectedInventoryCollapsed}`)
+    }
+
+    if (!validAdjustedCount(profile.primaryHumanPublicationCount, profile.primaryHumanUnderlyingStudyCount)) {
+      add('underlying-study-invalid-primary-human-adjusted-count', `${profile.url}: publication=${profile.primaryHumanPublicationCount}; underlying=${profile.primaryHumanUnderlyingStudyCount}`)
+    }
+    const expectedPrimaryHumanCollapsed = Math.max(0, profile.primaryHumanPublicationCount - profile.primaryHumanUnderlyingStudyCount)
+    if (profile.collapsedPrimaryHumanPublicationCount !== expectedPrimaryHumanCollapsed) {
+      add('underlying-study-primary-human-collapse-mismatch', `${profile.url}: rows=${profile.collapsedPrimaryHumanPublicationCount}; expected=${expectedPrimaryHumanCollapsed}`)
+    }
+
     if (profile.newlyOverDependentAfterIndependenceAdjustment !== (profile.overDependentOnSingleUnderlyingStudy && !source.overDependentOnSingleStudy)) {
       add('underlying-study-new-overdependent-state-mismatch', profile.url)
     }


### PR DESCRIPTION
Repairs stale underlying-study snapshot invariants after the independence graph expanded to full profile inventory. Zero-claim profiles with unmapped/orphan evidence are now valid; profile cardinality uses `profilesAnalyzed`; reduced-study summary checks use inventory collapse; primary-human reduction/count summaries are validated; and claim-linked, inventory, and primary-human adjusted-count arithmetic are checked independently. Adds a functional zero-approved-claim fixture with 2 human publications collapsing to 1 underlying study. Replayed onto current main after the original PR's base moved.