### PR TITLE
feat(research): audit outcome metadata coverage

### DIFF
--- a/lib/__tests__/research-outcome-metadata-coverage.test.ts
+++ b/lib/__tests__/research-outcome-metadata-coverage.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeOutcomeMetadataCoverage } from '@/lib/research-outcome-metadata-coverage'
+import type { OutcomeMetadataAnalysis } from '@/lib/research-outcome-metadata'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+
+function analysis(): ResearchQualityAnalysis {
+  return {
+    cache: {},
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: {
+        slug: 'example',
+        sources: [
+          { id: 's1', pmid: '1', studyClass: 'rct' },
+          { id: 's2', pmid: '2', studyClass: 'controlled-trial' },
+          { id: 's3', pmid: '3', studyClass: 'rct' },
+        ],
+        claimMap: [{
+          id: 'claim-1',
+          predicate: 'supports_outcome',
+          confidence: 0.9,
+          reviewStatus: 'approved',
+          sourceRefIds: ['s1', 's2'],
+        }],
+      },
+    }],
+    claimAnalyses: [],
+    structuredClaimAnalyses: [],
+    profileAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+}
+
+function metadata(): OutcomeMetadataAnalysis {
+  return {
+    studies: [
+      {
+        url: '/herbs/example/', studyId: 'pmid:1', trialRegistrationIds: ['NCT12345678'],
+        primaryOutcomes: ['ISI'], secondaryOutcomes: [], registeredPrimaryOutcomes: ['ISI'], reportedPrimaryOutcomes: [],
+        primaryOutcomeStatus: 'unknown', explicitOutcomeSwitch: false, explicitRegisteredOutcomeNotReported: false,
+        structuredFieldCount: 2, hasOutcomeMetadata: true,
+      },
+      {
+        url: '/herbs/example/', studyId: 'pmid:2', trialRegistrationIds: [],
+        primaryOutcomes: [], secondaryOutcomes: [], registeredPrimaryOutcomes: [], reportedPrimaryOutcomes: [],
+        primaryOutcomeStatus: 'unknown', explicitOutcomeSwitch: false, explicitRegisteredOutcomeNotReported: false,
+        structuredFieldCount: 0, hasOutcomeMetadata: false,
+      },
+      {
+        url: '/herbs/example/', studyId: 'pmid:3', trialRegistrationIds: [],
+        primaryOutcomes: [], secondaryOutcomes: [], registeredPrimaryOutcomes: [], reportedPrimaryOutcomes: [],
+        primaryOutcomeStatus: 'unknown', explicitOutcomeSwitch: false, explicitRegisteredOutcomeNotReported: false,
+        structuredFieldCount: 0, hasOutcomeMetadata: false,
+      },
+    ],
+    summary: {
+      canonicalStudies: 3,
+      studiesWithOutcomeMetadata: 1,
+      studiesWithPrimaryOutcomes: 1,
+      studiesWithSecondaryOutcomes: 0,
+      studiesWithRegisteredPrimaryOutcomes: 1,
+      studiesWithReportedPrimaryOutcomes: 0,
+      studiesWithRegistryIds: 1,
+      primaryOutcomeNotMet: 0,
+      explicitOutcomeSwitches: 0,
+      explicitRegisteredOutcomeNonReporting: 0,
+    },
+  }
+}
+
+describe('outcome metadata coverage', () => {
+  it('flags profiles with sparse primary-human outcome metadata and named alignment data', () => {
+    const result = analyzeOutcomeMetadataCoverage({ analysis: analysis(), outcomeMetadata: metadata() })
+
+    expect(result.profiles[0]).toMatchObject({
+      primaryHumanStudies: 3,
+      studiesWithOutcomeMetadata: 1,
+      studiesWithNamedAlignmentData: 0,
+      lowOutcomeMetadataCoverage: true,
+      lowNamedAlignmentCoverage: true,
+    })
+    expect(result.summary.profileCoverageGaps).toBe(1)
+  })
+
+  it('flags high-confidence approved outcome claims that cannot be directly aligned', () => {
+    const result = analyzeOutcomeMetadataCoverage({ analysis: analysis(), outcomeMetadata: metadata() })
+
+    expect(result.claims[0]).toMatchObject({
+      claimId: 'claim-1',
+      primaryHumanStudies: 2,
+      outcomeMetadataCoverage: 0.5,
+      namedAlignmentCoverage: 0,
+      outcomeMetadataGap: true,
+      highConfidenceOutcomeMetadataGap: true,
+    })
+    expect(result.summary.highConfidenceClaimCoverageGaps).toBe(1)
+  })
+
+  it('does not confuse absence of primary-human evidence with an outcome metadata gap', () => {
+    const input = analysis()
+    input.profiles[0].record.sources = [{ id: 's1', pmid: '1', studyClass: 'systematic-review' }]
+    input.profiles[0].record.claimMap![0].sourceRefIds = ['s1']
+
+    const result = analyzeOutcomeMetadataCoverage({ analysis: input, outcomeMetadata: metadata() })
+
+    expect(result.profiles[0].primaryHumanStudies).toBe(0)
+    expect(result.profiles[0].lowOutcomeMetadataCoverage).toBe(false)
+    expect(result.claims).toHaveLength(0)
+  })
+})

