### PR TITLE
SEO: guard legacy quick-answer extraction semantics

### DIFF
--- a/.github/workflows/ai-entity-enrichment-check.yml
+++ b/.github/workflows/ai-entity-enrichment-check.yml
@@ -12,6 +12,7 @@ on:
       - 'app/guides/other/collagen-supplements/page.tsx'
       - 'components/articles/GoalClusterArticlePage.tsx'
       - 'components/articles/MentalHealthArticlePage.tsx'
+      - 'components/LegacyGuideQuickAnswer.tsx'
       - 'components/LegacyGuideReference.tsx'
       - 'components/References.tsx'
       - 'components/seo/**'
@@ -129,6 +130,7 @@ jobs:
           app/learn/rhabdomyolysis/page.tsx
           components/articles/GoalClusterArticlePage.tsx
           components/articles/MentalHealthArticlePage.tsx
+          components/LegacyGuideQuickAnswer.tsx
           components/LegacyGuideReference.tsx
           components/References.tsx
           components/StructuredData.tsx

--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -16,6 +16,7 @@ const MENTAL_HEALTH_ARTICLE = path.join(ROOT, 'components', 'articles', 'MentalH
 const GOAL_CLUSTER_ARTICLE = path.join(ROOT, 'components', 'articles', 'GoalClusterArticlePage.tsx')
 const RHABDO_PAGE = path.join(ROOT, 'app', 'learn', 'rhabdomyolysis', 'page.tsx')
 const LEGACY_GUIDE_REFERENCE = path.join(ROOT, 'components', 'LegacyGuideReference.tsx')
+const LEGACY_GUIDE_QUICK_ANSWER = path.join(ROOT, 'components', 'LegacyGuideQuickAnswer.tsx')
 const LEGACY_GUIDE_PAGES = [
   ['prebiotics', path.join(ROOT, 'app', 'guides', 'other', 'prebiotics', 'page.tsx')],
   ['greens-powders', path.join(ROOT, 'app', 'guides', 'other', 'greens-powders', 'page.tsx')],
@@ -236,6 +237,30 @@ function auditLegacyGuideReferencePrimitives() {
   }
 }
 
+function auditLegacyGuideQuickAnswerPrimitives() {
+  requireSignals(LEGACY_GUIDE_QUICK_ANSWER, 'legacy-guide-answers', 'LegacyGuideQuickAnswer', [
+    ['id="quick-answer"', 'stable quick-answer anchor'],
+    ['aria-labelledby="quick-answer-heading"', 'accessible heading relationship'],
+    ['data-answer-engine-summary="true"', 'answer-engine summary marker'],
+    ['data-claim="true"', 'claim marker'],
+    ['href="#quick-answer"', 'durable answer self-link'],
+    ['referencesHref', 'optional reference-ledger target'],
+    ['data-citation-sources="true"', 'claim-adjacent source marker'],
+  ])
+
+  for (const [slug, file] of LEGACY_GUIDE_PAGES) {
+    const source = text(file)
+    if (!source.includes("@/components/LegacyGuideQuickAnswer")) continue
+
+    for (const [signal, label] of [
+      ['<LegacyGuideQuickAnswer referencesHref="#references">', 'shared quick-answer wrapper with source target'],
+      ['id="references"', 'matching references target'],
+    ]) {
+      if (!source.includes(signal)) add('error', 'legacy-guide-answers', `${slug} guide missing ${label}`)
+    }
+  }
+}
+
 function auditProfilePrimitives() {
   requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
     ['data-evidence="true"', 'evidence marker'],
@@ -317,6 +342,7 @@ auditMentalHealthCitationPrimitives()
 auditGoalClusterCitationPrimitives()
 auditRhabdoCitationPrimitives()
 auditLegacyGuideReferencePrimitives()
+auditLegacyGuideQuickAnswerPrimitives()
 auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()


### PR DESCRIPTION
Fixes #3680

Parent: #3674

## Summary
- adds `LegacyGuideQuickAnswer` to the canonical AI answer-engine audit
- requires stable `#quick-answer`, accessible heading linkage, answer-engine summary/claim markers, permanent self-link, optional source target support, and citation-source semantics
- audits only legacy guides that have actually migrated to the wrapper, requiring `referencesHref="#references"` plus a matching `id="references"` target
- leaves the two unmigrated long-form legacy guides eligible for follow-up migration rather than falsely failing them now
- adds the shared wrapper to the existing AI-search workflow trigger and lint surface
- creates no new validator or workflow

## Acceptance criteria
- Shared wrapper semantics are blocking invariants in the canonical audit.
- Migrated legacy consumers must have a resolvable source-ledger jump.
- Unmigrated legacy consumers do not fail merely for not importing the wrapper yet.
- Wrapper changes trigger and lint in the existing AI-search workflow.

## Validation commands
- `npm run audit:ai-citations`
- `npx eslint components/LegacyGuideQuickAnswer.tsx scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- AI search quality check
- Atomic upgrade gate

## Before → after metrics
- Canonical audit contracts for `LegacyGuideQuickAnswer`: 0 → 1.
- Required shared wrapper semantic signals: 0 → 7.
- Migrated legacy consumer source-target validation: 0 → all currently migrated consumers.
- AI-search workflow trigger/lint coverage for the wrapper: 0 → 1 each.
- New validators/workflows introduced: 0 → 0.

## Generator/source-of-truth decision
Legacy guide prose remains page-owned. `LegacyGuideQuickAnswer` remains structural/extraction-only. `audit-ai-answer-engine-readiness.mjs` remains the canonical answer-engine policy surface and the existing AI-search workflow remains the execution boundary.

## Regression contract
- The wrapper must not infer evidence grades or claim-to-source relationships.
- Stable answer and reference navigation must remain available for migrated pages.
- Future migrations become covered automatically when they import the wrapper.
- No parallel quick-answer governance pipeline should be added.

## AI SEO / trust impact
The legacy answer-surface migration is now durable as it proceeds: shared extraction semantics are enforced centrally without overstating the evidence model or blocking pages that have not yet migrated.