### PR TITLE
fix(research): split packed PMID rows into distinct studies

### DIFF
--- a/lib/__tests__/packed-pmid-study-splitting.test.ts
+++ b/lib/__tests__/packed-pmid-study-splitting.test.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { extractCitationsFromRecord } from '@/lib/citations'
+import { analyzeResearchQuality } from '@/lib/research-quality-analysis'
+
+const roots: string[] = []
+
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop() as string, { recursive: true, force: true })
+})
+
+describe('packed PMID study splitting', () => {
+  it('expands one packed research source into distinct canonical studies and claim edges', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ths-packed-pmid-'))
+    roots.push(root)
+    const detailDir = path.join(root, 'public', 'data', 'herbs-detail')
+    mkdirSync(detailDir, { recursive: true })
+
+    writeFileSync(path.join(detailDir, 'example.json'), JSON.stringify({
+      slug: 'example',
+      sources: [{
+        id: 's1',
+        pmid: '15070181; 22167571',
+        doi: '10.1000/ambiguous-packed-doi',
+        studyClass: 'rct',
+        title: 'Legacy packed trial row',
+      }],
+      claimMap: [{
+        id: 'claim-1',
+        predicate: 'supports_outcome',
+        reviewStatus: 'approved',
+        confidence: 0.8,
+        sourceRefIds: ['s1'],
+      }],
+    }))
+
+    const analysis = analyzeResearchQuality(root)
+    const profile = analysis.profiles[0]
+    const claim = analysis.claimAnalyses[0]
+
+    expect(profile.record.sources).toHaveLength(2)
+    expect(profile.record.sources?.map((source) => source.pmid)).toEqual(['15070181', '22167571'])
+    expect(profile.record.sources?.map((source) => source.id)).toEqual(['s1', 's1::pmid:22167571'])
+    expect(profile.record.sources?.every((source) => source.doi === undefined)).toBe(true)
+    expect(profile.record.claimMap?.[0].sourceRefIds).toEqual(['s1', 's1::pmid:22167571'])
+    expect(claim).toMatchObject({
+      sourceRefCount: 2,
+      validSourceRefCount: 2,
+      studyCount: 2,
+      structuredSupportTier: 'adequate',
+      singleStudy: false,
+    })
+    expect(analysis.profileAnalyses[0].canonicalStudyCount).toBe(2)
+  })
+
+  it('emits separate public citation entities for packed structured PMIDs', () => {
+    const citations = extractCitationsFromRecord({
+      sources: [{
+        title: 'Legacy packed trial row',
+        pmid: '15070181; 22167571',
+        doi: '10.1000/ambiguous-packed-doi',
+        study_type: 'randomized controlled trial',
+      }],
+    })
+
+    expect(citations).toHaveLength(2)
+    expect(citations.map((citation) => citation.id)).toEqual(['pmid:15070181', 'pmid:22167571'])
+    expect(citations.map((citation) => citation.pmid)).toEqual(['15070181', '22167571'])
+    expect(citations.every((citation) => citation.doi === undefined)).toBe(true)
+  })
+
+  it('splits packed entries in the legacy pmids array too', () => {
+    const citations = extractCitationsFromRecord({ pmids: ['15070181; 22167571'] })
+
+    expect(citations.map((citation) => citation.id)).toEqual(['pmid:15070181', 'pmid:22167571'])
+  })
+})

--- a/lib/citations.ts
+++ b/lib/citations.ts
@@ -1,4 +1,5 @@
 import type { Citation } from '@/components/ui/ShowMeTheStudies'
+import { normalizePmidList } from '@/lib/citation-identifiers.mjs'
 import {
   evidenceStudyId,
   normalizeEvidenceConfidence,
@@ -57,7 +58,9 @@ function sourceObjectToCitation(src: Record<string, unknown>): Citation {
   const pmid =
     src.pmid
       ? String(src.pmid)
-      : parsePmid(rawUrl) || parsePmid(citationText)
+      : src.pubmedId
+        ? String(src.pubmedId)
+        : parsePmid(rawUrl) || parsePmid(citationText)
   const url = rawUrl || doiUrl(doi) || (pmid ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/` : undefined)
   const studyType = firstString(src, ['studyType', 'study_type', 'design', 'design_type', 'publication_type', 'type'])
   const relationshipRaw = firstString(src, ['relationship', 'evidence_direction', 'direction', 'direction_of_effect'])
@@ -93,6 +96,25 @@ function sourceObjectToCitation(src: Record<string, unknown>): Citation {
   return citation
 }
 
+/**
+ * Expand a structured row that packs multiple PubMed studies into one field.
+ * Metadata is copied to each publication, but a DOI is deliberately not assigned
+ * when several PMIDs are present because the row does not establish which PMID
+ * that DOI aliases.
+ */
+function sourceObjectToCitations(src: Record<string, unknown>): Citation[] {
+  const pmids = normalizePmidList(src.pmid ?? src.pubmedId)
+  if (pmids.length <= 1) return [sourceObjectToCitation(src)]
+
+  return pmids.map((pmid) => sourceObjectToCitation({
+    ...src,
+    pmid,
+    pubmedId: undefined,
+    doi: undefined,
+    url: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
+  }))
+}
+
 function stringToCitation(src: string): Citation {
   const pmid = parsePmid(src)
   const doi = parseDoi(src)
@@ -108,6 +130,20 @@ function stringToCitation(src: string): Citation {
     relationship: 'background',
     confidence: 'unknown',
   }
+}
+
+function stringToCitations(src: string): Citation[] {
+  const pmids = normalizePmidList(src)
+  if (pmids.length <= 1) return [stringToCitation(src)]
+  return pmids.map((pmid) => ({
+    id: `pmid:${pmid}`,
+    title: src,
+    pmid,
+    url: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
+    evidenceClass: 'other',
+    relationship: 'background',
+    confidence: 'unknown',
+  }))
 }
 
 function citationKey(citation: Citation): string {
@@ -137,27 +173,28 @@ export function extractCitationsFromRecord(record: Record<string, unknown>): Cit
     for (const src of sources) {
       if (!src) continue
       if (typeof src === 'string') {
-        pushCitation(stringToCitation(src))
+        for (const citation of stringToCitations(src)) pushCitation(citation)
       } else if (typeof src === 'object') {
-        pushCitation(sourceObjectToCitation(src as Record<string, unknown>))
+        for (const citation of sourceObjectToCitations(src as Record<string, unknown>)) pushCitation(citation)
       }
     }
   }
 
   const pmids = record?.pmids
   if (Array.isArray(pmids)) {
-    for (const pmid of pmids) {
-      if (!pmid) continue
-      const id = String(pmid)
-      pushCitation({
-        id: `pmid:${id}`,
-        title: `PubMed ${id}`,
-        pmid: id,
-        url: `https://pubmed.ncbi.nlm.nih.gov/${id}/`,
-        evidenceClass: 'other',
-        relationship: 'background',
-        confidence: 'unknown',
-      })
+    for (const value of pmids) {
+      if (!value) continue
+      for (const id of normalizePmidList(value)) {
+        pushCitation({
+          id: `pmid:${id}`,
+          title: `PubMed ${id}`,
+          pmid: id,
+          url: `https://pubmed.ncbi.nlm.nih.gov/${id}/`,
+          evidenceClass: 'other',
+          relationship: 'background',
+          confidence: 'unknown',
+        })
+      }
     }
   }
 
