### PR TITLE
test(research): align source ID gate fixture

### DIFF
--- a/lib/__tests__/research-source-id-snapshot-invariant.test.ts
+++ b/lib/__tests__/research-source-id-snapshot-invariant.test.ts
@@ -47,6 +47,8 @@ function fixture(source: Record<string, unknown>) {
     evidenceGradeContradictions: [],
     summary: {
       structuralFailures: 0,
+      unsupportedApprovedClaims: 0,
+      danglingClaimSourceEdges: 0,
       severeStudyClassConflicts: 0,
       evidenceGradeContradictions: 0,
       blockingFailures: 0,


### PR DESCRIPTION
Update the source-ID invariant test gate summary with the two counters required by the current canonical gate contract. No production logic changes.