### PR TITLE
fix(evidence-report): scope research topology to public profiles

### DIFF
--- a/lib/__tests__/research-quality-scoped-topology.test.ts
+++ b/lib/__tests__/research-quality-scoped-topology.test.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  buildScopedResearchQualityTopology,
+  scopeResearchQualityAnalysis,
+} from '@/lib/research-quality-snapshot'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+const roots: string[] = []
+
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop() as string, { recursive: true, force: true })
+})
+
+function analysisFixture(): ResearchQualityAnalysis {
+  return {
+    cache: {},
+    profiles: [
+      { kind: 'herbs', url: '/herbs/public/', file: 'public.json', record: { slug: 'public' } },
+      { kind: 'herbs', url: '/herbs/hidden/', file: 'hidden.json', record: { slug: 'hidden' } },
+    ],
+    profileAnalyses: [
+      { url: '/herbs/public/' },
+      { url: '/herbs/hidden/' },
+    ],
+    claimAnalyses: [
+      { url: '/herbs/public/', claimId: 'public-claim' },
+      { url: '/herbs/hidden/', claimId: 'hidden-claim' },
+    ],
+    structuredClaimAnalyses: [
+      { url: '/herbs/public/', claimId: 'public-claim' },
+      { url: '/herbs/hidden/', claimId: 'hidden-claim' },
+    ],
+  } as unknown as ResearchQualityAnalysis
+}
+
+describe('scoped research-quality topology', () => {
+  it('scopes every derived analysis row by the same profile URL set', () => {
+    const scoped = scopeResearchQualityAnalysis(analysisFixture(), ['/herbs/public/'])
+
+    expect(scoped.profiles.map((profile) => profile.url)).toEqual(['/herbs/public/'])
+    expect(scoped.profileAnalyses.map((profile) => profile.url)).toEqual(['/herbs/public/'])
+    expect(scoped.claimAnalyses.map((claim) => claim.url)).toEqual(['/herbs/public/'])
+    expect(scoped.structuredClaimAnalyses.map((claim) => claim.url)).toEqual(['/herbs/public/'])
+  })
+
+  it('excludes an unselected canonical profile from downstream global topology counts', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ths-scoped-topology-'))
+    roots.push(root)
+    const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+    mkdirSync(detailDir, { recursive: true })
+
+    writeFileSync(path.join(detailDir, 'public.json'), JSON.stringify({
+      slug: 'public',
+      sources: [{ id: 'public-rct', pmid: '11111111', studyClass: 'rct', title: 'Public trial' }],
+      claimMap: [],
+    }))
+    writeFileSync(path.join(detailDir, 'hidden.json'), JSON.stringify({
+      slug: 'hidden',
+      sources: [{ id: 'hidden-rct', pmid: '22222222', studyClass: 'rct', title: 'Hidden trial' }],
+      claimMap: [],
+    }))
+
+    const scoped = buildScopedResearchQualityTopology(root, ['/herbs/public/'])
+
+    expect(scoped.analysis.profiles.map((profile) => profile.url)).toEqual(['/herbs/public/'])
+    expect(scoped.topology.underlyingStudyIndependence.summary).toMatchObject({
+      profilesAnalyzed: 1,
+      globalInventoryPublicationCount: 1,
+      globalPrimaryHumanPublicationCount: 1,
+    })
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -14,7 +14,7 @@ import {
   type EvidenceStudyClass,
   type EvidenceStudyRecord,
 } from '@/lib/evidence-study'
-import { buildResearchQualitySnapshot } from '@/lib/research-quality-snapshot'
+import { buildScopedResearchQualityTopology } from '@/lib/research-quality-snapshot'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import {
   getCompoundBySlug,
@@ -103,15 +103,15 @@ export type PublicEvidenceReportMetrics = {
   disagreementStudyCount: number
   /** Null for synthetic/pure builders that do not execute canonical topology. */
   underlyingStudyMetricsSource: 'canonical-research-topology' | null
-  /** Unique site-wide publication identities across every canonical research profile. */
+  /** Unique publication identities within the current public/indexable dataset scope. */
   globalInventoryPublicationCount: number | null
-  /** Site-wide evidence units remaining after explicitly proven registry/lineage dependence is collapsed. */
+  /** Evidence units remaining in the current public scope after explicitly proven registry/lineage dependence is collapsed. */
   globalInventoryUnderlyingStudyCount: number | null
   globalCollapsedInventoryPublicationCount: number | null
   globalInventoryPublicationsWithIndependenceMetadata: number | null
   globalInventoryPublicationsWithoutIndependenceMetadata: number | null
   globalInventoryIndependenceMetadataCoverage: number | null
-  /** Unique site-wide primary-human publication identities. */
+  /** Unique primary-human publication identities within the current public/indexable dataset scope. */
   globalPrimaryHumanPublicationCount: number | null
   /** Primary-human evidence units remaining after explicitly proven dependence collapse; unresolved lineage is not assumed independent. */
   globalPrimaryHumanUnderlyingStudyCount: number | null
@@ -493,7 +493,10 @@ export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset>
     hydrateIndexableRecords(compounds, 'compound'),
   ])
   const dataset = buildPublicEvidenceDatasetFromRecords([...herbRecords, ...compoundRecords])
-  const topology = buildResearchQualitySnapshot(process.cwd()).topology
+  const topology = buildScopedResearchQualityTopology(
+    process.cwd(),
+    dataset.ingredients.map((ingredient) => ingredient.path),
+  ).topology
   const independence = topology.underlyingStudyIndependence.summary
   const coverage = topology.evidenceIndependenceCoverage.summary
 

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -26,6 +26,50 @@ export type ResearchQualitySnapshot = {
   remediationInvariants: ResearchRemediationInvariantReport
 }
 
+export type ScopedResearchQualityTopology = {
+  analysis: ResearchQualityAnalysis
+  topology: ResearchQualityTopology
+}
+
+/**
+ * Restrict an already-canonical research analysis to an explicit URL set.
+ * Every derived row is selected by the same profile URL key, so scoped
+ * consumers cannot accidentally mix a public profile denominator with hidden
+ * claim/profile rows from the full repository analysis.
+ */
+export function scopeResearchQualityAnalysis(
+  analysis: ResearchQualityAnalysis,
+  profileUrls: Iterable<string>,
+): ResearchQualityAnalysis {
+  const selected = new Set(profileUrls)
+  return {
+    ...analysis,
+    profiles: analysis.profiles.filter((profile) => selected.has(profile.url)),
+    profileAnalyses: analysis.profileAnalyses.filter((profile) => selected.has(profile.url)),
+    claimAnalyses: analysis.claimAnalyses.filter((claim) => selected.has(claim.url)),
+    structuredClaimAnalyses: analysis.structuredClaimAnalyses.filter((claim) => selected.has(claim.url)),
+  }
+}
+
+/**
+ * Canonical analysis+topology boundary for consumers whose visibility scope is
+ * intentionally narrower than the full repository. The full analysis is built
+ * with the same loaders/classifiers as CI, then scoped before any topology is
+ * derived. This is deliberately narrower than buildResearchQualitySnapshot:
+ * grade/gate/remediation products are repository-wide and must not be presented
+ * as scoped unless their own data loaders are scoped too.
+ */
+export function buildScopedResearchQualityTopology(
+  root = process.cwd(),
+  profileUrls: Iterable<string>,
+): ScopedResearchQualityTopology {
+  const analysis = scopeResearchQualityAnalysis(analyzeResearchQuality(root), profileUrls)
+  return {
+    analysis,
+    topology: buildResearchQualityTopology(analysis),
+  }
+}
+
 /**
  * Canonical execution boundary for research-quality consumers.
  *


### PR DESCRIPTION
Prevents the public evidence report from mixing indexable runtime records with hidden/noindex canonical research profiles. Adds a canonical scoped analysis+topology view, drives it from the exact published ingredient paths, and adds a filesystem regression proving unselected research profiles cannot enter global topology counts.