### PR TITLE
polish(theme): align dark mode toggle semantics

### DIFF
--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -19,9 +19,9 @@ export default function DarkModeToggle({ showLabel = false, className = '' }: Pr
       type="button"
       onClick={toggle}
       aria-pressed={isDark}
-      aria-label='Dark mode'
+      aria-label={label}
       title={`${label}${themePreference === 'system' ? ' (currently following system)' : ''}`}
-      className={`inline-flex min-h-11 min-w-11 items-center justify-center gap-1.5 rounded-full border border-brand-900/10 bg-white/80 px-2.5 text-sm font-semibold text-muted shadow-sm transition hover:border-brand-700/20 hover:bg-brand-50 hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-[var(--bg)] ${className}`}
+      className={`inline-flex min-h-11 min-w-11 items-center justify-center gap-1.5 rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-2.5 text-sm font-semibold text-muted shadow-sm transition hover:border-brand-700/20 hover:bg-[var(--surface-subtle)] hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-[var(--bg)] ${className}`}
     >
       {isDark ? (
         <Sun


### PR DESCRIPTION
Make the dark-mode toggle announce the actual switch action to assistive tech and use shared theme-aware surface tokens instead of a hard-coded light background. Toggle behavior is unchanged.