### PR TITLE
SEO: migrate legacy quick answers batch 1

### DIFF
--- a/app/guides/other/electrolyte-supplements/page.tsx
+++ b/app/guides/other/electrolyte-supplements/page.tsx
@@ -5,6 +5,7 @@ import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
+import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'
 import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
 
@@ -30,7 +31,9 @@ export default function ElectrolyteGuidePage() {
       <section className="space-y-5 max-w-4xl"><p className="eyebrow-label">Evidence Review · 2 References</p><h1 className="text-5xl font-bold tracking-tight text-ink">Electrolyte Supplements: Who Actually Needs Them?</h1><p className="text-lg leading-8 text-muted">LMNT ($1.50/serving), Liquid IV, DripDrop — the electrolyte category has expanded from sports nutrition into mainstream wellness. But for most people, these products solve a problem they don&rsquo;t have. The AIS classifies electrolytes as a sports food for specific use cases only [1]. Here&rsquo;s the evidence.</p>
         <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/electrolyte-supplements.jpg" alt="Electrolyte supplement packets and a glass of water on a gym surface" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Electrolyte supplements — essential for athletes, unnecessary for everyone else.</figcaption></figure></section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Quick answer</h2><p className="text-sm leading-7 text-muted">Electrolyte supplements are <strong>medically indicated for a small fraction of the population</strong>: endurance athletes (&gt;90 min exercise), outdoor laborers in heat, those on very low-carb diets (increased natriuresis), and illness with significant fluid loss [1,5]. For everyone else, they are an expensive way to consume salt, potassium, and magnesium — all abundantly available in food [2]. The marketing positions them as daily wellness products, but evidence for everyday use by non-athletes is nonexistent.</p></section>
+      <LegacyGuideQuickAnswer referencesHref="#references">
+        <p>Electrolyte supplements are <strong>medically indicated for a small fraction of the population</strong>: endurance athletes (&gt;90 min exercise), outdoor laborers in heat, those on very low-carb diets (increased natriuresis), and illness with significant fluid loss [1,5]. For everyone else, they are an expensive way to consume salt, potassium, and magnesium — all abundantly available in food [2]. The marketing positions them as daily wellness products, but evidence for everyday use by non-athletes is nonexistent.</p>
+      </LegacyGuideQuickAnswer>
 
       <section className="card-premium p-6 space-y-5 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Evidence by use case</h2>
         <div className="space-y-4">
@@ -63,7 +66,7 @@ export default function ElectrolyteGuidePage() {
         </div>
         <p className="text-xs leading-5 text-muted">DIY alternative: 1/4 tsp salt + 1/8 tsp potassium chloride in water with lemon = ~$0.05/serving vs $1.50 for LMNT.</p></section>
 
-      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-xl font-semibold text-ink">References</h2><ol className="space-y-2 list-decimal list-inside text-xs leading-5 text-muted">
+      <section id="references" className="card-premium scroll-mt-24 p-6 space-y-3 max-w-4xl"><h2 className="text-xl font-semibold text-ink">References</h2><ol className="space-y-2 list-decimal list-inside text-xs leading-5 text-muted">
         <Ref n={1} text="Australian Institute of Sport (AIS). Electrolyte Supplement: Sports Food fact sheet. AIS Supplement Framework, Group A." url="https://www.ausport.gov.au/ais/nutrition/supplements/group_a/sports-foods2/electrolyte-supplement2" />
         <Ref n={2} text="IOM (2005). Dietary Reference Intakes for Water, Potassium, Sodium, Chloride, and Sulfate. National Academies Press." url="https://pubmed.ncbi.nlm.nih.gov/15883093/" />
         <Ref n={3} text="Baker LB. (2017). Sweating rate and sweat sodium concentration in athletes. Sports Med, 47(Suppl 1): 65-77." url="https://pubmed.ncbi.nlm.nih.gov/28332115/" />

--- a/app/guides/other/greens-powders/page.tsx
+++ b/app/guides/other/greens-powders/page.tsx
@@ -5,6 +5,7 @@ import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FAQSchema from '@/components/seo/FAQSchema'
+import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'
 import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
 
@@ -48,7 +49,9 @@ export default function GreensPowdersPage() {
           </figcaption>
         </figure></section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Quick answer</h2><p className="text-sm leading-7 text-muted">Greens powders are fundamentally <strong>powdered multivitamins with plant extracts</strong>. They can fill nutrient gaps in people with poor diets — the vitamin and mineral component produces measurable effects [1,2]. But the claims that separate them from a basic multivitamin (gut health transformation, immune supercharging, detoxification) are unsupported by independent clinical evidence [3,4]. The category is defined by proprietary blends that hide ingredient doses [5], celebrity endorsements that substitute for clinical data, and pricing ($79-99/month) that far exceeds the cost of the nutrients they contain.</p></section>
+      <LegacyGuideQuickAnswer referencesHref="#references">
+        <p>Greens powders are fundamentally <strong>powdered multivitamins with plant extracts</strong>. They can fill nutrient gaps in people with poor diets — the vitamin and mineral component produces measurable effects [1,2]. But the claims that separate them from a basic multivitamin (gut health transformation, immune supercharging, detoxification) are unsupported by independent clinical evidence [3,4]. The category is defined by proprietary blends that hide ingredient doses [5], celebrity endorsements that substitute for clinical data, and pricing ($79-99/month) that far exceeds the cost of the nutrients they contain.</p>
+      </LegacyGuideQuickAnswer>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30"><p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Greens Powder Reality Check</p>
         <div className="overflow-x-auto"><table className="min-w-full text-sm"><thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Product</th><th className="text-left py-2 pr-4 font-semibold text-ink">Cost/mo</th><th className="text-left py-2 pr-4 font-semibold text-ink">$/serving</th><th className="text-left py-2 pr-4 font-semibold text-ink">Ingredients</th><th className="text-left py-2 font-semibold text-ink">Third-Party Tested</th></tr></thead><tbody className="text-muted">
@@ -73,7 +76,7 @@ export default function GreensPowdersPage() {
 
       <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">If your diet is genuinely poor, a greens powder is a reasonable — if expensive — nutritional insurance policy. But understand you are paying primarily for marketing and convenience, not for evidence of superior efficacy over a multivitamin [3,4]. If you eat vegetables regularly, you almost certainly do not need one. At $30-40/month with transparent labeling, it can be reasonable. At $79-99/month, you are paying for influencer marketing, not your health.</p></section>
 
-      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-xl font-semibold text-ink">References</h2><ol className="space-y-2 list-decimal list-inside text-xs leading-5 text-muted">
+      <section id="references" className="card-premium scroll-mt-24 p-6 space-y-3 max-w-4xl"><h2 className="text-xl font-semibold text-ink">References</h2><ol className="space-y-2 list-decimal list-inside text-xs leading-5 text-muted">
         <Ref n={1} text="AG1 Clinical Research page. Reports 70% folate increase, 73% vitamin C increase in 12-week trial." url="https://drinkag1.com/en-eu/clinical-research" />
         <Ref n={2} text="De Spirt S, et al. (2012). Fruit/vegetable juice powder supplementation reduces oxidative stress. Br J Nutr, 108(3): 452-460." url="https://pubmed.ncbi.nlm.nih.gov/22078226/" />
         <Ref n={3} text="Kennedy DO. (2016). B vitamins and the brain: mechanisms, dose and efficacy — a review. Nutrients, 8(2): 68." url="https://pubmed.ncbi.nlm.nih.gov/26828517/" />


### PR DESCRIPTION
Refs #3676

## Summary
- migrates greens powders and electrolyte supplements to the shared `LegacyGuideQuickAnswer` surface
- preserves both authored Quick answer paragraphs exactly
- adds stable `#quick-answer` answer-engine surfaces through the shared wrapper
- adds stable `#references` anchors to both existing source sections so verification links resolve
- adds no evidence grades, claim-to-source mappings, or bibliographic inference

## Acceptance criteria
- Greens powders and electrolytes use `LegacyGuideQuickAnswer` with `referencesHref="#references"`.
- Existing Quick answer scientific wording is unchanged.
- Existing source text/URLs are unchanged.
- `#references` resolves on both pages.
- No duplicate Quick answer structural implementation is introduced.

## Validation commands
- `npx eslint app/guides/other/greens-powders/page.tsx app/guides/other/electrolyte-supplements/page.tsx components/LegacyGuideQuickAnswer.tsx --max-warnings=0`
- `npm run typecheck`
- `npm run build:deploy`
- AI search quality check
- Atomic upgrade gate

## Before → after metrics
- Matching legacy guides using the shared Quick answer wrapper: 1/5 → 3/5.
- New stable answer anchors in this PR: 0 → 2.
- New stable reference-ledger targets in this PR: 0 → 2.
- Scientific claim sentences changed: 0.

## Generator/source-of-truth decision
Each guide remains the source of truth for its authored Quick answer prose and citations. `LegacyGuideQuickAnswer` owns only extraction/navigation structure.

## Regression contract
- Guide prose remains page-owned and must not be rewritten by the wrapper.
- No evidence/citation relationship may be inferred beyond the page-level source-ledger jump.
- Stable `#quick-answer` and `#references` targets remain available.

## AI SEO / trust impact
Two more hand-authored authority guides now expose predictable answer-engine summary and verification targets without changing their scientific claims.