### PR TITLE
feat(evidence-report): publish independent human-study metrics

### DIFF
--- a/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
+++ b/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
@@ -1,0 +1,57 @@
+import type { PublicEvidenceReportMetrics } from '@/lib/public-evidence-dataset'
+
+type Props = {
+  metrics: PublicEvidenceReportMetrics
+}
+
+function value(value: number | null): string {
+  return value === null ? '—' : value.toLocaleString()
+}
+
+export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
+  const available = metrics.underlyingStudyMetricsSource === 'canonical-research-topology'
+    && metrics.globalPrimaryHumanPublicationCount !== null
+    && metrics.globalPrimaryHumanUnderlyingStudyCount !== null
+    && metrics.globalCollapsedPrimaryHumanPublicationCount !== null
+
+  if (!available) return null
+
+  return (
+    <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8" aria-labelledby="underlying-study-independence-heading">
+      <p className="eyebrow-label">Evidence independence</p>
+      <h2 id="underlying-study-independence-heading" className="mt-2 text-2xl font-semibold text-ink">
+        Publications are not automatically independent studies
+      </h2>
+      <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
+        The canonical research graph first deduplicates publication identities across profiles, then collapses publications only when explicit trial-registration, cohort, dataset, or parent-study lineage shows they belong to the same underlying evidence unit. Missing lineage is never treated as proof of dependence.
+      </p>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Primary-human publications</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalPrimaryHumanPublicationCount)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Unique site-wide publication identities classified as primary human research.</p>
+        </article>
+        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Underlying human studies</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalPrimaryHumanUnderlyingStudyCount)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Independent primary-human evidence units after explicit cross-publication dependence is collapsed.</p>
+        </article>
+        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Human publications collapsed</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalCollapsedPrimaryHumanPublicationCount)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Publication records removed from the independence-adjusted count because shared underlying-study identity was positively established.</p>
+        </article>
+        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">All underlying evidence units</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalInventoryUnderlyingStudyCount)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">All canonical study classes after site-wide publication alias and explicit dependence collapse.</p>
+        </article>
+      </div>
+
+      <p className="mt-5 text-xs leading-5 text-muted">
+        These counts are narrower than the report’s “human evidence source records” metric: syntheses and reviews remain publication-level evidence records, while the independence-adjusted figure above is restricted to primary human research. It is not an estimate of unique participants and is not an RCT-only count.
+      </p>
+    </section>
+  )
+}

--- a/app/evidence/evidence-report/page.tsx
+++ b/app/evidence/evidence-report/page.tsx
@@ -5,11 +5,12 @@ import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
 import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
 import EvidenceReportClient from './EvidenceReportClient'
 import CategoryEvidenceMixPanel from './CategoryEvidenceMixPanel'
+import UnderlyingStudyIndependencePanel from './UnderlyingStudyIndependencePanel'
 import UnassignedEvidenceStatusPanel from './UnassignedEvidenceStatusPanel'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'State of Supplement Evidence 2026',
-  description: 'Original data report on evidence grades, structured study/source records, human-study record coverage, preclinical reliance, safety cautions, disagreement, and downloadable research data from The Hippie Scientist.',
+  description: 'Original data report on evidence grades, structured study/source records, independence-adjusted primary-human research counts, preclinical reliance, safety cautions, disagreement, and downloadable research data from The Hippie Scientist.',
   path: '/evidence/evidence-report/',
   openGraphType: 'article',
 })
@@ -25,6 +26,7 @@ export default async function EvidenceReportPage() {
         metrics={dataset.metrics}
         changeHistory={evidenceGradeHistory}
       />
+      <UnderlyingStudyIndependencePanel metrics={dataset.metrics} />
       <UnassignedEvidenceStatusPanel dataset={dataset} />
       <CategoryEvidenceMixPanel dataset={dataset} />
     </>

--- a/lib/__tests__/public-evidence-dataset.test.ts
+++ b/lib/__tests__/public-evidence-dataset.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  PUBLIC_EVIDENCE_DATASET_VERSION,
   buildPublicEvidenceDatasetFromRecords,
   publicEvidenceDatasetToCsv,
 } from '@/lib/public-evidence-dataset'
