### PR TITLE
feat(research): unify outcome-reporting integrity

### DIFF
--- a/lib/__tests__/research-outcome-reporting-integrity.test.ts
+++ b/lib/__tests__/research-outcome-reporting-integrity.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeOutcomeReportingIntegrity } from '@/lib/research-outcome-reporting-integrity'
+import type { OutcomeMetadataAnalysis } from '@/lib/research-outcome-metadata'
+import type { OutcomeRegistrationAlignmentAnalysis } from '@/lib/research-outcome-registration-alignment'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import type { SelectiveOutcomeReportingReport } from '@/lib/research-selective-outcome-reporting'
+
+function analysis(): ResearchQualityAnalysis {
+  return {
+    cache: {},
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: {
+        slug: 'example',
+        sources: [
+          { id: 's1', pmid: '123', studyClass: 'rct' },
+          { id: 's2', pmid: '456', studyClass: 'rct' },
+        ],
+        claimMap: [{
+          id: 'claim-1',
+          predicate: 'supports_outcome',
+          confidence: 0.9,
+          reviewStatus: 'approved',
+          sourceRefIds: ['s1', 's2'],
+        }],
+      },
+    }],
+    claimAnalyses: [],
+    structuredClaimAnalyses: [],
+    profileAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+}
+
+function outcomeMetadata(): OutcomeMetadataAnalysis {
+  const studies = [
+    {
+      url: '/herbs/example/', studyId: 'pmid:123', trialRegistrationIds: ['NCT12345678'],
+      primaryOutcomes: [], secondaryOutcomes: [], registeredPrimaryOutcomes: ['ISI'], reportedPrimaryOutcomes: ['Quality of life'],
+      primaryOutcomeStatus: 'not-met' as const, explicitOutcomeSwitch: false, explicitRegisteredOutcomeNotReported: false,
+      structuredFieldCount: 2, hasOutcomeMetadata: true,
+    },
+    {
+      url: '/herbs/example/', studyId: 'pmid:456', trialRegistrationIds: [],
+      primaryOutcomes: [], secondaryOutcomes: [], registeredPrimaryOutcomes: [], reportedPrimaryOutcomes: [],
+      primaryOutcomeStatus: 'unknown' as const, explicitOutcomeSwitch: false, explicitRegisteredOutcomeNotReported: false,
+      structuredFieldCount: 0, hasOutcomeMetadata: false,
+    },
+  ]
+  return {
+    studies,
+    summary: {
+      canonicalStudies: 2,
+      studiesWithOutcomeMetadata: 1,
+      studiesWithPrimaryOutcomes: 0,
+      studiesWithSecondaryOutcomes: 0,
+      studiesWithRegisteredPrimaryOutcomes: 1,
+      studiesWithReportedPrimaryOutcomes: 1,
+      studiesWithRegistryIds: 1,
+      primaryOutcomeNotMet: 1,
+      explicitOutcomeSwitches: 0,
+      explicitRegisteredOutcomeNonReporting: 0,
+    },
+  }
+}
+
+function alignment(): OutcomeRegistrationAlignmentAnalysis {
+  const finding = {
+    url: '/herbs/example/',
+    studyId: 'pmid:123',
+    trialRegistrationIds: ['NCT12345678'],
+    status: 'mismatch' as const,
+    registeredPrimaryOutcomes: ['ISI'],
+    reportedPrimaryOutcomes: ['Quality of life'],
+    matchedPrimaryOutcomes: [],
+    missingRegisteredPrimaryOutcomes: ['ISI'],
+    unregisteredReportedPrimaryOutcomes: ['Quality of life'],
+    explicitOutcomeSwitch: false,
+    explicitRegisteredOutcomeNotReported: false,
+    outcomeHierarchyConcern: true,
+  }
+  return {
+    studies: [finding],
+    assessableStudies: [finding],
+    findings: [finding],
+    summary: {
+      canonicalStudies: 1,
+      assessableStudies: 1,
+      matchedStudies: 0,
+      partialMismatchStudies: 0,
+      mismatchStudies: 1,
+      explicitOutcomeSwitches: 0,
+      explicitRegisteredOutcomeNonReporting: 0,
+      findings: 1,
+    },
+  }
+}
+
+function selective(): SelectiveOutcomeReportingReport {
+  const finding = {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    predicate: 'supports_outcome',
+    confidence: 0.9,
+    humanSourceCount: 2,
+    assessableSourceCount: 1,
+    registeredOrPrespecifiedPrimaryNullCount: 1,
+    favorableSecondaryOrExploratoryCount: 1,
+    explicitOutcomeSwitchCount: 0,
+    primaryOutcomeNotMetCount: 1,
+    selectiveOutcomeRisk: true,
+    explicitOutcomeSwitchRisk: false,
+    reasons: ['null primary plus favorable secondary'],
+  }
+  return {
+    summary: {
+      approvedOutcomeClaims: 1,
+      assessableClaims: 1,
+      findings: 1,
+      highConfidenceFindings: 1,
+      selectiveOutcomeRisks: 1,
+      explicitOutcomeSwitchRisks: 0,
+    },
+    claims: [finding],
+    findings: [finding],
+    highConfidenceFindings: [finding],
+  }
+}
+
+describe('outcome-reporting integrity', () => {
+  it('joins study-level mismatch and claim-level selective reporting into one affected claim', () => {
+    const result = analyzeOutcomeReportingIntegrity({
+      analysis: analysis(),
+      outcomeMetadata: outcomeMetadata(),
+      outcomeRegistrationAlignment: alignment(),
+      selectiveOutcomeReporting: selective(),
+    })
+
+    expect(result.summary.affectedStudies).toBe(1)
+    expect(result.summary.affectedApprovedOutcomeClaims).toBe(1)
+    expect(result.claims[0]).toMatchObject({
+      claimId: 'claim-1',
+      affectedStudyIds: ['pmid:123'],
+      severity: 'high',
+    })
+    expect(result.claims[0].risks).toEqual(expect.arrayContaining([
+      'registered-reported-primary-mismatch',
+      'null-primary-with-favorable-secondary',
+    ]))
+  })
+
+  it('does not create findings for clean or unassessable studies without selective-reporting risk', () => {
+    const cleanAlignment: OutcomeRegistrationAlignmentAnalysis = {
+      studies: [{
+        url: '/herbs/example/', studyId: 'pmid:456', trialRegistrationIds: [], status: 'unassessable',
+        registeredPrimaryOutcomes: [], reportedPrimaryOutcomes: [], matchedPrimaryOutcomes: [],
+        missingRegisteredPrimaryOutcomes: [], unregisteredReportedPrimaryOutcomes: [],
+        explicitOutcomeSwitch: false, explicitRegisteredOutcomeNotReported: false, outcomeHierarchyConcern: false,
+      }],
+      assessableStudies: [],
+      findings: [],
+      summary: {
+        canonicalStudies: 1, assessableStudies: 0, matchedStudies: 0, partialMismatchStudies: 0,
+        mismatchStudies: 0, explicitOutcomeSwitches: 0, explicitRegisteredOutcomeNonReporting: 0, findings: 0,
+      },
+    }
+    const emptySelective: SelectiveOutcomeReportingReport = {
+      summary: {
+        approvedOutcomeClaims: 1, assessableClaims: 0, findings: 0, highConfidenceFindings: 0,
+        selectiveOutcomeRisks: 0, explicitOutcomeSwitchRisks: 0,
+      },
+      claims: [], findings: [], highConfidenceFindings: [],
+    }
+
+    const result = analyzeOutcomeReportingIntegrity({
+      analysis: analysis(),
+      outcomeMetadata: outcomeMetadata(),
+      outcomeRegistrationAlignment: cleanAlignment,
+      selectiveOutcomeReporting: emptySelective,
+    })
+
+    expect(result.summary.affectedStudies).toBe(0)
+    expect(result.summary.affectedApprovedOutcomeClaims).toBe(0)
+  })
+})

