### PR TITLE
feat(research): normalize canonical outcome metadata

### DIFF
--- a/lib/__tests__/research-outcome-metadata.test.ts
+++ b/lib/__tests__/research-outcome-metadata.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeOutcomeMetadata } from '@/lib/research-outcome-metadata'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import type { TrialRegistrationIndependenceAnalysis } from '@/lib/research-trial-registration-independence'
+
+function analysis(sources: Array<Record<string, unknown>>, cache: Record<string, Record<string, unknown>> = {}): ResearchQualityAnalysis {
+  return {
+    cache,
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: { slug: 'example', sources, claimMap: [] },
+    }],
+    claimAnalyses: [],
+    structuredClaimAnalyses: [],
+    profileAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+}
+
+function registration(studies: TrialRegistrationIndependenceAnalysis['studies']): TrialRegistrationIndependenceAnalysis {
+  return {
+    studies,
+    claims: [],
+    sameTrialReuseClaims: [],
+    highConfidenceSameTrialReuseClaims: [],
+    summary: {
+      canonicalStudies: studies.length,
+      studiesWithRegistryCoverage: studies.filter((study) => study.registryIds.length > 0).length,
+      studiesWithAmbiguousRegistryEvidence: studies.filter((study) => study.ambiguous).length,
+      multiStudyApprovedClaims: 0,
+      claimsWithRegistryCoverage: 0,
+      claimsWithAmbiguousRegistryEvidence: 0,
+      sameTrialReuseClaims: 0,
+      highConfidenceSameTrialReuseClaims: 0,
+      duplicatePublicationCount: 0,
+    },
+  }
+}
+
+describe('canonical outcome metadata', () => {
+  it('preserves explicit outcome hierarchy and registration on one canonical study', () => {
+    const input = analysis([{
+      id: 's1',
+      pmid: '123',
+      primaryOutcome: 'Insomnia Severity Index',
+      secondaryOutcomes: ['Sleep onset latency', 'Wake after sleep onset'],
+      registeredPrimaryOutcome: 'Insomnia Severity Index',
+      reportedPrimaryOutcome: 'Insomnia Severity Index',
+      primaryOutcomeStatus: 'met',
+    }])
+    const trialRegistrationIndependence = registration([{
+      url: '/herbs/example/',
+      studyId: 'pmid:123',
+      registryIds: ['NCT12345678'],
+      stableRegistryId: 'NCT12345678',
+      ambiguous: false,
+    }])
+
+    const result = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+
+    expect(result.studies).toHaveLength(1)
+    expect(result.studies[0]).toMatchObject({
+      primaryOutcomes: ['Insomnia Severity Index'],
+      secondaryOutcomes: ['Sleep onset latency', 'Wake after sleep onset'],
+      registeredPrimaryOutcomes: ['Insomnia Severity Index'],
+      reportedPrimaryOutcomes: ['Insomnia Severity Index'],
+      primaryOutcomeStatus: 'met',
+      trialRegistrationIds: ['NCT12345678'],
+      hasOutcomeMetadata: true,
+    })
+  })
+
+  it('collapses alias source rows before counting study-level outcome metadata', () => {
+    const input = analysis([
+      { id: 'a', pmid: '123', doi: '10.1000/example', primaryOutcome: 'Fatigue score' },
+      { id: 'b', doi: '10.1000/example', secondaryOutcome: 'Quality of life' },
+    ])
+    const trialRegistrationIndependence = registration([{
+      url: '/herbs/example/',
+      studyId: 'doi:10.1000/example',
+      registryIds: [],
+      stableRegistryId: null,
+      ambiguous: false,
+    }])
+
+    const result = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+
+    expect(result.summary.canonicalStudies).toBe(1)
+    expect(result.studies[0].primaryOutcomes).toEqual(['Fatigue score'])
+    expect(result.studies[0].secondaryOutcomes).toEqual(['Quality of life'])
+  })
+
+  it('uses explicit publication language for status/flags without inventing outcome names', () => {
+    const input = analysis(
+      [{ id: 's1', pmid: '123' }],
+      { '123': { abstract: 'The primary endpoint was not met. The prespecified primary outcome was not reported and the primary outcome was changed after registration.' } },
+    )
+    const trialRegistrationIndependence = registration([{
+      url: '/herbs/example/',
+      studyId: 'pmid:123',
+      registryIds: [],
+      stableRegistryId: null,
+      ambiguous: false,
+    }])
+
+    const result = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+    const study = result.studies[0]
+
+    expect(study.primaryOutcomes).toEqual([])
+    expect(study.registeredPrimaryOutcomes).toEqual([])
+    expect(study.primaryOutcomeStatus).toBe('not-met')
+    expect(study.explicitOutcomeSwitch).toBe(true)
+    expect(study.explicitRegisteredOutcomeNotReported).toBe(true)
+  })
+
+  it('keeps missing outcome metadata unknown', () => {
+    const input = analysis([{ id: 's1', pmid: '123', title: 'Randomized clinical trial' }])
+    const trialRegistrationIndependence = registration([{
+      url: '/herbs/example/',
+      studyId: 'pmid:123',
+      registryIds: [],
+      stableRegistryId: null,
+      ambiguous: false,
+    }])
+
+    const result = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+
+    expect(result.studies[0]).toMatchObject({
+      primaryOutcomeStatus: 'unknown',
+      explicitOutcomeSwitch: false,
+      explicitRegisteredOutcomeNotReported: false,
+      hasOutcomeMetadata: false,
+    })
+  })
+})

