### PR TITLE
feat(evidence-report): expose research topology coverage

### DIFF
--- a/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
+++ b/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
@@ -24,6 +24,9 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
   const multiStudy = metrics.independenceMultiStudyApprovedClaims ?? 0
   const highConfidenceUnresolved = metrics.highConfidenceIndependenceUnresolvedClaims ?? 0
   const primaryHumanMissingMetadata = metrics.globalPrimaryHumanPublicationsWithoutIndependenceMetadata ?? 0
+  const topologyRequested = metrics.researchTopologyRequestedProfiles ?? 0
+  const topologyMatched = metrics.researchTopologyMatchedProfiles ?? 0
+  const topologyMissing = metrics.researchTopologyMissingProfiles ?? 0
 
   return (
     <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8" aria-labelledby="underlying-study-independence-heading">
@@ -35,11 +38,18 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
         The canonical research graph first deduplicates publication identities across profiles, then collapses publications only when explicit trial-registration, cohort, dataset, or parent-study lineage shows they belong to the same underlying evidence unit. Missing lineage stays unresolved and is never treated as proof that publications are either dependent or independent.
       </p>
 
+      {topologyMissing > 0 ? (
+        <div className="mt-5 rounded-xl border border-amber-900/15 bg-amber-50/70 p-4 text-sm leading-6 text-amber-950">
+          <strong>Research-topology coverage is {topologyMatched} of {topologyRequested} public profiles ({pct(metrics.researchTopologyProfileCoverage)}).</strong>{' '}
+          {topologyMissing} public profile{topologyMissing === 1 ? '' : 's'} currently lack a matching canonical research-detail profile, so the independence-adjusted counts below cover only the matched subset. Ingredient, grade, and public source-record metrics elsewhere in this report still use the full indexable dataset.
+        </div>
+      ) : null}
+
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Primary-human publications</p>
           <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalPrimaryHumanPublicationCount)}</p>
-          <p className="mt-2 text-xs leading-5 text-muted">Unique site-wide publication identities classified as primary human research.</p>
+          <p className="mt-2 text-xs leading-5 text-muted">Unique publication identities within the matched public research-profile scope, classified as primary human research.</p>
         </article>
         <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Independence-adjusted human units</p>
@@ -73,7 +83,7 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
       ) : null}
 
       <p className="mt-5 text-xs leading-5 text-muted">
-        Because unknown relationships are left separate, the adjusted study count is a conservative upper bound with respect to unobserved publication dependence—not proof that every remaining evidence unit is independently recruited or generated. These counts are narrower than the report’s “human evidence source records” metric: syntheses and reviews remain publication-level evidence records, while the independence-adjusted figure above is restricted to primary human research. It is not an estimate of unique participants and is not an RCT-only count. Across all study classes, the current topology retains {value(metrics.globalInventoryUnderlyingStudyCount)} evidence units after explicitly proven dependence collapse.
+        Because unknown relationships are left separate, the adjusted study count is a conservative upper bound with respect to unobserved publication dependence—not proof that every remaining evidence unit is independently recruited or generated. These counts are narrower than the report’s “human evidence source records” metric: syntheses and reviews remain publication-level evidence records, while the independence-adjusted figure above is restricted to primary human research. It is not an estimate of unique participants and is not an RCT-only count. Across all study classes in the matched public research-profile scope, the current topology retains {value(metrics.globalInventoryUnderlyingStudyCount)} evidence units after explicitly proven dependence collapse.
       </p>
     </section>
   )

--- a/lib/__tests__/public-evidence-dataset.test.ts
+++ b/lib/__tests__/public-evidence-dataset.test.ts
@@ -82,7 +82,7 @@ describe('public evidence dataset', () => {
     expect(dataset.metrics.ingredientsWithSafetyCautions).toBe(1)
   })
 
