### PR TITLE
refactor(research): centralize semantic evidence text

### DIFF
--- a/lib/research-directional-consistency.ts
+++ b/lib/research-directional-consistency.ts
@@ -6,6 +6,7 @@ import {
   uniqueSourceRefs,
   type ResearchClaim,
 } from './research-coverage'
+import { researchSourceEvidenceText } from './research-evidence-text'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 
 export type DirectionalConsistencyFinding = {
@@ -54,21 +55,6 @@ function text(value: unknown): string {
   return String(value ?? '').replace(/\s+/g, ' ').trim()
 }
 
-function sourceEvidenceText(source: Record<string, unknown>, cache: ResearchQualityAnalysis['cache']): string {
-  const pmid = text(source.pmid ?? source.pubmedId)
-  const meta = pmid ? cache[pmid] ?? {} : {}
-  return [
-    source.title,
-    source.note,
-    source.citation,
-    source.result,
-    source.results,
-    source.effect,
-    meta.title,
-    meta.abstract,
-  ].map(text).filter(Boolean).join(' · ')
-}
-
 function isOutcomeClaim(claim: ResearchClaim): boolean {
   return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
 }
@@ -115,7 +101,7 @@ export function analyzeDirectionalConsistency(analysis: ResearchQualityAnalysis)
         .filter((source) => PRIMARY_HUMAN_STUDY_CLASSES.has(sourceStudyClass(source, analysis.cache)))
       if (!humanSources.length) continue
 
-      const sourceTexts = humanSources.map((source) => sourceEvidenceText(source, analysis.cache)).filter(Boolean)
+      const sourceTexts = humanSources.map((source) => researchSourceEvidenceText(source, analysis.cache)).filter(Boolean)
       if (!sourceTexts.length) continue
       const explicitDirectionalSourceCount = sourceTexts.filter(hasExplicitDirectionalSignal).length
       if (!explicitDirectionalSourceCount) continue

--- a/lib/research-evidence-text.ts
+++ b/lib/research-evidence-text.ts
@@ -1,0 +1,36 @@
+import type { PubmedCache } from './research-coverage'
+
+function text(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+const SOURCE_EVIDENCE_FIELDS = [
+  'title',
+  'note',
+  'citation',
+  'abstract',
+  'result',
+  'results',
+  'effect',
+  'primaryOutcome',
+  'secondaryOutcome',
+  'outcomeRegistration',
+] as const
+
+/**
+ * Canonical semantic evidence text for claim-level research analyzers.
+ * Source-local metadata and cached PubMed metadata are intentionally combined
+ * in one place so breadth, directionality, certainty, and reporting-bias
+ * analyses cannot drift on which evidence fields they inspect.
+ */
+export function researchSourceEvidenceText(
+  source: Record<string, unknown>,
+  cache: PubmedCache,
+): string {
+  const pmid = text(source.pmid ?? source.pubmedId)
+  const cached = pmid ? cache[pmid] ?? {} : {}
+  return [
+    ...SOURCE_EVIDENCE_FIELDS.map((field) => source[field]),
+    ...SOURCE_EVIDENCE_FIELDS.map((field) => cached[field]),
+  ].map(text).filter(Boolean).join(' · ')
+}

--- a/lib/research-selective-outcome-reporting.ts
+++ b/lib/research-selective-outcome-reporting.ts
@@ -6,6 +6,7 @@ import {
   uniqueSourceRefs,
   type ResearchClaim,
 } from './research-coverage'
+import { researchSourceEvidenceText } from './research-evidence-text'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 
 export type SelectiveOutcomeReportingFinding = {
@@ -48,27 +49,6 @@ function text(value: unknown): string {
   return String(value ?? '').replace(/\s+/g, ' ').trim()
 }
 
-function sourceEvidenceText(source: Record<string, unknown>, cache: ResearchQualityAnalysis['cache']): string {
-  const pmid = text(source.pmid ?? source.pubmedId)
-  const meta = pmid ? cache[pmid] ?? {} : {}
-  return [
-    source.title,
-    source.note,
-    source.citation,
-    source.result,
-    source.results,
-    source.effect,
-    source.primaryOutcome,
-    source.secondaryOutcome,
-    source.outcomeRegistration,
-    meta.title,
-    meta.abstract,
-    meta.primaryOutcome,
-    meta.secondaryOutcome,
-    meta.outcomeRegistration,
-  ].map(text).filter(Boolean).join(' · ')
-}
-
 function isOutcomeClaim(claim: ResearchClaim): boolean {
   return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
 }
@@ -91,7 +71,7 @@ export function analyzeSelectiveOutcomeReporting(
         .filter((source) => PRIMARY_HUMAN_STUDY_CLASSES.has(sourceStudyClass(source, analysis.cache)))
       if (!humanSources.length) continue
 
-      const sourceTexts = humanSources.map((source) => sourceEvidenceText(source, analysis.cache)).filter(Boolean)
+      const sourceTexts = humanSources.map((source) => researchSourceEvidenceText(source, analysis.cache)).filter(Boolean)
       const assessable = sourceTexts.filter((value) =>
         REGISTERED_PRIMARY_NULL.test(value)
         || PRIMARY_NOT_MET.test(value)


### PR DESCRIPTION
Extracts one canonical source+PubMed evidence-text primitive and rewires directional-consistency and selective-outcome analyzers to consume it. This removes duplicated source-field/abstract assembly and gives future semantic analyzers one authoritative evidence-text surface.