### PR TITLE
SEO: lock all legacy guides to shared quick-answer surface

### DIFF
--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -249,15 +249,11 @@ function auditLegacyGuideQuickAnswerPrimitives() {
   ])
 
   for (const [slug, file] of LEGACY_GUIDE_PAGES) {
-    const source = text(file)
-    if (!source.includes("@/components/LegacyGuideQuickAnswer")) continue
-
-    for (const [signal, label] of [
+    requireSignals(file, 'legacy-guide-answers', `${slug} guide`, [
+      ["import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'", 'shared quick-answer import'],
       ['<LegacyGuideQuickAnswer referencesHref="#references">', 'shared quick-answer wrapper with source target'],
       ['id="references"', 'matching references target'],
-    ]) {
-      if (!source.includes(signal)) add('error', 'legacy-guide-answers', `${slug} guide missing ${label}`)
-    }
+    ])
   }
 }
 


### PR DESCRIPTION
Fixes #3686

Parent: #3674

## Summary
- removes the transitional conditional skip from the canonical legacy Quick answer audit
- requires all five migrated legacy authority guides to import `LegacyGuideQuickAnswer`
- requires all five to use `referencesHref="#references"` and retain a matching `id="references"` target
- keeps the shared wrapper and existing AI-search audit/workflow as the only governance architecture
- adds no new pipeline or metadata inference

## Acceptance criteria
- Prebiotics, greens powders, bovine colostrum, electrolyte supplements, and collagen supplements are all blocking consumers of the shared Quick answer surface.
- Removing the wrapper from any one of the five fails the canonical audit.
- Removing the source target from any one of the five fails the canonical audit.
- Shared wrapper semantics remain separately enforced.

## Validation commands
- `npm run audit:ai-citations`
- `npx eslint scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- AI search quality check
- Atomic upgrade gate

## Before → after metrics
- Migrated legacy guides: 5/5 → 5/5.
- Guides where wrapper removal could evade consumer validation: 5 → 0.
- Guides with blocking shared wrapper/import/source-target invariants: 0/5 → 5/5.
- New validators/workflows: 0.

## Generator/source-of-truth decision
The five guide files remain the source of truth for their scientific prose. `LegacyGuideQuickAnswer` remains structural only. The canonical AI answer-engine audit remains the policy authority.

## Regression contract
- All five guides remain on the shared Quick answer surface.
- All five retain stable `#references` targets.
- Scientific copy remains page-owned and no evidence relationships are inferred by the wrapper.
- No parallel legacy-answer governance pipeline is introduced.

## AI SEO / trust impact
The completed five-guide migration is now durable: answer-engine extraction and source navigation cannot silently regress on an individual legacy guide without failing the site's existing canonical AI-search audit.