### PR TITLE
feat(research): compare registered and reported primary outcomes

### DIFF
--- a/lib/__tests__/research-outcome-registration-alignment.test.ts
+++ b/lib/__tests__/research-outcome-registration-alignment.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeOutcomeRegistrationAlignment } from '@/lib/research-outcome-registration-alignment'
+import type { OutcomeMetadataAnalysis, StudyOutcomeMetadata } from '@/lib/research-outcome-metadata'
+
+function study(overrides: Partial<StudyOutcomeMetadata> = {}): StudyOutcomeMetadata {
+  return {
+    url: '/herbs/example/',
+    studyId: 'pmid:123',
+    trialRegistrationIds: ['NCT12345678'],
+    primaryOutcomes: [],
+    secondaryOutcomes: [],
+    registeredPrimaryOutcomes: [],
+    reportedPrimaryOutcomes: [],
+    primaryOutcomeStatus: 'unknown',
+    explicitOutcomeSwitch: false,
+    explicitRegisteredOutcomeNotReported: false,
+    structuredFieldCount: 0,
+    hasOutcomeMetadata: false,
+    ...overrides,
+  }
+}
+
+function metadata(studies: StudyOutcomeMetadata[]): OutcomeMetadataAnalysis {
+  return {
+    studies,
+    summary: {
+      canonicalStudies: studies.length,
+      studiesWithOutcomeMetadata: studies.filter((item) => item.hasOutcomeMetadata).length,
+      studiesWithPrimaryOutcomes: 0,
+      studiesWithSecondaryOutcomes: 0,
+      studiesWithRegisteredPrimaryOutcomes: studies.filter((item) => item.registeredPrimaryOutcomes.length > 0).length,
+      studiesWithReportedPrimaryOutcomes: studies.filter((item) => item.reportedPrimaryOutcomes.length > 0).length,
+      studiesWithRegistryIds: studies.filter((item) => item.trialRegistrationIds.length > 0).length,
+      primaryOutcomeNotMet: 0,
+      explicitOutcomeSwitches: studies.filter((item) => item.explicitOutcomeSwitch).length,
+      explicitRegisteredOutcomeNonReporting: studies.filter((item) => item.explicitRegisteredOutcomeNotReported).length,
+    },
+  }
+}
+
+describe('outcome registration alignment', () => {
+  it('matches outcome names after conservative formatting normalization', () => {
+    const result = analyzeOutcomeRegistrationAlignment(metadata([
+      study({
+        registeredPrimaryOutcomes: ['Insomnia Severity Index (ISI)'],
+        reportedPrimaryOutcomes: ['Insomnia Severity Index (ISI)'],
+      }),
+    ]))
+
+    expect(result.studies[0].status).toBe('matched')
+    expect(result.summary.matchedStudies).toBe(1)
+    expect(result.summary.findings).toBe(0)
+  })
+
+  it('detects partial divergence when only some registered outcomes are reported as primary', () => {
+    const result = analyzeOutcomeRegistrationAlignment(metadata([
+      study({
+        registeredPrimaryOutcomes: ['Sleep onset latency', 'Wake after sleep onset'],
+        reportedPrimaryOutcomes: ['Sleep onset latency', 'Total sleep time'],
+      }),
+    ]))
+
+    expect(result.studies[0]).toMatchObject({
+      status: 'partial-mismatch',
+      missingRegisteredPrimaryOutcomes: ['Wake after sleep onset'],
+      unregisteredReportedPrimaryOutcomes: ['Total sleep time'],
+      outcomeHierarchyConcern: true,
+    })
+  })
+
+  it('detects a full mismatch when named registered and reported primaries do not overlap', () => {
+    const result = analyzeOutcomeRegistrationAlignment(metadata([
+      study({
+        registeredPrimaryOutcomes: ['Insomnia Severity Index'],
+        reportedPrimaryOutcomes: ['Quality of life'],
+      }),
+    ]))
+
+    expect(result.studies[0].status).toBe('mismatch')
+    expect(result.summary.mismatchStudies).toBe(1)
+    expect(result.summary.findings).toBe(1)
+  })
+
+  it('keeps missing named outcome metadata unassessable', () => {
+    const result = analyzeOutcomeRegistrationAlignment(metadata([
+      study({ registeredPrimaryOutcomes: ['Insomnia Severity Index'] }),
+    ]))
+
+    expect(result.studies[0].status).toBe('unassessable')
+    expect(result.studies[0].outcomeHierarchyConcern).toBe(false)
+  })
+
+  it('preserves explicit switch and non-reporting concerns without inventing named mismatches', () => {
+    const result = analyzeOutcomeRegistrationAlignment(metadata([
+      study({
+        explicitOutcomeSwitch: true,
+        explicitRegisteredOutcomeNotReported: true,
+      }),
+    ]))
+
+    expect(result.studies[0].status).toBe('unassessable')
+    expect(result.studies[0].outcomeHierarchyConcern).toBe(true)
+    expect(result.summary.explicitOutcomeSwitches).toBe(1)
+    expect(result.summary.explicitRegisteredOutcomeNonReporting).toBe(1)
+  })
+})

