### PR TITLE
feat(i18n): add Spanish localization foundation and core pages

### DIFF
--- a/app/es/compuestos/page.tsx
+++ b/app/es/compuestos/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.compounds
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishCompoundsPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/hierbas/page.tsx
+++ b/app/es/hierbas/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.herbs
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishHerbsPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/layout.tsx
+++ b/app/es/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function SpanishLayout({ children }: { children: ReactNode }) {
+  return (
+    <div lang='es' dir='ltr' data-locale='es'>
+      {children}
+    </div>
+  )
+}

--- a/app/es/metodologia/page.tsx
+++ b/app/es/metodologia/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.methodology
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishMethodologyPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/objetivos/ansiedad/page.tsx
+++ b/app/es/objetivos/ansiedad/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.anxiety
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishAnxietyGoalPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/objetivos/concentracion/page.tsx
+++ b/app/es/objetivos/concentracion/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.focus
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishFocusGoalPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/objetivos/estres/page.tsx
+++ b/app/es/objetivos/estres/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.stress
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishStressGoalPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/objetivos/page.tsx
+++ b/app/es/objetivos/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.goals
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishGoalsPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/objetivos/sueno/page.tsx
+++ b/app/es/objetivos/sueno/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.sleep
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishSleepGoalPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/page.tsx
+++ b/app/es/page.tsx
@@ -1,0 +1,52 @@
+import type { SpanishPageData } from '@/src/lib/spanish-content'
+import { buildSpanishPageMetadata } from '@/src/lib/spanish-content'
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+
+const page: SpanishPageData = {
+  path: '/es/',
+  eyebrow: 'The Hippie Scientist en español',
+  title: 'Investiga suplementos sin adivinar',
+  description:
+    'Compara hierbas y suplementos por evidencia humana, mecanismos, dosis, seguridad e interacciones. Investigación clara y basada en evidencia en español.',
+  intro:
+    'Compara hierbas y suplementos según evidencia en humanos, mecanismos, dosis y seguridad. Empieza por tu objetivo, no por el marketing.',
+  sections: [
+    {
+      title: 'Empieza por un objetivo',
+      body:
+        'Cada ruta organiza la decisión antes de entrar en ingredientes individuales. Elige el resultado que quieres investigar y compara opciones con el mismo marco.',
+      links: [
+        { href: '/es/objetivos/sueno/', label: 'Sueño', note: 'Horario, calidad del sueño y efectos al día siguiente' },
+        { href: '/es/objetivos/estres/', label: 'Estrés', note: 'Patrón de estrés, evidencia y tolerabilidad' },
+        { href: '/es/objetivos/ansiedad/', label: 'Ansiedad', note: 'Evidencia, sedación, seguridad y límites' },
+        { href: '/es/objetivos/concentracion/', label: 'Concentración', note: 'Atención, estimulación, sueño y compensaciones' },
+      ],
+    },
+    {
+      title: 'Explora la biblioteca',
+      body:
+        'Separamos la evidencia clínica de los mecanismos y mantenemos las advertencias visibles. Las bibliotecas españolas ya están publicadas; los perfiles detallados se traducirán de forma progresiva.',
+      links: [
+        { href: '/es/hierbas/', label: 'Hierbas', note: 'Investigación, mecanismos y seguridad' },
+        { href: '/es/compuestos/', label: 'Compuestos y suplementos', note: 'Evidencia, dosis e interacciones' },
+      ],
+    },
+    {
+      title: 'Cómo protegemos el significado científico',
+      body:
+        'No publicamos traducciones automáticas de conclusiones médicas sensibles. La versión española debe conservar el grado de certeza, las limitaciones, las interacciones y el contexto de la evidencia del contenido original.',
+      links: [
+        { href: '/es/metodologia/', label: 'Cómo evaluamos la evidencia' },
+        { href: '/es/seguridad/', label: 'Seguridad e interacciones' },
+      ],
+    },
+  ],
+  primaryCta: { href: '/es/objetivos/', label: 'Elegir un objetivo' },
+  secondaryCta: { href: '/', label: 'English version' },
+}
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishHomePage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/es/seguridad/page.tsx
+++ b/app/es/seguridad/page.tsx
@@ -1,0 +1,10 @@
+import SpanishCorePage from '@/components/localization/SpanishCorePage'
+import { buildSpanishPageMetadata, SPANISH_PAGES } from '@/src/lib/spanish-content'
+
+const page = SPANISH_PAGES.safety
+
+export const metadata = buildSpanishPageMetadata(page)
+
+export default function SpanishSafetyPage() {
+  return <SpanishCorePage page={page} />
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
 import '@fontsource-variable/inter'
 import '@fontsource-variable/fraunces/wght.css'
-import { Navigation } from '@/components/Navigation'
 import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { NavigationSchema } from '@/components/NavigationSchema'
 import { BreadcrumbSchema } from '@/components/BreadcrumbSchema'
@@ -16,6 +15,9 @@ import EmailReturnAttribution from '@/components/EmailReturnAttribution'
 import ConsentBanner from '../src/components/ConsentBanner'
 import CitationDrawerLazy from '@/components/education/CitationDrawerLazy'
 import GlobalTOC from '@/components/content/GlobalTOC'
+import LocalizedNavigation from '@/components/localization/LocalizedNavigation'
+import SpanishFooter from '@/components/localization/SpanishFooter'
+import { EnglishOnly, SpanishOnly } from '@/components/localization/LocaleGate'
 import { buildPageMetadata, DEFAULT_DESCRIPTION, SITE_NAME, SITE_URL, websiteJsonLd, organizationJsonLd } from '../src/lib/seo'
 import { serializeJsonLd } from '../src/lib/schema-injector'
 import { DEFAULT_LOCALE, DEFAULT_OG_LOCALE, LOCALE_TEXT_DIRECTION } from '../src/lib/international-seo'
@@ -124,18 +126,22 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           type='application/ld+json'
           dangerouslySetInnerHTML={{ __html: serializeJsonLd(siteOrgLd) }}
         />
-        <NavigationSchema />
-        <BreadcrumbSchema />
+        <EnglishOnly>
+          <NavigationSchema />
+          <BreadcrumbSchema />
+        </EnglishOnly>
         <a href='#main-content' className='skip-link'>
           Skip to main content
         </a>
         <DarkModeProvider>
           <div className='hs-shell min-h-screen bg-background text-ink transition-colors duration-300'>
             <header>
-              <Navigation />
+              <LocalizedNavigation />
             </header>
-            <Breadcrumbs />
-            <CommercialIntentBridge />
+            <EnglishOnly>
+              <Breadcrumbs />
+              <CommercialIntentBridge />
+            </EnglishOnly>
             <main
               id='main-content'
               data-pagefind-body
@@ -144,12 +150,21 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             >
               <GlobalTOC />
               {children}
-              <ContextualLeadMagnet />
+              <EnglishOnly>
+                <ContextualLeadMagnet />
+              </EnglishOnly>
             </main>
-            <Footer />
-            <MobileBottomNav />
+            <EnglishOnly>
+              <Footer />
+              <MobileBottomNav />
+            </EnglishOnly>
+            <SpanishOnly>
+              <SpanishFooter />
+            </SpanishOnly>
             <ScrollToTopButton />
-            <CitationDrawerLazy />
+            <EnglishOnly>
+              <CitationDrawerLazy />
+            </EnglishOnly>
             <ClickTracker />
             <EmailReturnAttribution />
             <ConsentBanner />

--- a/components/localization/LocaleGate.tsx
+++ b/components/localization/LocaleGate.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import type { ReactNode } from 'react'
+
+function isSpanishPath(pathname: string | null) {
+  return pathname === '/es' || Boolean(pathname?.startsWith('/es/'))
+}
+
+export function EnglishOnly({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  return isSpanishPath(pathname) ? null : <>{children}</>
+}
+
+export function SpanishOnly({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  return isSpanishPath(pathname) ? <>{children}</> : null
+}

--- a/components/localization/LocalizedNavigation.tsx
+++ b/components/localization/LocalizedNavigation.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Languages, Leaf } from 'lucide-react'
+import { Navigation } from '@/components/Navigation'
+import DarkModeToggle from '@/components/DarkModeToggle'
+import {
+  DEFAULT_LOCALE,
+  SPANISH_LOCALE,
+  getLocalizedRoute,
+} from '@/src/lib/international-seo'
+
+const spanishLinks = [
+  { href: '/es/hierbas/', label: 'Hierbas' },
+  { href: '/es/compuestos/', label: 'Compuestos' },
+  { href: '/es/objetivos/', label: 'Objetivos' },
+  { href: '/es/metodologia/', label: 'Metodología' },
+  { href: '/es/seguridad/', label: 'Seguridad' },
+]
+
+function isSpanishPath(pathname: string) {
+  return pathname === '/es' || pathname.startsWith('/es/')
+}
+
+export default function LocalizedNavigation() {
+  const pathname = usePathname() || '/'
+  const spanish = isSpanishPath(pathname)
+
+  useEffect(() => {
+    document.documentElement.lang = spanish ? SPANISH_LOCALE : DEFAULT_LOCALE
+    document.documentElement.dir = 'ltr'
+  }, [spanish])
+
+  if (!spanish) {
+    const spanishHref = getLocalizedRoute(pathname, SPANISH_LOCALE) || '/es/'
+    return (
+      <>
+        <Navigation />
+        <div className='border-b border-[#123c2f]/10 bg-[#fffdf8]/90 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card-strong)]'>
+          <div className='mx-auto flex max-w-7xl justify-end px-4 py-1.5 sm:px-6 lg:px-8'>
+            <Link
+              href={spanishHref}
+              hrefLang='es'
+              className='inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-[#526159] transition hover:bg-[#f5efe2] hover:text-[#123c2f] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#b88a42]/50 dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)] dark:hover:text-[var(--text-primary)]'
+              aria-label='Ver esta sección en español'
+            >
+              <Languages className='h-3.5 w-3.5' aria-hidden='true' />
+              Español
+            </Link>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  const englishHref = getLocalizedRoute(pathname, DEFAULT_LOCALE) || '/'
+
+  return (
+    <nav
+      className='sticky top-0 z-[110] border-b border-[#123c2f]/10 bg-[#fffdf8]/95 backdrop-blur-xl dark:border-[var(--border-strong)] dark:bg-[rgba(20,38,29,0.95)]'
+      aria-label='Navegación principal'
+    >
+      <div className='mx-auto max-w-7xl px-3 sm:px-6 lg:px-8'>
+        <div className='flex min-h-[4.6rem] items-center justify-between gap-3'>
+          <Link
+            href='/es/'
+            className='flex min-w-0 items-center gap-2.5 font-display text-base font-semibold tracking-[-0.025em] text-[#123c2f] dark:text-[var(--text-primary)] sm:text-lg'
+            aria-label='Inicio de The Hippie Scientist en español'
+          >
+            <span className='editorial-icon-disc h-9 w-9 shrink-0 border-none bg-transparent shadow-none'>
+              <Leaf aria-hidden='true' className='h-6 w-6 text-[#315f50] dark:text-[var(--accent-teal)]' strokeWidth={1.7} />
+            </span>
+            <span className='truncate'>The Hippie Scientist</span>
+          </Link>
+
+          <div className='hidden items-center gap-5 text-sm md:flex'>
+            {spanishLinks.map((link) => {
+              const active = pathname === link.href.replace(/\/$/, '') || pathname.startsWith(link.href)
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  aria-current={active ? 'page' : undefined}
+                  className={`font-semibold transition ${
+                    active
+                      ? 'text-[#123c2f] dark:text-[var(--text-primary)]'
+                      : 'text-[#526159] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              )
+            })}
+          </div>
+
+          <div className='flex shrink-0 items-center gap-2'>
+            <Link
+              href={englishHref}
+              hrefLang='en-US'
+              className='inline-flex min-h-10 items-center gap-1.5 rounded-full border border-[#123c2f]/10 bg-[#fffdf8] px-3 py-2 text-xs font-bold text-[#44544d] transition hover:border-[#b88a42]/30 hover:bg-[#f5efe2] dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)] dark:text-[var(--text-secondary)] dark:hover:bg-[var(--surface-subtle)]'
+            >
+              <Languages className='h-3.5 w-3.5' aria-hidden='true' />
+              English
+            </Link>
+            <DarkModeToggle />
+          </div>
+        </div>
+
+        <div className='-mx-1 flex gap-1 overflow-x-auto pb-2 md:hidden' aria-label='Secciones en español'>
+          {spanishLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className='shrink-0 rounded-full bg-[#f5efe2]/75 px-3 py-2 text-xs font-semibold text-[#33433c] dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/components/localization/SpanishCorePage.tsx
+++ b/components/localization/SpanishCorePage.tsx
@@ -1,0 +1,115 @@
+import Link from 'next/link'
+import { ArrowRight, BookOpen, Languages, ShieldCheck } from 'lucide-react'
+import type { SpanishPageData } from '@/src/lib/spanish-content'
+
+export default function SpanishCorePage({ page }: { page: SpanishPageData }) {
+  return (
+    <div className='mx-auto max-w-5xl px-5 py-10 sm:px-8 sm:py-16 lg:px-10'>
+      <section className='rounded-[2rem] border border-[#123c2f]/10 bg-[#fffdf8] p-6 shadow-[0_18px_48px_rgba(45,35,19,0.08)] dark:border-[var(--border-strong)] dark:bg-[var(--surface-card-strong)] sm:p-10'>
+        <div className='flex flex-wrap items-center gap-2 text-xs font-extrabold uppercase tracking-[0.14em] text-[#8a6a38] dark:text-[var(--accent-gold)]'>
+          <Languages className='h-4 w-4' aria-hidden='true' />
+          <span>{page.eyebrow}</span>
+        </div>
+        <h1 className='mt-5 max-w-4xl font-display text-4xl font-semibold leading-tight tracking-[-0.035em] text-[#123c2f] dark:text-[var(--text-primary)] sm:text-5xl'>
+          {page.title}
+        </h1>
+        <p className='mt-6 max-w-3xl text-base leading-8 text-[#44544d] dark:text-[var(--text-secondary)] sm:text-lg'>
+          {page.intro}
+        </p>
+
+        <div className='mt-7 flex items-start gap-3 rounded-2xl border border-[#b88a42]/20 bg-[#f8f3e8] px-4 py-4 text-sm leading-6 text-[#44544d] dark:border-[var(--border-soft)] dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'>
+          <BookOpen className='mt-0.5 h-4 w-4 shrink-0 text-[#8a6a38] dark:text-[var(--accent-gold)]' aria-hidden='true' />
+          <p>
+            Esta es una traducción editorial en español. Los perfiles científicos que todavía no tienen una versión española completa se identifican como contenido en inglés.
+          </p>
+        </div>
+      </section>
+
+      <div className='mt-10 space-y-8'>
+        {page.sections.map((section) => (
+          <section
+            key={section.title}
+            className='rounded-[1.75rem] border border-[#123c2f]/10 bg-white/70 p-6 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card)] sm:p-8'
+          >
+            <h2 className='font-display text-2xl font-semibold tracking-[-0.02em] text-[#123c2f] dark:text-[var(--text-primary)] sm:text-3xl'>
+              {section.title}
+            </h2>
+            <p className='mt-4 max-w-3xl text-[0.98rem] leading-7 text-[#44544d] dark:text-[var(--text-secondary)]'>
+              {section.body}
+            </p>
+
+            {section.bullets?.length ? (
+              <ul className='mt-5 grid gap-3 sm:grid-cols-2'>
+                {section.bullets.map((bullet) => (
+                  <li
+                    key={bullet}
+                    className='flex gap-3 rounded-2xl bg-[#f8f3e8]/75 px-4 py-3 text-sm leading-6 text-[#33433c] dark:bg-[var(--surface-subtle)] dark:text-[var(--text-secondary)]'
+                  >
+                    <ShieldCheck className='mt-0.5 h-4 w-4 shrink-0 text-[#315f50] dark:text-[var(--accent-teal)]' aria-hidden='true' />
+                    <span>{bullet}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            {section.links?.length ? (
+              <div className='mt-6 grid gap-3 sm:grid-cols-2'>
+                {section.links.map((link) => (
+                  <Link
+                    key={`${section.title}-${link.href}`}
+                    href={link.href}
+                    className='group rounded-2xl border border-[#123c2f]/10 bg-[#fffdf8] px-4 py-4 transition hover:border-[#b88a42]/35 hover:bg-[#f8f3e8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#b88a42]/50 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card-strong)] dark:hover:bg-[var(--surface-subtle)]'
+                  >
+                    <span className='flex items-center justify-between gap-3 font-semibold text-[#123c2f] dark:text-[var(--text-primary)]'>
+                      {link.label}
+                      <ArrowRight className='h-4 w-4 transition group-hover:translate-x-0.5' aria-hidden='true' />
+                    </span>
+                    {link.note ? (
+                      <span className='mt-1.5 block text-xs leading-5 text-[#66736d] dark:text-[var(--text-muted)]'>
+                        {link.note}
+                      </span>
+                    ) : null}
+                  </Link>
+                ))}
+              </div>
+            ) : null}
+          </section>
+        ))}
+      </div>
+
+      {(page.primaryCta || page.secondaryCta) ? (
+        <section className='mt-10 flex flex-col gap-3 rounded-[1.75rem] border border-[#123c2f]/10 bg-[#123c2f] p-6 text-[#fffdf8] sm:flex-row sm:items-center sm:justify-between sm:p-8'>
+          <div>
+            <p className='text-xs font-extrabold uppercase tracking-[0.14em] text-[#e2cba3]'>Siguiente paso</p>
+            <p className='mt-2 max-w-xl text-sm leading-6 text-[#f4efe5]'>
+              Sigue comparando con el mismo criterio: evidencia primero, seguridad visible y límites claros.
+            </p>
+          </div>
+          <div className='flex flex-col gap-2 sm:flex-row'>
+            {page.secondaryCta ? (
+              <Link
+                href={page.secondaryCta.href}
+                className='inline-flex min-h-11 items-center justify-center rounded-full border border-white/20 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#e2cba3]'
+              >
+                {page.secondaryCta.label}
+              </Link>
+            ) : null}
+            {page.primaryCta ? (
+              <Link
+                href={page.primaryCta.href}
+                className='inline-flex min-h-11 items-center justify-center gap-2 rounded-full bg-[#e2cba3] px-5 py-2.5 text-sm font-bold text-[#123c2f] transition hover:bg-[#f0ddba] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white'
+              >
+                {page.primaryCta.label}
+                <ArrowRight className='h-4 w-4' aria-hidden='true' />
+              </Link>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      <p className='mx-auto mt-8 max-w-3xl text-center text-xs leading-5 text-[#66736d] dark:text-[var(--text-muted)]'>
+        Contenido educativo. No sustituye la evaluación individual de un profesional sanitario, especialmente si tomas medicamentos, estás embarazada o tienes una condición médica.
+      </p>
+    </div>
+  )
+}

--- a/components/localization/SpanishFooter.tsx
+++ b/components/localization/SpanishFooter.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { Leaf } from 'lucide-react'
+
+export default function SpanishFooter() {
+  return (
+    <footer className='border-t border-[#123c2f]/10 bg-[#f8f3e8]/70 dark:border-[var(--border-soft)] dark:bg-[var(--surface-card-strong)]' lang='es'>
+      <div className='mx-auto grid max-w-7xl gap-8 px-5 py-10 sm:px-8 md:grid-cols-[1.2fr_1fr] lg:px-10'>
+        <div>
+          <Link href='/es/' className='inline-flex items-center gap-2 font-display text-lg font-semibold text-[#123c2f] dark:text-[var(--text-primary)]'>
+            <Leaf className='h-5 w-5 text-[#315f50] dark:text-[var(--accent-teal)]' aria-hidden='true' />
+            The Hippie Scientist
+          </Link>
+          <p className='mt-3 max-w-xl text-sm leading-6 text-[#526159] dark:text-[var(--text-secondary)]'>
+            Referencia educativa basada en evidencia para investigar hierbas, suplementos y compuestos con la seguridad y la incertidumbre siempre visibles.
+          </p>
+        </div>
+        <nav className='grid grid-cols-2 gap-x-6 gap-y-3 text-sm' aria-label='Enlaces del pie de página'>
+          <Link href='/es/hierbas/' className='font-semibold text-[#33433c] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'>Hierbas</Link>
+          <Link href='/es/compuestos/' className='font-semibold text-[#33433c] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'>Compuestos</Link>
+          <Link href='/es/objetivos/' className='font-semibold text-[#33433c] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'>Objetivos</Link>
+          <Link href='/es/metodologia/' className='font-semibold text-[#33433c] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'>Metodología</Link>
+          <Link href='/es/seguridad/' className='font-semibold text-[#33433c] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'>Seguridad</Link>
+          <Link href='/' hrefLang='en-US' className='font-semibold text-[#33433c] hover:text-[#123c2f] dark:text-[var(--text-secondary)] dark:hover:text-[var(--text-primary)]'>English</Link>
+        </nav>
+      </div>
+      <div className='border-t border-[#123c2f]/10 px-5 py-5 text-center text-xs leading-5 text-[#66736d] dark:border-[var(--border-soft)] dark:text-[var(--text-muted)]'>
+        Información educativa, no consejo médico. Para decisiones personales de salud, consulta a un profesional sanitario cualificado.
+      </div>
+    </footer>
+  )
+}

--- a/src/lib/__tests__/international-seo.test.ts
+++ b/src/lib/__tests__/international-seo.test.ts
@@ -3,19 +3,26 @@ import {
   DEFAULT_LOCALE,
   DEFAULT_LANGUAGE,
   DEFAULT_REGION,
+  LOCALIZED_ROUTE_PAIRS,
   LOCALE_TEXT_DIRECTION,
+  SPANISH_LOCALE,
+  SUPPORTED_LOCALES,
   buildDefaultLocaleUrl,
   getCurrentLocaleAlternates,
   getLocaleMetadata,
+  getLocalizedRoute,
   normalizeInternationalPath,
 } from '../international-seo'
+import { shouldIndexRoute } from '../seo'
 
 describe('international SEO helpers', () => {
-  it('declares the current production locale explicitly', () => {
+  it('declares English as the default and Spanish as a supported locale', () => {
     expect(DEFAULT_LOCALE).toBe('en-US')
     expect(DEFAULT_LANGUAGE).toBe('en')
     expect(DEFAULT_REGION).toBe('US')
     expect(LOCALE_TEXT_DIRECTION).toBe('ltr')
+    expect(SPANISH_LOCALE).toBe('es')
+    expect(SUPPORTED_LOCALES).toEqual(['en-US', 'es'])
   })
 
   it('normalizes paths for locale alternates without query strings', () => {
@@ -23,19 +30,47 @@ describe('international SEO helpers', () => {
     expect(normalizeInternationalPath('/robots.txt')).toBe('/robots.txt')
   })
 
-  it('builds current safe alternates with en-US and x-default only', () => {
-    expect(getCurrentLocaleAlternates('/guides/sleep/')).toEqual([
-      { locale: 'en-US', url: 'https://thehippiescientist.net/guides/sleep/' },
-      { locale: 'x-default', url: 'https://thehippiescientist.net/guides/sleep/' },
+  it('builds translated hreflang pairs only for published Spanish equivalents', () => {
+    expect(getCurrentLocaleAlternates('/herbs/')).toEqual([
+      { locale: 'en-US', url: 'https://thehippiescientist.net/herbs/' },
+      { locale: 'es', url: 'https://thehippiescientist.net/es/hierbas/' },
+      { locale: 'x-default', url: 'https://thehippiescientist.net/herbs/' },
     ])
+
+    expect(getCurrentLocaleAlternates('/herbs/ashwagandha/')).toEqual([
+      { locale: 'en-US', url: 'https://thehippiescientist.net/herbs/ashwagandha/' },
+      { locale: 'x-default', url: 'https://thehippiescientist.net/herbs/ashwagandha/' },
+    ])
+  })
+
+  it('resolves translated routes in both directions', () => {
+    expect(getLocalizedRoute('/herbs/', 'es')).toBe('/es/hierbas/')
+    expect(getLocalizedRoute('/es/hierbas/', 'en-US')).toBe('/herbs/')
+    expect(getLocalizedRoute('/goals/sleep', 'es')).toBe('/es/objetivos/sueno/')
   })
 
   it('builds the default locale homepage URL', () => {
     expect(buildDefaultLocaleUrl('/')).toBe('https://thehippiescientist.net/')
   })
 
-  it('exposes locale metadata for layout and future localized routes', () => {
-    expect(getLocaleMetadata('/').alternates).toHaveLength(2)
+  it('exposes locale metadata for both language versions', () => {
+    expect(getLocaleMetadata('/').alternates).toHaveLength(3)
     expect(getLocaleMetadata('/').openGraphLocale).toBe('en_US')
+    expect(getLocaleMetadata('/es/', 'es').openGraphLocale).toBe('es_ES')
+  })
+
+  it('keeps every published Spanish translation indexable', () => {
+    for (const pair of LOCALIZED_ROUTE_PAIRS) {
+      const decision = shouldIndexRoute(pair.spanish)
+      expect(decision.index, `${pair.spanish} should be indexable`).toBe(true)
+      expect(decision.follow).toBe(true)
+    }
+  })
+
+  it('does not contain duplicate translation paths', () => {
+    const english = LOCALIZED_ROUTE_PAIRS.map((pair) => pair.english)
+    const spanish = LOCALIZED_ROUTE_PAIRS.map((pair) => pair.spanish)
+    expect(new Set(english).size).toBe(english.length)
+    expect(new Set(spanish).size).toBe(spanish.length)
   })
 })

--- a/src/lib/index-allowlist.ts
+++ b/src/lib/index-allowlist.ts
@@ -23,6 +23,16 @@ export const CORE_INDEXABLE_ROUTES = [
   '/tools/botanical-activity-atlas/calming-botanicals',
   '/tools/botanical-activity-atlas/dream-and-perception-herbs',
   '/tools/botanical-activity-atlas/serotonergic-interaction-risk',
+  '/es',
+  '/es/hierbas',
+  '/es/compuestos',
+  '/es/objetivos',
+  '/es/objetivos/sueno',
+  '/es/objetivos/estres',
+  '/es/objetivos/ansiedad',
+  '/es/objetivos/concentracion',
+  '/es/metodologia',
+  '/es/seguridad',
 ] as const
 
 export const MONEY_ENTRY_ROUTES = [

--- a/src/lib/international-seo.ts
+++ b/src/lib/international-seo.ts
@@ -6,13 +6,43 @@ export const DEFAULT_LANGUAGE = 'en'
 export const DEFAULT_REGION = 'US'
 export const LOCALE_TEXT_DIRECTION = 'ltr'
 
-export const SUPPORTED_LOCALES = [DEFAULT_LOCALE] as const
+export const SPANISH_LOCALE = 'es'
+export const SPANISH_OG_LOCALE = 'es_ES'
+export const SPANISH_LANGUAGE = 'es'
+export const SPANISH_TEXT_DIRECTION = 'ltr'
+
+export const SUPPORTED_LOCALES = [DEFAULT_LOCALE, SPANISH_LOCALE] as const
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
 
 export type LocaleAlternate = {
   locale: SupportedLocale | 'x-default'
   url: string
 }
+
+export type LocalizedRoutePair = {
+  english: string
+  spanish: string
+}
+
+/**
+ * Canonical translation registry.
+ *
+ * Only add a pair after the Spanish URL is published with substantive,
+ * equivalent editorial content. This prevents hreflang from advertising
+ * placeholder, partial, or nonexistent translations.
+ */
+export const LOCALIZED_ROUTE_PAIRS: readonly LocalizedRoutePair[] = [
+  { english: '/', spanish: '/es/' },
+  { english: '/herbs/', spanish: '/es/hierbas/' },
+  { english: '/compounds/', spanish: '/es/compuestos/' },
+  { english: '/goals/', spanish: '/es/objetivos/' },
+  { english: '/goals/sleep/', spanish: '/es/objetivos/sueno/' },
+  { english: '/goals/stress/', spanish: '/es/objetivos/estres/' },
+  { english: '/goals/anxiety/', spanish: '/es/objetivos/ansiedad/' },
+  { english: '/goals/focus/', spanish: '/es/objetivos/concentracion/' },
+  { english: '/info/methodology/', spanish: '/es/metodologia/' },
+  { english: '/safety-checker/', spanish: '/es/seguridad/' },
+] as const
 
 const withLeadingSlash = (path: string) => {
   if (!path) return '/'
@@ -31,31 +61,68 @@ export function normalizeInternationalPath(path = '/') {
   return withTrailingSlash(url.pathname)
 }
 
-export function buildDefaultLocaleUrl(path = '/') {
+export function buildLocaleUrl(path = '/') {
   return new URL(normalizeInternationalPath(path), SITE_URL).toString()
 }
 
+export function buildDefaultLocaleUrl(path = '/') {
+  return buildLocaleUrl(path)
+}
+
+export function getLocalizedRoute(path = '/', locale: SupportedLocale): string | null {
+  const normalized = normalizeInternationalPath(path)
+  const pair = LOCALIZED_ROUTE_PAIRS.find(
+    (candidate) =>
+      normalizeInternationalPath(candidate.english) === normalized ||
+      normalizeInternationalPath(candidate.spanish) === normalized,
+  )
+
+  if (!pair) return null
+  return locale === SPANISH_LOCALE
+    ? normalizeInternationalPath(pair.spanish)
+    : normalizeInternationalPath(pair.english)
+}
+
+export function hasSpanishTranslation(path = '/'): boolean {
+  return Boolean(getLocalizedRoute(path, SPANISH_LOCALE))
+}
+
 /**
- * Safe current-state alternates.
+ * Safe published alternates.
  *
- * The site currently publishes one English locale. Do not add translated hreflang
- * entries until the translated URL exists and has equivalent content.
+ * Hreflang is emitted only for routes in LOCALIZED_ROUTE_PAIRS. Untranslated
+ * English pages continue to advertise only English + x-default so crawlers are
+ * never sent to a thin or nonexistent Spanish URL.
  */
 export function getCurrentLocaleAlternates(path = '/'): LocaleAlternate[] {
-  const url = buildDefaultLocaleUrl(path)
+  const normalized = normalizeInternationalPath(path)
+  const englishPath = getLocalizedRoute(normalized, DEFAULT_LOCALE)
+  const spanishPath = getLocalizedRoute(normalized, SPANISH_LOCALE)
+
+  if (englishPath && spanishPath) {
+    const englishUrl = buildLocaleUrl(englishPath)
+    return [
+      { locale: DEFAULT_LOCALE, url: englishUrl },
+      { locale: SPANISH_LOCALE, url: buildLocaleUrl(spanishPath) },
+      { locale: 'x-default', url: englishUrl },
+    ]
+  }
+
+  const url = buildDefaultLocaleUrl(normalized)
   return [
     { locale: DEFAULT_LOCALE, url },
     { locale: 'x-default', url },
   ]
 }
 
-export function getLocaleMetadata(path = '/') {
+export function getLocaleMetadata(path = '/', locale: SupportedLocale = DEFAULT_LOCALE) {
+  const isSpanish = locale === SPANISH_LOCALE
   return {
-    language: DEFAULT_LANGUAGE,
-    locale: DEFAULT_LOCALE,
-    openGraphLocale: DEFAULT_OG_LOCALE,
-    region: DEFAULT_REGION,
-    textDirection: LOCALE_TEXT_DIRECTION,
+    language: isSpanish ? SPANISH_LANGUAGE : DEFAULT_LANGUAGE,
+    locale,
+    openGraphLocale: isSpanish ? SPANISH_OG_LOCALE : DEFAULT_OG_LOCALE,
+    region: isSpanish ? undefined : DEFAULT_REGION,
+    textDirection: isSpanish ? SPANISH_TEXT_DIRECTION : LOCALE_TEXT_DIRECTION,
     alternates: getCurrentLocaleAlternates(path),
   }
 }

--- a/src/lib/spanish-content.ts
+++ b/src/lib/spanish-content.ts
@@ -1,0 +1,361 @@
+import type { Metadata } from 'next'
+import { buildPageMetadata } from './seo'
+import { DEFAULT_OG_LOCALE, SPANISH_OG_LOCALE } from './international-seo'
+
+export type SpanishLink = {
+  href: string
+  label: string
+  note?: string
+}
+
+export type SpanishSection = {
+  title: string
+  body: string
+  bullets?: readonly string[]
+  links?: readonly SpanishLink[]
+}
+
+export type SpanishPageData = {
+  path: string
+  eyebrow: string
+  title: string
+  description: string
+  intro: string
+  sections: readonly SpanishSection[]
+  primaryCta?: SpanishLink
+  secondaryCta?: SpanishLink
+}
+
+export const SPANISH_PAGES = {
+  herbs: {
+    path: '/es/hierbas/',
+    eyebrow: 'Biblioteca de investigación',
+    title: 'Hierbas: evidencia, mecanismos y seguridad',
+    description:
+      'Explora hierbas con un enfoque basado en evidencia: investigación en humanos, mecanismos, dosis, seguridad e interacciones, explicado en español.',
+    intro:
+      'Empieza por una hierba conocida o por el objetivo que te interesa. Priorizamos la evidencia en humanos y mantenemos la seguridad visible antes de cualquier conclusión práctica.',
+    sections: [
+      {
+        title: 'Cómo leer la biblioteca',
+        body:
+          'Una hierba no se evalúa por popularidad. Separamos lo que se ha observado en personas de lo que solo es plausible por mecanismos, tradición o estudios preclínicos.',
+        bullets: [
+          'Busca primero la calidad y el tipo de evidencia humana.',
+          'Revisa interacciones, contraindicaciones y contexto de dosis.',
+          'Trata los mecanismos como contexto biológico, no como prueba clínica.',
+          'Ten en cuenta la incertidumbre cuando los estudios sean pequeños, mixtos o indirectos.',
+        ],
+      },
+      {
+        title: 'Perfiles populares',
+        body:
+          'Estos perfiles detallados todavía se abren en inglés mientras completamos la traducción científica campo por campo.',
+        links: [
+          { href: '/herbs/ashwagandha/', label: 'Ashwagandha', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/rhodiola/', label: 'Rhodiola', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/valerian/', label: 'Valeriana', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/bacopa/', label: 'Bacopa', note: 'Perfil detallado en inglés' },
+        ],
+      },
+      {
+        title: 'Qué estamos traduciendo',
+        body:
+          'La prioridad es conservar el significado científico: resumen de evidencia, seguridad, dosis, mecanismos y referencias. No publicamos una versión española de un perfil hasta que esos elementos sean equivalentes y coherentes.',
+      },
+    ],
+    primaryCta: { href: '/es/objetivos/', label: 'Buscar por objetivo' },
+    secondaryCta: { href: '/herbs/', label: 'Abrir biblioteca completa en inglés' },
+  },
+  compounds: {
+    path: '/es/compuestos/',
+    eyebrow: 'Biblioteca de investigación',
+    title: 'Compuestos y suplementos: compara la evidencia',
+    description:
+      'Explora compuestos y suplementos con evidencia, mecanismos, dosis, seguridad e interacciones en un formato claro y basado en investigación.',
+    intro:
+      'La biblioteca de compuestos organiza lo que sabemos, lo que todavía no sabemos y qué riesgos conviene revisar antes de comparar opciones.',
+    sections: [
+      {
+        title: 'Qué priorizamos',
+        body:
+          'La evidencia clínica en personas pesa más que los mecanismos aislados o las afirmaciones de marketing. Una señal prometedora no se presenta como un beneficio demostrado.',
+        bullets: [
+          'Tipo y calidad de estudios en humanos.',
+          'Consistencia entre estudios y revisiones.',
+          'Dosis estudiadas y contexto de uso.',
+          'Interacciones, contraindicaciones y efectos adversos relevantes.',
+        ],
+      },
+      {
+        title: 'Puntos de partida',
+        body:
+          'Los perfiles completos de estos compuestos siguen en inglés durante la primera fase de traducción.',
+        links: [
+          { href: '/compounds/magnesium/', label: 'Magnesio', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/l-theanine/', label: 'L-teanina', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/melatonin/', label: 'Melatonina', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/omega-3/', label: 'Omega-3', note: 'Perfil detallado en inglés' },
+        ],
+      },
+      {
+        title: 'Sin falsas equivalencias',
+        body:
+          'No traducimos automáticamente términos científicos sensibles si eso puede cambiar el significado. Cada versión española debe conservar el nivel de certeza, los límites de la evidencia y las advertencias del original.',
+      },
+    ],
+    primaryCta: { href: '/es/objetivos/', label: 'Comparar por objetivo' },
+    secondaryCta: { href: '/compounds/', label: 'Abrir biblioteca completa en inglés' },
+  },
+  goals: {
+    path: '/es/objetivos/',
+    eyebrow: 'Empieza por lo que quieres mejorar',
+    title: 'Explora suplementos por objetivo',
+    description:
+      'Compara opciones por objetivo — sueño, estrés, ansiedad y concentración — usando evidencia, seguridad, dosis y contexto práctico en español.',
+    intro:
+      'En vez de empezar por un ingrediente de moda, empieza por el resultado que te importa. Cada guía te ayuda a reducir opciones antes de entrar en perfiles individuales.',
+    sections: [
+      {
+        title: 'Objetivos principales',
+        body: 'Elige una ruta para ver qué preguntas importan antes de comparar suplementos.',
+        links: [
+          { href: '/es/objetivos/sueno/', label: 'Sueño', note: 'Calidad del sueño, horario y efectos al día siguiente' },
+          { href: '/es/objetivos/estres/', label: 'Estrés', note: 'Patrón de estrés, tiempo de uso y tolerabilidad' },
+          { href: '/es/objetivos/ansiedad/', label: 'Ansiedad', note: 'Evidencia, sedación, interacciones y límites' },
+          { href: '/es/objetivos/concentracion/', label: 'Concentración', note: 'Atención, estimulación, sueño y compensaciones' },
+        ],
+      },
+      {
+        title: 'Cómo comparar',
+        body:
+          'Una opción puede ser interesante en un contexto y mala en otro. Compara evidencia, tiempo de acción, duración, seguridad, compatibilidad con medicamentos y qué tan bien coincide con tu situación.',
+      },
+    ],
+    primaryCta: { href: '/es/seguridad/', label: 'Revisar seguridad primero' },
+    secondaryCta: { href: '/goals/', label: 'Ver todos los objetivos en inglés' },
+  },
+  sleep: {
+    path: '/es/objetivos/sueno/',
+    eyebrow: 'Objetivo: sueño',
+    title: 'Suplementos para el sueño: cómo comparar opciones',
+    description:
+      'Compara suplementos para el sueño considerando evidencia humana, horario, duración, efectos al día siguiente, dosis e interacciones importantes.',
+    intro:
+      '“Dormir mejor” puede significar conciliar el sueño, despertarse menos, mejorar la calidad percibida o evitar somnolencia al día siguiente. La comparación cambia según el problema real.',
+    sections: [
+      {
+        title: 'Preguntas que cambian la decisión',
+        body: 'Antes de elegir un ingrediente, define qué aspecto del sueño estás intentando mejorar.',
+        bullets: [
+          '¿El problema principal es conciliar el sueño o mantenerlo?',
+          '¿Necesitas evitar sedación o lentitud al día siguiente?',
+          '¿Tomas medicamentos u otros suplementos con efectos sedantes?',
+          '¿La evidencia disponible estudia una situación parecida a la tuya?',
+        ],
+      },
+      {
+        title: 'Perfiles para investigar',
+        body: 'Los perfiles científicos detallados aún están en inglés durante esta fase.',
+        links: [
+          { href: '/compounds/melatonin/', label: 'Melatonina', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/magnesium/', label: 'Magnesio', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/l-theanine/', label: 'L-teanina', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/valerian/', label: 'Valeriana', note: 'Perfil detallado en inglés' },
+        ],
+      },
+    ],
+    primaryCta: { href: '/es/seguridad/', label: 'Revisar seguridad' },
+    secondaryCta: { href: '/goals/sleep/', label: 'Abrir guía completa en inglés' },
+  },
+  stress: {
+    path: '/es/objetivos/estres/',
+    eyebrow: 'Objetivo: estrés',
+    title: 'Estrés: compara opciones sin confundir mecanismo con evidencia',
+    description:
+      'Compara suplementos para el estrés por evidencia humana, patrón de síntomas, tiempo de uso, seguridad, dosis e interacciones, con límites claros.',
+    intro:
+      'El estrés no es una sola experiencia. La utilidad de una opción depende de si buscas calma aguda, apoyo durante una etapa exigente o una estrategia que no interfiera con energía y concentración.',
+    sections: [
+      {
+        title: 'Qué conviene separar',
+        body:
+          'Muchos productos se venden con lenguaje de “adaptógenos” o cortisol. Esas etiquetas no sustituyen ensayos clínicos ni demuestran que una opción sea adecuada para una persona concreta.',
+        bullets: [
+          'Efectos percibidos frente a cambios en biomarcadores.',
+          'Uso agudo frente a uso durante semanas.',
+          'Calma útil frente a sedación no deseada.',
+          'Beneficio potencial frente a interacciones y contraindicaciones.',
+        ],
+      },
+      {
+        title: 'Perfiles para investigar',
+        body: 'Los perfiles completos enlazados aquí todavía están en inglés.',
+        links: [
+          { href: '/herbs/ashwagandha/', label: 'Ashwagandha', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/rhodiola/', label: 'Rhodiola', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/l-theanine/', label: 'L-teanina', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/magnesium/', label: 'Magnesio', note: 'Perfil detallado en inglés' },
+        ],
+      },
+    ],
+    primaryCta: { href: '/es/seguridad/', label: 'Revisar seguridad' },
+    secondaryCta: { href: '/goals/stress/', label: 'Abrir guía completa en inglés' },
+  },
+  anxiety: {
+    path: '/es/objetivos/ansiedad/',
+    eyebrow: 'Objetivo: ansiedad',
+    title: 'Ansiedad: evidencia y seguridad antes que promesas rápidas',
+    description:
+      'Compara suplementos estudiados para ansiedad considerando calidad de evidencia, sedación, dosis, interacciones y cuándo la incertidumbre sigue siendo alta.',
+    intro:
+      'En temas de ansiedad, una señal pequeña no debe convertirse en una promesa grande. Aquí la prioridad es distinguir evidencia clínica de mecanismos teóricos y mantener visibles las precauciones.',
+    sections: [
+      {
+        title: 'Qué mirar primero',
+        body:
+          'La calidad del estudio, la población estudiada y la magnitud del efecto importan tanto como el nombre del ingrediente.',
+        bullets: [
+          '¿Hay ensayos controlados en humanos o solo evidencia indirecta?',
+          '¿Los resultados son consistentes entre estudios?',
+          '¿Puede causar sedación o potenciar otros depresores del sistema nervioso?',
+          '¿Existen interacciones relevantes con medicamentos?',
+        ],
+      },
+      {
+        title: 'Perfiles para investigar',
+        body: 'Los perfiles completos enlazados aquí todavía están en inglés.',
+        links: [
+          { href: '/compounds/l-theanine/', label: 'L-teanina', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/ashwagandha/', label: 'Ashwagandha', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/valerian/', label: 'Valeriana', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/magnesium/', label: 'Magnesio', note: 'Perfil detallado en inglés' },
+        ],
+      },
+    ],
+    primaryCta: { href: '/es/seguridad/', label: 'Revisar seguridad' },
+    secondaryCta: { href: '/goals/anxiety/', label: 'Abrir guía completa en inglés' },
+  },
+  focus: {
+    path: '/es/objetivos/concentracion/',
+    eyebrow: 'Objetivo: concentración',
+    title: 'Concentración: compara beneficios, estimulación y compensaciones',
+    description:
+      'Compara suplementos para concentración por evidencia humana, estimulación, duración, sueño, tolerabilidad, dosis e interacciones relevantes.',
+    intro:
+      'Más estimulación no siempre significa mejor concentración. Una comparación útil considera atención, fatiga, sueño, tolerabilidad y la calidad real de la evidencia.',
+    sections: [
+      {
+        title: 'Preguntas útiles',
+        body:
+          'Define si buscas alerta, resistencia mental, menos distracción o apoyo durante fatiga. Son objetivos distintos y no todos los estudios miden lo mismo.',
+        bullets: [
+          '¿La evidencia mide atención objetiva o solo sensación subjetiva?',
+          '¿El ingrediente es estimulante y puede afectar el sueño?',
+          '¿Hay tolerancia, efectos rebote o interacciones que deban considerarse?',
+          '¿La dosis estudiada coincide con la forma del producto que estás comparando?',
+        ],
+      },
+      {
+        title: 'Perfiles para investigar',
+        body: 'Los perfiles completos enlazados aquí todavía están en inglés.',
+        links: [
+          { href: '/compounds/caffeine/', label: 'Cafeína', note: 'Perfil detallado en inglés' },
+          { href: '/compounds/l-theanine/', label: 'L-teanina', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/rhodiola/', label: 'Rhodiola', note: 'Perfil detallado en inglés' },
+          { href: '/herbs/bacopa/', label: 'Bacopa', note: 'Perfil detallado en inglés' },
+        ],
+      },
+    ],
+    primaryCta: { href: '/es/seguridad/', label: 'Revisar seguridad' },
+    secondaryCta: { href: '/goals/focus/', label: 'Abrir guía completa en inglés' },
+  },
+  methodology: {
+    path: '/es/metodologia/',
+    eyebrow: 'Cómo trabajamos',
+    title: 'Metodología: cómo evaluamos la evidencia',
+    description:
+      'Conoce cómo The Hippie Scientist separa evidencia humana, mecanismos, seguridad y límites de investigación para evaluar suplementos con rigor.',
+    intro:
+      'El objetivo no es encontrar una razón para recomendar cada ingrediente. El objetivo es representar con fidelidad qué tan fuerte es la evidencia, qué preguntas siguen abiertas y qué riesgos importan.',
+    sections: [
+      {
+        title: '1. Evidencia humana primero',
+        body:
+          'Los ensayos y estudios en personas tienen prioridad para evaluar resultados humanos. Estudios celulares y animales ayudan a explicar hipótesis, pero no se presentan como beneficios clínicos demostrados.',
+      },
+      {
+        title: '2. Mecanismo separado del resultado',
+        body:
+          'Una vía biológica plausible puede explicar por qué algo merece estudio. No convierte por sí sola una intervención en eficaz.',
+      },
+      {
+        title: '3. Seguridad antes del veredicto',
+        body:
+          'Interacciones, contraindicaciones, efectos adversos y contexto de dosis deben seguir visibles incluso cuando la evidencia de beneficio sea prometedora.',
+      },
+      {
+        title: '4. Incertidumbre explícita',
+        body:
+          'Resultados mixtos, muestras pequeñas, dependencia excesiva de un solo estudio y evidencia indirecta reducen la confianza. Esa incertidumbre se conserva en el lenguaje editorial.',
+      },
+    ],
+    primaryCta: { href: '/info/methodology/', label: 'Ver metodología completa en inglés' },
+    secondaryCta: { href: '/es/seguridad/', label: 'Ver enfoque de seguridad' },
+  },
+  safety: {
+    path: '/es/seguridad/',
+    eyebrow: 'Seguridad primero',
+    title: 'Seguridad de suplementos e interacciones',
+    description:
+      'Revisa interacciones, contraindicaciones, sedación, duplicación de efectos y contexto de dosis antes de combinar hierbas o suplementos.',
+    intro:
+      'Que un producto sea “natural” no significa que sea neutro. La seguridad depende de dosis, medicamentos, condiciones médicas, embarazo, combinaciones y otros factores personales.',
+    sections: [
+      {
+        title: 'Antes de combinar productos',
+        body: 'Busca riesgos acumulativos, no solo advertencias aisladas de cada ingrediente.',
+        bullets: [
+          'Efectos sedantes que puedan sumarse.',
+          'Cambios potenciales en presión arterial, glucosa o coagulación.',
+          'Ingredientes repetidos entre varios productos.',
+          'Interacciones con medicamentos y condiciones médicas.',
+          'Dosis o formas del ingrediente que no coinciden con las estudiadas.',
+        ],
+      },
+      {
+        title: 'Herramientas actuales',
+        body:
+          'Las herramientas interactivas detalladas siguen en inglés durante esta fase, pero puedes usarlas como apoyo para identificar preguntas de seguridad que después conviene confirmar con un profesional sanitario.',
+        links: [
+          { href: '/safety-checker/', label: 'Comprobador de interacciones', note: 'Herramienta en inglés' },
+          { href: '/info/supplement-safety-checklist/', label: 'Lista de seguridad de suplementos', note: 'Guía en inglés' },
+        ],
+      },
+    ],
+    primaryCta: { href: '/safety-checker/', label: 'Abrir comprobador en inglés' },
+    secondaryCta: { href: '/es/metodologia/', label: 'Cómo evaluamos la evidencia' },
+  },
+} as const satisfies Record<string, SpanishPageData>
+
+export type SpanishPageKey = keyof typeof SPANISH_PAGES
+
+export function buildSpanishPageMetadata(page: SpanishPageData): Metadata {
+  const metadata = buildPageMetadata({
+    title: page.title,
+    description: page.description,
+    path: page.path,
+    openGraphType: 'website',
+  })
+
+  return {
+    ...metadata,
+    openGraph: metadata.openGraph
+      ? {
+          ...metadata.openGraph,
+          locale: SPANISH_OG_LOCALE,
+          alternateLocale: [DEFAULT_OG_LOCALE],
+        }
+      : metadata.openGraph,
+  }
+}


### PR DESCRIPTION
## Summary
- publish 10 substantive Spanish routes under `/es/`
- add a canonical English ↔ Spanish route registry and safe hreflang generation
- keep untranslated detail profiles English-only in hreflang rather than advertising placeholder translations
- add Spanish navigation/footer and locale-aware global chrome
- add Spanish core-route indexability
- update international SEO tests for the bilingual state

## Spanish routes
- `/es/`
- `/es/hierbas/`
- `/es/compuestos/`
- `/es/objetivos/`
- `/es/objetivos/sueno/`
- `/es/objetivos/estres/`
- `/es/objetivos/ansiedad/`
- `/es/objetivos/concentracion/`
- `/es/metodologia/`
- `/es/seguridad/`

## Translation policy
Scientific detail profiles are not automatically machine-translated in this first release. Spanish pages explicitly identify links that still open in English. Hreflang is emitted only when a substantive Spanish equivalent actually exists, preserving scientific meaning and avoiding thin/placeholder international SEO pages.

## Validation focus
- typecheck/static-export compatibility
- international SEO tests
- route/indexability governance
- sitemap/metadata checks