### PR TITLE
feat(research): prioritize profile independence metadata gaps

### DIFF
--- a/lib/__tests__/research-quality-policy-topology-signals.test.ts
+++ b/lib/__tests__/research-quality-policy-topology-signals.test.ts
@@ -36,6 +36,8 @@ function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopol
     narrowCrossProfileEvidenceBundles: [],
     semanticAlignment: { findings: [], concentrationFindings: [], coverageGapFindings: [] },
     claimBreadth: { findings: [] },
+    effectCertainty: { findings: [] },
+    directionalConsistency: { findings: [] },
     claimLanguageCalibration: { directEvidenceFindings: [] },
     claimCitationMetadata: { lowCoverageClaims: [] },
     metadataIntegrity: { profiles: [] },
@@ -43,7 +45,7 @@ function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopol
     edgeCardinality: { pseudoMultiSourceClaims: [] },
     trialRegistrationIndependence: { sameTrialReuseClaims: [] },
     evidenceLineage: { sharedNonRegistryLineageClaims: [] },
-    underlyingStudyIndependence: { reducedClaims: [] },
+    underlyingStudyIndependence: { reducedClaims: [], profiles: [], newlyOverDependentProfiles: [] },
     evidenceIndependenceCoverage: { unresolvedClaims: [] },
     studyClassConflicts: { conflicts: [], severeConflicts: [] },
     ...overrides,
@@ -121,6 +123,8 @@ describe('aggregated topology gap signals', () => {
             highConfidencePseudoMultiStudySupport: true,
           },
         ],
+        profiles: [],
+        newlyOverDependentProfiles: [],
       },
     }), weights)
 
