### PR TITLE
fix(evidence-report): qualify independence-adjusted study counts

### DIFF
--- a/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
+++ b/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
@@ -8,6 +8,10 @@ function value(value: number | null): string {
   return value === null ? '—' : value.toLocaleString()
 }
 
+function pct(value: number | null): string {
+  return value === null ? '—' : `${Math.round(value * 100)}%`
+}
+
 export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
   const available = metrics.underlyingStudyMetricsSource === 'canonical-research-topology'
     && metrics.globalPrimaryHumanPublicationCount !== null
@@ -16,14 +20,18 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
 
   if (!available) return null
 
+  const unresolved = metrics.independenceUnresolvedClaims ?? 0
+  const multiStudy = metrics.independenceMultiStudyApprovedClaims ?? 0
+  const highConfidenceUnresolved = metrics.highConfidenceIndependenceUnresolvedClaims ?? 0
+
   return (
     <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8" aria-labelledby="underlying-study-independence-heading">
       <p className="eyebrow-label">Evidence independence</p>
       <h2 id="underlying-study-independence-heading" className="mt-2 text-2xl font-semibold text-ink">
-        Publications are not automatically independent studies
+        Independence-adjusted counts, not assumed independence
       </h2>
       <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
-        The canonical research graph first deduplicates publication identities across profiles, then collapses publications only when explicit trial-registration, cohort, dataset, or parent-study lineage shows they belong to the same underlying evidence unit. Missing lineage is never treated as proof of dependence.
+        The canonical research graph first deduplicates publication identities across profiles, then collapses publications only when explicit trial-registration, cohort, dataset, or parent-study lineage shows they belong to the same underlying evidence unit. Missing lineage stays unresolved and is never treated as proof that publications are either dependent or independent.
       </p>
 
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -33,24 +41,32 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
           <p className="mt-2 text-xs leading-5 text-muted">Unique site-wide publication identities classified as primary human research.</p>
         </article>
         <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
-          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Underlying human studies</p>
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Independence-adjusted human units</p>
           <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalPrimaryHumanUnderlyingStudyCount)}</p>
-          <p className="mt-2 text-xs leading-5 text-muted">Independent primary-human evidence units after explicit cross-publication dependence is collapsed.</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Primary-human evidence units remaining after explicitly proven cross-publication dependence is collapsed.</p>
         </article>
         <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Human publications collapsed</p>
           <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalCollapsedPrimaryHumanPublicationCount)}</p>
-          <p className="mt-2 text-xs leading-5 text-muted">Publication records removed from the independence-adjusted count because shared underlying-study identity was positively established.</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Publication identities removed from the adjusted count because shared underlying-study identity was positively established.</p>
         </article>
         <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
-          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">All underlying evidence units</p>
-          <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalInventoryUnderlyingStudyCount)}</p>
-          <p className="mt-2 text-xs leading-5 text-muted">All canonical study classes after site-wide publication alias and explicit dependence collapse.</p>
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Mean explicit lineage coverage</p>
+          <p className="mt-2 text-3xl font-bold text-ink">{pct(metrics.meanIndependenceCoverage)}</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Mean registry-or-lineage coverage across approved claims supported by multiple publication-level studies.</p>
         </article>
       </div>
 
+      {multiStudy > 0 ? (
+        <div className="mt-5 rounded-xl border border-amber-900/15 bg-amber-50/70 p-4 text-sm leading-6 text-amber-950">
+          <strong>Independence remains unresolved for {unresolved} of {multiStudy} multi-study approved claims.</strong>{' '}
+          {highConfidenceUnresolved > 0 ? `${highConfidenceUnresolved} high-confidence claim${highConfidenceUnresolved === 1 ? '' : 's'} still lack complete explicit independence coverage. ` : ''}
+          Because unknown relationships are left separate, the adjusted study count is a conservative upper bound with respect to unobserved publication dependence—not proof that every remaining evidence unit is independently recruited or generated.
+        </div>
+      ) : null}
+
       <p className="mt-5 text-xs leading-5 text-muted">
-        These counts are narrower than the report’s “human evidence source records” metric: syntheses and reviews remain publication-level evidence records, while the independence-adjusted figure above is restricted to primary human research. It is not an estimate of unique participants and is not an RCT-only count.
+        These counts are narrower than the report’s “human evidence source records” metric: syntheses and reviews remain publication-level evidence records, while the independence-adjusted figure above is restricted to primary human research. It is not an estimate of unique participants and is not an RCT-only count. Across all study classes, the current topology retains {value(metrics.globalInventoryUnderlyingStudyCount)} evidence units after explicitly proven dependence collapse.
       </p>
     </section>
   )

--- a/lib/__tests__/public-evidence-dataset.test.ts
+++ b/lib/__tests__/public-evidence-dataset.test.ts
@@ -82,7 +82,7 @@ describe('public evidence dataset', () => {
     expect(dataset.metrics.ingredientsWithSafetyCautions).toBe(1)
   })
 
