### PR TITLE
feat(research): build outcome editorial review queue

### DIFF
--- a/lib/__tests__/research-outcome-review-queue.test.ts
+++ b/lib/__tests__/research-outcome-review-queue.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildOutcomeReviewQueue } from '@/lib/research-outcome-review-queue'
+import type { OutcomeMetadataCoverageAnalysis } from '@/lib/research-outcome-metadata-coverage'
+import type { OutcomeReportingIntegrityAnalysis } from '@/lib/research-outcome-reporting-integrity'
+
+function integrity(): OutcomeReportingIntegrityAnalysis {
+  const claim = {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    predicate: 'supports_outcome',
+    confidence: 0.9,
+    linkedStudyCount: 2,
+    affectedStudyIds: ['pmid:1'],
+    risks: ['registered-reported-primary-mismatch' as const],
+    severity: 'high' as const,
+  }
+  return {
+    studies: [],
+    claims: [claim],
+    highPriorityStudies: [],
+    highPriorityClaims: [claim],
+    summary: {
+      affectedStudies: 0,
+      affectedApprovedOutcomeClaims: 1,
+      highPriorityStudies: 0,
+      highPriorityClaims: 1,
+      explicitOutcomeSwitches: 0,
+      explicitRegisteredOutcomeNonReporting: 0,
+      primaryOutcomeMismatches: 1,
+      primaryOutcomePartialMismatches: 0,
+      selectiveOutcomeClaims: 0,
+    },
+  }
+}
+
+function coverage(): OutcomeMetadataCoverageAnalysis {
+  const claim = {
+    url: '/herbs/example/',
+    claimId: 'claim-1',
+    predicate: 'supports_outcome',
+    confidence: 0.9,
+    primaryHumanStudies: 2,
+    studiesWithOutcomeMetadata: 1,
+    studiesWithRegistryIds: 1,
+    studiesWithNamedRegisteredPrimary: 1,
+    studiesWithNamedReportedPrimary: 1,
+    studiesWithNamedAlignmentData: 1,
+    outcomeMetadataCoverage: 0.5,
+    namedAlignmentCoverage: 0.5,
+    outcomeMetadataGap: false,
+    highConfidenceOutcomeMetadataGap: false,
+  }
+  const backfill = {
+    ...claim,
+    claimId: 'claim-2',
+    confidence: 0.85,
+    studiesWithNamedAlignmentData: 0,
+    namedAlignmentCoverage: 0,
+    outcomeMetadataGap: true,
+    highConfidenceOutcomeMetadataGap: true,
+  }
+  return {
+    profiles: [],
+    claims: [claim, backfill],
+    profileCoverageGaps: [],
+    claimCoverageGaps: [backfill],
+    highConfidenceClaimCoverageGaps: [backfill],
+    summary: {
+      profiles: 0,
+      profilesWithPrimaryHumanEvidence: 0,
+      profileCoverageGaps: 0,
+      approvedOutcomeClaimsWithPrimaryHumanEvidence: 2,
+      claimCoverageGaps: 1,
+      highConfidenceClaimCoverageGaps: 1,
+    },
+  }
+}
+
+describe('outcome review queue', () => {
+  it('prioritizes high-confidence high-severity integrity findings as urgent', () => {
+    const result = buildOutcomeReviewQueue({
+      outcomeReportingIntegrity: integrity(),
+      outcomeMetadataCoverage: coverage(),
+    })
+
+    expect(result.items[0]).toMatchObject({
+      claimId: 'claim-1',
+      priority: 'urgent',
+      integritySeverity: 'high',
+    })
+    expect(result.summary.urgent).toBe(1)
+  })
+
+  it('keeps coverage-only gaps as metadata backfill work rather than integrity findings', () => {
+    const result = buildOutcomeReviewQueue({
+      outcomeReportingIntegrity: integrity(),
+      outcomeMetadataCoverage: coverage(),
+    })
+    const backfill = result.items.find((item) => item.claimId === 'claim-2')
+
+    expect(backfill).toMatchObject({
+      priority: 'medium',
+      integritySeverity: null,
+      outcomeMetadataGap: true,
+      highConfidenceOutcomeMetadataGap: true,
+    })
+    expect(backfill?.risks).toEqual([])
+    expect(result.summary.metadataBackfill).toBe(1)
+  })
+})

