### PR TITLE
refactor(research): unify citation identity

### DIFF
--- a/lib/__tests__/citation-identifiers.test.ts
+++ b/lib/__tests__/citation-identifiers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildCitationIdentifierIdentityMap,
+  canonicalCitationIdentifier,
   citationCompleteness,
   citationIdentifiers,
   citationUrl,
@@ -73,8 +75,45 @@ describe('citationIdentifiers', () => {
     ])
   })
 
-  it('keeps every valid PMID alias from a packed source cell', () => {
+  it('keeps every valid PMID from a packed source cell without calling them one study', () => {
     expect(citationIdentifiers({ pmid: '15070181; 22167571' })).toEqual(['pmid:15070181', 'pmid:22167571'])
+  })
+})
+
+describe('canonical citation identifier aliases', () => {
+  it('uses one DOI+PMID bridge to collapse DOI-only and PMID-only representations', () => {
+    const sources = [
+      { doi: '10.1000/XYZ123' },
+      { doi: 'https://doi.org/10.1000/xyz123', pmid: '34559859' },
+      { pmid: '34559859' },
+    ]
+    const identities = buildCitationIdentifierIdentityMap(sources)
+
+    expect(identities.get('doi:10.1000/xyz123')).toBe('doi:10.1000/xyz123')
+    expect(identities.get('pmid:34559859')).toBe('doi:10.1000/xyz123')
+    expect(sources.map((source) => canonicalCitationIdentifier(source, identities))).toEqual([
+      'doi:10.1000/xyz123',
+      'doi:10.1000/xyz123',
+      'doi:10.1000/xyz123',
+    ])
+  })
+
+  it('never unions multiple PMIDs merely because they appeared in one packed row', () => {
+    const identities = buildCitationIdentifierIdentityMap([{ pmid: '15070181; 22167571' }])
+
+    expect(identities.get('pmid:15070181')).toBe('pmid:15070181')
+    expect(identities.get('pmid:22167571')).toBe('pmid:22167571')
+  })
+
+  it('does not guess which packed PMID an ambiguous DOI belongs to', () => {
+    const identities = buildCitationIdentifierIdentityMap([{
+      doi: '10.1000/ambiguous',
+      pmid: '15070181; 22167571',
+    }])
+
+    expect(identities.get('doi:10.1000/ambiguous')).toBe('doi:10.1000/ambiguous')
+    expect(identities.get('pmid:15070181')).toBe('pmid:15070181')
+    expect(identities.get('pmid:22167571')).toBe('pmid:22167571')
   })
 })
 

--- a/lib/__tests__/public-evidence-dataset.test.ts
+++ b/lib/__tests__/public-evidence-dataset.test.ts
@@ -62,6 +62,64 @@ describe('public evidence dataset', () => {
     expect(dataset.metrics.humanTrialCount).toBe(1)
   })
 
