### PR TITLE
fix(research): tolerate identifier-less inventory sources

### DIFF
--- a/lib/__tests__/research-source-id-snapshot-invariant.test.ts
+++ b/lib/__tests__/research-source-id-snapshot-invariant.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../research-effect-certainty-snapshot-invariants', () => ({
+  validateEffectCertaintySnapshotInvariants: () => [],
+}))
+vi.mock('../research-directional-consistency-snapshot-invariants', () => ({
+  validateDirectionalConsistencySnapshotInvariants: () => [],
+}))
+vi.mock('../research-underlying-study-snapshot-invariants', () => ({
+  validateUnderlyingStudySnapshotInvariants: () => [],
+}))
+
+import type { ResearchQualityAnalysis } from '../research-quality-analysis'
+import type { ResearchQualityGate } from '../research-quality-gate'
+import { validateResearchQualitySnapshotInvariants } from '../research-quality-snapshot-invariants'
+import type { ResearchQualityTopology } from '../research-quality-topology'
+
+function fixture(source: Record<string, unknown>) {
+  const analysis = {
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: { slug: 'example', sources: [source], claimMap: [] },
+    }],
+    profileAnalyses: [{ url: '/herbs/example/' }],
+    claimAnalyses: [],
+    structuredClaimAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+
+  const topology = {
+    semanticAlignment: { summary: { approvedClaims: 0 }, findings: [], concentrationFindings: [] },
+    claimBreadth: { summary: { approvedClaimsWithHumanEvidence: 0, overbroadClaims: 0 }, claims: [], findings: [] },
+    edgeCardinality: { summary: { claims: 0 }, duplicateEdgeClaims: [] },
+    evidenceIndependenceCoverage: { summary: { multiStudyApprovedClaims: 0 }, claims: [] },
+    claimLanguageCalibration: { directEvidenceFindings: [] },
+    claimCitationMetadata: { claims: [] },
+    claimEvidenceDiversity: [],
+    claimProvenanceIndependence: [],
+    claimEvidenceAge: [],
+  } as unknown as ResearchQualityTopology
+
+  const gate = {
+    passed: true,
+    structuralFailures: [],
+    severeStudyClassConflicts: [],
+    evidenceGradeContradictions: [],
+    summary: {
+      structuralFailures: 0,
+      severeStudyClassConflicts: 0,
+      evidenceGradeContradictions: 0,
+      blockingFailures: 0,
+    },
+  } as ResearchQualityGate
+
+  return { analysis, topology, gate }
+}
+
+describe('research snapshot source ID invariants', () => {
+  it('allows an identifier-less legacy inventory source that cannot participate in claim edges', () => {
+    const { analysis, topology, gate } = fixture({ title: 'Legacy bibliography row', url: 'https://example.com/reference' })
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, [])
+
+    expect(report.passed).toBe(true)
+    expect(report.summary.missingSourceIds).toBe(0)
+  })
+
+  it('still detects normalization drift when a stable PMID exists without a source ID', () => {
+    const { analysis, topology, gate } = fixture({ title: 'Identified study', pmid: '123' })
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, [])
+
+    expect(report.passed).toBe(false)
+    expect(report.failures.map((failure) => failure.kind)).toContain('missing-source-id')
+  })
+})

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -1,3 +1,4 @@
+import { citationIdentifiers } from './citation-identifiers.mjs'
 import {
   canonicalStudyGroups,
   crossProfileStudyIdentity,
@@ -108,10 +109,21 @@ export function validateResearchQualitySnapshotInvariants(
     rawSourceCount += sources.length
     const seenSources = new Set<string>()
     for (let index = 0; index < sources.length; index += 1) {
-      const id = text(sources[index]?.id)
+      const source = sources[index]
+      const id = text(source?.id)
       if (!id) {
-        add('missing-source-id', `${profile.url} · sources[${index}]`)
-      } else if (seenSources.has(id)) {
+        // listResearchProfiles() assigns a canonical source ID whenever DOI/PMID
+        // identity exists. A remaining identifier-less row is valid legacy
+        // inventory: it cannot participate in claim edges or canonical study
+        // identity, so its missing authored ID is not an internal contradiction.
+        // If a stable DOI/PMID exists but the ID is missing, normalization has
+        // drifted and the invariant should still fail.
+        if (citationIdentifiers(source).length) {
+          add('missing-source-id', `${profile.url} · sources[${index}]`)
+        }
+        continue
+      }
+      if (seenSources.has(id)) {
         add('duplicate-source-id', `${profile.url}::${id}`)
       } else {
         seenSources.add(id)


### PR DESCRIPTION
Fixes the snapshot-invariant blast radius exposed by deploy tests. Canonical loading already assigns source IDs whenever a valid DOI/PMID exists; truly identifier-less legacy bibliography rows cannot participate in claim edges or canonical study identity and therefore are not an internal snapshot contradiction. The invariant now tolerates only those rows, while still failing missing IDs when stable DOI/PMID identity exists and still preserving duplicate-ID/dangling-edge enforcement. Adds focused regression coverage for both cases.