### PR TITLE
refactor(visual): simplify herb directory hero

### DIFF
--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -41,12 +41,6 @@ export default async function HerbsPage() {
   const leanHerbs = toLeanProfileIndexRecords(herbs)
   const leanPageItems = toLeanProfileIndexRecords(pageData.pageItems as RuntimeRecord[])
 
-  const heroMetrics = [
-    { value: herbs.length, label: 'profiles' },
-    { value: pageData.totalPages, label: 'index pages' },
-    { value: 'A–Z', label: 'searchable' },
-  ]
-
   return (
     <div className="mx-auto max-w-6xl space-y-6 px-4 py-4 sm:py-6">
       <header className="hero-shell rounded-[2rem] border px-5 py-6 sm:p-8">
@@ -55,25 +49,6 @@ export default async function HerbsPage() {
         <p className="text-reading mt-4 max-w-3xl">
           Mechanisms, safety notes, active compounds, and research context for {herbs.length} herbs — plain language, conservative claims.
         </p>
-
-        <dl className="mt-6 grid grid-cols-3 overflow-hidden rounded-2xl border border-[color:var(--hs-hairline)] bg-[color:color-mix(in_srgb,var(--hs-surface)_76%,transparent)] backdrop-blur-sm">
-          {heroMetrics.map((metric, index) => (
-            <div
-              key={metric.label}
-              className={`px-3 py-3.5 text-center sm:px-5 sm:py-4 ${index > 0 ? 'border-l border-[color:var(--hs-hairline)]' : ''}`}
-            >
-              <dt className="sr-only">{metric.label}</dt>
-              <dd>
-                <span className="block font-display text-2xl font-semibold tracking-[-0.035em] text-[color:var(--hs-ink)] sm:text-[1.7rem]">
-                  {metric.value}
-                </span>
-                <span className="mt-1 block text-[0.62rem] font-bold uppercase tracking-[0.1em] text-[color:var(--hs-body)] sm:text-[0.7rem] sm:tracking-[0.12em]">
-                  {metric.label}
-                </span>
-              </dd>
-            </div>
-          ))}
-        </dl>
       </header>
 
       <Pagination basePath="/herbs" currentPage={1} totalPages={pageData.totalPages} itemLabel="Herb profiles" />


### PR DESCRIPTION
Removes the herb-directory metric rail that surfaced implementation/status details such as index-page count and A–Z searchability. The hero now communicates only the library purpose and published profile count, reducing the number of stacked visual layers before search and profile content.