### PR TITLE
feat(research): expose selective outcome reporting in canonical rollup

### DIFF
--- a/scripts/ci/research-quality.ts
+++ b/scripts/ci/research-quality.ts
@@ -40,6 +40,7 @@ const {
   claimBreadth,
   effectCertainty,
   directionalConsistency,
+  selectiveOutcomeReporting,
   claimLanguageCalibration: languageCalibration,
   crossProfileStudyLoad,
   systemicLoadBearingStudies,
@@ -119,6 +120,7 @@ results.unshift({
     `claimBreadthOverreach=${claimBreadth.summary.overbroadClaims}`,
     `effectCertaintyOverreach=${effectCertainty.summary.findings}`,
     `directionalFindings=${directionalConsistency.summary.findings}`,
+    `selectiveOutcomeFindings=${selectiveOutcomeReporting.summary.findings}`,
     `causalWithoutControlled=${languageCalibration.summary.causalWithoutControlledSupport}`,
     `pseudoMultiSource=${edgeCardinality.summary.pseudoMultiSourceClaims}`,
     `sameTrialReuse=${trialRegistrationIndependence.summary.sameTrialReuseClaims}`,
@@ -188,6 +190,7 @@ const coreSummary = {
   claimBreadth: claimBreadth.summary,
   effectCertainty: effectCertainty.summary,
   directionalConsistency: directionalConsistency.summary,
+  selectiveOutcomeReporting: selectiveOutcomeReporting.summary,
   claimLanguageCalibration: languageCalibration.summary,
   claimCitationMetadata: claimCitationMetadata.summary,
   edgeCardinality: edgeCardinality.summary,
@@ -229,7 +232,7 @@ const coreSummary = {
 
 fs.mkdirSync(REPORT_DIR, { recursive: true })
 fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
-  schemaVersion: 28,
+  schemaVersion: 29,
   generatedAt: new Date().toISOString(),
   passed: !failed,
   source: {
@@ -246,6 +249,7 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     claimBreadth: 'lib/research-claim-breadth.ts',
     effectCertainty: 'lib/research-effect-certainty.ts',
     directionalConsistency: 'lib/research-directional-consistency.ts',
+    selectiveOutcomeReporting: 'lib/research-selective-outcome-reporting.ts',
   },
   coreSummary,
   structuralFailures: gate.structuralFailures,
@@ -279,6 +283,12 @@ fs.writeFileSync(REPORT_PATH, `${JSON.stringify({
     findings: directionalConsistency.findings.slice(0, 150),
     highConfidenceFindings: directionalConsistency.highConfidenceFindings.slice(0, 100),
     assessableClaims: directionalConsistency.claims.slice(0, 200),
+  },
+  selectiveOutcomeReporting: {
+    summary: selectiveOutcomeReporting.summary,
+    findings: selectiveOutcomeReporting.findings.slice(0, 150),
+    highConfidenceFindings: selectiveOutcomeReporting.highConfidenceFindings.slice(0, 100),
+    assessableClaims: selectiveOutcomeReporting.claims.slice(0, 200),
   },
   claimLanguageCalibration: {
     summary: languageCalibration.summary,
@@ -351,6 +361,7 @@ console.log(`Semantic alignment: ${semanticAlignment.summary.anyMismatch} explic
 console.log(`Claim breadth: ${claimBreadth.summary.overbroadClaims} overbroad claim(s) · ${claimBreadth.summary.highConfidenceOverbroadClaims} high-confidence · population ${claimBreadth.summary.populationOverbroadClaims} · dose ${claimBreadth.summary.doseOverbroadClaims} · duration ${claimBreadth.summary.durationOverbroadClaims} · formulation ${claimBreadth.summary.formulationOverbroadClaims} · endpoint ${claimBreadth.summary.endpointOverbroadClaims}`)
 console.log(`Effect/certainty: ${effectCertainty.summary.findings} overstatement finding(s) · ${effectCertainty.summary.highConfidenceFindings} high-confidence · magnitude ${effectCertainty.summary.magnitudeOverstatements} · clinical importance ${effectCertainty.summary.clinicalImportanceOverstatements} · certainty ${effectCertainty.summary.certaintyOverstatements}`)
 console.log(`Directional consistency: ${directionalConsistency.summary.findings} finding(s) · ${directionalConsistency.summary.highConfidenceFindings} high-confidence · endpoint cherry-pick ${directionalConsistency.summary.endpointCherryPickRisks} · heterogeneous ${directionalConsistency.summary.directionalHeterogeneityClaims} · uniformly-positive overstatement ${directionalConsistency.summary.uniformlyPositiveOverstatements}`)
+console.log(`Selective outcome reporting: ${selectiveOutcomeReporting.summary.findings} finding(s) · ${selectiveOutcomeReporting.summary.highConfidenceFindings} high-confidence · selective outcome ${selectiveOutcomeReporting.summary.selectiveOutcomeRisks} · explicit outcome switch/non-reporting ${selectiveOutcomeReporting.summary.explicitOutcomeSwitchRisks}`)
 console.log(`Language calibration: ${languageCalibration.summary.causalWithoutControlledSupport} unsupported direct-causal claim(s)`)
 console.log(`Edge cardinality: ${edgeCardinality.summary.pseudoMultiSourceClaims} pseudo-multi-source · ${edgeCardinality.summary.aliasCollapsedClaims} alias-collapsed · ${edgeCardinality.summary.duplicateEdges} duplicate edge(s)`)
 console.log(`Underlying-study reuse: ${trialRegistrationIndependence.summary.sameTrialReuseClaims} same-trial claim(s) · ${evidenceLineage.summary.sharedNonRegistryLineageClaims} shared lineage claim(s)`)


### PR DESCRIPTION
## What changed
- expose the already-canonical `selectiveOutcomeReporting` topology analysis in the unified research-quality roll-up
- include its summary in `coreSummary` and canonical stdout telemetry
- serialize findings, high-confidence findings, and assessable claims into `ops/reports/research-quality.json`
- record the analyzer source and bump the roll-up schema from 28 to 29

## Why
Selective-outcome findings were already computed once in topology, validated by snapshot invariants, and folded into canonical remediation scoring, but they were absent from the authoritative roll-up/console. This closes that computed-but-invisible gap without adding another execution path.

## Scope
One file, 13 changed lines. No analyzer, scoring, or threshold changes.