### PR TITLE
refactor(research): score canonical outcome integrity once

### DIFF
--- a/lib/__tests__/research-quality-policy-topology-signals.test.ts
+++ b/lib/__tests__/research-quality-policy-topology-signals.test.ts
@@ -39,6 +39,8 @@ function topology(overrides: Record<string, unknown> = {}): ResearchQualityTopol
     effectCertainty: { findings: [] },
     directionalConsistency: { findings: [] },
     selectiveOutcomeReporting: { findings: [] },
+    outcomeReportingIntegrity: { claims: [] },
+    outcomeMetadataCoverage: { claimCoverageGaps: [] },
     claimLanguageCalibration: { directEvidenceFindings: [] },
     claimCitationMetadata: { lowCoverageClaims: [] },
     metadataIntegrity: { profiles: [] },
@@ -69,6 +71,102 @@ describe('aggregated topology gap signals', () => {
     expect(semantic[0]).toMatchObject({ url: '/herbs/a/' })
     expect(semantic[0].detail).toContain('3 explicit alignment mismatch(es)')
     expect(semantic[0].detail).toContain('2 high-confidence')
+  })
+
+  it('scores existing selective-outcome behavior once through canonical outcome integrity', () => {
+    const outcomeFinding = {
+      url: '/herbs/a/',
+      claimId: 'c1',
+      predicate: 'supports_outcome',
+      confidence: 0.9,
+      linkedStudyCount: 1,
+      affectedStudyIds: ['pmid:1'],
+      risks: ['null-primary-with-favorable-secondary'],
+      severity: 'moderate',
+    }
+    const legacyFinding = {
+      url: '/herbs/a/',
+      claimId: 'c1',
+      confidence: 0.9,
+      selectiveOutcomeRisk: true,
+      explicitOutcomeSwitchRisk: false,
+    }
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      outcomeReportingIntegrity: { claims: [outcomeFinding] },
+      selectiveOutcomeReporting: { findings: [legacyFinding] },
+    }), weights)
+
+    const semantic = signals.filter((signal) => signal.kind === 'semantic-claim-source-mismatch')
+    expect(semantic).toHaveLength(1)
+    expect(semantic[0]).toMatchObject({ weight: 28 })
+    expect(semantic[0].detail).toContain('1 outcome-reporting integrity finding(s)')
+    expect(semantic[0].detail).toContain('selective outcome 1')
+  })
+
+  it('surfaces registered-vs-reported primary mismatch and non-reporting in policy', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      outcomeReportingIntegrity: {
+        claims: [{
+          url: '/herbs/a/',
+          claimId: 'c1',
+          predicate: 'supports_outcome',
+          confidence: 0.9,
+          linkedStudyCount: 2,
+          affectedStudyIds: ['pmid:1'],
+          risks: [
+            'registered-reported-primary-mismatch',
+            'explicit-registered-outcome-nonreporting',
+          ],
+          severity: 'high',
+        }],
+      },
+    }), weights)
+
+    const semantic = signals.find((signal) => signal.kind === 'semantic-claim-source-mismatch')
+    expect(semantic).toMatchObject({ url: '/herbs/a/', weight: 28 })
+    expect(semantic?.detail).toContain('registered/reported primary mismatch 1')
+    expect(semantic?.detail).toContain('registered outcome non-reporting 1')
+  })
+
+  it('does not stack weight when one claim carries multiple outcome-integrity risks', () => {
+    const oneRisk = buildAggregatedTopologyGapSignals(topology({
+      outcomeReportingIntegrity: {
+        claims: [{
+          url: '/herbs/a/', claimId: 'c1', predicate: 'supports_outcome', confidence: 0.9,
+          linkedStudyCount: 1, affectedStudyIds: ['pmid:1'],
+          risks: ['registered-reported-primary-mismatch'], severity: 'high',
+        }],
+      },
+    }), weights)
+    const threeRisks = buildAggregatedTopologyGapSignals(topology({
+      outcomeReportingIntegrity: {
+        claims: [{
+          url: '/herbs/a/', claimId: 'c1', predicate: 'supports_outcome', confidence: 0.9,
+          linkedStudyCount: 1, affectedStudyIds: ['pmid:1'],
+          risks: [
+            'registered-reported-primary-mismatch',
+            'explicit-outcome-switch',
+            'null-primary-with-favorable-secondary',
+          ], severity: 'high',
+        }],
+      },
+    }), weights)
+
+    expect(oneRisk.find((signal) => signal.kind === 'semantic-claim-source-mismatch')?.weight).toBe(28)
+    expect(threeRisks.find((signal) => signal.kind === 'semantic-claim-source-mismatch')?.weight).toBe(28)
+  })
+
+  it('does not penalize outcome metadata coverage gaps by themselves', () => {
+    const signals = buildAggregatedTopologyGapSignals(topology({
+      outcomeMetadataCoverage: {
+        claimCoverageGaps: [{
+          url: '/herbs/a/', claimId: 'c1', confidence: 0.95,
+          outcomeMetadataGap: true, highConfidenceOutcomeMetadataGap: true,
+        }],
+      },
+    }), weights)
+
+    expect(signals.some((signal) => signal.url === '/herbs/a/')).toBe(false)
   })
 
   it('routes narrow multi-study provenance once per affected profile', () => {

--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -78,9 +78,9 @@ export function buildAggregatedTopologyGapSignals(
     breadth: typeof topology.claimBreadth.findings
     effect: typeof topology.effectCertainty.findings
     directional: typeof topology.directionalConsistency.findings
-    selective: typeof topology.selectiveOutcomeReporting.findings
+    outcomeIntegrity: typeof topology.outcomeReportingIntegrity.claims
   }>()
-  const emptySemanticGroup = () => ({ explicit: [], breadth: [], effect: [], directional: [], selective: [] })
+  const emptySemanticGroup = () => ({ explicit: [], breadth: [], effect: [], directional: [], outcomeIntegrity: [] })
   for (const item of topology.semanticAlignment.findings) {
     const group = semanticByUrl.get(item.url) ?? emptySemanticGroup()
     group.explicit.push(item)
@@ -101,9 +101,9 @@ export function buildAggregatedTopologyGapSignals(
     group.directional.push(item)
     semanticByUrl.set(item.url, group)
   }
-  for (const item of topology.selectiveOutcomeReporting.findings) {
+  for (const item of topology.outcomeReportingIntegrity.claims) {
     const group = semanticByUrl.get(item.url) ?? emptySemanticGroup()
-    group.selective.push(item)
+    group.outcomeIntegrity.push(item)
     semanticByUrl.set(item.url, group)
   }
   for (const [url, group] of semanticByUrl) {
@@ -112,9 +112,9 @@ export function buildAggregatedTopologyGapSignals(
       ...group.breadth.filter((item) => item.confidence >= 0.75),
       ...group.effect.filter((item) => item.confidence >= 0.75),
       ...group.directional.filter((item) => item.confidence >= 0.75),
-      ...group.selective.filter((item) => item.confidence >= 0.75),
+      ...group.outcomeIntegrity.filter((item) => item.confidence >= 0.75),
     ].length
-    const issueCount = group.explicit.length + group.breadth.length + group.effect.length + group.directional.length + group.selective.length
+    const issueCount = group.explicit.length + group.breadth.length + group.effect.length + group.directional.length + group.outcomeIntegrity.length
     const breadthDimensions = {
       population: group.breadth.filter((item) => item.populationOverbroad).length,
       dose: group.breadth.filter((item) => item.doseOverbroad).length,
@@ -132,15 +132,18 @@ export function buildAggregatedTopologyGapSignals(
       heterogeneous: group.directional.filter((item) => item.directionalHeterogeneity).length,
       uniformlyPositive: group.directional.filter((item) => item.uniformlyPositiveOverstatement).length,
     }
-    const selectiveDimensions = {
-      selectiveOutcome: group.selective.filter((item) => item.selectiveOutcomeRisk).length,
-      outcomeSwitch: group.selective.filter((item) => item.explicitOutcomeSwitchRisk).length,
+    const outcomeIntegrityDimensions = {
+      selectiveOutcome: group.outcomeIntegrity.filter((item) => item.risks.includes('null-primary-with-favorable-secondary')).length,
+      primaryMismatch: group.outcomeIntegrity.filter((item) => item.risks.includes('registered-reported-primary-mismatch')).length,
+      partialPrimaryMismatch: group.outcomeIntegrity.filter((item) => item.risks.includes('registered-reported-primary-partial-mismatch')).length,
+      outcomeSwitch: group.outcomeIntegrity.filter((item) => item.risks.includes('explicit-outcome-switch')).length,
+      registeredNonreporting: group.outcomeIntegrity.filter((item) => item.risks.includes('explicit-registered-outcome-nonreporting')).length,
     }
     signals.push({
       url,
       kind: 'semantic-claim-source-mismatch',
       weight: weights.semanticMismatch + Math.min(10, Math.max(0, issueCount - 1) * 2) + (highConfidence ? weights.highConfidenceSemanticMismatchBonus : 0),
-      detail: `${group.explicit.length} explicit alignment mismatch(es), ${group.breadth.length} claim-breadth overreach finding(s), ${group.effect.length} effect/certainty overstatement finding(s), ${group.directional.length} endpoint/directional consistency finding(s), and ${group.selective.length} selective-outcome/reporting finding(s); ${highConfidence} high-confidence; role ${group.explicit.filter((item) => item.roleMismatch).length}, domain ${group.explicit.filter((item) => item.domainMismatch).length}, population mismatch ${group.explicit.filter((item) => item.populationMismatch).length}; breadth population ${breadthDimensions.population}, dose ${breadthDimensions.dose}, duration ${breadthDimensions.duration}, formulation ${breadthDimensions.formulation}, endpoint ${breadthDimensions.endpoint}; effect magnitude ${effectDimensions.magnitude}, clinical importance ${effectDimensions.clinicalImportance}, certainty ${effectDimensions.certainty}; endpoint cherry-pick ${directionalDimensions.cherryPick}, directional heterogeneity ${directionalDimensions.heterogeneous}, uniformly-positive overstatement ${directionalDimensions.uniformlyPositive}; selective outcome ${selectiveDimensions.selectiveOutcome}, explicit outcome switch/non-reporting ${selectiveDimensions.outcomeSwitch}`,
+      detail: `${group.explicit.length} explicit alignment mismatch(es), ${group.breadth.length} claim-breadth overreach finding(s), ${group.effect.length} effect/certainty overstatement finding(s), ${group.directional.length} endpoint/directional consistency finding(s), and ${group.outcomeIntegrity.length} outcome-reporting integrity finding(s); ${highConfidence} high-confidence; role ${group.explicit.filter((item) => item.roleMismatch).length}, domain ${group.explicit.filter((item) => item.domainMismatch).length}, population mismatch ${group.explicit.filter((item) => item.populationMismatch).length}; breadth population ${breadthDimensions.population}, dose ${breadthDimensions.dose}, duration ${breadthDimensions.duration}, formulation ${breadthDimensions.formulation}, endpoint ${breadthDimensions.endpoint}; effect magnitude ${effectDimensions.magnitude}, clinical importance ${effectDimensions.clinicalImportance}, certainty ${effectDimensions.certainty}; endpoint cherry-pick ${directionalDimensions.cherryPick}, directional heterogeneity ${directionalDimensions.heterogeneous}, uniformly-positive overstatement ${directionalDimensions.uniformlyPositive}; selective outcome ${outcomeIntegrityDimensions.selectiveOutcome}, registered/reported primary mismatch ${outcomeIntegrityDimensions.primaryMismatch}, partial primary mismatch ${outcomeIntegrityDimensions.partialPrimaryMismatch}, explicit outcome switch ${outcomeIntegrityDimensions.outcomeSwitch}, registered outcome non-reporting ${outcomeIntegrityDimensions.registeredNonreporting}`,
     })
   }
 


### PR DESCRIPTION
Rewires semantic policy aggregation from the legacy selective-outcome report to the canonical outcome-reporting integrity product. Existing selective-outcome behavior remains one claim-level issue, while registered-vs-reported primary mismatch and explicit registered-outcome non-reporting now reach policy. Multiple risk labels on one claim do not stack additional issue weight, and outcome-metadata coverage gaps remain editorial backfill rather than score penalties. Adds regression coverage for all four invariants.