### PR TITLE
refactor(research): route selective reporting through canonical outcomes

### DIFF
--- a/lib/__tests__/research-selective-outcome-reporting.test.ts
+++ b/lib/__tests__/research-selective-outcome-reporting.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+import { analyzeOutcomeMetadata } from '@/lib/research-outcome-metadata'
 import { analyzeSelectiveOutcomeReporting } from '@/lib/research-selective-outcome-reporting'
+import { analyzeTrialRegistrationIndependence } from '@/lib/research-trial-registration-independence'
 import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
 
 function analysis(abstracts: string[], confidence = 0.8): ResearchQualityAnalysis {
@@ -33,43 +35,50 @@ function analysis(abstracts: string[], confidence = 0.8): ResearchQualityAnalysi
   } as unknown as ResearchQualityAnalysis
 }
 
+function report(abstracts: string[], confidence = 0.8) {
+  const input = analysis(abstracts, confidence)
+  const trialRegistrationIndependence = analyzeTrialRegistrationIndependence(input)
+  const outcomeMetadata = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+  return analyzeSelectiveOutcomeReporting({ analysis: input, outcomeMetadata })
+}
+
 describe('selective outcome reporting', () => {
   it('flags favorable secondary evidence when a prespecified primary outcome is explicitly null', () => {
-    const report = analyzeSelectiveOutcomeReporting(analysis([
+    const result = report([
       'The prespecified primary outcome showed no significant difference. A secondary endpoint significantly improved versus placebo.',
-    ]))
+    ])
 
-    expect(report.summary.selectiveOutcomeRisks).toBe(1)
-    expect(report.findings[0]).toMatchObject({
+    expect(result.summary.selectiveOutcomeRisks).toBe(1)
+    expect(result.findings[0]).toMatchObject({
       selectiveOutcomeRisk: true,
       explicitOutcomeSwitchRisk: false,
     })
   })
 
   it('flags explicit outcome switching or non-reporting of registered outcomes', () => {
-    const report = analyzeSelectiveOutcomeReporting(analysis([
+    const result = report([
       'The primary outcome was changed after trial registration and the registered outcome was not reported.',
-    ]))
+    ])
 
-    expect(report.summary.explicitOutcomeSwitchRisks).toBe(1)
-    expect(report.findings[0].explicitOutcomeSwitchRisk).toBe(true)
+    expect(result.summary.explicitOutcomeSwitchRisks).toBe(1)
+    expect(result.findings[0].explicitOutcomeSwitchRisk).toBe(true)
   })
 
   it('does not call a clean prespecified positive primary outcome selective reporting', () => {
-    const report = analyzeSelectiveOutcomeReporting(analysis([
+    const result = report([
       'The prespecified primary endpoint significantly improved compared with placebo.',
-    ]))
+    ])
 
-    expect(report.summary.assessableClaims).toBe(1)
-    expect(report.summary.findings).toBe(0)
+    expect(result.summary.assessableClaims).toBe(1)
+    expect(result.summary.findings).toBe(0)
   })
 
   it('leaves studies without explicit registration or outcome-hierarchy language unassessable', () => {
-    const report = analyzeSelectiveOutcomeReporting(analysis([
+    const result = report([
       'Symptoms improved during the eight-week randomized trial.',
-    ]))
+    ])
 
-    expect(report.summary.assessableClaims).toBe(0)
-    expect(report.summary.findings).toBe(0)
+    expect(result.summary.assessableClaims).toBe(0)
+    expect(result.summary.findings).toBe(0)
   })
 })

--- a/lib/__tests__/research-selective-outcome-reporting.test.ts
+++ b/lib/__tests__/research-selective-outcome-reporting.test.ts
@@ -35,11 +35,14 @@ function analysis(abstracts: string[], confidence = 0.8): ResearchQualityAnalysi
   } as unknown as ResearchQualityAnalysis
 }
 
