### PR TITLE
test(research): align topology gap weights

### DIFF
--- a/lib/__tests__/research-independence-coverage-policy.test.ts
+++ b/lib/__tests__/research-independence-coverage-policy.test.ts
@@ -18,6 +18,8 @@ const weights = {
   highConfidenceCausalLanguageBonus: 8,
   claimCitationMetadataGap: 8,
   highConfidenceCitationMetadataBonus: 4,
+  metadataIntegrity: 8,
+  highConfidenceMetadataIntegrityBonus: 4,
   provenanceNarrowMultiStudySupport: 8,
   highConfidenceProvenanceNarrowBonus: 4,
   pseudoMultiSourceSupport: 9,


### PR DESCRIPTION
Update the remediation policy fixture with the two metadata-integrity weights required by the current canonical gap-weight contract. No production scoring changes.