@@ -132,6 +136,73 @@ describe('aggregated topology gap signals', () => {
     expect(reuse[0].detail).toContain('1 claim(s) reduce to one underlying study')
     expect(reuse[0].detail).toContain('1 high-confidence pseudo-multi-study')
     expect(reuse[0].detail).toContain('minimum adjusted count 1')
+  })
+
+  it('prioritizes low primary-human inventory independence coverage without approved multi-study claims', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      underlyingStudyIndependence: {
+        reducedClaims: [],
+        newlyOverDependentProfiles: [],
+        profiles: [{
+          url: '/herbs/a/',
+          primaryHumanPublicationCount: 2,
+          primaryHumanPublicationsWithoutIndependenceMetadata: 1,
+          primaryHumanIndependenceMetadataCoverage: 0.5,
+        }],
+      },
+    }), weights)
+
+    const independence = signals.filter((signal) => signal.kind === 'evidence-independence-metadata-gap')
+    expect(independence).toHaveLength(1)
+    expect(independence[0]).toMatchObject({ url: '/herbs/a/', weight: 9 })
+    expect(independence[0].detail).toContain('1 of 2 primary-human inventory publication(s) lack explicit')
+    expect(independence[0].detail).toContain('profile coverage 50%')
+  })
+
+  it('combines claim-level and inventory-level independence gaps into one profile signal', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      underlyingStudyIndependence: {
+        reducedClaims: [],
+        newlyOverDependentProfiles: [],
+        profiles: [{
+          url: '/herbs/a/',
+          primaryHumanPublicationCount: 3,
+          primaryHumanPublicationsWithoutIndependenceMetadata: 2,
+          primaryHumanIndependenceMetadataCoverage: 0.333,
+        }],
+      },
+      evidenceIndependenceCoverage: {
+        unresolvedClaims: [{
+          url: '/herbs/a/',
+          highConfidenceIndependenceUnresolved: true,
+          unresolvedStudyCount: 1,
+          combinedCoverage: 0.5,
+        }],
+      },
+    }), weights)
+
+    const independence = signals.filter((signal) => signal.kind === 'evidence-independence-metadata-gap')
+    expect(independence).toHaveLength(1)
+    expect(independence[0]).toMatchObject({ url: '/herbs/a/', weight: 17 })
+    expect(independence[0].detail).toContain('1 approved multi-study claim(s) have unresolved independence')
+    expect(independence[0].detail).toContain('2 of 3 primary-human inventory publication(s) lack explicit')
+  })
+
+  it('does not create an inventory independence gap for a single primary-human publication', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      underlyingStudyIndependence: {
+        reducedClaims: [],
+        newlyOverDependentProfiles: [],
+        profiles: [{
+          url: '/herbs/a/',
+          primaryHumanPublicationCount: 1,
+          primaryHumanPublicationsWithoutIndependenceMetadata: 1,
+          primaryHumanIndependenceMetadataCoverage: 0,
+        }],
+      },
+    }), weights)
+
+    expect(signals.some((signal) => signal.kind === 'evidence-independence-metadata-gap')).toBe(false)
   })
 
   it('aggregates advisory metadata once while leaving severe class conflicts structural', () => {

--- a/lib/__tests__/research-underlying-human-counts.test.ts
+++ b/lib/__tests__/research-underlying-human-counts.test.ts
@@ -52,17 +52,48 @@ describe('underlying primary-human inventory counts', () => {
       inventoryPublicationStudyCount: 3,
       inventoryUnderlyingStudyCount: 2,
       inventoryCollapsedPublicationCount: 1,
+      inventoryPublicationsWithIndependenceMetadata: 2,
+      inventoryPublicationsWithoutIndependenceMetadata: 1,
+      inventoryIndependenceMetadataCoverage: 0.667,
       primaryHumanPublicationCount: 2,
       primaryHumanUnderlyingStudyCount: 1,
       collapsedPrimaryHumanPublicationCount: 1,
+      primaryHumanPublicationsWithIndependenceMetadata: 2,
+      primaryHumanPublicationsWithoutIndependenceMetadata: 0,
+      primaryHumanIndependenceMetadataCoverage: 1,
     })
     expect(result.summary).toMatchObject({
       profilesAnalyzed: 1,
       profilesWithSupportedClaims: 0,
       profilesWithReducedHumanStudyCount: 1,
+      profilesWithIncompletePrimaryHumanIndependenceMetadata: 0,
       primaryHumanPublicationCount: 2,
       primaryHumanUnderlyingStudyCount: 1,
       collapsedPrimaryHumanPublicationCount: 1,
     })
+  })
+
+  it('tracks primary-human lineage gaps even when evidence is not linked to approved claims', () => {
+    const analysis = fixtureAnalysis()
+    const studyIds = [...canonicalStudyGroups(analysis.profiles[0].record).keys()]
+    const first = studyIds.find((studyId) => studyId.includes('11111111')) as string
+
+    const result = analyzeUnderlyingStudyIndependence({
+      analysis,
+      trialRegistrationIndependence: {
+        studies: [{ url: '/herbs/example/', studyId: first, stableRegistryId: 'NCT01234567' }],
+        claims: [],
+      } as never,
+      evidenceLineage: { studies: [], claims: [] } as never,
+    })
+
+    expect(result.profiles[0]).toMatchObject({
+      supportedApprovedClaimCount: 0,
+      primaryHumanPublicationCount: 2,
+      primaryHumanPublicationsWithIndependenceMetadata: 1,
+      primaryHumanPublicationsWithoutIndependenceMetadata: 1,
+      primaryHumanIndependenceMetadataCoverage: 0.5,
+    })
+    expect(result.summary.profilesWithIncompletePrimaryHumanIndependenceMetadata).toBe(1)
   })
 })