--- a/lib/research-outcome-reporting-integrity.ts
+++ b/lib/research-outcome-reporting-integrity.ts
@@ -1,0 +1,191 @@
+import {
+  approvedClaims,
+  canonicalStudyIdentityMap,
+  uniqueClaimStudyIdentities,
+  type ResearchClaim,
+} from './research-coverage'
+import type { OutcomeMetadataAnalysis } from './research-outcome-metadata'
+import type { OutcomeRegistrationAlignmentAnalysis } from './research-outcome-registration-alignment'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+import type { SelectiveOutcomeReportingReport } from './research-selective-outcome-reporting'
+
+export type OutcomeReportingRisk =
+  | 'registered-reported-primary-mismatch'
+  | 'registered-reported-primary-partial-mismatch'
+  | 'explicit-outcome-switch'
+  | 'explicit-registered-outcome-nonreporting'
+  | 'null-primary-with-favorable-secondary'
+
+export type OutcomeReportingSeverity = 'moderate' | 'high'
+
+export type StudyOutcomeReportingIntegrityFinding = {
+  url: string
+  studyId: string
+  trialRegistrationIds: string[]
+  risks: OutcomeReportingRisk[]
+  severity: OutcomeReportingSeverity
+}
+
+export type ClaimOutcomeReportingIntegrityFinding = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  linkedStudyCount: number
+  affectedStudyIds: string[]
+  risks: OutcomeReportingRisk[]
+  severity: OutcomeReportingSeverity
+}
+
+export type OutcomeReportingIntegrityAnalysis = {
+  studies: StudyOutcomeReportingIntegrityFinding[]
+  claims: ClaimOutcomeReportingIntegrityFinding[]
+  highPriorityStudies: StudyOutcomeReportingIntegrityFinding[]
+  highPriorityClaims: ClaimOutcomeReportingIntegrityFinding[]
+  summary: {
+    affectedStudies: number
+    affectedApprovedOutcomeClaims: number
+    highPriorityStudies: number
+    highPriorityClaims: number
+    explicitOutcomeSwitches: number
+    explicitRegisteredOutcomeNonReporting: number
+    primaryOutcomeMismatches: number
+    primaryOutcomePartialMismatches: number
+    selectiveOutcomeClaims: number
+  }
+}
+
+function text(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function isOutcomeClaim(claim: ResearchClaim): boolean {
+  return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
+}
+
+function severityFor(risks: readonly OutcomeReportingRisk[]): OutcomeReportingSeverity {
+  return risks.some((risk) =>
+    risk === 'registered-reported-primary-mismatch'
+    || risk === 'explicit-outcome-switch'
+    || risk === 'explicit-registered-outcome-nonreporting',
+  ) ? 'high' : 'moderate'
+}
+
+function uniqueRisks(risks: OutcomeReportingRisk[]): OutcomeReportingRisk[] {
+  return [...new Set(risks)]
+}
+
+/**
+ * Canonical integration layer for outcome-reporting integrity. Study-level
+ * registered/reported alignment and explicit reporting flags are joined to
+ * claim-level selective-outcome findings so downstream policy/editorial code
+ * does not have to recompute or reconcile these signals independently.
+ */
+export function analyzeOutcomeReportingIntegrity(input: {
+  analysis: ResearchQualityAnalysis
+  outcomeMetadata: OutcomeMetadataAnalysis
+  outcomeRegistrationAlignment: OutcomeRegistrationAlignmentAnalysis
+  selectiveOutcomeReporting: SelectiveOutcomeReportingReport
+}): OutcomeReportingIntegrityAnalysis {
+  const {
+    analysis,
+    outcomeMetadata,
+    outcomeRegistrationAlignment,
+    selectiveOutcomeReporting,
+  } = input
+
+  const metadataByStudy = new Map(
+    outcomeMetadata.studies.map((study) => [`${study.url}::${study.studyId}`, study]),
+  )
+  const studyRisks = new Map<string, OutcomeReportingRisk[]>()
+
+  for (const alignment of outcomeRegistrationAlignment.studies) {
+    const risks: OutcomeReportingRisk[] = []
+    if (alignment.status === 'mismatch') risks.push('registered-reported-primary-mismatch')
+    if (alignment.status === 'partial-mismatch') risks.push('registered-reported-primary-partial-mismatch')
+    if (alignment.explicitOutcomeSwitch) risks.push('explicit-outcome-switch')
+    if (alignment.explicitRegisteredOutcomeNotReported) risks.push('explicit-registered-outcome-nonreporting')
+    if (risks.length) studyRisks.set(`${alignment.url}::${alignment.studyId}`, uniqueRisks(risks))
+  }
+
+  const selectiveByClaim = new Map(
+    selectiveOutcomeReporting.findings.map((claim) => [`${claim.url}::${claim.claimId}`, claim]),
+  )
+
+  const studies = [...studyRisks.entries()].map(([key, risks]) => {
+    const separator = key.indexOf('::')
+    const url = key.slice(0, separator)
+    const studyId = key.slice(separator + 2)
+    return {
+      url,
+      studyId,
+      trialRegistrationIds: metadataByStudy.get(key)?.trialRegistrationIds ?? [],
+      risks,
+      severity: severityFor(risks),
+    }
+  }).sort((a, b) =>
+    Number(b.severity === 'high') - Number(a.severity === 'high')
+    || a.url.localeCompare(b.url)
+    || a.studyId.localeCompare(b.studyId),
+  )
+
+  const claims: ClaimOutcomeReportingIntegrityFinding[] = []
+  for (const { url, record } of analysis.profiles) {
+    const identities = canonicalStudyIdentityMap(record)
+    for (const claim of approvedClaims(record)) {
+      if (!isOutcomeClaim(claim)) continue
+      const claimId = text(claim.id) || 'unknown-claim'
+      const studyIds = uniqueClaimStudyIdentities(claim, identities)
+      const affectedStudyIds = studyIds.filter((studyId) => studyRisks.has(`${url}::${studyId}`))
+      const risks = affectedStudyIds.flatMap((studyId) => studyRisks.get(`${url}::${studyId}`) ?? [])
+      const selective = selectiveByClaim.get(`${url}::${claimId}`)
+      if (selective?.selectiveOutcomeRisk) risks.push('null-primary-with-favorable-secondary')
+      if (selective?.explicitOutcomeSwitchRisk && !risks.some((risk) =>
+        risk === 'explicit-outcome-switch' || risk === 'explicit-registered-outcome-nonreporting')) {
+        risks.push('explicit-outcome-switch')
+      }
+      const unique = uniqueRisks(risks)
+      if (!unique.length) continue
+
+      claims.push({
+        url,
+        claimId,
+        predicate: text(claim.predicate),
+        confidence: Number(claim.confidence ?? 0),
+        linkedStudyCount: studyIds.length,
+        affectedStudyIds,
+        risks: unique,
+        severity: severityFor(unique),
+      })
+    }
+  }
+
+  claims.sort((a, b) =>
+    Number(b.severity === 'high') - Number(a.severity === 'high')
+    || b.confidence - a.confidence
+    || b.affectedStudyIds.length - a.affectedStudyIds.length
+    || a.url.localeCompare(b.url)
+    || a.claimId.localeCompare(b.claimId),
+  )
+
+  const highPriorityStudies = studies.filter((study) => study.severity === 'high')
+  const highPriorityClaims = claims.filter((claim) => claim.severity === 'high')
+
+  return {
+    studies,
+    claims,
+    highPriorityStudies,
+    highPriorityClaims,
+    summary: {
+      affectedStudies: studies.length,
+      affectedApprovedOutcomeClaims: claims.length,
+      highPriorityStudies: highPriorityStudies.length,
+      highPriorityClaims: highPriorityClaims.length,
+      explicitOutcomeSwitches: studies.filter((study) => study.risks.includes('explicit-outcome-switch')).length,
+      explicitRegisteredOutcomeNonReporting: studies.filter((study) => study.risks.includes('explicit-registered-outcome-nonreporting')).length,
+      primaryOutcomeMismatches: studies.filter((study) => study.risks.includes('registered-reported-primary-mismatch')).length,
+      primaryOutcomePartialMismatches: studies.filter((study) => study.risks.includes('registered-reported-primary-partial-mismatch')).length,
+      selectiveOutcomeClaims: claims.filter((claim) => claim.risks.includes('null-primary-with-favorable-secondary')).length,
+    },
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -14,6 +14,7 @@ import { analyzeClaimEvidenceAge, analyzeStudyYearConflicts, summarizeEvidenceAg
 import { buildResearchMetadataIntegrity } from './research-metadata-integrity'
 import { analyzeOutcomeMetadata } from './research-outcome-metadata'
 import { analyzeOutcomeRegistrationAlignment } from './research-outcome-registration-alignment'
+import { analyzeOutcomeReportingIntegrity } from './research-outcome-reporting-integrity'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
@@ -86,6 +87,12 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const effectCertainty = analyzeEffectCertainty(analysis)
   const directionalConsistency = analyzeDirectionalConsistency(analysis)
   const selectiveOutcomeReporting = analyzeSelectiveOutcomeReporting({ analysis, outcomeMetadata })
+  const outcomeReportingIntegrity = analyzeOutcomeReportingIntegrity({
+    analysis,
+    outcomeMetadata,
+    outcomeRegistrationAlignment,
+    selectiveOutcomeReporting,
+  })
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
   const metadataIntegrity = buildResearchMetadataIntegrity({
@@ -134,6 +141,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     effectCertainty,
     directionalConsistency,
     selectiveOutcomeReporting,
+    outcomeReportingIntegrity,
     claimLanguageCalibration,
     claimCitationMetadata,
     metadataIntegrity,


### PR DESCRIPTION
Creates one canonical outcome-reporting integrity product that joins study-level registered/reported outcome alignment with claim-level selective-outcome findings. Produces affected studies and approved outcome claims, stable risk categories, and conservative moderate/high severity without treating missing metadata as evidence of bias. Exposes the unified product through the research-quality topology with regression coverage.