--- a/lib/research-outcome-registration-alignment.ts
+++ b/lib/research-outcome-registration-alignment.ts
@@ -1,0 +1,133 @@
+import type { OutcomeMetadataAnalysis, StudyOutcomeMetadata } from './research-outcome-metadata'
+
+export type OutcomeRegistrationAlignmentStatus =
+  | 'unassessable'
+  | 'matched'
+  | 'partial-mismatch'
+  | 'mismatch'
+
+export type StudyOutcomeRegistrationAlignment = {
+  url: string
+  studyId: string
+  trialRegistrationIds: string[]
+  status: OutcomeRegistrationAlignmentStatus
+  registeredPrimaryOutcomes: string[]
+  reportedPrimaryOutcomes: string[]
+  matchedPrimaryOutcomes: string[]
+  missingRegisteredPrimaryOutcomes: string[]
+  unregisteredReportedPrimaryOutcomes: string[]
+  explicitOutcomeSwitch: boolean
+  explicitRegisteredOutcomeNotReported: boolean
+  outcomeHierarchyConcern: boolean
+}
+
+export type OutcomeRegistrationAlignmentAnalysis = {
+  studies: StudyOutcomeRegistrationAlignment[]
+  assessableStudies: StudyOutcomeRegistrationAlignment[]
+  findings: StudyOutcomeRegistrationAlignment[]
+  summary: {
+    canonicalStudies: number
+    assessableStudies: number
+    matchedStudies: number
+    partialMismatchStudies: number
+    mismatchStudies: number
+    explicitOutcomeSwitches: number
+    explicitRegisteredOutcomeNonReporting: number
+    findings: number
+  }
+}
+
+function normalizeOutcomeName(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[‐‑‒–—]/g, '-')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function normalizedLookup(values: string[]): Map<string, string> {
+  const lookup = new Map<string, string>()
+  for (const value of values) {
+    const normalized = normalizeOutcomeName(value)
+    if (normalized && !lookup.has(normalized)) lookup.set(normalized, value)
+  }
+  return lookup
+}
+
+function alignmentForStudy(study: StudyOutcomeMetadata): StudyOutcomeRegistrationAlignment {
+  const registered = normalizedLookup(study.registeredPrimaryOutcomes)
+  const reported = normalizedLookup(study.reportedPrimaryOutcomes)
+  const registeredKeys = [...registered.keys()]
+  const reportedKeys = [...reported.keys()]
+
+  let status: OutcomeRegistrationAlignmentStatus = 'unassessable'
+  if (registeredKeys.length && reportedKeys.length) {
+    const matchedKeys = registeredKeys.filter((key) => reported.has(key))
+    const sameCardinality = registeredKeys.length === reportedKeys.length
+    if (matchedKeys.length === registeredKeys.length && sameCardinality) status = 'matched'
+    else if (matchedKeys.length > 0) status = 'partial-mismatch'
+    else status = 'mismatch'
+  }
+
+  const matchedPrimaryOutcomes = registeredKeys
+    .filter((key) => reported.has(key))
+    .map((key) => registered.get(key)!)
+  const missingRegisteredPrimaryOutcomes = registeredKeys
+    .filter((key) => !reported.has(key))
+    .map((key) => registered.get(key)!)
+  const unregisteredReportedPrimaryOutcomes = reportedKeys
+    .filter((key) => !registered.has(key))
+    .map((key) => reported.get(key)!)
+  const outcomeHierarchyConcern = status === 'partial-mismatch'
+    || status === 'mismatch'
+    || study.explicitOutcomeSwitch
+    || study.explicitRegisteredOutcomeNotReported
+
+  return {
+    url: study.url,
+    studyId: study.studyId,
+    trialRegistrationIds: study.trialRegistrationIds,
+    status,
+    registeredPrimaryOutcomes: study.registeredPrimaryOutcomes,
+    reportedPrimaryOutcomes: study.reportedPrimaryOutcomes,
+    matchedPrimaryOutcomes,
+    missingRegisteredPrimaryOutcomes,
+    unregisteredReportedPrimaryOutcomes,
+    explicitOutcomeSwitch: study.explicitOutcomeSwitch,
+    explicitRegisteredOutcomeNotReported: study.explicitRegisteredOutcomeNotReported,
+    outcomeHierarchyConcern,
+  }
+}
+
+/**
+ * Compare explicit structured registered/prespecified primary outcomes with
+ * explicit structured reported primary outcomes at canonical-study level.
+ * Missing metadata is deliberately unassessable rather than inferred as a
+ * mismatch. Explicit switch/non-reporting flags remain independent evidence and
+ * can surface a concern even when named outcomes are unavailable.
+ */
+export function analyzeOutcomeRegistrationAlignment(
+  outcomeMetadata: OutcomeMetadataAnalysis,
+): OutcomeRegistrationAlignmentAnalysis {
+  const studies = outcomeMetadata.studies.map(alignmentForStudy)
+  const assessableStudies = studies.filter((study) => study.status !== 'unassessable')
+  const findings = studies.filter((study) => study.outcomeHierarchyConcern)
+
+  return {
+    studies,
+    assessableStudies,
+    findings,
+    summary: {
+      canonicalStudies: studies.length,
+      assessableStudies: assessableStudies.length,
+      matchedStudies: assessableStudies.filter((study) => study.status === 'matched').length,
+      partialMismatchStudies: assessableStudies.filter((study) => study.status === 'partial-mismatch').length,
+      mismatchStudies: assessableStudies.filter((study) => study.status === 'mismatch').length,
+      explicitOutcomeSwitches: studies.filter((study) => study.explicitOutcomeSwitch).length,
+      explicitRegisteredOutcomeNonReporting: studies.filter((study) => study.explicitRegisteredOutcomeNotReported).length,
+      findings: findings.length,
+    },
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -13,6 +13,7 @@ import { analyzeEvidenceLineage } from './research-evidence-lineage'
 import { analyzeClaimEvidenceAge, analyzeStudyYearConflicts, summarizeEvidenceAge } from './research-evidence-age'
 import { buildResearchMetadataIntegrity } from './research-metadata-integrity'
 import { analyzeOutcomeMetadata } from './research-outcome-metadata'
+import { analyzeOutcomeRegistrationAlignment } from './research-outcome-registration-alignment'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
@@ -68,6 +69,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   )
   const trialRegistrationIndependence = analyzeTrialRegistrationIndependence(analysis)
   const outcomeMetadata = analyzeOutcomeMetadata({ analysis, trialRegistrationIndependence })
+  const outcomeRegistrationAlignment = analyzeOutcomeRegistrationAlignment(outcomeMetadata)
   const evidenceLineage = analyzeEvidenceLineage(analysis)
   const evidenceIndependenceCoverage = analyzeEvidenceIndependenceCoverage({
     trialRegistrationIndependence,
@@ -122,6 +124,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     highConfidenceProvenanceNarrowMultiStudyClaims,
     trialRegistrationIndependence,
     outcomeMetadata,
+    outcomeRegistrationAlignment,
     evidenceLineage,
     evidenceIndependenceCoverage,
     underlyingStudyIndependence,


### PR DESCRIPTION
Adds canonical study-level registered-vs-reported primary outcome alignment. Structured named outcomes are compared conservatively with formatting-only normalization, producing matched, partial-mismatch, mismatch, or unassessable states. Explicit outcome-switch and registered-outcome non-reporting signals remain independent concerns. Missing metadata is never inferred as misconduct. Adds focused regression coverage and exposes the analysis through the canonical research-quality topology.