--- a/lib/__tests__/research-underlying-study-full-inventory-invariants.test.ts
+++ b/lib/__tests__/research-underlying-study-full-inventory-invariants.test.ts
@@ -23,9 +23,15 @@ function fixture() {
     inventoryPublicationStudyCount: 2,
     inventoryUnderlyingStudyCount: 1,
     inventoryCollapsedPublicationCount: 1,
+    inventoryPublicationsWithIndependenceMetadata: 2,
+    inventoryPublicationsWithoutIndependenceMetadata: 0,
+    inventoryIndependenceMetadataCoverage: 1,
     primaryHumanPublicationCount: 2,
     primaryHumanUnderlyingStudyCount: 1,
     collapsedPrimaryHumanPublicationCount: 1,
+    primaryHumanPublicationsWithIndependenceMetadata: 2,
+    primaryHumanPublicationsWithoutIndependenceMetadata: 0,
+    primaryHumanIndependenceMetadataCoverage: 1,
     mostUsedUnderlyingStudyId: null,
     mostUsedUnderlyingStudyClaimCount: 0,
     dominantUnderlyingStudySupportedClaimShare: 0,
@@ -55,6 +61,7 @@ function fixture() {
         profilesWithSupportedClaims: 0,
         profilesWithReducedStudyCount: 1,
         profilesWithReducedHumanStudyCount: 1,
+        profilesWithIncompletePrimaryHumanIndependenceMetadata: 0,
         primaryHumanPublicationCount: 2,
         primaryHumanUnderlyingStudyCount: 1,
         collapsedPrimaryHumanPublicationCount: 1,
@@ -97,5 +104,13 @@ describe('underlying-study full-inventory snapshot invariants', () => {
     topology.underlyingStudyIndependence.profiles[0].collapsedPrimaryHumanPublicationCount = 0
     const failures = validateUnderlyingStudySnapshotInvariants(analysis, topology)
     expect(failures.map((failure) => failure.kind)).toContain('underlying-study-primary-human-collapse-mismatch')
+  })
+
+  it('detects profile independence metadata coverage drift', () => {
+    const { analysis, topology } = fixture()
+    topology.underlyingStudyIndependence.profiles[0].primaryHumanPublicationsWithIndependenceMetadata = 1
+    const kinds = validateUnderlyingStudySnapshotInvariants(analysis, topology).map((failure) => failure.kind)
+    expect(kinds).toContain('underlying-study-profile-primary-human-metadata-gap-mismatch')
+    expect(kinds).toContain('underlying-study-profile-primary-human-metadata-coverage-mismatch')
   })
 })

--- a/lib/__tests__/research-underlying-study-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-underlying-study-snapshot-invariants.test.ts
@@ -45,9 +45,15 @@ function fixtures() {
     inventoryPublicationStudyCount: 2,
     inventoryUnderlyingStudyCount: 1,
     inventoryCollapsedPublicationCount: 1,
+    inventoryPublicationsWithIndependenceMetadata: 2,
+    inventoryPublicationsWithoutIndependenceMetadata: 0,
+    inventoryIndependenceMetadataCoverage: 1,
     primaryHumanPublicationCount: 2,
     primaryHumanUnderlyingStudyCount: 1,
     collapsedPrimaryHumanPublicationCount: 1,
+    primaryHumanPublicationsWithIndependenceMetadata: 2,
+    primaryHumanPublicationsWithoutIndependenceMetadata: 0,
+    primaryHumanIndependenceMetadataCoverage: 1,
     mostUsedUnderlyingStudyId: 'a',
     mostUsedUnderlyingStudyClaimCount: 1,
     dominantUnderlyingStudySupportedClaimShare: 1,
@@ -76,6 +82,7 @@ function fixtures() {
         profilesWithSupportedClaims: 1,
         profilesWithReducedStudyCount: 1,
         profilesWithReducedHumanStudyCount: 1,
+        profilesWithIncompletePrimaryHumanIndependenceMetadata: 0,
         primaryHumanPublicationCount: 2,
         primaryHumanUnderlyingStudyCount: 1,
         collapsedPrimaryHumanPublicationCount: 1,
@@ -145,5 +152,12 @@ describe('underlying-study snapshot invariants', () => {
     const kinds = validateUnderlyingStudySnapshotInvariants(analysis, topology).map((failure) => failure.kind)
     expect(kinds).toContain('underlying-study-global-primary-human-metadata-gap-mismatch')
     expect(kinds).toContain('underlying-study-global-primary-human-metadata-coverage-mismatch')
+  })
+
+  it('rejects incomplete-profile summary drift', () => {
+    const { analysis, topology } = fixtures()
+    topology.underlyingStudyIndependence.summary.profilesWithIncompletePrimaryHumanIndependenceMetadata = 1
+    const kinds = validateUnderlyingStudySnapshotInvariants(analysis, topology).map((failure) => failure.kind)
+    expect(kinds).toContain('underlying-study-incomplete-primary-human-metadata-profile-count-mismatch')
   })
 })