--- a/lib/research-outcome-metadata-coverage.ts
+++ b/lib/research-outcome-metadata-coverage.ts
@@ -1,0 +1,197 @@
+import {
+  PRIMARY_HUMAN_STUDY_CLASSES,
+  approvedClaims,
+  canonicalStudyClass,
+  canonicalStudyGroups,
+  canonicalStudyIdentityMap,
+  uniqueClaimStudyIdentities,
+  type ResearchClaim,
+} from './research-coverage'
+import type { OutcomeMetadataAnalysis } from './research-outcome-metadata'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type OutcomeMetadataCoverageCounts = {
+  primaryHumanStudies: number
+  studiesWithOutcomeMetadata: number
+  studiesWithRegistryIds: number
+  studiesWithNamedRegisteredPrimary: number
+  studiesWithNamedReportedPrimary: number
+  studiesWithNamedAlignmentData: number
+}
+
+export type ProfileOutcomeMetadataCoverage = OutcomeMetadataCoverageCounts & {
+  url: string
+  outcomeMetadataCoverage: number
+  registryCoverage: number
+  namedRegisteredPrimaryCoverage: number
+  namedReportedPrimaryCoverage: number
+  namedAlignmentCoverage: number
+  lowOutcomeMetadataCoverage: boolean
+  lowNamedAlignmentCoverage: boolean
+}
+
+export type ClaimOutcomeMetadataCoverage = OutcomeMetadataCoverageCounts & {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  outcomeMetadataCoverage: number
+  namedAlignmentCoverage: number
+  outcomeMetadataGap: boolean
+  highConfidenceOutcomeMetadataGap: boolean
+}
+
+export type OutcomeMetadataCoverageAnalysis = {
+  profiles: ProfileOutcomeMetadataCoverage[]
+  claims: ClaimOutcomeMetadataCoverage[]
+  profileCoverageGaps: ProfileOutcomeMetadataCoverage[]
+  claimCoverageGaps: ClaimOutcomeMetadataCoverage[]
+  highConfidenceClaimCoverageGaps: ClaimOutcomeMetadataCoverage[]
+  summary: {
+    profiles: number
+    profilesWithPrimaryHumanEvidence: number
+    profileCoverageGaps: number
+    approvedOutcomeClaimsWithPrimaryHumanEvidence: number
+    claimCoverageGaps: number
+    highConfidenceClaimCoverageGaps: number
+  }
+}
+
+function text(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000
+}
+
+function rate(numerator: number, denominator: number): number {
+  return denominator ? round(numerator / denominator) : 1
+}
+
+function isOutcomeClaim(claim: ResearchClaim): boolean {
+  return /supports_outcome|benefit|efficacy/i.test(text(claim.predicate))
+}
+
+function countsForStudyIds(
+  url: string,
+  studyIds: readonly string[],
+  metadataByStudy: Map<string, OutcomeMetadataAnalysis['studies'][number]>,
+): OutcomeMetadataCoverageCounts {
+  const rows = studyIds.map((studyId) => metadataByStudy.get(`${url}::${studyId}`)).filter(Boolean)
+  return {
+    primaryHumanStudies: studyIds.length,
+    studiesWithOutcomeMetadata: rows.filter((row) => row!.hasOutcomeMetadata).length,
+    studiesWithRegistryIds: rows.filter((row) => row!.trialRegistrationIds.length > 0).length,
+    studiesWithNamedRegisteredPrimary: rows.filter((row) => row!.registeredPrimaryOutcomes.length > 0).length,
+    studiesWithNamedReportedPrimary: rows.filter((row) => row!.reportedPrimaryOutcomes.length > 0).length,
+    studiesWithNamedAlignmentData: rows.filter((row) =>
+      row!.registeredPrimaryOutcomes.length > 0 && row!.reportedPrimaryOutcomes.length > 0,
+    ).length,
+  }
+}
+
+function coverageFields(counts: OutcomeMetadataCoverageCounts) {
+  return {
+    outcomeMetadataCoverage: rate(counts.studiesWithOutcomeMetadata, counts.primaryHumanStudies),
+    registryCoverage: rate(counts.studiesWithRegistryIds, counts.primaryHumanStudies),
+    namedRegisteredPrimaryCoverage: rate(counts.studiesWithNamedRegisteredPrimary, counts.primaryHumanStudies),
+    namedReportedPrimaryCoverage: rate(counts.studiesWithNamedReportedPrimary, counts.primaryHumanStudies),
+    namedAlignmentCoverage: rate(counts.studiesWithNamedAlignmentData, counts.primaryHumanStudies),
+  }
+}
+
+/**
+ * Audit how much canonical primary-human evidence is actually assessable for
+ * outcome-reporting integrity. Coverage gaps remain distinct from integrity
+ * findings: missing metadata means unknown, not clean and not biased.
+ */
+export function analyzeOutcomeMetadataCoverage(input: {
+  analysis: ResearchQualityAnalysis
+  outcomeMetadata: OutcomeMetadataAnalysis
+}): OutcomeMetadataCoverageAnalysis {
+  const { analysis, outcomeMetadata } = input
+  const metadataByStudy = new Map(
+    outcomeMetadata.studies.map((study) => [`${study.url}::${study.studyId}`, study]),
+  )
+  const profiles: ProfileOutcomeMetadataCoverage[] = []
+  const claims: ClaimOutcomeMetadataCoverage[] = []
+
+  for (const { url, record } of analysis.profiles) {
+    const groups = canonicalStudyGroups(record)
+    const primaryHumanStudyIds = [...groups.entries()]
+      .filter(([, group]) => PRIMARY_HUMAN_STUDY_CLASSES.has(canonicalStudyClass(group, analysis.cache)))
+      .map(([studyId]) => studyId)
+    const profileCounts = countsForStudyIds(url, primaryHumanStudyIds, metadataByStudy)
+    const profileCoverage = coverageFields(profileCounts)
+    profiles.push({
+      url,
+      ...profileCounts,
+      ...profileCoverage,
+      lowOutcomeMetadataCoverage: profileCounts.primaryHumanStudies >= 3 && profileCoverage.outcomeMetadataCoverage < 0.5,
+      lowNamedAlignmentCoverage: profileCounts.primaryHumanStudies >= 3 && profileCoverage.namedAlignmentCoverage < 0.25,
+    })
+
+    const identities = canonicalStudyIdentityMap(record)
+    for (const claim of approvedClaims(record)) {
+      if (!isOutcomeClaim(claim)) continue
+      const linkedStudyIds = uniqueClaimStudyIdentities(claim, identities)
+        .filter((studyId) => {
+          const group = groups.get(studyId) ?? []
+          return group.length > 0 && PRIMARY_HUMAN_STUDY_CLASSES.has(canonicalStudyClass(group, analysis.cache))
+        })
+      if (!linkedStudyIds.length) continue
+
+      const claimCounts = countsForStudyIds(url, linkedStudyIds, metadataByStudy)
+      const claimCoverage = coverageFields(claimCounts)
+      const outcomeMetadataGap = claimCoverage.outcomeMetadataCoverage < 0.5 || claimCoverage.namedAlignmentCoverage === 0
+      const confidence = Number(claim.confidence ?? 0)
+      claims.push({
+        url,
+        claimId: text(claim.id) || 'unknown-claim',
+        predicate: text(claim.predicate),
+        confidence,
+        ...claimCounts,
+        outcomeMetadataCoverage: claimCoverage.outcomeMetadataCoverage,
+        namedAlignmentCoverage: claimCoverage.namedAlignmentCoverage,
+        outcomeMetadataGap,
+        highConfidenceOutcomeMetadataGap: outcomeMetadataGap && confidence >= 0.75,
+      })
+    }
+  }
+
+  profiles.sort((a, b) =>
+    Number(b.lowNamedAlignmentCoverage) - Number(a.lowNamedAlignmentCoverage)
+    || Number(b.lowOutcomeMetadataCoverage) - Number(a.lowOutcomeMetadataCoverage)
+    || a.namedAlignmentCoverage - b.namedAlignmentCoverage
+    || a.url.localeCompare(b.url),
+  )
+  claims.sort((a, b) =>
+    Number(b.highConfidenceOutcomeMetadataGap) - Number(a.highConfidenceOutcomeMetadataGap)
+    || Number(b.outcomeMetadataGap) - Number(a.outcomeMetadataGap)
+    || b.confidence - a.confidence
+    || a.namedAlignmentCoverage - b.namedAlignmentCoverage
+    || a.url.localeCompare(b.url)
+    || a.claimId.localeCompare(b.claimId),
+  )
+
+  const profileCoverageGaps = profiles.filter((profile) => profile.lowOutcomeMetadataCoverage || profile.lowNamedAlignmentCoverage)
+  const claimCoverageGaps = claims.filter((claim) => claim.outcomeMetadataGap)
+  const highConfidenceClaimCoverageGaps = claims.filter((claim) => claim.highConfidenceOutcomeMetadataGap)
+
+  return {
+    profiles,
+    claims,
+    profileCoverageGaps,
+    claimCoverageGaps,
+    highConfidenceClaimCoverageGaps,
+    summary: {
+      profiles: profiles.length,
+      profilesWithPrimaryHumanEvidence: profiles.filter((profile) => profile.primaryHumanStudies > 0).length,
+      profileCoverageGaps: profileCoverageGaps.length,
+      approvedOutcomeClaimsWithPrimaryHumanEvidence: claims.length,
+      claimCoverageGaps: claimCoverageGaps.length,
+      highConfidenceClaimCoverageGaps: highConfidenceClaimCoverageGaps.length,
+    },
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -13,6 +13,7 @@ import { analyzeEvidenceLineage } from './research-evidence-lineage'
 import { analyzeClaimEvidenceAge, analyzeStudyYearConflicts, summarizeEvidenceAge } from './research-evidence-age'
 import { buildResearchMetadataIntegrity } from './research-metadata-integrity'
 import { analyzeOutcomeMetadata } from './research-outcome-metadata'
+import { analyzeOutcomeMetadataCoverage } from './research-outcome-metadata-coverage'
 import { analyzeOutcomeRegistrationAlignment } from './research-outcome-registration-alignment'
 import { analyzeOutcomeReportingIntegrity } from './research-outcome-reporting-integrity'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
@@ -70,6 +71,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   )
   const trialRegistrationIndependence = analyzeTrialRegistrationIndependence(analysis)
   const outcomeMetadata = analyzeOutcomeMetadata({ analysis, trialRegistrationIndependence })
+  const outcomeMetadataCoverage = analyzeOutcomeMetadataCoverage({ analysis, outcomeMetadata })
   const outcomeRegistrationAlignment = analyzeOutcomeRegistrationAlignment(outcomeMetadata)
   const evidenceLineage = analyzeEvidenceLineage(analysis)
   const evidenceIndependenceCoverage = analyzeEvidenceIndependenceCoverage({
@@ -131,6 +133,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     highConfidenceProvenanceNarrowMultiStudyClaims,
     trialRegistrationIndependence,
     outcomeMetadata,
+    outcomeMetadataCoverage,
     outcomeRegistrationAlignment,
     evidenceLineage,
     evidenceIndependenceCoverage,


### PR DESCRIPTION
Adds profile- and approved-claim-level coverage auditing for outcome-reporting metadata across canonical primary-human studies. Tracks registry coverage, named registered primaries, named reported primaries, and direct alignment assessability; flags sparse coverage separately from integrity findings so unknown evidence is not misclassified as clean or biased. Includes regression coverage and exposes the product through the canonical topology.