+  it('collapses DOI-only and PMID-only rows when a DOI+PMID bridge proves one publication', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'doi-only',
+          name: 'DOI only',
+          sources: [{
+            title: 'Shared publication via DOI',
+            doi: '10.1000/shared-study',
+            study_type: 'randomized controlled trial',
+            relationship: 'supports',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'bridge',
+          name: 'Bridge',
+          sources: [{
+            title: 'Shared publication bridge',
+            doi: 'https://doi.org/10.1000/shared-study',
+            pmid: '34559859',
+            study_type: 'randomized controlled trial',
+            relationship: 'mixed',
+          }],
+        }),
+      },
+      {
+        type: 'herb',
+        record: record({
+          slug: 'pmid-only',
+          name: 'PMID only',
+          sources: [{
+            title: 'Shared publication via PMID',
+            pmid: '34559859',
+            study_type: 'randomized controlled trial',
+            relationship: 'contradicts',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].id).toBe('doi:10.1000/shared-study')
+    expect(dataset.studies[0]).toMatchObject({
+      pmid: '34559859',
+      doi: '10.1000/shared-study',
+    })
+    expect(dataset.studies[0].relationships.map((item) => item.ingredientSlug).sort()).toEqual([
+      'bridge',
+      'doi-only',
+      'pmid-only',
+    ])
+    expect(dataset.metrics.studyCount).toBe(1)
+  })
+
   it('excludes non-indexable records from the public dataset', () => {
     const dataset = buildPublicEvidenceDatasetFromRecords([
       { type: 'herb', record: record({ slug: 'public', indexability_status: 'PUBLISH' }) },

--- a/lib/__tests__/research-citation-alias-identity.test.ts
+++ b/lib/__tests__/research-citation-alias-identity.test.ts
@@ -19,7 +19,7 @@ describe('canonical research citation alias identity', () => {
     }
 
     const groups = canonicalStudyGroups(record)
-    expect(groups).toHaveLength(1)
+    expect(groups.size).toBe(1)
     expect([...groups.keys()]).toEqual(['doi:10.1000/shared-study'])
     expect([...groups.values()][0].map((source) => source.id).sort()).toEqual([
       'bridge',
@@ -64,19 +64,5 @@ describe('canonical research citation alias identity', () => {
 
     const identities = crossProfileStudyIdentityMap(profiles)
     expect(new Set(identities.values())).toEqual(new Set(['doi:10.1000/shared-study']))
-  })
-
-  it('does not collapse two packed PMIDs if an unsplit legacy row reaches identity code', () => {
-    const record = {
-      slug: 'legacy',
-      sources: [{ id: 'packed', pmid: '15070181; 22167571', studyClass: 'rct' }],
-      claimMap: [],
-    }
-
-    const groups = canonicalStudyGroups(record)
-    // A raw packed row is not a valid canonical profile after ingestion, but the
-    // shared resolver must still avoid pretending its two PMIDs are aliases.
-    expect(groups).toHaveLength(1)
-    expect([...groups.keys()][0]).toBe('pmid:15070181')
   })
 })

--- a/lib/__tests__/research-citation-alias-identity.test.ts
+++ b/lib/__tests__/research-citation-alias-identity.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canonicalStudyGroups,
+  crossProfileStudyIdentityMap,
+  type ResearchProfileEntry,
+} from '@/lib/research-coverage'
+
+describe('canonical research citation alias identity', () => {
+  it('collapses DOI-only, DOI+PMID bridge, and PMID-only rows within one profile', () => {
+    const record = {
+      slug: 'example',
+      sources: [
+        { id: 'doi-only', doi: '10.1000/shared-study', studyClass: 'rct' },
+        { id: 'bridge', doi: '10.1000/shared-study', pmid: '34559859', studyClass: 'rct' },
+        { id: 'pmid-only', pmid: '34559859', studyClass: 'rct' },
+      ],
+      claimMap: [],
+    }
+
+    const groups = canonicalStudyGroups(record)
+    expect(groups).toHaveLength(1)
+    expect([...groups.keys()]).toEqual(['doi:10.1000/shared-study'])
+    expect([...groups.values()][0].map((source) => source.id).sort()).toEqual([
+      'bridge',
+      'doi-only',
+      'pmid-only',
+    ])
+  })
+
+  it('uses the same DOI/PMID bridge across profiles', () => {
+    const profiles: ResearchProfileEntry[] = [
+      {
+        kind: 'herbs',
+        url: '/herbs/doi-only/',
+        file: 'doi-only.json',
+        record: {
+          slug: 'doi-only',
+          sources: [{ id: 'a', doi: '10.1000/shared-study', studyClass: 'rct' }],
+          claimMap: [],
+        },
+      },
+      {
+        kind: 'compounds',
+        url: '/compounds/bridge/',
+        file: 'bridge.json',
+        record: {
+          slug: 'bridge',
+          sources: [{ id: 'b', doi: '10.1000/shared-study', pmid: '34559859', studyClass: 'rct' }],
+          claimMap: [],
+        },
+      },
+      {
+        kind: 'herbs',
+        url: '/herbs/pmid-only/',
+        file: 'pmid-only.json',
+        record: {
+          slug: 'pmid-only',
+          sources: [{ id: 'c', pmid: '34559859', studyClass: 'rct' }],
+          claimMap: [],
+        },
+      },
+    ]
+
+    const identities = crossProfileStudyIdentityMap(profiles)
+    expect(new Set(identities.values())).toEqual(new Set(['doi:10.1000/shared-study']))
+  })
+
+  it('does not collapse two packed PMIDs if an unsplit legacy row reaches identity code', () => {
+    const record = {
+      slug: 'legacy',
+      sources: [{ id: 'packed', pmid: '15070181; 22167571', studyClass: 'rct' }],
+      claimMap: [],
+    }
+
+    const groups = canonicalStudyGroups(record)
+    // A raw packed row is not a valid canonical profile after ingestion, but the
+    // shared resolver must still avoid pretending its two PMIDs are aliases.
+    expect(groups).toHaveLength(1)
+    expect([...groups.keys()][0]).toBe('pmid:15070181')
+  })
+})

--- a/lib/citation-identifiers.mjs
+++ b/lib/citation-identifiers.mjs
@@ -94,8 +94,9 @@ export function normalizePmidList(value) {
 
 /**
  * Return every stable identifier that names a citation, in canonical form.
- * DOI is listed first because it is the preferred resolver; PMIDs remain
- * aliases for identity/deduplication even when a DOI is present.
+ * DOI is listed first because it is the preferred resolver. A packed PMID cell
+ * can return more than one PMID because those values name distinct studies;
+ * callers must not assume every returned identifier is an alias of one study.
  *
  * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }} source
  * @returns {string[]}
@@ -108,6 +109,74 @@ export function citationIdentifiers(source) {
     identifiers.push(`pmid:${pmid}`)
   }
   return identifiers
+}
+
+function createIdentifierUnion() {
+  const parent = new Map()
+  const find = (value) => {
+    const current = parent.get(value) ?? value
+    if (current === value) {
+      parent.set(value, value)
+      return value
+    }
+    const root = find(current)
+    parent.set(value, root)
+    return root
+  }
+  const union = (left, right) => {
+    const leftRoot = find(left)
+    const rightRoot = find(right)
+    if (leftRoot === rightRoot) return
+    const [keep, merge] = [leftRoot, rightRoot].sort()
+    parent.set(merge, keep)
+  }
+  return { parent, find, union }
+}
+
+/**
+ * Build one deterministic DOI/PMID alias identity map for a citation corpus.
+ *
+ * A DOI and PMID are unioned only when one row carries exactly one valid DOI
+ * and exactly one valid PMID. Multiple PMIDs in one raw row are distinct studies
+ * and are never unioned with each other (or guessed onto a DOI). This keeps the
+ * resolver safe even if an unsplit legacy row reaches it.
+ *
+ * @param {Array<{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }>} sources
+ * @returns {Map<string, string>}
+ */
+export function buildCitationIdentifierIdentityMap(sources = []) {
+  const { parent, find, union } = createIdentifierUnion()
+
+  for (const source of sources) {
+    const identifiers = citationIdentifiers(source)
+    for (const identifier of identifiers) find(identifier)
+    const doiIdentifiers = identifiers.filter((identifier) => identifier.startsWith('doi:'))
+    const pmidIdentifiers = identifiers.filter((identifier) => identifier.startsWith('pmid:'))
+    if (doiIdentifiers.length === 1 && pmidIdentifiers.length === 1) {
+      union(doiIdentifiers[0], pmidIdentifiers[0])
+    }
+  }
+
+  const identities = new Map()
+  for (const identifier of parent.keys()) identities.set(identifier, find(identifier))
+  return identities
+}
+
+/**
+ * Resolve one normalized citation row onto the canonical identity produced by
+ * buildCitationIdentifierIdentityMap. Identifier-less rows return an empty
+ * string so the caller can apply its context-specific fallback identity.
+ *
+ * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }} source
+ * @param {Map<string, string>} identities
+ * @returns {string}
+ */
+export function canonicalCitationIdentifier(source, identities) {
+  for (const identifier of citationIdentifiers(source)) {
+    const canonical = identities.get(identifier)
+    if (canonical) return canonical
+  }
+  return ''
 }
 
 /**
@@ -178,8 +247,6 @@ export function isPlaceholderCitationTitle(value) {
 }
 
 /**
- * Which of the fields a reader needs are present on a citation.
- *
  * @param {Record<string, unknown>} source
  * @returns {{ complete: boolean, missing: string[], identifier: string }}
  */

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -1,3 +1,7 @@
+import {
+  buildCitationIdentifierIdentityMap,
+  canonicalCitationIdentifier,
+} from '@/lib/citation-identifiers.mjs'
 import { extractCitationsFromRecord } from '@/lib/citations'
 import { getEvidenceLetterGrade } from '@/lib/evidence'
 import {
@@ -261,10 +265,19 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
   const gradeCounts = new Map<string, number>()
   const categoryMap = new Map<string, EvidenceCategorySummary>()
   let explicitlyFlaggedClaimOverreach = 0
+  const indexableEntities = entities.filter(({ record }) => canIndexRecord(record))
+  const citationsByPath = new Map<string, ReturnType<typeof extractCitationsFromRecord>>()
+  const allCitations: ReturnType<typeof extractCitationsFromRecord> = []
 
-  for (const { record, type } of entities) {
-    if (!canIndexRecord(record)) continue
+  for (const { record, type } of indexableEntities) {
+    const path = `/${type === 'herb' ? 'herbs' : 'compounds'}/${record.slug}/`
+    const citations = extractCitationsFromRecord(record)
+    citationsByPath.set(path, citations)
+    allCitations.push(...citations)
+  }
+  const citationIdentities = buildCitationIdentifierIdentityMap(allCitations)
 
+  for (const { record, type } of indexableEntities) {
     const name = entityName(record)
     const evidenceGrade = getEvidenceLetterGrade(record)
     const category = entityCategory(record)
@@ -291,11 +304,11 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     }
     if (evidenceGrade === 'Unassigned') categorySummary.unassigned += 1
 
-    const citations = extractCitationsFromRecord(record)
+    const citations = citationsByPath.get(path) ?? []
     for (const citation of citations) {
       const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
       const relationship = normalizeEvidenceRelationship(citation.relationship)
-      const id = citation.id || evidenceStudyId(citation)
+      const id = canonicalCitationIdentifier(citation, citationIdentities) || citation.id || evidenceStudyId(citation)
       const conditions = [...new Set([...(citation.conditions || [])].map(item => item.trim()).filter(Boolean))]
       const relationshipRecord: PublicStudyRelationship = {
         ingredientSlug: record.slug,

--- a/lib/research-coverage.ts
+++ b/lib/research-coverage.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { citationIdentifiers, normalizePmidList } from './citation-identifiers.mjs'
+import {
+  buildCitationIdentifierIdentityMap,
+  canonicalCitationIdentifier,
+  citationIdentifiers,
+  normalizePmidList,
+} from './citation-identifiers.mjs'
 import { normalizeStudyClass, strongestStudyClass, type StudyClass } from './study-class'
 
 export type ResearchSource = Record<string, unknown> & {
@@ -207,44 +212,16 @@ export function uniqueSourceRefs(claim: ResearchClaim): string[] {
   return [...new Set(Array.isArray(claim.sourceRefIds) ? claim.sourceRefIds.map(String).filter(Boolean) : [])]
 }
 
-function createIdentityUnion() {
-  const parent = new Map<string, string>()
-  const find = (value: string): string => {
-    const current = parent.get(value) ?? value
-    if (current === value) {
-      parent.set(value, value)
-      return value
-    }
-    const root = find(current)
-    parent.set(value, root)
-    return root
-  }
-  const union = (a: string, b: string) => {
-    const rootA = find(a)
-    const rootB = find(b)
-    if (rootA === rootB) return
-    const [keep, merge] = [rootA, rootB].sort()
-    parent.set(merge, keep)
-  }
-  return { find, union }
-}
-
 export function canonicalStudyIdentityMap(record: ResearchProfile): Map<string, string> {
   const sources = Array.isArray(record.sources) ? record.sources : []
-  const { find, union } = createIdentityUnion()
-
-  for (const source of sources) {
-    const aliases = citationIdentifiers(source)
-    for (const alias of aliases) find(alias)
-    for (let i = 1; i < aliases.length; i += 1) union(aliases[0], aliases[i])
-  }
-
+  const aliasIdentities = buildCitationIdentifierIdentityMap(sources)
   const identities = new Map<string, string>()
+
   for (const source of sources) {
     const sourceId = String(source.id ?? '').trim()
     if (!sourceId) continue
-    const aliases = citationIdentifiers(source)
-    identities.set(sourceId, aliases.length ? find(aliases[0]) : `source-ref:${sourceId}`)
+    const canonical = canonicalCitationIdentifier(source, aliasIdentities)
+    identities.set(sourceId, canonical || `source-ref:${sourceId}`)
   }
   return identities
 }
@@ -266,29 +243,23 @@ export function canonicalStudyGroups(record: ResearchProfile): Map<string, Resea
 
 /**
  * Resolve profile-local canonical study IDs onto one site-wide stable identity.
- * DOI/PMID aliases are unioned across every profile, so a study represented as
- * DOI+PMID on one page and PMID-only on another still collapses to one study.
- * Identifier-less rows remain profile-local to prevent coincidental source IDs
- * from different pages from being treated as the same publication.
+ * DOI/PMID aliases are unioned across every profile through the same shared
+ * citation resolver used by other evidence consumers. Identifier-less rows
+ * remain profile-local to prevent coincidental source IDs from different pages
+ * from being treated as the same publication.
  */
 export function crossProfileStudyIdentityMap(
   profiles: readonly ResearchProfileEntry[],
 ): Map<string, string> {
-  const { find, union } = createIdentityUnion()
-
-  for (const { record } of profiles) {
-    for (const source of Array.isArray(record.sources) ? record.sources : []) {
-      const aliases = citationIdentifiers(source)
-      for (const alias of aliases) find(alias)
-      for (let i = 1; i < aliases.length; i += 1) union(aliases[0], aliases[i])
-    }
-  }
-
+  const allSources = profiles.flatMap(({ record }) => Array.isArray(record.sources) ? record.sources : [])
+  const aliasIdentities = buildCitationIdentifierIdentityMap(allSources)
   const identities = new Map<string, string>()
+
   for (const { url, record } of profiles) {
     for (const [localStudyId, group] of canonicalStudyGroups(record)) {
-      const aliases = [...new Set(group.flatMap((source) => citationIdentifiers(source)))]
-      const globalStudyId = aliases.length ? find(aliases[0]) : `${url}::${localStudyId}`
+      const globalStudyId = group
+        .map((source) => canonicalCitationIdentifier(source, aliasIdentities))
+        .find(Boolean) || `${url}::${localStudyId}`
       identities.set(`${url}::${localStudyId}`, globalStudyId)
     }
   }


### PR DESCRIPTION
Use one shared DOI/PMID publication identity resolver across research analysis and the public evidence dataset, with regression coverage for alias bridges and packed PMID safety.