-function report(abstracts: string[], confidence = 0.8) {
-  const input = analysis(abstracts, confidence)
+function analyze(input: ResearchQualityAnalysis) {
   const trialRegistrationIndependence = analyzeTrialRegistrationIndependence(input)
   const outcomeMetadata = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
   return analyzeSelectiveOutcomeReporting({ analysis: input, outcomeMetadata })
+}
+
+function report(abstracts: string[], confidence = 0.8) {
+  return analyze(analysis(abstracts, confidence))
 }
 
 describe('selective outcome reporting', () => {
@@ -80,5 +83,23 @@ describe('selective outcome reporting', () => {
 
     expect(result.summary.assessableClaims).toBe(0)
     expect(result.summary.findings).toBe(0)
+  })
+
+  it('counts canonical studies rather than duplicate source aliases', () => {
+    const input = analysis([
+      'The prespecified primary outcome showed no significant difference. A secondary endpoint significantly improved versus placebo.',
+      'Duplicate publication row.',
+    ])
+    input.profiles[0].record.sources = [
+      { id: 's1', pmid: '1', doi: '10.1000/example', studyClass: 'rct' },
+      { id: 's2', doi: '10.1000/example', studyClass: 'rct' },
+    ]
+    input.profiles[0].record.claimMap![0].sourceRefIds = ['s1', 's2']
+
+    const result = analyze(input)
+
+    expect(result.claims[0].humanSourceCount).toBe(1)
+    expect(result.claims[0].primaryOutcomeNotMetCount).toBe(1)
+    expect(result.summary.selectiveOutcomeRisks).toBe(1)
   })
 })

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -83,7 +83,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const claimBreadth = analyzeClaimBreadth(analysis)
   const effectCertainty = analyzeEffectCertainty(analysis)
   const directionalConsistency = analyzeDirectionalConsistency(analysis)
-  const selectiveOutcomeReporting = analyzeSelectiveOutcomeReporting(analysis)
+  const selectiveOutcomeReporting = analyzeSelectiveOutcomeReporting({ analysis, outcomeMetadata })
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
   const metadataIntegrity = buildResearchMetadataIntegrity({

--- a/lib/research-selective-outcome-reporting.ts
+++ b/lib/research-selective-outcome-reporting.ts
@@ -1,12 +1,14 @@
 import {
   PRIMARY_HUMAN_STUDY_CLASSES,
   approvedClaims,
-  sourceMap,
-  sourceStudyClass,
-  uniqueSourceRefs,
+  canonicalStudyClass,
+  canonicalStudyGroups,
+  canonicalStudyIdentityMap,
+  uniqueClaimStudyIdentities,
   type ResearchClaim,
 } from './research-coverage'
 import { researchSourceEvidenceText } from './research-evidence-text'
+import type { OutcomeMetadataAnalysis } from './research-outcome-metadata'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 
 export type SelectiveOutcomeReportingFinding = {
@@ -39,10 +41,7 @@ export type SelectiveOutcomeReportingReport = {
   highConfidenceFindings: SelectiveOutcomeReportingFinding[]
 }
 
-const REGISTERED_PRIMARY_NULL = /\b(?:registered|prespecified|pre[- ]specified|protocol[- ]specified) (?:primary )?(?:outcome|endpoint)[^.]{0,220}(?:no significant|not statistically significant|non[- ]significant|did not|failed to|not met|was not met|null)\b/i
-const PRIMARY_NOT_MET = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was not met|not met|failed to meet|did not meet|no significant|not statistically significant|non[- ]significant)\b/i
 const FAVORABLE_SECONDARY = /\b(?:secondary (?:outcome|endpoint)|subgroup|sub-group|post[- ]hoc|exploratory (?:outcome|endpoint|analysis))[^.]{0,220}(?:significant|improv|reduc|benefit|favou?r|superior|positive)\b/i
-const OUTCOME_SWITCH = /\b(outcome switch(?:ing|ed)?|switched (?:the )?(?:primary )?(?:outcome|endpoint)|changed (?:the )?(?:primary )?(?:outcome|endpoint)|primary outcome (?:was )?changed|deviation from (?:the )?(?:registered|prespecified|protocol[- ]specified) outcome|registered outcome[^.]{0,120}not reported|prespecified outcome[^.]{0,120}not reported)\b/i
 const REGISTERED_LANGUAGE = /\b(registered|prespecified|pre[- ]specified|protocol[- ]specified|trial registration|registry)\b/i
 
 function text(value: unknown): string {
@@ -53,50 +52,70 @@ function isOutcomeClaim(claim: ResearchClaim): boolean {
   return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
 }
 
-export function analyzeSelectiveOutcomeReporting(
-  analysis: ResearchQualityAnalysis,
-): SelectiveOutcomeReportingReport {
+/**
+ * Claim-level selective-reporting analysis over canonical study outcome metadata.
+ * Primary-outcome status, registration, switching, and non-reporting are owned by
+ * the study-level outcome metadata product. This layer only adds claim-specific
+ * favorable secondary/subgroup context and aggregates linked study findings.
+ */
+export function analyzeSelectiveOutcomeReporting(input: {
+  analysis: ResearchQualityAnalysis
+  outcomeMetadata: OutcomeMetadataAnalysis
+}): SelectiveOutcomeReportingReport {
+  const { analysis, outcomeMetadata } = input
   const claims: SelectiveOutcomeReportingFinding[] = []
   let approvedOutcomeClaims = 0
+  const outcomeByStudy = new Map(outcomeMetadata.studies.map((study) => [`${study.url}::${study.studyId}`, study]))
 
   for (const { url, record } of analysis.profiles) {
-    const sourcesById = sourceMap(record)
+    const identities = canonicalStudyIdentityMap(record)
+    const groups = canonicalStudyGroups(record)
     for (const claim of approvedClaims(record)) {
       if (!isOutcomeClaim(claim)) continue
       approvedOutcomeClaims += 1
 
-      const humanSources = uniqueSourceRefs(claim)
-        .map((id) => sourcesById.get(id))
-        .filter((source): source is Record<string, unknown> => Boolean(source))
-        .filter((source) => PRIMARY_HUMAN_STUDY_CLASSES.has(sourceStudyClass(source, analysis.cache)))
-      if (!humanSources.length) continue
+      const studyIds = uniqueClaimStudyIdentities(claim, identities)
+      const linkedHumanStudies = studyIds
+        .map((studyId) => ({ studyId, group: groups.get(studyId) ?? [] }))
+        .filter(({ group }) => group.length > 0 && PRIMARY_HUMAN_STUDY_CLASSES.has(canonicalStudyClass(group, analysis.cache)))
+      if (!linkedHumanStudies.length) continue
 
-      const sourceTexts = humanSources.map((source) => researchSourceEvidenceText(source, analysis.cache)).filter(Boolean)
-      const assessable = sourceTexts.filter((value) =>
-        REGISTERED_PRIMARY_NULL.test(value)
-        || PRIMARY_NOT_MET.test(value)
-        || FAVORABLE_SECONDARY.test(value)
-        || OUTCOME_SWITCH.test(value)
-        || REGISTERED_LANGUAGE.test(value),
-      )
+      const studyRows = linkedHumanStudies.map(({ studyId, group }) => {
+        const metadata = outcomeByStudy.get(`${url}::${studyId}`)
+        const evidenceText = group.map((source) => researchSourceEvidenceText(source, analysis.cache)).filter(Boolean).join(' · ')
+        const favorableSecondary = FAVORABLE_SECONDARY.test(evidenceText)
+        const explicitHierarchy = Boolean(
+          metadata?.hasOutcomeMetadata
+          || metadata?.trialRegistrationIds.length
+          || REGISTERED_LANGUAGE.test(evidenceText)
+          || favorableSecondary,
+        )
+        return { metadata, favorableSecondary, explicitHierarchy }
+      })
+      const assessable = studyRows.filter((row) => row.explicitHierarchy)
       if (!assessable.length) continue
 
-      const registeredOrPrespecifiedPrimaryNullCount = assessable.filter((value) => REGISTERED_PRIMARY_NULL.test(value)).length
-      const primaryOutcomeNotMetCount = assessable.filter((value) => PRIMARY_NOT_MET.test(value)).length
-      const favorableSecondaryOrExploratoryCount = assessable.filter((value) => FAVORABLE_SECONDARY.test(value)).length
-      const explicitOutcomeSwitchCount = assessable.filter((value) => OUTCOME_SWITCH.test(value)).length
+      const registeredOrPrespecifiedPrimaryNullCount = assessable.filter(({ metadata }) =>
+        metadata?.primaryOutcomeStatus === 'not-met'
+        && Boolean(metadata.registeredPrimaryOutcomes.length || metadata.trialRegistrationIds.length),
+      ).length
+      const primaryOutcomeNotMetCount = assessable.filter(({ metadata }) => metadata?.primaryOutcomeStatus === 'not-met').length
+      const favorableSecondaryOrExploratoryCount = assessable.filter((row) => row.favorableSecondary).length
+      const explicitOutcomeSwitchCount = assessable.filter(({ metadata }) =>
+        Boolean(metadata?.explicitOutcomeSwitch || metadata?.explicitRegisteredOutcomeNotReported),
+      ).length
 
-      const selectiveOutcomeRisk = assessable.some((value) =>
-        (REGISTERED_PRIMARY_NULL.test(value) || PRIMARY_NOT_MET.test(value)) && FAVORABLE_SECONDARY.test(value),
+      const selectiveOutcomeRisk = assessable.some(({ metadata, favorableSecondary }) =>
+        Boolean(metadata?.primaryOutcomeStatus === 'not-met' && favorableSecondary),
       )
       const explicitOutcomeSwitchRisk = explicitOutcomeSwitchCount > 0
 
       const reasons: string[] = []
       if (selectiveOutcomeRisk) {
-        reasons.push('linked human evidence explicitly pairs a null/not-met primary outcome with a favorable secondary, subgroup, post-hoc, or exploratory result')
+        reasons.push('linked human evidence pairs a canonical not-met primary outcome with a favorable secondary, subgroup, post-hoc, or exploratory result')
       }
       if (explicitOutcomeSwitchRisk) {
-        reasons.push(`${explicitOutcomeSwitchCount} linked human source(s) explicitly describe outcome switching, changed primary outcomes, or unreported registered/prespecified outcomes`)
+        reasons.push(`${explicitOutcomeSwitchCount} canonical linked study/studies explicitly indicate outcome switching, changed primary outcomes, or unreported registered/prespecified outcomes`)
       }
 
       claims.push({
@@ -104,7 +123,7 @@ export function analyzeSelectiveOutcomeReporting(
         claimId: text(claim.id) || 'unknown-claim',
         predicate: text(claim.predicate),
         confidence: Number(claim.confidence ?? 0),
-        humanSourceCount: humanSources.length,
+        humanSourceCount: linkedHumanStudies.length,
         assessableSourceCount: assessable.length,
         registeredOrPrespecifiedPrimaryNullCount,
         favorableSecondaryOrExploratoryCount,


### PR DESCRIPTION
Superseded by #3713 after main moved under the first merge attempt. The same selective-outcome canonicalization was replayed on the current tip and merged cleanly there.