@@ -79,6 +80,23 @@ describe('public evidence dataset', () => {
     expect(dataset.metrics.strongOrModerateIngredients).toBe(1)
     expect(dataset.metrics.preliminaryOrInsufficientIngredients).toBe(1)
     expect(dataset.metrics.ingredientsWithSafetyCautions).toBe(1)
+  })
+
+  it('does not fabricate independence metrics in the pure record builder', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      { type: 'herb', record: record({ slug: 'alpha' }) },
+    ])
+
+    expect(PUBLIC_EVIDENCE_DATASET_VERSION).toBe('2026.08.16')
+    expect(dataset.metrics).toMatchObject({
+      underlyingStudyMetricsSource: null,
+      globalInventoryPublicationCount: null,
+      globalInventoryUnderlyingStudyCount: null,
+      globalCollapsedInventoryPublicationCount: null,
+      globalPrimaryHumanPublicationCount: null,
+      globalPrimaryHumanUnderlyingStudyCount: null,
+      globalCollapsedPrimaryHumanPublicationCount: null,
+    })
   })
 
   it('exports structured study relationships to CSV without losing stable IDs', () => {

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -14,6 +14,7 @@ import {
   type EvidenceStudyClass,
   type EvidenceStudyRecord,
 } from '@/lib/evidence-study'
+import { buildResearchQualitySnapshot } from '@/lib/research-quality-snapshot'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import {
   getCompoundBySlug,
@@ -23,7 +24,7 @@ import {
 } from '@/src/lib/runtime-data'
 import type { RuntimeRecord } from '@/src/types/content'
 
-export const PUBLIC_EVIDENCE_DATASET_VERSION = '2026.08.15'
+export const PUBLIC_EVIDENCE_DATASET_VERSION = '2026.08.16'
 export const PUBLIC_EVIDENCE_DATASET_TITLE = 'The Hippie Scientist Public Evidence Dataset 2026'
 
 export type PublicEvidenceIngredient = {
@@ -100,6 +101,18 @@ export type PublicEvidenceReportMetrics = {
   contradictingRelationships: number
   noClearEffectRelationships: number
   disagreementStudyCount: number
+  /** Null for synthetic/pure builders that do not execute canonical topology. */
+  underlyingStudyMetricsSource: 'canonical-research-topology' | null
+  /** Unique site-wide publication identities across every canonical research profile. */
+  globalInventoryPublicationCount: number | null
+  /** Site-wide evidence units after explicit registry/lineage dependence collapse. */
+  globalInventoryUnderlyingStudyCount: number | null
+  globalCollapsedInventoryPublicationCount: number | null
+  /** Unique site-wide primary-human publication identities. */
+  globalPrimaryHumanPublicationCount: number | null
+  /** Independent site-wide primary-human evidence units after explicit dependence collapse. */
+  globalPrimaryHumanUnderlyingStudyCount: number | null
+  globalCollapsedPrimaryHumanPublicationCount: number | null
   gradeDistribution: Array<{ grade: string; count: number; pct: number }>
   categories: EvidenceCategorySummary[]
 }
@@ -406,6 +419,13 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     contradictingRelationships,
     noClearEffectRelationships,
     disagreementStudyCount: studies.filter(study => study.relationshipSummary === 'mixed').length,
+    underlyingStudyMetricsSource: null,
+    globalInventoryPublicationCount: null,
+    globalInventoryUnderlyingStudyCount: null,
+    globalCollapsedInventoryPublicationCount: null,
+    globalPrimaryHumanPublicationCount: null,
+    globalPrimaryHumanUnderlyingStudyCount: null,
+    globalCollapsedPrimaryHumanPublicationCount: null,
     gradeDistribution,
     categories,
   }
@@ -449,7 +469,22 @@ export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset>
     hydrateIndexableRecords(herbs, 'herb'),
     hydrateIndexableRecords(compounds, 'compound'),
   ])
-  return buildPublicEvidenceDatasetFromRecords([...herbRecords, ...compoundRecords])
+  const dataset = buildPublicEvidenceDatasetFromRecords([...herbRecords, ...compoundRecords])
+  const independence = buildResearchQualitySnapshot(process.cwd()).topology.underlyingStudyIndependence.summary
+
+  return {
+    ...dataset,
+    metrics: {
+      ...dataset.metrics,
+      underlyingStudyMetricsSource: 'canonical-research-topology',
+      globalInventoryPublicationCount: independence.globalInventoryPublicationCount,
+      globalInventoryUnderlyingStudyCount: independence.globalInventoryUnderlyingStudyCount,
+      globalCollapsedInventoryPublicationCount: independence.globalCollapsedInventoryPublicationCount,
+      globalPrimaryHumanPublicationCount: independence.globalPrimaryHumanPublicationCount,
+      globalPrimaryHumanUnderlyingStudyCount: independence.globalPrimaryHumanUnderlyingStudyCount,
+      globalCollapsedPrimaryHumanPublicationCount: independence.globalCollapsedPrimaryHumanPublicationCount,
+    },
+  }
 }
 
 function csvEscape(value: unknown): string {


### PR DESCRIPTION
Uses the new site-wide canonical underlying-study identity layer in the public evidence dataset and State of Supplement Evidence report. Publication/source metrics remain intact; new nullable fields expose unique global inventory publications, global underlying evidence units, unique primary-human publications, independent primary-human studies, and explicit collapse deltas. Pure record builders leave these metrics null so synthetic callers never fabricate independence without topology. Production dataset generation enriches them from the canonical research-quality snapshot and records the provenance. Adds a dedicated report panel explaining that publication identity is deduplicated site-wide and publications collapse only with explicit registry/cohort/dataset/parent-study lineage; missing lineage is never treated as dependence. Dataset version advances to 2026.08.16 and tests lock the no-topology null behavior.