@@ -166,9 +203,9 @@ export function extractCitationsFromRecord(record: Record<string, unknown>): Cit
     for (const ref of references) {
       if (!ref) continue
       if (typeof ref === 'string') {
-        pushCitation(stringToCitation(ref))
+        for (const citation of stringToCitations(ref)) pushCitation(citation)
       } else if (typeof ref === 'object') {
-        pushCitation(sourceObjectToCitation(ref as Record<string, unknown>))
+        for (const citation of sourceObjectToCitations(ref as Record<string, unknown>)) pushCitation(citation)
       }
     }
   }

--- a/lib/research-coverage.ts
+++ b/lib/research-coverage.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { citationIdentifiers } from './citation-identifiers.mjs'
+import { citationIdentifiers, normalizePmidList } from './citation-identifiers.mjs'
 import { normalizeStudyClass, strongestStudyClass, type StudyClass } from './study-class'
 
 export type ResearchSource = Record<string, unknown> & {
@@ -106,11 +106,62 @@ function normalizeResearchSourceIdentity(source: ResearchSource): ResearchSource
   return canonicalId ? { ...source, id: canonicalId } : source
 }
 
+/**
+ * A legacy workbook source row can contain multiple PMIDs even though each PMID
+ * names a distinct publication. Expand those rows before any canonical study or
+ * claim analysis runs. Claims referencing the original row are expanded to all
+ * split source IDs, preserving the intended multi-study support.
+ */
 function normalizeResearchProfileSources(record: ResearchProfile): ResearchProfile {
   if (!Array.isArray(record.sources)) return record
+
+  const sources: ResearchSource[] = []
+  const sourceRefExpansion = new Map<string, string[]>()
+
+  for (const rawSource of record.sources) {
+    const source = normalizeResearchSourceIdentity(rawSource)
+    const pmids = normalizePmidList(source.pmid ?? source.pubmedId)
+    if (pmids.length <= 1) {
+      sources.push(source)
+      continue
+    }
+
+    const originalId = String(source.id ?? '').trim()
+    const expandedIds: string[] = []
+    for (let index = 0; index < pmids.length; index += 1) {
+      const pmid = pmids[index]
+      const id = originalId
+        ? index === 0 ? originalId : `${originalId}::pmid:${pmid}`
+        : `pmid:${pmid}`
+      const splitSource: ResearchSource = {
+        ...source,
+        id,
+        pmid,
+        url: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
+      }
+      delete splitSource.pubmedId
+      // One DOI cannot be assigned safely to one of several distinct PMIDs.
+      // Keep publication identity conservative rather than creating a false alias.
+      delete splitSource.doi
+      sources.push(splitSource)
+      expandedIds.push(id)
+    }
+    if (originalId) sourceRefExpansion.set(originalId, expandedIds)
+  }
+
+  const claimMap = Array.isArray(record.claimMap)
+    ? record.claimMap.map((claim) => ({
+        ...claim,
+        sourceRefIds: Array.isArray(claim.sourceRefIds)
+          ? claim.sourceRefIds.flatMap((sourceRefId) => sourceRefExpansion.get(String(sourceRefId)) ?? [String(sourceRefId)])
+          : claim.sourceRefIds,
+      }))
+    : record.claimMap
+
   return {
     ...record,
-    sources: record.sources.map(normalizeResearchSourceIdentity),
+    sources,
+    claimMap,
   }
 }
 


### PR DESCRIPTION
Normalizes legacy source rows containing multiple PMIDs before research analysis, expands claim source references to the split studies, and makes public citation extraction emit separate valid PMID entities across sources/references/pmids arrays. Ambiguous single-DOI-plus-multiple-PMID rows do not guess a DOI alias. Adds regressions proving packed rows produce two canonical studies and two public citation entities.