### PR TITLE
Trust: guard legacy guide reference-count accuracy

### DIFF
--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -244,6 +244,14 @@ function auditLegacyGuideReferencePrimitives() {
     ])
 
     const source = text(file)
+    const visibleCount = source.match(/Evidence Review · (\d+) References/)?.[1]
+    const renderedCount = (source.match(/<Ref n=\{/g) || []).length
+    if (!visibleCount) {
+      add('error', 'legacy-guide-citations', `${slug} guide missing visible Evidence Review reference count`)
+    } else if (Number(visibleCount) !== renderedCount) {
+      add('error', 'legacy-guide-citations', `${slug} guide displays ${visibleCount} references but renders ${renderedCount}`)
+    }
+
     if (/^type RefProps\b/m.test(source) || /^function Ref\s*\(/m.test(source)) {
       add('error', 'legacy-guide-citations', `${slug} guide reintroduced a local legacy reference renderer`)
     }


### PR DESCRIPTION
Fixes #3722

## Summary
- extends the existing canonical AI answer-engine audit with a derived legacy-guide reference-count invariant
- parses each guide's visible `Evidence Review · N References` label
- counts the actual rendered `<Ref n={...}>` entries in the same source file
- fails if the visible count is missing or differs from the rendered source ledger
- covers all five legacy authority guides, including bovine colostrum
- uses no hard-coded per-page counts and adds no new validator/workflow

## Acceptance criteria
- visible reference-count labels must exist on all five target guides
- visible counts must exactly match rendered `LegacyGuideReference` entries
- adding/removing a reference without updating the label fails the canonical audit
- existing citation, quick-answer, source-identifier, and anti-duplication invariants remain intact

## Before → after
- accurate visible labels: 5/5 → 5/5
- regression coverage for count drift: 0/5 → 5/5
- hard-coded expected counts in governance: 0
- new pipelines: 0

## Validation
- `npm run audit:ai-citations`
- `npx eslint scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- AI search quality check / Atomic upgrade gate

## Trust impact
The evidence-review count shown to readers is now mechanically tied to the source ledger instead of relying on editorial memory.