### PR TITLE
refactor(research): fold selective reporting into semantic remediation

### DIFF
--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -78,25 +78,32 @@ export function buildAggregatedTopologyGapSignals(
     breadth: typeof topology.claimBreadth.findings
     effect: typeof topology.effectCertainty.findings
     directional: typeof topology.directionalConsistency.findings
+    selective: typeof topology.selectiveOutcomeReporting.findings
   }>()
+  const emptySemanticGroup = () => ({ explicit: [], breadth: [], effect: [], directional: [], selective: [] })
   for (const item of topology.semanticAlignment.findings) {
-    const group = semanticByUrl.get(item.url) ?? { explicit: [], breadth: [], effect: [], directional: [] }
+    const group = semanticByUrl.get(item.url) ?? emptySemanticGroup()
     group.explicit.push(item)
     semanticByUrl.set(item.url, group)
   }
   for (const item of topology.claimBreadth.findings) {
-    const group = semanticByUrl.get(item.url) ?? { explicit: [], breadth: [], effect: [], directional: [] }
+    const group = semanticByUrl.get(item.url) ?? emptySemanticGroup()
     group.breadth.push(item)
     semanticByUrl.set(item.url, group)
   }
   for (const item of topology.effectCertainty.findings) {
-    const group = semanticByUrl.get(item.url) ?? { explicit: [], breadth: [], effect: [], directional: [] }
+    const group = semanticByUrl.get(item.url) ?? emptySemanticGroup()
     group.effect.push(item)
     semanticByUrl.set(item.url, group)
   }
   for (const item of topology.directionalConsistency.findings) {
-    const group = semanticByUrl.get(item.url) ?? { explicit: [], breadth: [], effect: [], directional: [] }
+    const group = semanticByUrl.get(item.url) ?? emptySemanticGroup()
     group.directional.push(item)
+    semanticByUrl.set(item.url, group)
+  }
+  for (const item of topology.selectiveOutcomeReporting.findings) {
+    const group = semanticByUrl.get(item.url) ?? emptySemanticGroup()
+    group.selective.push(item)
     semanticByUrl.set(item.url, group)
   }
   for (const [url, group] of semanticByUrl) {
@@ -105,8 +112,9 @@ export function buildAggregatedTopologyGapSignals(
       ...group.breadth.filter((item) => item.confidence >= 0.75),
       ...group.effect.filter((item) => item.confidence >= 0.75),
       ...group.directional.filter((item) => item.confidence >= 0.75),
+      ...group.selective.filter((item) => item.confidence >= 0.75),
     ].length
-    const issueCount = group.explicit.length + group.breadth.length + group.effect.length + group.directional.length
+    const issueCount = group.explicit.length + group.breadth.length + group.effect.length + group.directional.length + group.selective.length
     const breadthDimensions = {
       population: group.breadth.filter((item) => item.populationOverbroad).length,
       dose: group.breadth.filter((item) => item.doseOverbroad).length,
@@ -124,11 +132,15 @@ export function buildAggregatedTopologyGapSignals(
       heterogeneous: group.directional.filter((item) => item.directionalHeterogeneity).length,
       uniformlyPositive: group.directional.filter((item) => item.uniformlyPositiveOverstatement).length,
     }
+    const selectiveDimensions = {
+      selectiveOutcome: group.selective.filter((item) => item.selectiveOutcomeRisk).length,
+      outcomeSwitch: group.selective.filter((item) => item.explicitOutcomeSwitchRisk).length,
+    }
     signals.push({
       url,
       kind: 'semantic-claim-source-mismatch',
       weight: weights.semanticMismatch + Math.min(10, Math.max(0, issueCount - 1) * 2) + (highConfidence ? weights.highConfidenceSemanticMismatchBonus : 0),
-      detail: `${group.explicit.length} explicit alignment mismatch(es), ${group.breadth.length} claim-breadth overreach finding(s), ${group.effect.length} effect/certainty overstatement finding(s), and ${group.directional.length} endpoint/directional consistency finding(s); ${highConfidence} high-confidence; role ${group.explicit.filter((item) => item.roleMismatch).length}, domain ${group.explicit.filter((item) => item.domainMismatch).length}, population mismatch ${group.explicit.filter((item) => item.populationMismatch).length}; breadth population ${breadthDimensions.population}, dose ${breadthDimensions.dose}, duration ${breadthDimensions.duration}, formulation ${breadthDimensions.formulation}, endpoint ${breadthDimensions.endpoint}; effect magnitude ${effectDimensions.magnitude}, clinical importance ${effectDimensions.clinicalImportance}, certainty ${effectDimensions.certainty}; endpoint cherry-pick ${directionalDimensions.cherryPick}, directional heterogeneity ${directionalDimensions.heterogeneous}, uniformly-positive overstatement ${directionalDimensions.uniformlyPositive}`,
+      detail: `${group.explicit.length} explicit alignment mismatch(es), ${group.breadth.length} claim-breadth overreach finding(s), ${group.effect.length} effect/certainty overstatement finding(s), ${group.directional.length} endpoint/directional consistency finding(s), and ${group.selective.length} selective-outcome/reporting finding(s); ${highConfidence} high-confidence; role ${group.explicit.filter((item) => item.roleMismatch).length}, domain ${group.explicit.filter((item) => item.domainMismatch).length}, population mismatch ${group.explicit.filter((item) => item.populationMismatch).length}; breadth population ${breadthDimensions.population}, dose ${breadthDimensions.dose}, duration ${breadthDimensions.duration}, formulation ${breadthDimensions.formulation}, endpoint ${breadthDimensions.endpoint}; effect magnitude ${effectDimensions.magnitude}, clinical importance ${effectDimensions.clinicalImportance}, certainty ${effectDimensions.certainty}; endpoint cherry-pick ${directionalDimensions.cherryPick}, directional heterogeneity ${directionalDimensions.heterogeneous}, uniformly-positive overstatement ${directionalDimensions.uniformlyPositive}; selective outcome ${selectiveDimensions.selectiveOutcome}, explicit outcome switch/non-reporting ${selectiveDimensions.outcomeSwitch}`,
     })
   }
 


### PR DESCRIPTION
Folds selective-outcome/reporting-bias findings into the existing bounded semantic claim↔evidence remediation root cause. Explicit outcome switching/non-reporting and favorable-secondary-over-null-primary signals now raise the same canonical semantic priority instead of creating a parallel policy dimension or separate queue reason.