-  it('does not fabricate independence metrics in the pure record builder', () => {
+  it('does not fabricate independence metrics or coverage in the pure record builder', () => {
     const dataset = buildPublicEvidenceDatasetFromRecords([
       { type: 'herb', record: record({ slug: 'alpha' }) },
     ])
@@ -96,6 +96,11 @@ describe('public evidence dataset', () => {
       globalPrimaryHumanPublicationCount: null,
       globalPrimaryHumanUnderlyingStudyCount: null,
       globalCollapsedPrimaryHumanPublicationCount: null,
+      independenceMultiStudyApprovedClaims: null,
+      independenceFullyResolvedClaims: null,
+      independenceUnresolvedClaims: null,
+      highConfidenceIndependenceUnresolvedClaims: null,
+      meanIndependenceCoverage: null,
     })
   })
 

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -105,14 +105,20 @@ export type PublicEvidenceReportMetrics = {
   underlyingStudyMetricsSource: 'canonical-research-topology' | null
   /** Unique site-wide publication identities across every canonical research profile. */
   globalInventoryPublicationCount: number | null
-  /** Site-wide evidence units after explicit registry/lineage dependence collapse. */
+  /** Site-wide evidence units remaining after explicitly proven registry/lineage dependence is collapsed. */
   globalInventoryUnderlyingStudyCount: number | null
   globalCollapsedInventoryPublicationCount: number | null
   /** Unique site-wide primary-human publication identities. */
   globalPrimaryHumanPublicationCount: number | null
-  /** Independent site-wide primary-human evidence units after explicit dependence collapse. */
+  /** Primary-human evidence units remaining after explicitly proven dependence collapse; unresolved lineage is not assumed independent. */
   globalPrimaryHumanUnderlyingStudyCount: number | null
   globalCollapsedPrimaryHumanPublicationCount: number | null
+  /** Claim-level coverage of explicit registry or non-registry lineage used to assess publication independence. */
+  independenceMultiStudyApprovedClaims: number | null
+  independenceFullyResolvedClaims: number | null
+  independenceUnresolvedClaims: number | null
+  highConfidenceIndependenceUnresolvedClaims: number | null
+  meanIndependenceCoverage: number | null
   gradeDistribution: Array<{ grade: string; count: number; pct: number }>
   categories: EvidenceCategorySummary[]
 }
@@ -426,6 +432,11 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     globalPrimaryHumanPublicationCount: null,
     globalPrimaryHumanUnderlyingStudyCount: null,
     globalCollapsedPrimaryHumanPublicationCount: null,
+    independenceMultiStudyApprovedClaims: null,
+    independenceFullyResolvedClaims: null,
+    independenceUnresolvedClaims: null,
+    highConfidenceIndependenceUnresolvedClaims: null,
+    meanIndependenceCoverage: null,
     gradeDistribution,
     categories,
   }
@@ -470,7 +481,9 @@ export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset>
     hydrateIndexableRecords(compounds, 'compound'),
   ])
   const dataset = buildPublicEvidenceDatasetFromRecords([...herbRecords, ...compoundRecords])
-  const independence = buildResearchQualitySnapshot(process.cwd()).topology.underlyingStudyIndependence.summary
+  const topology = buildResearchQualitySnapshot(process.cwd()).topology
+  const independence = topology.underlyingStudyIndependence.summary
+  const coverage = topology.evidenceIndependenceCoverage.summary
 
   return {
     ...dataset,
@@ -483,6 +496,11 @@ export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset>
       globalPrimaryHumanPublicationCount: independence.globalPrimaryHumanPublicationCount,
       globalPrimaryHumanUnderlyingStudyCount: independence.globalPrimaryHumanUnderlyingStudyCount,
       globalCollapsedPrimaryHumanPublicationCount: independence.globalCollapsedPrimaryHumanPublicationCount,
+      independenceMultiStudyApprovedClaims: coverage.multiStudyApprovedClaims,
+      independenceFullyResolvedClaims: coverage.fullyResolvedClaims,
+      independenceUnresolvedClaims: coverage.unresolvedClaims,
+      highConfidenceIndependenceUnresolvedClaims: coverage.highConfidenceUnresolvedClaims,
+      meanIndependenceCoverage: coverage.meanCombinedCoverage,
     },
   }
 }


### PR DESCRIPTION
Tightens the semantics of the new public underlying-study metrics. Because missing lineage is intentionally never collapsed, the remaining count is independence-adjusted rather than proof that every evidence unit is independently recruited/generated. The public dataset now also exposes canonical evidence-independence coverage: multi-study claims assessed, fully resolved claims, unresolved claims, high-confidence unresolved claims, and mean explicit registry/lineage coverage. The report panel renames the headline metric to `Independence-adjusted human units`, surfaces mean lineage coverage and unresolved-claim counts, and explicitly describes the adjusted count as a conservative upper bound with respect to unobserved publication dependence. Pure builders leave all coverage fields null; tests lock that provenance boundary.