### PR TITLE
fix(evidence): require real human-study signals

### DIFF
--- a/lib/evidence.ts
+++ b/lib/evidence.ts
@@ -1,8 +1,10 @@
 import type { RuntimeRecord } from '../src/types/content'
+import { extractCitationsFromRecord } from './citations'
 import {
   reconcileEvidenceGrade,
   type CanonicalEvidenceGrade,
 } from './evidence-grade'
+import { isHumanEvidenceClass } from './evidence-study'
 
 type EvidenceTier = 'strong' | 'moderate' | 'limited' | 'preliminary' | 'traditional' | 'mixed' | 'insufficient' | 'review'
 
@@ -62,25 +64,33 @@ function authoredEvidenceSignals(record: RuntimeRecord) {
   return { rawGrade, rawTier, present: Boolean(text(rawGrade) || text(rawTier)) }
 }
 
-export function hasHumanEvidence(record: RuntimeRecord): boolean {
-  const evidence = evidenceText(record)
+/**
+ * Resolve direct human-evidence presence from normalized structured citations.
+ * `null` means the record has no classifiable structured citation evidence and
+ * may use the conservative legacy text fallback. Once at least one citation is
+ * explicitly classified, non-human classes are authoritative rather than being
+ * overridden by grade adjectives or raw source cardinality.
+ */
+function structuredHumanEvidence(record: RuntimeRecord): boolean | null {
+  const citations = extractCitationsFromRecord(record as Record<string, unknown>)
+  const classified = citations.filter(citation => citation.evidenceClass !== 'other')
+  if (!classified.length) return null
+  return classified.some(citation => isHumanEvidenceClass(citation.evidenceClass))
+}
 
+export function hasHumanEvidence(record: RuntimeRecord): boolean {
+  const structured = structuredHumanEvidence(record)
+  if (structured !== null) return structured
+
+  const evidence = evidenceText(record)
   if (/\b(no|none|theoretical|traditional|preclinical|in\s*vitro|animal)\b/.test(evidence)) {
     return false
   }
 
-  if (
-    /\b(human|clinical|trial|rct|randomi[sz]ed|meta|systematic|strong|high|moderate|grade\s*[ab]|tier\s*[ab])\b/.test(
-      evidence,
-    )
-  ) {
-    return true
-  }
-
-  const sourceCount = Number(record?.sourceCount ?? record?.source_count ?? record?.sources_count)
-  return (
-    Number.isFinite(sourceCount) && sourceCount >= 5 && !/\b(low|limited|partial)\b/.test(evidence)
-  )
+  // Legacy fallback is deliberately explicit about human research. Generic
+  // strength words ("strong", "moderate") and source counts are not evidence
+  // that any cited research actually involved humans.
+  return /\b(human|clinical|trial|rct|randomi[sz]ed|meta-analysis|meta analysis|systematic review)\b/.test(evidence)
 }
 
 export function hasMechanismEvidence(record: RuntimeRecord): boolean {

--- a/src/lib/__tests__/evidence.test.ts
+++ b/src/lib/__tests__/evidence.test.ts
@@ -24,9 +24,30 @@ describe('hasHumanEvidence', () => {
     expect(hasHumanEvidence(record({ evidence_tier: 'Strong human clinical trial evidence' }))).toBe(true)
   })
 
-  it('falls back to source count when text is ambiguous', () => {
-    expect(hasHumanEvidence(record({ summary_quality: 'reviewed', sourceCount: 6 }))).toBe(true)
+  it('does not manufacture human evidence from raw source count', () => {
+    expect(hasHumanEvidence(record({ summary_quality: 'reviewed', sourceCount: 20 }))).toBe(false)
     expect(hasHumanEvidence(record({ summary_quality: 'reviewed', sourceCount: 2 }))).toBe(false)
+  })
+
+  it('uses structured study classes ahead of optimistic grade language', () => {
+    expect(hasHumanEvidence(record({
+      evidence_grade: 'A',
+      evidence_tier: 'Strong Evidence',
+      sources: [
+        { id: 'animal-1', title: 'Animal study', studyType: 'animal study' },
+        { id: 'vitro-1', title: 'Cell study', studyType: 'in vitro study' },
+      ],
+    }))).toBe(false)
+  })
+
+  it('detects human evidence from structured human-study classes', () => {
+    expect(hasHumanEvidence(record({
+      evidence_tier: 'Limited Evidence',
+      sources: [
+        { id: 'rct-1', title: 'Human trial', studyType: 'randomized controlled trial' },
+        { id: 'animal-1', title: 'Animal study', studyType: 'animal study' },
+      ],
+    }))).toBe(true)
   })
 
   it('does not use source count fallback when text says evidence is limited', () => {


### PR DESCRIPTION
Removes a legacy human-evidence inflation path from `hasHumanEvidence()`. Structured citations are now authoritative when they contain classified study designs: normalized human classes produce true, while explicitly classified animal/in-vitro/mechanistic-only evidence remains false even if the profile carries optimistic grade language. For records without classifiable structured citations, the fallback now requires explicit human/clinical/trial/review language; generic `strong`/`moderate` adjectives and raw source counts can no longer manufacture human evidence. Adds regressions for many-source false positives, strong-grade preclinical profiles, and structured RCT detection.