### PR TITLE
refactor(visual): move compound pagination after browsing

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -37,8 +37,6 @@ export default async function CompoundsPage() {
         </p>
       </section>
 
-      <Pagination basePath="/compounds" currentPage={1} totalPages={pageData.totalPages} itemLabel="Compound profiles" />
-
       <nav aria-label="Published compound profiles index" className="sr-only">
         <ul>
           {allCompounds.map((c) => (


### PR DESCRIPTION
Removes the duplicate top pager from the compound directory while keeping the bottom pager. Readers now move from the real page hero into search/filter and profile browsing before encountering page navigation.