### PR TITLE
fix(research): preserve selective-outcome negation

### DIFF
--- a/lib/__tests__/research-selective-outcome-reporting.test.ts
+++ b/lib/__tests__/research-selective-outcome-reporting.test.ts
@@ -55,6 +55,31 @@ describe('selective outcome reporting', () => {
     })
   })
 
+  it('does not treat a negated secondary result as favorable evidence', () => {
+    const result = report([
+      'The primary outcome was not met. The secondary endpoint was not statistically significant versus placebo.',
+    ])
+
+    expect(result.summary.selectiveOutcomeRisks).toBe(0)
+    expect(result.claims[0]).toMatchObject({
+      primaryOutcomeNotMetCount: 1,
+      favorableSecondaryOrExploratoryCount: 0,
+      selectiveOutcomeRisk: false,
+    })
+  })
+
+  it('retains a real favorable subgroup result beside a negated secondary endpoint', () => {
+    const result = report([
+      'The primary outcome was not met. The secondary endpoint was not significant, but subgroup analysis improved versus placebo.',
+    ])
+
+    expect(result.summary.selectiveOutcomeRisks).toBe(1)
+    expect(result.findings[0]).toMatchObject({
+      favorableSecondaryOrExploratoryCount: 1,
+      selectiveOutcomeRisk: true,
+    })
+  })
+
   it('flags explicit outcome switching or non-reporting of registered outcomes', () => {
     const result = report([
       'The primary outcome was changed after trial registration and the registered outcome was not reported.',

--- a/lib/research-selective-outcome-reporting.ts
+++ b/lib/research-selective-outcome-reporting.ts
@@ -41,7 +41,7 @@ export type SelectiveOutcomeReportingReport = {
   highConfidenceFindings: SelectiveOutcomeReportingFinding[]
 }
 
-const FAVORABLE_SECONDARY = /\b(?:secondary (?:outcome|endpoint)|subgroup|sub-group|post[- ]hoc|exploratory (?:outcome|endpoint|analysis))[^.]{0,220}(?:significant|improv|reduc|benefit|favou?r|superior|positive)\b/i
+const FAVORABLE_SECONDARY = /\b(?:secondary (?:outcome|endpoint)|subgroup|sub-group|post[- ]hoc|exploratory (?:outcome|endpoint|analysis))[^.]{0,220}(?:statistically\s+significant|significant(?:ly)?|improv\w*|reduc\w*|benefit\w*|favou?r\w*|superior|positive)\b/i
 const NEGATED_FAVORABLE_SIGNAL = /\b(?:not|no|did not|didn't|failed to|without)\s+(?:(?:statistically|clinically)\s+)?(?:significant|significantly\s+(?:improv\w*|reduc\w*)|improv\w*|reduc\w*|benefit\w*|favou?r\w*|superior|positive)\b|\bnon[- ]?significant\b/gi
 const REGISTERED_LANGUAGE = /\b(registered|prespecified|pre[- ]specified|protocol[- ]specified|trial registration|registry)\b/i
 

--- a/lib/research-selective-outcome-reporting.ts
+++ b/lib/research-selective-outcome-reporting.ts
@@ -42,6 +42,7 @@ export type SelectiveOutcomeReportingReport = {
 }
 
 const FAVORABLE_SECONDARY = /\b(?:secondary (?:outcome|endpoint)|subgroup|sub-group|post[- ]hoc|exploratory (?:outcome|endpoint|analysis))[^.]{0,220}(?:significant|improv|reduc|benefit|favou?r|superior|positive)\b/i
+const NEGATED_FAVORABLE_SIGNAL = /\b(?:not|no|did not|didn't|failed to|without)\s+(?:(?:statistically|clinically)\s+)?(?:significant|significantly\s+(?:improv\w*|reduc\w*)|improv\w*|reduc\w*|benefit\w*|favou?r\w*|superior|positive)\b|\bnon[- ]?significant\b/gi
 const REGISTERED_LANGUAGE = /\b(registered|prespecified|pre[- ]specified|protocol[- ]specified|trial registration|registry)\b/i
 
 function text(value: unknown): string {
@@ -50,6 +51,16 @@ function text(value: unknown): string {
 
 function isOutcomeClaim(claim: ResearchClaim): boolean {
   return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
+}
+
+/**
+ * Look for an affirmative secondary/subgroup/exploratory signal after removing
+ * explicitly negated result phrases. Removing only the negated signal preserves
+ * mixed sentences where a null secondary endpoint is followed by a genuinely
+ * favorable subgroup or post-hoc result.
+ */
+function hasFavorableSecondaryEvidence(value: string): boolean {
+  return FAVORABLE_SECONDARY.test(value.replace(NEGATED_FAVORABLE_SIGNAL, ''))
 }
 
 /**
@@ -83,7 +94,7 @@ export function analyzeSelectiveOutcomeReporting(input: {
       const studyRows = linkedHumanStudies.map(({ studyId, group }) => {
         const metadata = outcomeByStudy.get(`${url}::${studyId}`)
         const evidenceText = group.map((source) => researchSourceEvidenceText(source, analysis.cache)).filter(Boolean).join(' · ')
-        const favorableSecondary = FAVORABLE_SECONDARY.test(evidenceText)
+        const favorableSecondary = hasFavorableSecondaryEvidence(evidenceText)
         const explicitHierarchy = Boolean(
           metadata?.hasOutcomeMetadata
           || metadata?.trialRegistrationIds.length


### PR DESCRIPTION
## Summary
- prevents negated secondary/subgroup results from being classified as favorable evidence
- normalizes ordinary affirmative forms such as `improved`, `reduced`, and `significantly improved`
- preserves true mixed sentences where a null secondary result is followed by a favorable subgroup/post-hoc result
- adds regressions for both the negated-only and mixed-sentence cases

## Why
The canonical selective-reporting refactor inherited a broad favorable-context regex. It could read `secondary endpoint was not statistically significant` as favorable, while truncated stems such as `improv\b` and `reduc\b` missed common affirmative forms like `improved` and `reduced`.

## Regression contract
- negated favorable terms do not trigger selective-outcome risk
- affirmative secondary/subgroup/exploratory results still trigger when paired with a canonical not-met primary outcome
- mixed sentences retain genuine favorable subgroup signals after a separate null secondary result