### PR TITLE
fix(build): restore discovery slug import

### DIFF
--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -1,4 +1,4 @@
-import { slugify } from './slug'
+import { slugify } from '../../lib/slug-utils'
 import { getCommonName } from './herbName'
 import { normalizeScientificTags } from './tags'
 


### PR DESCRIPTION
Debug pass 2.

- fixes src/lib/discovery.ts importing the deleted src/lib/slug compatibility module
- rewires it to the canonical TypeScript slug implementation at lib/slug-utils.ts
- preserves discovery scoring and runtime behavior

This addresses the production build type failure: Cannot find module './slug'.