### PR TITLE
fix(research): integrate selective outcome snapshot invariants

### DIFF
--- a/lib/__tests__/research-quality-snapshot-invariants.test.ts
+++ b/lib/__tests__/research-quality-snapshot-invariants.test.ts
@@ -60,6 +60,19 @@ function fixtures() {
       findings: [],
       highConfidenceFindings: [],
     },
+    selectiveOutcomeReporting: {
+      summary: {
+        approvedOutcomeClaims: 0,
+        assessableClaims: 0,
+        findings: 0,
+        highConfidenceFindings: 0,
+        selectiveOutcomeRisks: 0,
+        explicitOutcomeSwitchRisks: 0,
+      },
+      claims: [],
+      findings: [],
+      highConfidenceFindings: [],
+    },
     underlyingStudyIndependence: {
       summary: {
         multiStudyApprovedClaims: 0,
@@ -194,6 +207,50 @@ describe('research quality snapshot invariants', () => {
     const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
     expect(report.passed).toBe(false)
     expect(report.failures.map((failure) => failure.kind)).toContain('semantic-approved-claim-count-mismatch')
+  })
+
+  it('detects selective-outcome summary drift', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    topology.selectiveOutcomeReporting.summary.assessableClaims = 1
+    topology.selectiveOutcomeReporting.summary.findings = 1
+    topology.selectiveOutcomeReporting.summary.highConfidenceFindings = 1
+    topology.selectiveOutcomeReporting.summary.selectiveOutcomeRisks = 1
+    topology.selectiveOutcomeReporting.summary.explicitOutcomeSwitchRisks = 1
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    const kinds = report.failures.map((failure) => failure.kind)
+    expect(kinds).toContain('selective-outcome-assessable-count-mismatch')
+    expect(kinds).toContain('selective-outcome-finding-count-mismatch')
+    expect(kinds).toContain('selective-outcome-high-confidence-count-mismatch')
+    expect(kinds).toContain('selective-outcome-risk-count-mismatch')
+    expect(kinds).toContain('selective-outcome-switch-count-mismatch')
+  })
+
+  it('detects selective-outcome rows that reference unknown canonical claims', () => {
+    const { analysis, topology, gate, queue, sourceIntegrity } = fixtures()
+    const row = {
+      url: '/herbs/example',
+      claimId: 'missing-claim',
+      predicate: 'supports_outcome',
+      confidence: 0.8,
+      humanSourceCount: 1,
+      assessableSourceCount: 1,
+      registeredOrPrespecifiedPrimaryNullCount: 1,
+      favorableSecondaryOrExploratoryCount: 1,
+      explicitOutcomeSwitchCount: 0,
+      primaryOutcomeNotMetCount: 1,
+      selectiveOutcomeRisk: true,
+      explicitOutcomeSwitchRisk: false,
+      reasons: ['fixture'],
+    }
+    topology.selectiveOutcomeReporting.claims = [row]
+    topology.selectiveOutcomeReporting.findings = [row]
+    topology.selectiveOutcomeReporting.highConfidenceFindings = [row]
+    topology.selectiveOutcomeReporting.summary.assessableClaims = 1
+    topology.selectiveOutcomeReporting.summary.findings = 1
+    topology.selectiveOutcomeReporting.summary.highConfidenceFindings = 1
+    topology.selectiveOutcomeReporting.summary.selectiveOutcomeRisks = 1
+    const report = validateResearchQualitySnapshotInvariants(analysis, topology, gate, queue, sourceIntegrity)
+    expect(report.failures.map((failure) => failure.kind)).toContain('selective-outcome-unknown-claim')
   })
 
   it('detects derived findings that reference an unknown approved claim', () => {

--- a/lib/research-quality-snapshot-invariants.ts
+++ b/lib/research-quality-snapshot-invariants.ts
@@ -149,6 +149,39 @@ export function validateResearchQualitySnapshotInvariants(
   }
   for (const invariant of validateEffectCertaintySnapshotInvariants(analysis, topology)) add(invariant.kind, invariant.detail)
   for (const invariant of validateDirectionalConsistencySnapshotInvariants(analysis, topology)) add(invariant.kind, invariant.detail)
+
+  const selectiveOutcome = topology.selectiveOutcomeReporting
+  if (selectiveOutcome.summary.assessableClaims !== selectiveOutcome.claims.length) {
+    add('selective-outcome-assessable-count-mismatch', `summary=${selectiveOutcome.summary.assessableClaims}; rows=${selectiveOutcome.claims.length}`)
+  }
+  if (selectiveOutcome.summary.findings !== selectiveOutcome.findings.length) {
+    add('selective-outcome-finding-count-mismatch', `summary=${selectiveOutcome.summary.findings}; rows=${selectiveOutcome.findings.length}`)
+  }
+  if (selectiveOutcome.summary.highConfidenceFindings !== selectiveOutcome.highConfidenceFindings.length) {
+    add('selective-outcome-high-confidence-count-mismatch', `summary=${selectiveOutcome.summary.highConfidenceFindings}; rows=${selectiveOutcome.highConfidenceFindings.length}`)
+  }
+  const computedSelectiveOutcomeRisks = selectiveOutcome.findings.filter((claim) => claim.selectiveOutcomeRisk).length
+  if (selectiveOutcome.summary.selectiveOutcomeRisks !== computedSelectiveOutcomeRisks) {
+    add('selective-outcome-risk-count-mismatch', `summary=${selectiveOutcome.summary.selectiveOutcomeRisks}; computed=${computedSelectiveOutcomeRisks}`)
+  }
+  const computedOutcomeSwitchRisks = selectiveOutcome.findings.filter((claim) => claim.explicitOutcomeSwitchRisk).length
+  if (selectiveOutcome.summary.explicitOutcomeSwitchRisks !== computedOutcomeSwitchRisks) {
+    add('selective-outcome-switch-count-mismatch', `summary=${selectiveOutcome.summary.explicitOutcomeSwitchRisks}; computed=${computedOutcomeSwitchRisks}`)
+  }
+  const selectiveOutcomeClaimKeys = new Set(selectiveOutcome.claims.map((claim) => claimKey(claim.url, claim.claimId)))
+  for (const finding of selectiveOutcome.findings) {
+    if (!selectiveOutcomeClaimKeys.has(claimKey(finding.url, finding.claimId))) {
+      add('selective-outcome-finding-not-assessable', `${finding.url}::${finding.claimId}`)
+    }
+  }
+  for (const finding of selectiveOutcome.highConfidenceFindings) {
+    const key = claimKey(finding.url, finding.claimId)
+    if (!selectiveOutcomeClaimKeys.has(key)) add('selective-outcome-high-confidence-not-assessable', `${finding.url}::${finding.claimId}`)
+    if (!selectiveOutcome.findings.some((candidate) => claimKey(candidate.url, candidate.claimId) === key)) {
+      add('selective-outcome-high-confidence-not-finding', `${finding.url}::${finding.claimId}`)
+    }
+  }
+
   if (topology.edgeCardinality.summary.claims !== analysis.structuredClaimAnalyses.length) {
     add('edge-cardinality-claim-count-mismatch', `edgeCardinality=${topology.edgeCardinality.summary.claims}; analysis=${analysis.structuredClaimAnalyses.length}`)
   }
@@ -177,6 +210,10 @@ export function validateResearchQualitySnapshotInvariants(
   for (const claim of topology.claimBreadth.claims) {
     requireProfile('claim-breadth-unknown-profile', claim.url, claim.claimId)
     requireApprovedClaim('claim-breadth-unknown-claim', claim.url, claim.claimId)
+  }
+  for (const claim of selectiveOutcome.claims) {
+    requireProfile('selective-outcome-unknown-profile', claim.url, claim.claimId)
+    requireApprovedClaim('selective-outcome-unknown-claim', claim.url, claim.claimId)
   }
   for (const finding of topology.claimLanguageCalibration.directEvidenceFindings) requireApprovedClaim('language-calibration-unknown-claim', finding.url, finding.claimId)
   for (const claim of topology.claimCitationMetadata.claims) requireApprovedClaim('citation-metadata-unknown-claim', claim.url, claim.claimId)


### PR DESCRIPTION
Integrates the newly added selective-outcome-reporting topology slice into the canonical research-quality snapshot invariant contract without re-running the analyzer. Validates summary/cardinality consistency, findings/high-confidence subset integrity, and canonical profile/approved-claim references. Updates the shared invariant fixture and adds regression coverage for summary drift and unknown claim references.