### PR TITLE
SEO: expose deterministic PMID/DOI identity on legacy references

### DIFF
--- a/components/LegacyGuideReference.tsx
+++ b/components/LegacyGuideReference.tsx
@@ -10,24 +10,51 @@ function sourceLabel(url: string): string {
   return 'Source →'
 }
 
+function sourceIdentifier(url?: string): string | undefined {
+  if (!url) return undefined
+
+  try {
+    const parsed = new URL(url)
+    const hostname = parsed.hostname.toLowerCase()
+    const pathname = decodeURIComponent(parsed.pathname)
+
+    if (hostname === 'pubmed.ncbi.nlm.nih.gov') {
+      const match = pathname.match(/^\/(\d+)\/?$/)
+      return match ? `PMID:${match[1]}` : undefined
+    }
+
+    if (hostname === 'doi.org' || hostname === 'www.doi.org') {
+      const doi = pathname.replace(/^\//, '').trim()
+      return /^10\.\d{4,9}\/\S+$/i.test(doi) ? `DOI:${doi}` : undefined
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
 /**
  * Compatibility reference item for older hand-authored guides that only model
  * an ordinal, citation text, and optional source URL. Keep this conservative:
- * do not infer PMID/DOI/authors/journal metadata that the source model does not
- * explicitly provide.
+ * identifiers may be derived from authoritative PubMed/DOI URLs only; do not
+ * parse citation prose to infer authors, journal metadata, dates, or study type.
  */
 export default function LegacyGuideReference({ n, text, url }: LegacyGuideReferenceProps) {
   const citationId = `ref-${n}`
+  const identifier = sourceIdentifier(url)
 
   return (
     <li
       id={citationId}
       data-citation-source="true"
       data-citation-id={citationId}
+      data-source-identifier={identifier}
       itemScope
       itemType="https://schema.org/CreativeWork"
       className="scroll-mt-24 text-xs leading-5 text-muted"
     >
+      {identifier ? <meta itemProp="identifier" content={identifier} /> : null}
       <a
         href={`#${citationId}`}
         aria-label={`Permanent link to reference ${n}`}


### PR DESCRIPTION
Refs #3689

## Summary
- derives deterministic source identifiers from authoritative source URLs inside `LegacyGuideReference`
- supports `PMID:<digits>` only for canonical `pubmed.ncbi.nlm.nih.gov/<digits>/` URLs
- supports `DOI:<doi>` only for canonical `doi.org/<doi>` URLs matching DOI syntax
- exposes the derived identifier as `data-source-identifier` plus schema.org `identifier` metadata on the existing `CreativeWork` reference item
- preserves all visible citation text, source URLs, and labels unchanged
- malformed, noncanonical, or unrelated URLs emit no identifier
- never parses citation prose to infer PMID/DOI/authors/journals/dates/study type/evidence grade

## Acceptance criteria
- PubMed identity comes from URL path only.
- DOI identity comes from doi.org URL path only.
- Nonmatching URLs produce no source identifier.
- Visible reference rendering is unchanged.
- No free-form bibliographic inference is introduced.

## Validation
- existing AI-search workflow trigger includes `components/LegacyGuideReference.tsx`
- existing AI-search lint includes `components/LegacyGuideReference.tsx`
- `npm run typecheck`
- `npm run audit:ai-citations`
- AI search quality check / Atomic upgrade gate

## Before → after
- explicit deterministic identifiers on legacy direct PubMed/DOI sources: implicit in URL → machine-readable
- prose-derived identifiers: 0 → 0
- new validators/workflows: 0 → 0

## Trust boundary
This intentionally treats the URL as the only identifier authority. Citation prose remains display text and is not parsed into structured bibliographic claims.