### PR TITLE
fix(research): preserve negated primary-outcome results

### DIFF
--- a/lib/__tests__/research-outcome-metadata.test.ts
+++ b/lib/__tests__/research-outcome-metadata.test.ts
@@ -115,6 +115,25 @@ describe('canonical outcome metadata', () => {
     expect(study.explicitRegisteredOutcomeNotReported).toBe(true)
   })
 
+  it('does not reinterpret negated statistical significance as a met outcome', () => {
+    const input = analysis(
+      [{ id: 's1', pmid: '123' }],
+      { '123': { abstract: 'The primary outcome was not statistically significant compared with placebo.' } },
+    )
+    const trialRegistrationIndependence = registration([{
+      url: '/herbs/example/',
+      studyId: 'pmid:123',
+      registryIds: [],
+      stableRegistryId: null,
+      ambiguous: false,
+    }])
+
+    const result = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+
+    expect(result.studies[0].primaryOutcomeStatus).toBe('not-met')
+    expect(result.summary.primaryOutcomeNotMet).toBe(1)
+  })
+
   it('keeps missing outcome metadata unknown', () => {
     const input = analysis([{ id: 's1', pmid: '123', title: 'Randomized clinical trial' }])
     const trialRegistrationIndependence = registration([{

--- a/lib/research-outcome-metadata.ts
+++ b/lib/research-outcome-metadata.ts
@@ -54,7 +54,7 @@ const SWITCH_FIELDS = ['outcomeSwitch', 'outcomeSwitched', 'primaryOutcomeChange
 const NON_REPORTING_FIELDS = ['registeredOutcomeNotReported', 'prespecifiedOutcomeNotReported'] as const
 
 const PRIMARY_NOT_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was not met|not met|failed to meet|did not meet|no significant|not statistically significant|non[- ]significant)\b/i
-const PRIMARY_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was met|met the|statistically significant|significantly (?:improved|reduced|increased|decreased)|favou?r(?:ed|s)|superior)\b/i
+const PRIMARY_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was met|met the|was statistically significant|was significantly (?:improved|reduced|increased|decreased)|favou?r(?:ed|s)|superior)\b/i
 const OUTCOME_SWITCH_TEXT = /\b(outcome switch(?:ing|ed)?|switched (?:the )?(?:primary )?(?:outcome|endpoint)|changed (?:the )?(?:primary )?(?:outcome|endpoint)|primary outcome (?:was )?changed|deviation from (?:the )?(?:registered|prespecified|protocol[- ]specified) outcome)\b/i
 const OUTCOME_NOT_REPORTED_TEXT = /\b(?:registered|prespecified|pre[- ]specified|protocol[- ]specified) (?:primary )?(?:outcome|endpoint)[^.]{0,140}(?:not reported|was not reported|unreported|omitted)\b/i
 


### PR DESCRIPTION
## Summary
- tightens prose-based positive primary-outcome matching
- prevents `not statistically significant` from also matching the positive `statistically significant` branch
- adds a regression proving the phrase resolves to `not-met`, not `mixed`

## Why
The canonical outcome metadata analyzer used overlapping regexes. A negative sentence such as `The primary outcome was not statistically significant` satisfied both the negative matcher and the broad positive matcher, incorrectly producing `mixed`.

## Regression contract
- explicit structured status continues to take precedence
- clear positive phrases remain positive
- explicit negation cannot be reinterpreted as a positive result
- missing metadata remains unknown