--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -73,11 +73,6 @@ export function buildAggregatedTopologyGapSignals(
     })
   }
 
-  // Explicit alignment mismatch, claim-breadth overreach, exaggerated effect/
-  // certainty wording, and endpoint/directional inconsistency are four views of
-  // the same editorial root cause: the claim says more than its linked evidence
-  // directly supports. Aggregate them once per profile instead of double-scoring
-  // parallel semantic analyzers.
   const semanticByUrl = new Map<string, {
     explicit: typeof topology.semanticAlignment.findings
     breadth: typeof topology.claimBreadth.findings
@@ -249,17 +244,37 @@ export function buildAggregatedTopologyGapSignals(
     })
   }
 
-  for (const [url, items] of groupByUrl(topology.evidenceIndependenceCoverage.unresolvedClaims)) {
+  const unresolvedByUrl = groupByUrl(topology.evidenceIndependenceCoverage.unresolvedClaims)
+  const profileCoverageByUrl = new Map(
+    topology.underlyingStudyIndependence.profiles
+      .filter((profile) => profile.primaryHumanPublicationCount >= 2 && profile.primaryHumanIndependenceMetadataCoverage < 0.75)
+      .map((profile) => [profile.url, profile] as const),
+  )
+  const independenceGapUrls = new Set([...unresolvedByUrl.keys(), ...profileCoverageByUrl.keys()])
+  for (const url of independenceGapUrls) {
+    const items = unresolvedByUrl.get(url) ?? []
+    const profile = profileCoverageByUrl.get(url)
     const highConfidence = items.filter((item) => item.highConfidenceIndependenceUnresolved).length
     const unresolvedStudies = items.reduce((sum, item) => sum + item.unresolvedStudyCount, 0)
-    const minimumCoverage = Math.min(...items.map((item) => item.combinedCoverage))
+    const missingHumanMetadata = profile?.primaryHumanPublicationsWithoutIndependenceMetadata ?? 0
+    const minimumClaimCoverage = items.length ? Math.min(...items.map((item) => item.combinedCoverage)) : null
+    const profileCoverage = profile?.primaryHumanIndependenceMetadataCoverage ?? null
+    const issueUnits = unresolvedStudies + missingHumanMetadata
+    const details = [
+      items.length
+        ? `${items.length} approved multi-study claim(s) have unresolved independence; ${unresolvedStudies} claim-linked study slot(s) lack explicit lineage; ${highConfidence} high-confidence${minimumClaimCoverage === null ? '' : `; minimum claim coverage ${Math.round(minimumClaimCoverage * 100)}%`}`
+        : '',
+      profile
+        ? `${missingHumanMetadata} of ${profile.primaryHumanPublicationCount} primary-human inventory publication(s) lack explicit registry/cohort/dataset/parent-study metadata; profile coverage ${Math.round((profileCoverage ?? 0) * 100)}%`
+        : '',
+    ].filter(Boolean)
     signals.push({
       url,
       kind: 'evidence-independence-metadata-gap',
       weight: weights.independenceMetadataGap
-        + Math.min(8, Math.max(0, items.length - 1) * 2 + unresolvedStudies)
+        + Math.min(12, Math.max(0, items.length - 1) * 2 + issueUnits)
         + (highConfidence ? weights.highConfidenceIndependenceMetadataBonus : 0),
-      detail: `${items.length} approved multi-study claim(s) have unresolved independence; ${unresolvedStudies} study slot(s) lack explicit registry/cohort/dataset/parent-study lineage; ${highConfidence} high-confidence; minimum explicit coverage ${Math.round(minimumCoverage * 100)}%`,
+      detail: details.join('; '),
     })
   }
 

--- a/lib/research-underlying-study-independence.ts
+++ b/lib/research-underlying-study-independence.ts
@@ -38,9 +38,15 @@ export type ProfileUnderlyingStudyIndependence = {
   inventoryPublicationStudyCount: number
   inventoryUnderlyingStudyCount: number
   inventoryCollapsedPublicationCount: number
+  inventoryPublicationsWithIndependenceMetadata: number
+  inventoryPublicationsWithoutIndependenceMetadata: number
+  inventoryIndependenceMetadataCoverage: number
   primaryHumanPublicationCount: number
   primaryHumanUnderlyingStudyCount: number
   collapsedPrimaryHumanPublicationCount: number
+  primaryHumanPublicationsWithIndependenceMetadata: number
+  primaryHumanPublicationsWithoutIndependenceMetadata: number
+  primaryHumanIndependenceMetadataCoverage: number
   mostUsedUnderlyingStudyId: string | null
   mostUsedUnderlyingStudyClaimCount: number
   dominantUnderlyingStudySupportedClaimShare: number
@@ -69,6 +75,7 @@ export type UnderlyingStudyIndependenceAnalysis = {
     profilesWithSupportedClaims: number
     profilesWithReducedStudyCount: number
     profilesWithReducedHumanStudyCount: number
+    profilesWithIncompletePrimaryHumanIndependenceMetadata: number
     /** Profile-study incidences; a publication reused on two profiles counts twice. */
     primaryHumanPublicationCount: number
     /** Profile-study incidences after profile-local independence adjustment. */
@@ -156,6 +163,29 @@ function addStudy(studyIdsByUrl: Map<string, Set<string>>, url: string, studyId:
   const studies = studyIdsByUrl.get(url) ?? new Set<string>()
   studies.add(studyId)
   studyIdsByUrl.set(url, studies)
+}
+
+function addMetadata(metadataByUrl: Map<string, Set<string>>, url: string, studyId: string) {
+  const studies = metadataByUrl.get(url) ?? new Set<string>()
+  studies.add(studyId)
+  metadataByUrl.set(url, studies)
+}
+
+function buildProfileIndependenceMetadata(inputs: UnderlyingStudyIndependenceInputs): Map<string, Set<string>> {
+  const metadataByUrl = new Map<string, Set<string>>()
+  for (const study of inputs.trialRegistrationIndependence.studies ?? []) {
+    if (study.stableRegistryId) addMetadata(metadataByUrl, study.url, study.studyId)
+  }
+  for (const claim of inputs.trialRegistrationIndependence.claims) {
+    for (const pair of claim.sameRegisteredTrialPairs) {
+      addMetadata(metadataByUrl, claim.url, pair.leftStudyId)
+      addMetadata(metadataByUrl, claim.url, pair.rightStudyId)
+    }
+  }
+  for (const study of inputs.evidenceLineage.studies) {
+    if (study.lineageIds.length) addMetadata(metadataByUrl, study.url, study.studyId)
+  }
+  return metadataByUrl
 }
 
 /**
@@ -265,10 +295,6 @@ function buildGlobalInventoryIndependence(
   }
   unionGroups(union, registryGroups.values())
 
-  // Compatibility path for synthetic/partial callers where claim diagnostics
-  // carry same-trial pairs but the canonical study registry index is absent.
-  // An explicit same-trial pair is also explicit independence metadata for both
-  // referenced publication identities.
   for (const claim of inputs.trialRegistrationIndependence.claims) {
     for (const pair of claim.sameRegisteredTrialPairs) {
       const left = crossProfileStudyIdentity(claim.url, pair.leftStudyId, identities)
@@ -345,6 +371,7 @@ export function analyzeUnderlyingStudyIndependence(
   inputs: UnderlyingStudyIndependenceInputs,
 ): UnderlyingStudyIndependenceAnalysis {
   const unions = buildProfileUnions(inputs)
+  const profileMetadata = buildProfileIndependenceMetadata(inputs)
   const globalInventory = buildGlobalInventoryIndependence(inputs)
   const claims: ClaimUnderlyingStudyIndependence[] = []
 
@@ -417,11 +444,26 @@ export function analyzeUnderlyingStudyIndependence(
     const inventoryGroups = canonicalStudyGroups(record)
     const inventoryPublicationStudyIds = [...inventoryGroups.keys()]
     const union = unions.get(url) ?? createUnion(inventoryPublicationStudyIds)
+    const metadataStudyIds = profileMetadata.get(url) ?? new Set<string>()
     const inventoryUnderlyingStudyIds = [...new Set(inventoryPublicationStudyIds.map((studyId) => union.find(studyId)))]
+    const inventoryPublicationsWithIndependenceMetadata = inventoryPublicationStudyIds.filter((studyId) => metadataStudyIds.has(studyId)).length
+    const inventoryPublicationsWithoutIndependenceMetadata = Math.max(0, inventoryPublicationStudyIds.length - inventoryPublicationsWithIndependenceMetadata)
+    const inventoryIndependenceMetadataCoverage = round(
+      inventoryPublicationStudyIds.length
+        ? inventoryPublicationsWithIndependenceMetadata / inventoryPublicationStudyIds.length
+        : 1,
+    )
     const primaryHumanPublicationIds = [...inventoryGroups.entries()]
       .filter(([, group]) => PRIMARY_HUMAN_STUDY_CLASSES.has(canonicalStudyClass(group, inputs.analysis.cache)))
       .map(([studyId]) => studyId)
     const primaryHumanUnderlyingStudyIds = [...new Set(primaryHumanPublicationIds.map((studyId) => union.find(studyId)))]
+    const primaryHumanPublicationsWithIndependenceMetadata = primaryHumanPublicationIds.filter((studyId) => metadataStudyIds.has(studyId)).length
+    const primaryHumanPublicationsWithoutIndependenceMetadata = Math.max(0, primaryHumanPublicationIds.length - primaryHumanPublicationsWithIndependenceMetadata)
+    const primaryHumanIndependenceMetadataCoverage = round(
+      primaryHumanPublicationIds.length
+        ? primaryHumanPublicationsWithIndependenceMetadata / primaryHumanPublicationIds.length
+        : 1,
+    )
 
     const publicationStudyIds = [...new Set(profileClaims.flatMap((claim) => claim.studyIds))]
     const underlyingStudyIds = [...new Set(publicationStudyIds.map((studyId) => union.find(studyId)))]
@@ -459,9 +501,15 @@ export function analyzeUnderlyingStudyIndependence(
       inventoryPublicationStudyCount: inventoryPublicationStudyIds.length,
       inventoryUnderlyingStudyCount: inventoryUnderlyingStudyIds.length,
       inventoryCollapsedPublicationCount: Math.max(0, inventoryPublicationStudyIds.length - inventoryUnderlyingStudyIds.length),
+      inventoryPublicationsWithIndependenceMetadata,
+      inventoryPublicationsWithoutIndependenceMetadata,
+      inventoryIndependenceMetadataCoverage,
       primaryHumanPublicationCount: primaryHumanPublicationIds.length,
       primaryHumanUnderlyingStudyCount: primaryHumanUnderlyingStudyIds.length,
       collapsedPrimaryHumanPublicationCount: Math.max(0, primaryHumanPublicationIds.length - primaryHumanUnderlyingStudyIds.length),
+      primaryHumanPublicationsWithIndependenceMetadata,
+      primaryHumanPublicationsWithoutIndependenceMetadata,
+      primaryHumanIndependenceMetadataCoverage,
       mostUsedUnderlyingStudyId: mostUsed?.[0] ?? null,
       mostUsedUnderlyingStudyClaimCount,
       dominantUnderlyingStudySupportedClaimShare: round(dominantUnderlyingStudySupportedClaimShare),
@@ -475,6 +523,7 @@ export function analyzeUnderlyingStudyIndependence(
   profiles.sort((a, b) =>
     Number(b.newlyOverDependentAfterIndependenceAdjustment) - Number(a.newlyOverDependentAfterIndependenceAdjustment)
     || Number(b.overDependentOnSingleUnderlyingStudy) - Number(a.overDependentOnSingleUnderlyingStudy)
+    || a.primaryHumanIndependenceMetadataCoverage - b.primaryHumanIndependenceMetadataCoverage
     || b.dominantUnderlyingStudySupportedClaimShare - a.dominantUnderlyingStudySupportedClaimShare
     || a.effectiveUnderlyingStudyCount - b.effectiveUnderlyingStudyCount
     || a.url.localeCompare(b.url),
@@ -500,6 +549,9 @@ export function analyzeUnderlyingStudyIndependence(
       profilesWithSupportedClaims: profiles.filter((profile) => profile.supportedApprovedClaimCount > 0).length,
       profilesWithReducedStudyCount: profiles.filter((profile) => profile.inventoryCollapsedPublicationCount > 0).length,
       profilesWithReducedHumanStudyCount: profiles.filter((profile) => profile.collapsedPrimaryHumanPublicationCount > 0).length,
+      profilesWithIncompletePrimaryHumanIndependenceMetadata: profiles.filter(
+        (profile) => profile.primaryHumanPublicationCount >= 2 && profile.primaryHumanIndependenceMetadataCoverage < 1,
+      ).length,
       primaryHumanPublicationCount: profiles.reduce((sum, profile) => sum + profile.primaryHumanPublicationCount, 0),
       primaryHumanUnderlyingStudyCount: profiles.reduce((sum, profile) => sum + profile.primaryHumanUnderlyingStudyCount, 0),
       collapsedPrimaryHumanPublicationCount: profiles.reduce((sum, profile) => sum + profile.collapsedPrimaryHumanPublicationCount, 0),

--- a/lib/research-underlying-study-snapshot-invariants.ts
+++ b/lib/research-underlying-study-snapshot-invariants.ts
@@ -136,6 +136,12 @@ export function validateUnderlyingStudySnapshotInvariants(
   if (product.summary.profilesWithReducedHumanStudyCount !== reducedHumanProfiles) {
     add('underlying-study-reduced-human-profile-count-mismatch', `summary=${product.summary.profilesWithReducedHumanStudyCount}; computed=${reducedHumanProfiles}`)
   }
+  const incompletePrimaryHumanMetadataProfiles = product.profiles.filter(
+    (profile) => profile.primaryHumanPublicationCount >= 2 && profile.primaryHumanIndependenceMetadataCoverage < 1,
+  ).length
+  if (product.summary.profilesWithIncompletePrimaryHumanIndependenceMetadata !== incompletePrimaryHumanMetadataProfiles) {
+    add('underlying-study-incomplete-primary-human-metadata-profile-count-mismatch', `summary=${product.summary.profilesWithIncompletePrimaryHumanIndependenceMetadata}; computed=${incompletePrimaryHumanMetadataProfiles}`)
+  }
   const primaryHumanPublicationCount = product.profiles.reduce((sum, profile) => sum + profile.primaryHumanPublicationCount, 0)
   if (product.summary.primaryHumanPublicationCount !== primaryHumanPublicationCount) {
     add('underlying-study-primary-human-publication-count-mismatch', `summary=${product.summary.primaryHumanPublicationCount}; computed=${primaryHumanPublicationCount}`)
@@ -269,12 +275,59 @@ export function validateUnderlyingStudySnapshotInvariants(
       add('underlying-study-inventory-collapse-mismatch', `${profile.url}: rows=${profile.inventoryCollapsedPublicationCount}; expected=${expectedInventoryCollapsed}`)
     }
 
+    const expectedInventoryWithoutMetadata = Math.max(
+      0,
+      profile.inventoryPublicationStudyCount - profile.inventoryPublicationsWithIndependenceMetadata,
+    )
+    if (
+      profile.inventoryPublicationsWithIndependenceMetadata < 0
+      || profile.inventoryPublicationsWithIndependenceMetadata > profile.inventoryPublicationStudyCount
+    ) {
+      add('underlying-study-profile-inventory-metadata-exceeds-publications', `${profile.url}: metadata=${profile.inventoryPublicationsWithIndependenceMetadata}; publications=${profile.inventoryPublicationStudyCount}`)
+    }
+    if (profile.inventoryPublicationsWithoutIndependenceMetadata !== expectedInventoryWithoutMetadata) {
+      add('underlying-study-profile-inventory-metadata-gap-mismatch', `${profile.url}: rows=${profile.inventoryPublicationsWithoutIndependenceMetadata}; expected=${expectedInventoryWithoutMetadata}`)
+    }
+    const expectedInventoryMetadataCoverage = round(
+      profile.inventoryPublicationStudyCount
+        ? profile.inventoryPublicationsWithIndependenceMetadata / profile.inventoryPublicationStudyCount
+        : 1,
+    )
+    if (profile.inventoryIndependenceMetadataCoverage !== expectedInventoryMetadataCoverage) {
+      add('underlying-study-profile-inventory-metadata-coverage-mismatch', `${profile.url}: rows=${profile.inventoryIndependenceMetadataCoverage}; expected=${expectedInventoryMetadataCoverage}`)
+    }
+
     if (!validAdjustedCount(profile.primaryHumanPublicationCount, profile.primaryHumanUnderlyingStudyCount)) {
       add('underlying-study-invalid-primary-human-adjusted-count', `${profile.url}: publication=${profile.primaryHumanPublicationCount}; underlying=${profile.primaryHumanUnderlyingStudyCount}`)
     }
     const expectedPrimaryHumanCollapsed = Math.max(0, profile.primaryHumanPublicationCount - profile.primaryHumanUnderlyingStudyCount)
     if (profile.collapsedPrimaryHumanPublicationCount !== expectedPrimaryHumanCollapsed) {
       add('underlying-study-primary-human-collapse-mismatch', `${profile.url}: rows=${profile.collapsedPrimaryHumanPublicationCount}; expected=${expectedPrimaryHumanCollapsed}`)
+    }
+
+    const expectedPrimaryHumanWithoutMetadata = Math.max(
+      0,
+      profile.primaryHumanPublicationCount - profile.primaryHumanPublicationsWithIndependenceMetadata,
+    )
+    if (
+      profile.primaryHumanPublicationsWithIndependenceMetadata < 0
+      || profile.primaryHumanPublicationsWithIndependenceMetadata > profile.primaryHumanPublicationCount
+    ) {
+      add('underlying-study-profile-primary-human-metadata-exceeds-publications', `${profile.url}: metadata=${profile.primaryHumanPublicationsWithIndependenceMetadata}; publications=${profile.primaryHumanPublicationCount}`)
+    }
+    if (profile.primaryHumanPublicationsWithoutIndependenceMetadata !== expectedPrimaryHumanWithoutMetadata) {
+      add('underlying-study-profile-primary-human-metadata-gap-mismatch', `${profile.url}: rows=${profile.primaryHumanPublicationsWithoutIndependenceMetadata}; expected=${expectedPrimaryHumanWithoutMetadata}`)
+    }
+    const expectedPrimaryHumanMetadataCoverage = round(
+      profile.primaryHumanPublicationCount
+        ? profile.primaryHumanPublicationsWithIndependenceMetadata / profile.primaryHumanPublicationCount
+        : 1,
+    )
+    if (profile.primaryHumanIndependenceMetadataCoverage !== expectedPrimaryHumanMetadataCoverage) {
+      add('underlying-study-profile-primary-human-metadata-coverage-mismatch', `${profile.url}: rows=${profile.primaryHumanIndependenceMetadataCoverage}; expected=${expectedPrimaryHumanMetadataCoverage}`)
+    }
+    if (profile.primaryHumanPublicationsWithIndependenceMetadata > profile.inventoryPublicationsWithIndependenceMetadata) {
+      add('underlying-study-profile-primary-human-metadata-exceeds-inventory-metadata', `${profile.url}: human=${profile.primaryHumanPublicationsWithIndependenceMetadata}; inventory=${profile.inventoryPublicationsWithIndependenceMetadata}`)
     }
 
     if (profile.newlyOverDependentAfterIndependenceAdjustment !== (profile.overDependentOnSingleUnderlyingStudy && !source.overDependentOnSingleStudy)) {


### PR DESCRIPTION
Adds profile-level primary-human independence metadata coverage to the canonical underlying-study analysis and folds low-coverage profiles into the existing evidence-independence-metadata-gap remediation signal. Inventory and claim-level gaps are aggregated once per profile. Includes full-inventory coverage, snapshot invariants, unmapped-evidence regressions, and queue tests.