### PR TITLE
refactor(visual): move herb pagination after browsing

### DIFF
--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -51,8 +51,6 @@ export default async function HerbsPage() {
         </p>
       </header>
 
-      <Pagination basePath="/herbs" currentPage={1} totalPages={pageData.totalPages} itemLabel="Herb profiles" />
-
       <nav aria-label="Herb profiles index" className="sr-only">
         <ul>
           {herbs.map((herb) => (


### PR DESCRIPTION
Removes the duplicate top pager from the herb directory while keeping the bottom pager. Readers now reach search and profile content immediately after the page hero instead of encountering pagination before they have browsed anything.