### PR TITLE
SEO: unify collagen and colostrum FAQ schema with visible content

### DIFF
--- a/app/guides/other/bovine-colostrum/page.tsx
+++ b/app/guides/other/bovine-colostrum/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
-import FAQSchema from '@/components/seo/FAQSchema'
+import LegacyGuideFAQ from '@/components/LegacyGuideFAQ'
 import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'
 import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
@@ -29,7 +29,6 @@ export default function BovineColostrumGuidePage() {
     <div className="container-page py-10 space-y-10">
       <AuthorityJsonLd title="Bovine Colostrum: Evidence, Benefits & Safety" description="Bovine colostrum is 2026's most hyped supplement — what does the evidence show?" url="https://thehippiescientist.net/guides/other/bovine-colostrum" type="Article" />
       <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Bovine Colostrum' }]} />
-      <FAQSchema pagePath="/guides/other/bovine-colostrum/" questions={FAQS} />
 
       <section className="space-y-5 max-w-4xl">
         <p className="eyebrow-label">Evidence Review · 12 References</p>
@@ -94,6 +93,7 @@ export default function BovineColostrumGuidePage() {
         <Ref n={12} text="Hemilä H, Chalker E. (2013). Vitamin C for preventing and treating the common cold. Cochrane Database Syst Rev, (1): CD000980." url="https://pubmed.ncbi.nlm.nih.gov/23440782/" />
       </ol></section>
 
+      <LegacyGuideFAQ pagePath="/guides/other/bovine-colostrum/" questions={FAQS} />
       <EmailCapture headline="Get evidence reviews like this" description="We track supplement claims against clinical evidence so you don't have to. No hype, no affiliate bias." ctaLabel="Get the evidence" location="guide-bovine-colostrum" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
     </div>

--- a/app/guides/other/collagen-supplements/page.tsx
+++ b/app/guides/other/collagen-supplements/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
-import FAQSchema from '@/components/seo/FAQSchema'
+import LegacyGuideFAQ from '@/components/LegacyGuideFAQ'
 import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'
 import Ref from '@/components/LegacyGuideReference'
 import EmailCapture from '../../../../components/EmailCapture'
@@ -31,7 +31,6 @@ export default function CollagenGuidePage() {
     <div className="container-page py-10 space-y-10">
       <AuthorityJsonLd title="Collagen: Evidence, Benefits & Types" description="Collagen is a $5B+ category with 100+ RCTs — here's what the evidence shows." url="https://thehippiescientist.net/guides/other/collagen-supplements" type="Article" />
       <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Collagen Supplements' }]} />
-      <FAQSchema pagePath="/guides/other/collagen-supplements/" questions={FAQS} />
 
       <section className="space-y-5 max-w-4xl"><p className="eyebrow-label">Evidence Review · 10 References</p><h1 className="text-5xl font-bold tracking-tight text-ink">Collagen: What 100+ Trials Actually Show</h1><p className="text-lg leading-8 text-muted">Collagen is a $5+ billion category, endorsed by celebrities and backed by more clinical trials than most supplement categories. A 2026 umbrella review of 100+ RCTs with nearly 8,000 participants provides the strongest synthesis to date [1]. The effects are real but modest — here is what the evidence supports, with citations.</p>
         <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/collagen-supplements.jpg" alt="Collagen peptide powder in a glass jar with capsules on a wood surface" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Collagen — one of the better-studied supplement categories, but effects are modest.</figcaption></figure></section>
@@ -80,6 +79,7 @@ export default function CollagenGuidePage() {
         <Ref n={9} text="ConsumerLab.com (2023). Collagen Supplements Review: per-gram cost ranges from $0.07 to $25+." url="https://www.consumerlab.com/reviews/collagen-supplements-review/collagen/" />
         <Ref n={10} text="Choi FD, et al. (2019). Oral collagen supplementation: systematic review of dermatological applications. J Drugs Dermatol, 18(1): 9-16." url="https://pubmed.ncbi.nlm.nih.gov/30681787/" />
       </ol></section>
+      <LegacyGuideFAQ pagePath="/guides/other/collagen-supplements/" questions={FAQS} />
       <div className="max-w-4xl">
         <RecommendationSection products={getRevenueProductSet('collagen')?.products ?? []} />
       </div>


### PR DESCRIPTION
Refs #3766

## Summary
- migrates collagen supplements and bovine colostrum to the shared `LegacyGuideFAQ` boundary
- removes standalone `FAQSchema` imports/calls from both pages
- renders the existing FAQ arrays visibly without changing any question or answer text
- keeps the same FAQ arrays as the source for structured data and visible FAQ cards
- places visible FAQs after each page's source ledger

## Before → after
- collagen visible FAQ items: 0 → 5
- bovine colostrum visible FAQ items: 0 → 5
- standalone FAQ schema consumers in this batch: 2 → 0
- FAQ text changes: 0

## Family status after merge
- legacy guides using shared FAQ boundary: 5/5
- legacy guides with visible FAQ content matching structured FAQ source: 5/5

## Validation
- `npx eslint app/guides/other/collagen-supplements/page.tsx app/guides/other/bovine-colostrum/page.tsx --max-warnings=0`
- `npm run audit:ai-citations`
- `npm run typecheck`
- AI search quality check / Atomic upgrade gate

## Trust impact
All five legacy authority guides now generate visible and structured FAQ content through one shared source boundary instead of allowing schema-only FAQ drift.