--- a/lib/research-outcome-review-queue.ts
+++ b/lib/research-outcome-review-queue.ts
@@ -1,0 +1,167 @@
+import type { OutcomeMetadataCoverageAnalysis } from './research-outcome-metadata-coverage'
+import type {
+  ClaimOutcomeReportingIntegrityFinding,
+  OutcomeReportingIntegrityAnalysis,
+  OutcomeReportingRisk,
+} from './research-outcome-reporting-integrity'
+
+export type OutcomeReviewPriority = 'urgent' | 'high' | 'medium' | 'low'
+
+export type OutcomeReviewQueueItem = {
+  url: string
+  claimId: string
+  predicate: string
+  confidence: number
+  priority: OutcomeReviewPriority
+  integritySeverity: ClaimOutcomeReportingIntegrityFinding['severity'] | null
+  risks: OutcomeReportingRisk[]
+  outcomeMetadataGap: boolean
+  highConfidenceOutcomeMetadataGap: boolean
+  primaryHumanStudies: number
+  studiesWithOutcomeMetadata: number
+  studiesWithNamedAlignmentData: number
+  namedAlignmentCoverage: number
+  affectedStudyIds: string[]
+  reasons: string[]
+}
+
+export type OutcomeReviewQueue = {
+  items: OutcomeReviewQueueItem[]
+  urgent: OutcomeReviewQueueItem[]
+  high: OutcomeReviewQueueItem[]
+  metadataBackfill: OutcomeReviewQueueItem[]
+  summary: {
+    items: number
+    urgent: number
+    high: number
+    medium: number
+    low: number
+    integrityFindings: number
+    metadataBackfill: number
+  }
+}
+
+const PRIORITY_ORDER: Record<OutcomeReviewPriority, number> = {
+  urgent: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+}
+
+function priorityFor(input: {
+  integrity: ClaimOutcomeReportingIntegrityFinding | undefined
+  outcomeMetadataGap: boolean
+  highConfidenceOutcomeMetadataGap: boolean
+  confidence: number
+}): OutcomeReviewPriority {
+  const { integrity, outcomeMetadataGap, highConfidenceOutcomeMetadataGap, confidence } = input
+  if (integrity?.severity === 'high' && confidence >= 0.75) return 'urgent'
+  if (integrity?.severity === 'high') return 'high'
+  if (integrity?.severity === 'moderate' && confidence >= 0.75) return 'high'
+  if (integrity?.severity === 'moderate') return 'medium'
+  if (highConfidenceOutcomeMetadataGap) return 'medium'
+  if (outcomeMetadataGap) return 'low'
+  return 'low'
+}
+
+function integrityReasons(integrity: ClaimOutcomeReportingIntegrityFinding | undefined): string[] {
+  if (!integrity) return []
+  const labels: Record<OutcomeReportingRisk, string> = {
+    'registered-reported-primary-mismatch': 'registered and reported primary outcomes do not match',
+    'registered-reported-primary-partial-mismatch': 'registered and reported primary outcomes only partially align',
+    'explicit-outcome-switch': 'linked evidence explicitly indicates outcome switching',
+    'explicit-registered-outcome-nonreporting': 'linked evidence explicitly indicates registered/prespecified outcome non-reporting',
+    'null-primary-with-favorable-secondary': 'a not-met primary outcome is paired with favorable secondary/subgroup/exploratory evidence',
+  }
+  return integrity.risks.map((risk) => labels[risk])
+}
+
+/**
+ * Build one actionable editorial queue from outcome-reporting integrity findings
+ * and outcome-metadata coverage gaps. Integrity concerns outrank backfill work;
+ * coverage-only items remain explicitly framed as missing assessability rather
+ * than evidence of reporting bias.
+ */
+export function buildOutcomeReviewQueue(input: {
+  outcomeReportingIntegrity: OutcomeReportingIntegrityAnalysis
+  outcomeMetadataCoverage: OutcomeMetadataCoverageAnalysis
+}): OutcomeReviewQueue {
+  const { outcomeReportingIntegrity, outcomeMetadataCoverage } = input
+  const integrityByClaim = new Map(
+    outcomeReportingIntegrity.claims.map((claim) => [`${claim.url}::${claim.claimId}`, claim]),
+  )
+  const coverageByClaim = new Map(
+    outcomeMetadataCoverage.claims.map((claim) => [`${claim.url}::${claim.claimId}`, claim]),
+  )
+  const keys = new Set([
+    ...integrityByClaim.keys(),
+    ...outcomeMetadataCoverage.claimCoverageGaps.map((claim) => `${claim.url}::${claim.claimId}`),
+  ])
+
+  const items: OutcomeReviewQueueItem[] = []
+  for (const key of keys) {
+    const integrity = integrityByClaim.get(key)
+    const coverage = coverageByClaim.get(key)
+    const url = integrity?.url ?? coverage?.url
+    const claimId = integrity?.claimId ?? coverage?.claimId
+    if (!url || !claimId) continue
+    const predicate = integrity?.predicate ?? coverage?.predicate ?? ''
+    const confidence = integrity?.confidence ?? coverage?.confidence ?? 0
+    const outcomeMetadataGap = coverage?.outcomeMetadataGap ?? false
+    const highConfidenceOutcomeMetadataGap = coverage?.highConfidenceOutcomeMetadataGap ?? false
+    const priority = priorityFor({ integrity, outcomeMetadataGap, highConfidenceOutcomeMetadataGap, confidence })
+    const reasons = integrityReasons(integrity)
+    if (outcomeMetadataGap) {
+      reasons.push(
+        `outcome-reporting assessability is incomplete (${coverage?.studiesWithNamedAlignmentData ?? 0}/${coverage?.primaryHumanStudies ?? 0} linked primary-human studies have named registered+reported primary outcomes)`,
+      )
+    }
+
+    items.push({
+      url,
+      claimId,
+      predicate,
+      confidence,
+      priority,
+      integritySeverity: integrity?.severity ?? null,
+      risks: integrity?.risks ?? [],
+      outcomeMetadataGap,
+      highConfidenceOutcomeMetadataGap,
+      primaryHumanStudies: coverage?.primaryHumanStudies ?? integrity?.linkedStudyCount ?? 0,
+      studiesWithOutcomeMetadata: coverage?.studiesWithOutcomeMetadata ?? 0,
+      studiesWithNamedAlignmentData: coverage?.studiesWithNamedAlignmentData ?? 0,
+      namedAlignmentCoverage: coverage?.namedAlignmentCoverage ?? 0,
+      affectedStudyIds: integrity?.affectedStudyIds ?? [],
+      reasons,
+    })
+  }
+
+  items.sort((a, b) =>
+    PRIORITY_ORDER[b.priority] - PRIORITY_ORDER[a.priority]
+    || b.confidence - a.confidence
+    || b.risks.length - a.risks.length
+    || a.namedAlignmentCoverage - b.namedAlignmentCoverage
+    || a.url.localeCompare(b.url)
+    || a.claimId.localeCompare(b.claimId),
+  )
+
+  const urgent = items.filter((item) => item.priority === 'urgent')
+  const high = items.filter((item) => item.priority === 'high')
+  const metadataBackfill = items.filter((item) => item.outcomeMetadataGap)
+
+  return {
+    items,
+    urgent,
+    high,
+    metadataBackfill,
+    summary: {
+      items: items.length,
+      urgent: urgent.length,
+      high: high.length,
+      medium: items.filter((item) => item.priority === 'medium').length,
+      low: items.filter((item) => item.priority === 'low').length,
+      integrityFindings: items.filter((item) => item.integritySeverity !== null).length,
+      metadataBackfill: metadataBackfill.length,
+    },
+  }
+}

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -16,6 +16,7 @@ import { analyzeOutcomeMetadata } from './research-outcome-metadata'
 import { analyzeOutcomeMetadataCoverage } from './research-outcome-metadata-coverage'
 import { analyzeOutcomeRegistrationAlignment } from './research-outcome-registration-alignment'
 import { analyzeOutcomeReportingIntegrity } from './research-outcome-reporting-integrity'
+import { buildOutcomeReviewQueue } from './research-outcome-review-queue'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
@@ -95,6 +96,10 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     outcomeRegistrationAlignment,
     selectiveOutcomeReporting,
   })
+  const outcomeReviewQueue = buildOutcomeReviewQueue({
+    outcomeReportingIntegrity,
+    outcomeMetadataCoverage,
+  })
   const claimLanguageCalibration = analyzeClaimLanguageCalibration(analysis)
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
   const metadataIntegrity = buildResearchMetadataIntegrity({
@@ -145,6 +150,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     directionalConsistency,
     selectiveOutcomeReporting,
     outcomeReportingIntegrity,
+    outcomeReviewQueue,
     claimLanguageCalibration,
     claimCitationMetadata,
     metadataIntegrity,


### PR DESCRIPTION
Adds one actionable outcome-review queue that merges approved-claim integrity findings with outcome-metadata backfill gaps. High-confidence severe integrity findings are prioritized first; coverage-only items remain explicitly metadata-assessability work rather than reporting-bias findings. Includes focused tests and exposes the queue through the canonical research topology.