### PR TITLE
SEO: strengthen shared authority article semantics

### DIFF
--- a/components/seo/AuthorityJsonLd.tsx
+++ b/components/seo/AuthorityJsonLd.tsx
@@ -67,6 +67,8 @@ export default function AuthorityJsonLd({
     headline: title,
     description,
     url: canonical,
+    inLanguage: 'en-US',
+    ...(hasEditorialAuthor ? { mainEntityOfPage: canonical } : {}),
     isPartOf: { '@id': WEBSITE_SCHEMA_ID },
     ...(hasEditorialAuthor ? { author: { '@id': AUTHOR_SCHEMA_ID } } : {}),
     publisher: { '@id': ORGANIZATION_SCHEMA_ID },


### PR DESCRIPTION
Fixes #3671

## Summary
- adds `inLanguage: en-US` to the shared `AuthorityJsonLd` page node
- adds explicit canonical `mainEntityOfPage` for Article and MedicalWebPage authority surfaces
- preserves canonical first-party author, publisher, and WebSite IDs
- preserves existing citation URL, FAQ, and breadcrumb behavior
- does not invent dates, images, reviewer credentials, or bibliographic metadata

## Acceptance criteria
- All AuthorityJsonLd consumers inherit explicit language semantics.
- Editorial Article/MedicalWebPage nodes point to their canonical page via `mainEntityOfPage`.
- Non-editorial collection/contact/profile nodes are not incorrectly promoted to editorial authorship.
- Existing identity/citation/FAQ behavior remains unchanged.

## Validation commands
- `npx eslint components/seo/AuthorityJsonLd.tsx --max-warnings=0`
- `npm run typecheck`
- `npm run build:deploy`
- Schema and Media Governance
- AI search quality check
- Atomic upgrade gate

## Before → after metrics
- AuthorityJsonLd page nodes with explicit language: 0 → all.
- AuthorityJsonLd Article/MedicalWebPage nodes with explicit canonical mainEntityOfPage: 0 → all.
- New inferred dates/images/reviewers/citation metadata: 0 → 0.
- New schema pipelines introduced: 0 → 0.

## Generator/source-of-truth decision
`AuthorityJsonLd` remains the shared authority-page schema boundary and continues to route through the canonical schema graph and JSON-LD serializer. The canonical URL already supplied by each caller is reused directly; no new page metadata source is introduced.

## Regression contract
- Editorial authority pages retain canonical author/publisher/WebSite identity references.
- `mainEntityOfPage` remains the canonical URL already known to the component.
- Language stays explicit rather than inferred from content text.
- Missing dates/images/reviewers must remain omitted rather than fabricated.

## AI SEO / trust impact
Hand-authored authority guides now expose a clearer page/article relationship and explicit language through one shared schema boundary, improving entity resolution for answer systems without increasing claim or metadata risk.