### PR TITLE
refactor(visual): remove redundant profile-card CTA row

### DIFF
--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -171,10 +171,6 @@ export function DecisionProfileCard({
           </p>
         ) : null}
       </div>
-
-      <div className="mt-3 flex items-center gap-1 text-sm font-bold text-brand-700 transition-all duration-200 group-hover:gap-2 group-hover:text-brand-900 dark:text-[var(--text-secondary)] dark:group-hover:text-[var(--text-primary)]">
-        View profile <span aria-hidden="true" className="transition-transform duration-200 group-hover:translate-x-0.5">→</span>
-      </div>
     </Link>
   )
 }


### PR DESCRIPTION
Removes the repeated “View profile →” footer from shared herb/compound cards because the entire card is already the link. This reduces card height and repetition while preserving the useful decision data.