### PR TITLE
refactor(visual): align commercial bridge with brand palette

### DIFF
--- a/components/CommercialIntentBridge.tsx
+++ b/components/CommercialIntentBridge.tsx
@@ -24,12 +24,26 @@ export default function CommercialIntentBridge() {
   const slug = pathname.split('/')[2] || ''
 
   return (
-    <aside className='border-y border-brand-900/10 bg-brand-50/70' aria-label='Commercial research next steps'>
-      <div className='mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-3'>
-        <p className='text-sm text-ink'><strong>Researching a purchase?</strong> Keep the evidence page intact, then move to comparison or product-quality criteria.</p>
-        <div className='flex flex-wrap gap-3 text-sm font-bold'>
-          <Link href={`/guides/compare/?from=${encodeURIComponent(slug)}`} onClick={() => trackRevenueEvent({ kind: 'cta_click', location: 'commercial-intent-bridge', label: 'Compare options', productSlug: slug })} className='text-indigo-800 hover:underline'>Compare options →</Link>
-          <Link href={`/learn/product-quality/?ingredient=${encodeURIComponent(slug)}`} onClick={() => trackRevenueEvent({ kind: 'cta_click', location: 'commercial-intent-bridge', label: 'Product quality', productSlug: slug })} className='text-indigo-800 hover:underline'>Product-quality checklist →</Link>
+    <aside className='border-y border-brand-900/10 bg-brand-50/65' aria-label='Commercial research next steps'>
+      <div className='mx-auto flex max-w-6xl flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4'>
+        <p className='text-sm leading-5 text-ink'>
+          <strong>Researching a purchase?</strong> Compare options and check product quality before choosing.
+        </p>
+        <div className='flex flex-wrap gap-x-4 gap-y-2 text-sm font-semibold'>
+          <Link
+            href={`/guides/compare/?from=${encodeURIComponent(slug)}`}
+            onClick={() => trackRevenueEvent({ kind: 'cta_click', location: 'commercial-intent-bridge', label: 'Compare options', productSlug: slug })}
+            className='text-brand-800 hover:text-brand-900 hover:underline'
+          >
+            Compare options →
+          </Link>
+          <Link
+            href={`/learn/product-quality/?ingredient=${encodeURIComponent(slug)}`}
+            onClick={() => trackRevenueEvent({ kind: 'cta_click', location: 'commercial-intent-bridge', label: 'Product quality', productSlug: slug })}
+            className='text-brand-800 hover:text-brand-900 hover:underline'
+          >
+            Product-quality checklist →
+          </Link>
         </div>
       </div>
     </aside>


### PR DESCRIPTION
Replaces the stray indigo commercial-intent links with the canonical forest brand palette, tightens the message, and improves mobile spacing so the strip reads as a concise next-step utility rather than another content section.