### PR TITLE
SEO: guard URL-only legacy source identifiers

### DIFF
--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -222,7 +222,20 @@ function auditLegacyGuideReferencePrimitives() {
     ['href={`#${citationId}`}', 'durable source self-link'],
     ['itemProp="name"', 'citation text name semantic'],
     ['itemProp="url"', 'source URL semantic'],
+    ['function sourceIdentifier(url?: string)', 'URL-only source identifier normalizer'],
+    ["hostname === 'pubmed.ncbi.nlm.nih.gov'", 'canonical PubMed host gate'],
+    ['return match ? `PMID:${match[1]}`', 'PMID identifier derivation'],
+    ["hostname === 'doi.org' || hostname === 'www.doi.org'", 'canonical DOI host gate'],
+    ['return /^10\\.\\d{4,9}\\/\\S+$/i.test(doi) ? `DOI:${doi}`', 'DOI identifier syntax gate'],
+    ['data-source-identifier={identifier}', 'machine-readable source identifier'],
+    ['itemProp="identifier"', 'CreativeWork identifier semantic'],
   ])
+
+  const legacyReferenceSource = text(LEGACY_GUIDE_REFERENCE)
+  const identifierNormalizer = legacyReferenceSource.split('function sourceIdentifier')[1]?.split('/**')[0] || ''
+  if (/\btext\b/.test(identifierNormalizer)) {
+    add('error', 'legacy-guide-citations', 'LegacyGuideReference source identifier normalizer reads citation prose instead of URL-only identity')
+  }
 
   for (const [slug, file] of LEGACY_GUIDE_PAGES) {
     requireSignals(file, 'legacy-guide-citations', `${slug} guide`, [


### PR DESCRIPTION
Fixes #3689

## Summary
- extends the existing canonical AI answer-engine audit for the already-merged `LegacyGuideReference` identifier enhancement
- requires URL-only `sourceIdentifier` normalization
- requires canonical PubMed host gating and `PMID:<digits>` derivation
- requires canonical DOI host gating, DOI syntax validation, and `DOI:<doi>` derivation
- requires `data-source-identifier` and schema.org `identifier` semantics
- explicitly fails if the source identifier normalizer starts reading citation prose (`text`)
- adds no new validator, workflow, or bibliographic parser

## Acceptance criteria
- deterministic identifiers remain derived from authoritative URLs only
- PubMed/DOI host and syntax gates are blocking invariants
- machine-readable identifier exposure is blocking
- citation prose cannot become an identifier source
- all existing legacy guide reference reuse checks remain intact

## Validation
- `npm run audit:ai-citations`
- `npx eslint scripts/ci/audit-ai-answer-engine-readiness.mjs components/LegacyGuideReference.tsx --max-warnings=0`
- `npm run typecheck`
- AI search quality check
- Atomic upgrade gate

## Before → after
- canonical audit checks for deterministic legacy source identity: 0 → 7 signals + 1 anti-inference guard
- new validators/workflows: 0 → 0

## Trust boundary
The URL remains the only identifier authority. The audit explicitly blocks migration toward free-form citation-text parsing.