### PR TITLE
fix(visual): stack guide database CTAs on mobile

### DIFF
--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -128,12 +128,12 @@ export default function LibraryHub() {
         ))}
       </div>
 
-      <div className="mt-16 rounded-2xl border border-brand-900/10 bg-brand-50/50 p-8 text-center">
+      <div className="mt-16 rounded-2xl border border-brand-900/10 bg-brand-50/50 p-5 text-center sm:p-8">
         <h2 className="text-xl font-bold text-ink">Browse the reference databases</h2>
         <p className="mt-2 text-muted">
           Prefer structured profiles? Browse the published herb and compound libraries, where public eligibility rules keep source inventory separate from what readers can actually browse.
         </p>
-        <div className="mt-4 flex justify-center gap-3">
+        <div className="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
           <Link href="/herbs/" className="rounded-full bg-brand-700 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-brand-800">Browse Herbs →</Link>
           <Link href="/compounds/" className="rounded-full border border-brand-700 px-6 py-2.5 text-sm font-semibold text-brand-700 transition hover:bg-brand-50">Browse Compounds →</Link>
         </div>


### PR DESCRIPTION
Prevents the Evidence Library's two database CTA pills from competing for narrow horizontal space. The CTA card now uses tighter mobile padding and stacks Herb/Compound buttons vertically until `sm`, while preserving the desktop horizontal layout.