### PR TITLE
fix(research): count ambiguous registry metadata as covered

### DIFF
--- a/lib/__tests__/research-underlying-study-global-counts.test.ts
+++ b/lib/__tests__/research-underlying-study-global-counts.test.ts
@@ -99,4 +99,41 @@ describe('global underlying-study identity', () => {
       globalPrimaryHumanIndependenceMetadataCoverage: 0.5,
     })
   })
+
+  it('counts ambiguous registry evidence as metadata without collapsing publications', () => {
+    const analysis = fixtureAnalysis()
+    const firstStudyId = [...canonicalStudyGroups(analysis.profiles[0].record).keys()][0]
+
+    const result = analyzeUnderlyingStudyIndependence({
+      analysis,
+      trialRegistrationIndependence: {
+        studies: [
+          {
+            url: '/herbs/first/',
+            studyId: firstStudyId,
+            registryIds: ['NCT01234567', 'ISRCTN12345678'],
+            stableRegistryId: null,
+            ambiguous: true,
+          },
+        ],
+        claims: [],
+      } as never,
+      evidenceLineage: { studies: [], claims: [] } as never,
+    })
+
+    expect(result.summary).toMatchObject({
+      globalInventoryPublicationCount: 2,
+      globalInventoryUnderlyingStudyCount: 2,
+      globalCollapsedInventoryPublicationCount: 0,
+      globalInventoryPublicationsWithIndependenceMetadata: 1,
+      globalInventoryPublicationsWithoutIndependenceMetadata: 1,
+      globalInventoryIndependenceMetadataCoverage: 0.5,
+      globalPrimaryHumanPublicationCount: 2,
+      globalPrimaryHumanUnderlyingStudyCount: 2,
+      globalCollapsedPrimaryHumanPublicationCount: 0,
+      globalPrimaryHumanPublicationsWithIndependenceMetadata: 1,
+      globalPrimaryHumanPublicationsWithoutIndependenceMetadata: 1,
+      globalPrimaryHumanIndependenceMetadataCoverage: 0.5,
+    })
+  })
 })

--- a/lib/research-underlying-study-independence.ts
+++ b/lib/research-underlying-study-independence.ts
@@ -231,8 +231,9 @@ function buildProfileUnions(inputs: UnderlyingStudyIndependenceInputs): Map<stri
  * registry/cohort/dataset/parent-study identifiers establish underlying-study
  * dependence across those publications. Metadata coverage is measured on the
  * same unique-publication denominator as these global counts. A publication is
- * considered covered only when explicit study-lineage metadata exists; DOI/PMID
- * identity alone does not count as independence metadata.
+ * considered covered when explicit registry or study-lineage metadata exists;
+ * ambiguous registry evidence counts as metadata but never authorizes collapse.
+ * DOI/PMID identity alone does not count as independence metadata.
  */
 function buildGlobalInventoryIndependence(
   inputs: UnderlyingStudyIndependenceInputs,
@@ -255,10 +256,12 @@ function buildGlobalInventoryIndependence(
   const explicitMetadataPublicationIds = new Set<string>()
   const registryGroups = new Map<string, string[]>()
   for (const study of inputs.trialRegistrationIndependence.studies ?? []) {
-    if (!study.stableRegistryId) continue
     const globalStudyId = crossProfileStudyIdentity(study.url, study.studyId, identities)
     if (!publicationIds.has(globalStudyId)) continue
-    explicitMetadataPublicationIds.add(globalStudyId)
+    if (study.stableRegistryId || study.registryIds?.length) {
+      explicitMetadataPublicationIds.add(globalStudyId)
+    }
+    if (!study.stableRegistryId) continue
     const group = registryGroups.get(study.stableRegistryId) ?? []
     group.push(globalStudyId)
     registryGroups.set(study.stableRegistryId, group)


### PR DESCRIPTION
## Summary
- treats explicit but conflicting registry IDs as independence metadata coverage
- preserves conservative collapse semantics: ambiguous registry evidence never collapses publications
- adds a regression test proving metadata coverage can increase without reducing underlying-study count

## Why
The new site-wide independence coverage metric previously counted ambiguous registry evidence as if no metadata existed because it only marked publications with a `stableRegistryId` as covered. That under-reported metadata coverage and conflated `metadata absent` with `metadata present but unresolved`.

## Regression contract
- stable registry IDs still establish eligible registry groups
- ambiguous registry IDs count as explicit metadata only
- ambiguous evidence cannot merge publication identities
- synthetic callers that provide only `stableRegistryId` remain compatible