### PR TITLE
SEO: guard legacy guide table semantics

### DIFF
--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -278,6 +278,37 @@ function auditLegacyGuideQuickAnswerPrimitives() {
   }
 }
 
+function auditLegacyGuideTablePrimitives() {
+  for (const [slug, file] of LEGACY_GUIDE_PAGES) {
+    const source = text(file)
+    const tableCount = (source.match(/<table\b/g) || []).length
+    if (!tableCount) continue
+
+    const semanticSurfaceCount = (source.match(/data-answer-engine-table="true"/g) || []).length
+    const stableSurfaceCount = (source.match(/<section id="[^"]+" data-answer-engine-table="true"/g) || []).length
+    const captionCount = (source.match(/<caption\b/g) || []).length
+    const columnScopeCount = (source.match(/scope="col"/g) || []).length
+    const rowScopeCount = (source.match(/scope="row"/g) || []).length
+    const unscopedHeaders = source.match(/<th(?![^>]*\bscope=)[^>]*>/g) || []
+
+    if (semanticSurfaceCount !== tableCount) {
+      add('error', 'legacy-guide-tables', `${slug} guide renders ${tableCount} table(s) but marks ${semanticSurfaceCount} answer-engine table surface(s)`)
+    }
+    if (stableSurfaceCount !== tableCount) {
+      add('error', 'legacy-guide-tables', `${slug} guide tables must each live in a stably identified semantic section`)
+    }
+    if (captionCount !== tableCount) {
+      add('error', 'legacy-guide-tables', `${slug} guide renders ${tableCount} table(s) but only ${captionCount} caption(s)`)
+    }
+    if (unscopedHeaders.length) {
+      add('error', 'legacy-guide-tables', `${slug} guide contains ${unscopedHeaders.length} table header(s) without scope`)
+    }
+    if (columnScopeCount < tableCount || rowScopeCount < tableCount) {
+      add('error', 'legacy-guide-tables', `${slug} guide tables require both column and row header scopes`)
+    }
+  }
+}
+
 function auditProfilePrimitives() {
   requireSignals(EVIDENCE_BADGE, 'profile-semantics', 'EvidenceScoreBadge', [
     ['data-evidence="true"', 'evidence marker'],
@@ -360,6 +391,7 @@ auditGoalClusterCitationPrimitives()
 auditRhabdoCitationPrimitives()
 auditLegacyGuideReferencePrimitives()
 auditLegacyGuideQuickAnswerPrimitives()
+auditLegacyGuideTablePrimitives()
 auditProfilePrimitives()
 auditExtractability()
 auditAntiPatterns()


### PR DESCRIPTION
Fixes #3744

## Summary
- extends the existing canonical AI answer-engine audit with a derived semantic-table contract for the five legacy authority guides
- counts every rendered `<table>` in each guide rather than relying on a hard-coded migration inventory
- requires one `data-answer-engine-table="true"` surface per table
- requires each table to live in a stably identified semantic section
- requires one real `<caption>` per table
- rejects any `<th>` without an explicit `scope`
- requires both column and row header scopes whenever a guide contains tables
- adds no new validator, workflow, table component, or duplicate content model

## Acceptance criteria
- every existing legacy guide table remains semantically addressable and captioned
- newly added tables are automatically governed
- visual-only header markup cannot silently regress
- all seven currently migrated tables satisfy the same derived contract
- existing citation, quick-answer, identifier, and reference-count invariants remain intact

## Before → after
- semantically upgraded hand-authored tables: 7/7 → 7/7
- tables covered by derived regression governance: 0/7 → 7/7 plus future tables
- hard-coded expected table inventory: 0
- new pipelines/components: 0

## Validation
- `npm run audit:ai-citations`
- `npx eslint scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- AI search quality check / Atomic upgrade gate

## Architecture decision
Legacy tables remain page-authored. The canonical answer-engine audit enforces the same semantic conventions as the shared table primitive without forcing a second data model or migration-only abstraction.