-  it('does not fabricate independence metrics or coverage in the pure record builder', () => {
+  it('does not fabricate independence metrics or topology coverage in the pure record builder', () => {
     const dataset = buildPublicEvidenceDatasetFromRecords([
       { type: 'herb', record: record({ slug: 'alpha' }) },
     ])
@@ -90,6 +90,10 @@ describe('public evidence dataset', () => {
     expect(PUBLIC_EVIDENCE_DATASET_VERSION).toBe('2026.08.16')
     expect(dataset.metrics).toMatchObject({
       underlyingStudyMetricsSource: null,
+      researchTopologyRequestedProfiles: null,
+      researchTopologyMatchedProfiles: null,
+      researchTopologyMissingProfiles: null,
+      researchTopologyProfileCoverage: null,
       globalInventoryPublicationCount: null,
       globalInventoryUnderlyingStudyCount: null,
       globalCollapsedInventoryPublicationCount: null,

--- a/lib/__tests__/research-quality-scoped-topology.test.ts
+++ b/lib/__tests__/research-quality-scoped-topology.test.ts
@@ -67,10 +67,42 @@ describe('scoped research-quality topology', () => {
     const scoped = buildScopedResearchQualityTopology(root, ['/herbs/public/'])
 
     expect(scoped.analysis.profiles.map((profile) => profile.url)).toEqual(['/herbs/public/'])
+    expect(scoped).toMatchObject({
+      requestedProfileUrls: ['/herbs/public/'],
+      matchedProfileUrls: ['/herbs/public/'],
+      missingProfileUrls: [],
+      profileCoverage: 1,
+    })
     expect(scoped.topology.underlyingStudyIndependence.summary).toMatchObject({
       profilesAnalyzed: 1,
       globalInventoryPublicationCount: 1,
       globalPrimaryHumanPublicationCount: 1,
     })
+  })
+
+  it('reports requested public profiles that have no canonical research-detail profile', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ths-scoped-topology-gap-'))
+    roots.push(root)
+    const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+    mkdirSync(detailDir, { recursive: true })
+
+    writeFileSync(path.join(detailDir, 'public.json'), JSON.stringify({
+      slug: 'public',
+      sources: [{ id: 'public-rct', pmid: '11111111', studyClass: 'rct', title: 'Public trial' }],
+      claimMap: [],
+    }))
+
+    const scoped = buildScopedResearchQualityTopology(
+      root,
+      ['/herbs/public/', '/herbs/missing/'],
+    )
+
+    expect(scoped).toMatchObject({
+      requestedProfileUrls: ['/herbs/missing/', '/herbs/public/'],
+      matchedProfileUrls: ['/herbs/public/'],
+      missingProfileUrls: ['/herbs/missing/'],
+      profileCoverage: 0.5,
+    })
+    expect(scoped.topology.underlyingStudyIndependence.summary.profilesAnalyzed).toBe(1)
   })
 })

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -103,6 +103,11 @@ export type PublicEvidenceReportMetrics = {
   disagreementStudyCount: number
   /** Null for synthetic/pure builders that do not execute canonical topology. */
   underlyingStudyMetricsSource: 'canonical-research-topology' | null
+  /** Public/indexable profiles requested from and matched by the canonical research topology. */
+  researchTopologyRequestedProfiles: number | null
+  researchTopologyMatchedProfiles: number | null
+  researchTopologyMissingProfiles: number | null
+  researchTopologyProfileCoverage: number | null
   /** Unique publication identities within the current public/indexable dataset scope. */
   globalInventoryPublicationCount: number | null
   /** Evidence units remaining in the current public scope after explicitly proven registry/lineage dependence is collapsed. */
@@ -432,6 +437,10 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     noClearEffectRelationships,
     disagreementStudyCount: studies.filter(study => study.relationshipSummary === 'mixed').length,
     underlyingStudyMetricsSource: null,
+    researchTopologyRequestedProfiles: null,
+    researchTopologyMatchedProfiles: null,
+    researchTopologyMissingProfiles: null,
+    researchTopologyProfileCoverage: null,
     globalInventoryPublicationCount: null,
     globalInventoryUnderlyingStudyCount: null,
     globalCollapsedInventoryPublicationCount: null,
@@ -493,10 +502,11 @@ export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset>
     hydrateIndexableRecords(compounds, 'compound'),
   ])
   const dataset = buildPublicEvidenceDatasetFromRecords([...herbRecords, ...compoundRecords])
-  const topology = buildScopedResearchQualityTopology(
+  const scopedTopology = buildScopedResearchQualityTopology(
     process.cwd(),
     dataset.ingredients.map((ingredient) => ingredient.path),
-  ).topology
+  )
+  const topology = scopedTopology.topology
   const independence = topology.underlyingStudyIndependence.summary
   const coverage = topology.evidenceIndependenceCoverage.summary
 
@@ -505,6 +515,10 @@ export async function getPublicEvidenceDataset(): Promise<PublicEvidenceDataset>
     metrics: {
       ...dataset.metrics,
       underlyingStudyMetricsSource: 'canonical-research-topology',
+      researchTopologyRequestedProfiles: scopedTopology.requestedProfileUrls.length,
+      researchTopologyMatchedProfiles: scopedTopology.matchedProfileUrls.length,
+      researchTopologyMissingProfiles: scopedTopology.missingProfileUrls.length,
+      researchTopologyProfileCoverage: scopedTopology.profileCoverage,
       globalInventoryPublicationCount: independence.globalInventoryPublicationCount,
       globalInventoryUnderlyingStudyCount: independence.globalInventoryUnderlyingStudyCount,
       globalCollapsedInventoryPublicationCount: independence.globalCollapsedInventoryPublicationCount,

--- a/lib/research-quality-snapshot.ts
+++ b/lib/research-quality-snapshot.ts
@@ -29,6 +29,15 @@ export type ResearchQualitySnapshot = {
 export type ScopedResearchQualityTopology = {
   analysis: ResearchQualityAnalysis
   topology: ResearchQualityTopology
+  requestedProfileUrls: string[]
+  matchedProfileUrls: string[]
+  missingProfileUrls: string[]
+  profileCoverage: number
+}
+
+function round(value: number, digits = 3): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
 }
 
 /**
@@ -55,7 +64,10 @@ export function scopeResearchQualityAnalysis(
  * Canonical analysis+topology boundary for consumers whose visibility scope is
  * intentionally narrower than the full repository. The full analysis is built
  * with the same loaders/classifiers as CI, then scoped before any topology is
- * derived. This is deliberately narrower than buildResearchQualitySnapshot:
+ * derived. The result also reports requested-vs-matched coverage so a consumer
+ * cannot silently treat missing canonical detail profiles as analyzed.
+ *
+ * This is deliberately narrower than buildResearchQualitySnapshot:
  * grade/gate/remediation products are repository-wide and must not be presented
  * as scoped unless their own data loaders are scoped too.
  */
@@ -63,10 +75,22 @@ export function buildScopedResearchQualityTopology(
   root = process.cwd(),
   profileUrls: Iterable<string>,
 ): ScopedResearchQualityTopology {
-  const analysis = scopeResearchQualityAnalysis(analyzeResearchQuality(root), profileUrls)
+  const requestedProfileUrls = [...new Set(profileUrls)].sort()
+  const analysis = scopeResearchQualityAnalysis(analyzeResearchQuality(root), requestedProfileUrls)
+  const matchedProfileUrls = analysis.profiles.map((profile) => profile.url).sort()
+  const matched = new Set(matchedProfileUrls)
+  const missingProfileUrls = requestedProfileUrls.filter((url) => !matched.has(url))
+  const profileCoverage = round(
+    requestedProfileUrls.length ? matchedProfileUrls.length / requestedProfileUrls.length : 1,
+  )
+
   return {
     analysis,
     topology: buildResearchQualityTopology(analysis),
+    requestedProfileUrls,
+    matchedProfileUrls,
+    missingProfileUrls,
+    profileCoverage,
   }
 }
 


### PR DESCRIPTION
Makes scoped research topology self-auditing by reporting requested, matched, and missing profile URLs plus coverage. Publishes the resulting profile counts/coverage in the public evidence dataset and warns readers when independence-adjusted metrics cover only a subset of indexable profiles. Adds regressions for missing canonical research-detail profiles and preserves null provenance in pure builders.