--- a/lib/research-outcome-metadata.ts
+++ b/lib/research-outcome-metadata.ts
@@ -1,0 +1,193 @@
+import { canonicalStudyGroups, type PubmedCache, type ResearchSource } from './research-coverage'
+import { researchSourceEvidenceText } from './research-evidence-text'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { TrialRegistrationIndependenceAnalysis } from './research-trial-registration-independence'
+
+export type PrimaryOutcomeStatus = 'met' | 'not-met' | 'mixed' | 'unknown'
+
+export type StudyOutcomeMetadata = {
+  url: string
+  studyId: string
+  trialRegistrationIds: string[]
+  primaryOutcomes: string[]
+  secondaryOutcomes: string[]
+  registeredPrimaryOutcomes: string[]
+  reportedPrimaryOutcomes: string[]
+  primaryOutcomeStatus: PrimaryOutcomeStatus
+  explicitOutcomeSwitch: boolean
+  explicitRegisteredOutcomeNotReported: boolean
+  structuredFieldCount: number
+  hasOutcomeMetadata: boolean
+}
+
+export type OutcomeMetadataAnalysis = {
+  studies: StudyOutcomeMetadata[]
+  summary: {
+    canonicalStudies: number
+    studiesWithOutcomeMetadata: number
+    studiesWithPrimaryOutcomes: number
+    studiesWithSecondaryOutcomes: number
+    studiesWithRegisteredPrimaryOutcomes: number
+    studiesWithReportedPrimaryOutcomes: number
+    studiesWithRegistryIds: number
+    primaryOutcomeNotMet: number
+    explicitOutcomeSwitches: number
+    explicitRegisteredOutcomeNonReporting: number
+  }
+}
+
+const PRIMARY_FIELDS = ['primaryOutcome', 'primaryOutcomes'] as const
+const SECONDARY_FIELDS = ['secondaryOutcome', 'secondaryOutcomes'] as const
+const REGISTERED_PRIMARY_FIELDS = [
+  'registeredPrimaryOutcome',
+  'registeredPrimaryOutcomes',
+  'prespecifiedPrimaryOutcome',
+  'prespecifiedPrimaryOutcomes',
+  'preSpecifiedPrimaryOutcome',
+  'preSpecifiedPrimaryOutcomes',
+  'protocolPrimaryOutcome',
+  'protocolPrimaryOutcomes',
+] as const
+const REPORTED_PRIMARY_FIELDS = ['reportedPrimaryOutcome', 'reportedPrimaryOutcomes'] as const
+const STATUS_FIELDS = ['primaryOutcomeStatus', 'outcomeStatus'] as const
+const SWITCH_FIELDS = ['outcomeSwitch', 'outcomeSwitched', 'primaryOutcomeChanged'] as const
+const NON_REPORTING_FIELDS = ['registeredOutcomeNotReported', 'prespecifiedOutcomeNotReported'] as const
+
+const PRIMARY_NOT_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was not met|not met|failed to meet|did not meet|no significant|not statistically significant|non[- ]significant)\b/i
+const PRIMARY_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was met|met the|statistically significant|significantly (?:improved|reduced|increased|decreased)|favou?r(?:ed|s)|superior)\b/i
+const OUTCOME_SWITCH_TEXT = /\b(outcome switch(?:ing|ed)?|switched (?:the )?(?:primary )?(?:outcome|endpoint)|changed (?:the )?(?:primary )?(?:outcome|endpoint)|primary outcome (?:was )?changed|deviation from (?:the )?(?:registered|prespecified|protocol[- ]specified) outcome)\b/i
+const OUTCOME_NOT_REPORTED_TEXT = /\b(?:registered|prespecified|pre[- ]specified|protocol[- ]specified) (?:primary )?(?:outcome|endpoint)[^.]{0,140}(?:not reported|was not reported|unreported|omitted)\b/i
+
+function text(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === 'string') return value.split(/[;\n|]+/).map(text).filter(Boolean)
+  if (Array.isArray(value)) return value.flatMap(stringValues)
+  return []
+}
+
+function booleanValue(value: unknown): boolean {
+  if (value === true) return true
+  return /^(?:true|yes|1|changed|switched|not[- ]?reported)$/i.test(text(value))
+}
+
+function sourceAndCacheRecords(source: ResearchSource, cache: PubmedCache): Record<string, unknown>[] {
+  const pmid = text(source.pmid ?? source.pubmedId)
+  return [source, ...(pmid && cache[pmid] ? [cache[pmid]] : [])]
+}
+
+function valuesForFields(group: ResearchSource[], cache: PubmedCache, fields: readonly string[]): string[] {
+  const values = group.flatMap((source) => sourceAndCacheRecords(source, cache))
+    .flatMap((record) => fields.flatMap((field) => stringValues(record[field])))
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b))
+}
+
+function anyBooleanField(group: ResearchSource[], cache: PubmedCache, fields: readonly string[]): boolean {
+  return group.flatMap((source) => sourceAndCacheRecords(source, cache))
+    .some((record) => fields.some((field) => booleanValue(record[field])))
+}
+
+function explicitStructuredFieldCount(group: ResearchSource[], cache: PubmedCache): number {
+  const fields = [
+    ...PRIMARY_FIELDS,
+    ...SECONDARY_FIELDS,
+    ...REGISTERED_PRIMARY_FIELDS,
+    ...REPORTED_PRIMARY_FIELDS,
+    ...STATUS_FIELDS,
+    ...SWITCH_FIELDS,
+    ...NON_REPORTING_FIELDS,
+  ]
+  return group.flatMap((source) => sourceAndCacheRecords(source, cache))
+    .reduce((sum, record) => sum + fields.filter((field) => {
+      const value = record[field]
+      return Array.isArray(value) ? value.length > 0 : text(value).length > 0
+    }).length, 0)
+}
+
+function normalizedStatus(group: ResearchSource[], cache: PubmedCache): PrimaryOutcomeStatus {
+  const explicit = valuesForFields(group, cache, STATUS_FIELDS).map((value) => value.toLowerCase())
+  const explicitMet = explicit.some((value) => /^(?:met|positive|significant|benefit)$/.test(value))
+  const explicitNotMet = explicit.some((value) => /^(?:not[- ]?met|null|negative|non[- ]?significant|nonsignificant)$/.test(value))
+  if (explicitMet && explicitNotMet) return 'mixed'
+  if (explicitNotMet) return 'not-met'
+  if (explicitMet) return 'met'
+
+  const evidenceText = group.map((source) => researchSourceEvidenceText(source, cache)).filter(Boolean).join(' · ')
+  const textMet = PRIMARY_MET_TEXT.test(evidenceText)
+  const textNotMet = PRIMARY_NOT_MET_TEXT.test(evidenceText)
+  if (textMet && textNotMet) return 'mixed'
+  if (textNotMet) return 'not-met'
+  if (textMet) return 'met'
+  return 'unknown'
+}
+
+/**
+ * Build one canonical outcome-hierarchy record per canonical publication.
+ * Explicit structured outcome names are preserved; prose is used only for
+ * conservative status/switch/non-reporting flags, never to manufacture outcome
+ * labels that are not present in structured metadata.
+ */
+export function analyzeOutcomeMetadata(input: {
+  analysis: ResearchQualityAnalysis
+  trialRegistrationIndependence: TrialRegistrationIndependenceAnalysis
+}): OutcomeMetadataAnalysis {
+  const { analysis, trialRegistrationIndependence } = input
+  const registryByStudy = new Map(
+    trialRegistrationIndependence.studies.map((study) => [`${study.url}::${study.studyId}`, study.registryIds]),
+  )
+  const studies: StudyOutcomeMetadata[] = []
+
+  for (const { url, record } of analysis.profiles) {
+    for (const [studyId, group] of canonicalStudyGroups(record)) {
+      const primaryOutcomes = valuesForFields(group, analysis.cache, PRIMARY_FIELDS)
+      const secondaryOutcomes = valuesForFields(group, analysis.cache, SECONDARY_FIELDS)
+      const registeredPrimaryOutcomes = valuesForFields(group, analysis.cache, REGISTERED_PRIMARY_FIELDS)
+      const reportedPrimaryOutcomes = valuesForFields(group, analysis.cache, REPORTED_PRIMARY_FIELDS)
+      const evidenceText = group.map((source) => researchSourceEvidenceText(source, analysis.cache)).filter(Boolean).join(' · ')
+      const explicitOutcomeSwitch = anyBooleanField(group, analysis.cache, SWITCH_FIELDS) || OUTCOME_SWITCH_TEXT.test(evidenceText)
+      const explicitRegisteredOutcomeNotReported = anyBooleanField(group, analysis.cache, NON_REPORTING_FIELDS)
+        || OUTCOME_NOT_REPORTED_TEXT.test(evidenceText)
+      const primaryOutcomeStatus = normalizedStatus(group, analysis.cache)
+      const structuredFieldCount = explicitStructuredFieldCount(group, analysis.cache)
+      const trialRegistrationIds = registryByStudy.get(`${url}::${studyId}`) ?? []
+      const hasOutcomeMetadata = structuredFieldCount > 0
+        || primaryOutcomeStatus !== 'unknown'
+        || explicitOutcomeSwitch
+        || explicitRegisteredOutcomeNotReported
+
+      studies.push({
+        url,
+        studyId,
+        trialRegistrationIds,
+        primaryOutcomes,
+        secondaryOutcomes,
+        registeredPrimaryOutcomes,
+        reportedPrimaryOutcomes,
+        primaryOutcomeStatus,
+        explicitOutcomeSwitch,
+        explicitRegisteredOutcomeNotReported,
+        structuredFieldCount,
+        hasOutcomeMetadata,
+      })
+    }
+  }
+
+  studies.sort((a, b) => a.url.localeCompare(b.url) || a.studyId.localeCompare(b.studyId))
+  return {
+    studies,
+    summary: {
+      canonicalStudies: studies.length,
+      studiesWithOutcomeMetadata: studies.filter((study) => study.hasOutcomeMetadata).length,
+      studiesWithPrimaryOutcomes: studies.filter((study) => study.primaryOutcomes.length > 0).length,
+      studiesWithSecondaryOutcomes: studies.filter((study) => study.secondaryOutcomes.length > 0).length,
+      studiesWithRegisteredPrimaryOutcomes: studies.filter((study) => study.registeredPrimaryOutcomes.length > 0).length,
+      studiesWithReportedPrimaryOutcomes: studies.filter((study) => study.reportedPrimaryOutcomes.length > 0).length,
+      studiesWithRegistryIds: studies.filter((study) => study.trialRegistrationIds.length > 0).length,
+      primaryOutcomeNotMet: studies.filter((study) => study.primaryOutcomeStatus === 'not-met').length,
+      explicitOutcomeSwitches: studies.filter((study) => study.explicitOutcomeSwitch).length,
+      explicitRegisteredOutcomeNonReporting: studies.filter((study) => study.explicitRegisteredOutcomeNotReported).length,
+    },
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -12,6 +12,7 @@ import { analyzeEvidenceIndependenceCoverage } from './research-evidence-indepen
 import { analyzeEvidenceLineage } from './research-evidence-lineage'
 import { analyzeClaimEvidenceAge, analyzeStudyYearConflicts, summarizeEvidenceAge } from './research-evidence-age'
 import { buildResearchMetadataIntegrity } from './research-metadata-integrity'
+import { analyzeOutcomeMetadata } from './research-outcome-metadata'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
@@ -66,6 +67,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     (claim) => claim.highConfidenceProvenanceNarrowMultiStudySupport,
   )
   const trialRegistrationIndependence = analyzeTrialRegistrationIndependence(analysis)
+  const outcomeMetadata = analyzeOutcomeMetadata({ analysis, trialRegistrationIndependence })
   const evidenceLineage = analyzeEvidenceLineage(analysis)
   const evidenceIndependenceCoverage = analyzeEvidenceIndependenceCoverage({
     trialRegistrationIndependence,
@@ -119,6 +121,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     provenanceNarrowMultiStudyClaims,
     highConfidenceProvenanceNarrowMultiStudyClaims,
     trialRegistrationIndependence,
+    outcomeMetadata,
     evidenceLineage,
     evidenceIndependenceCoverage,
     underlyingStudyIndependence,


### PR DESCRIPTION
Adds one canonical study-level outcome metadata product keyed to existing canonical publication identities and normalized trial registration. Explicit primary/secondary/registered/reported outcome fields are preserved; prose is used only for conservative primary-status, outcome-switch, and registered-outcome-nonreporting flags. Missing metadata remains unknown. Adds the product to the canonical research topology with regression coverage for alias collapse and sparse metadata.