### PR TITLE
SEO: guard shared legacy guide reference reuse

### DIFF
--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -15,6 +15,14 @@ const ARTICLE_PAGE = path.join(ROOT, 'app', 'articles', '[slug]', 'page.tsx')
 const MENTAL_HEALTH_ARTICLE = path.join(ROOT, 'components', 'articles', 'MentalHealthArticlePage.tsx')
 const GOAL_CLUSTER_ARTICLE = path.join(ROOT, 'components', 'articles', 'GoalClusterArticlePage.tsx')
 const RHABDO_PAGE = path.join(ROOT, 'app', 'learn', 'rhabdomyolysis', 'page.tsx')
+const LEGACY_GUIDE_REFERENCE = path.join(ROOT, 'components', 'LegacyGuideReference.tsx')
+const LEGACY_GUIDE_PAGES = [
+  ['prebiotics', path.join(ROOT, 'app', 'guides', 'other', 'prebiotics', 'page.tsx')],
+  ['greens-powders', path.join(ROOT, 'app', 'guides', 'other', 'greens-powders', 'page.tsx')],
+  ['bovine-colostrum', path.join(ROOT, 'app', 'guides', 'other', 'bovine-colostrum', 'page.tsx')],
+  ['electrolyte-supplements', path.join(ROOT, 'app', 'guides', 'other', 'electrolyte-supplements', 'page.tsx')],
+  ['collagen-supplements', path.join(ROOT, 'app', 'guides', 'other', 'collagen-supplements', 'page.tsx')],
+]
 const REFERENCES = path.join(ROOT, 'components', 'References.tsx')
 const EVIDENCE_BADGE = path.join(ROOT, 'components', 'ui', 'EvidenceScoreBadge.tsx')
 const SAFETY_GAUGE = path.join(ROOT, 'components', 'ui', 'SafetyGaugeMeter.tsx')
@@ -204,6 +212,29 @@ function auditRhabdoCitationPrimitives() {
   }
 }
 
+function auditLegacyGuideReferencePrimitives() {
+  requireSignals(LEGACY_GUIDE_REFERENCE, 'legacy-guide-citations', 'LegacyGuideReference', [
+    ['id={`ref-${n}`}', 'stable ordinal source anchors'],
+    ['data-citation-source="true"', 'citation-source marker'],
+    ['itemType="https://schema.org/CreativeWork"', 'conservative CreativeWork semantics'],
+    ['href={`#ref-${n}`}', 'durable source self-link'],
+    ['itemProp="name"', 'citation text name semantic'],
+    ['itemProp="url"', 'source URL semantic'],
+  ])
+
+  for (const [slug, file] of LEGACY_GUIDE_PAGES) {
+    requireSignals(file, 'legacy-guide-citations', `${slug} guide`, [
+      ["import Ref from '@/components/LegacyGuideReference'", 'shared legacy reference import'],
+      ['<Ref n={', 'shared legacy reference usage'],
+    ])
+
+    const source = text(file)
+    if (/^type RefProps\b/m.test(source) || /^function Ref\s*\(/m.test(source)) {
+      add('error', 'legacy-guide-citations', `${slug} guide reintroduced a local legacy reference renderer`)
+    }
+  }
+}
+
 function auditProfilePrimitives() {
   requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
     ['data-evidence="true"', 'evidence marker'],
@@ -284,6 +315,7 @@ auditArticleExtractionPrimitives()
 auditMentalHealthCitationPrimitives()
 auditGoalClusterCitationPrimitives()
 auditRhabdoCitationPrimitives()
+auditLegacyGuideReferencePrimitives()
 auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -214,10 +214,11 @@ function auditRhabdoCitationPrimitives() {
 
 function auditLegacyGuideReferencePrimitives() {
   requireSignals(LEGACY_GUIDE_REFERENCE, 'legacy-guide-citations', 'LegacyGuideReference', [
-    ['id={`ref-${n}`}', 'stable ordinal source anchors'],
+    ['const citationId = `ref-${n}`', 'canonical ordinal citation ID'],
+    ['id={citationId}', 'stable ordinal source anchor'],
     ['data-citation-source="true"', 'citation-source marker'],
     ['itemType="https://schema.org/CreativeWork"', 'conservative CreativeWork semantics'],
-    ['href={`#ref-${n}`}', 'durable source self-link'],
+    ['href={`#${citationId}`}', 'durable source self-link'],
     ['itemProp="name"', 'citation text name semantic'],
     ['itemProp="url"', 'source URL semantic'],
   ])


### PR DESCRIPTION
Fixes #3664

## Summary
- extends the existing canonical AI answer-engine audit with one family-level contract for `LegacyGuideReference`
- verifies the shared compatibility primitive keeps one derived ordinal citation ID, stable source anchors/self-links, citation-source markers, and conservative `CreativeWork` name/URL semantics
- verifies prebiotics, greens powders, bovine colostrum, electrolyte supplements, and collagen supplements all continue importing and using the shared primitive
- fails if any of those five guides reintroduces a local `RefProps` type or `function Ref(...)` renderer
- reuses the existing AI-search workflow, which already triggers on all five guide pages plus `LegacyGuideReference` and already contains a shell anti-duplication guard
- adds no new validator, workflow, citation parser, or bibliographic inference

## Acceptance criteria
- `LegacyGuideReference` semantics are enforced by `audit-ai-answer-engine-readiness.mjs`.
- All five legacy guide pages must import and use the shared primitive.
- Local `RefProps`/`Ref` implementations are blocking regressions.
- No richer PMID/DOI/author/journal metadata is inferred from free-form citation text.
- Existing workflow ownership remains the execution boundary.

## Validation commands
- `npm run audit:ai-citations`
- `npx eslint scripts/ci/audit-ai-answer-engine-readiness.mjs components/LegacyGuideReference.tsx --max-warnings=0`
- `npm run typecheck`
- AI search quality check
- Atomic upgrade gate

## Before → after metrics
- Family-level canonical audit contracts for the five legacy guide citation renderers: 0 → 1.
- Shared primitive semantic checks in canonical audit: 0 → 7 required signals.
- Legacy guide reuse checks: 0 → 5 pages required to import/use the shared primitive.
- Local duplicated renderer anti-pattern checks in canonical audit: 0 → 5 pages covered.
- New validators/workflows introduced: 0 → 0.

## Generator/source-of-truth decision
The five guide files remain the source of truth for authored citation text and URLs. `LegacyGuideReference` remains presentation/extraction compatibility only. The existing answer-engine audit is the canonical policy surface; the existing AI-search workflow remains the execution boundary.

## Regression contract
- Public legacy-guide reference anchors remain ordinal and derived from `citationId = ref-N`.
- The shared primitive remains conservative and must not parse free-form citations into invented bibliographic fields.
- The five covered guides must not regain local reference components.
- Richer structured pages continue using `References`; this compatibility primitive must not replace the richer ledger.

## AI SEO / trust impact
This makes the five-guide consolidation durable inside the same canonical AI-search audit as the stronger article, mental-health, sleep, and safety citation surfaces, reducing future drift without adding another governance pipeline.