### PR TITLE
refactor(research): centralize DOI PMID citation identity

### DIFF
--- a/lib/__tests__/canonical-citation-identity.test.ts
+++ b/lib/__tests__/canonical-citation-identity.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildCitationIdentifierIdentityMap,
+  canonicalCitationIdentifier,
+} from '@/lib/citation-identifiers.mjs'
+import {
+  canonicalStudyGroups,
+  crossProfileStudyIdentityMap,
+  type ResearchProfileEntry,
+} from '@/lib/research-coverage'
+
+describe('canonical citation identity', () => {
+  it('collapses DOI-only, bridge, and PMID-only representations', () => {
+    const sources = [
+      { doi: '10.1000/shared-study' },
+      { doi: 'https://doi.org/10.1000/shared-study', pmid: '34559859' },
+      { pmid: '34559859' },
+    ]
+    const identities = buildCitationIdentifierIdentityMap(sources)
+    expect(sources.map(source => canonicalCitationIdentifier(source, identities))).toEqual([
+      'doi:10.1000/shared-study',
+      'doi:10.1000/shared-study',
+      'doi:10.1000/shared-study',
+    ])
+  })
+
+  it('never unions packed multiple PMIDs or guesses an ambiguous DOI bridge', () => {
+    const identities = buildCitationIdentifierIdentityMap([
+      { doi: '10.1000/ambiguous', pmid: '15070181; 22167571' },
+    ])
+    expect(identities.get('doi:10.1000/ambiguous')).toBe('doi:10.1000/ambiguous')
+    expect(identities.get('pmid:15070181')).toBe('pmid:15070181')
+    expect(identities.get('pmid:22167571')).toBe('pmid:22167571')
+  })
+
+  it('uses the same bridge locally and across research profiles', () => {
+    const record = {
+      slug: 'example',
+      sources: [
+        { id: 'doi', doi: '10.1000/shared-study', studyClass: 'rct' },
+        { id: 'bridge', doi: '10.1000/shared-study', pmid: '34559859', studyClass: 'rct' },
+        { id: 'pmid', pmid: '34559859', studyClass: 'rct' },
+      ],
+      claimMap: [],
+    }
+    expect(canonicalStudyGroups(record).size).toBe(1)
+
+    const profiles: ResearchProfileEntry[] = [
+      { kind: 'herbs', url: '/herbs/a/', file: 'a.json', record: { slug: 'a', sources: [{ id: 'a', doi: '10.1000/shared-study' }], claimMap: [] } },
+      { kind: 'compounds', url: '/compounds/b/', file: 'b.json', record: { slug: 'b', sources: [{ id: 'b', doi: '10.1000/shared-study', pmid: '34559859' }], claimMap: [] } },
+      { kind: 'herbs', url: '/herbs/c/', file: 'c.json', record: { slug: 'c', sources: [{ id: 'c', pmid: '34559859' }], claimMap: [] } },
+    ]
+    expect(new Set(crossProfileStudyIdentityMap(profiles).values())).toEqual(new Set(['doi:10.1000/shared-study']))
+  })
+})

--- a/lib/citation-identifiers.mjs
+++ b/lib/citation-identifiers.mjs
@@ -13,60 +13,164 @@
  * from how many independent sources back a claim.
  */
 
+/**
+ * PubMed IDs are positive integers, currently 8 digits and growing. No leading
+ * zero has ever been issued, so one signals a malformed or truncated value.
+ */
 export const PMID_PATTERN = /^[1-9]\d{0,8}$/
+
+/** DOIs are a `10.` registrant prefix and a non-empty suffix. */
 export const DOI_PATTERN = /^10\.\d{4,9}\/\S+$/
+
+/** Separators seen between identifiers packed into one cell. */
 const IDENTIFIER_SEPARATOR = /[;,]|\s+and\s+|\s{2,}/i
+
+/** Separators seen between full URLs packed into one workbook cell. */
 const URL_SEPARATOR = /\s*\|\s*|\r?\n+/
-function text(value) { return String(value ?? '').trim() }
-export function isValidPmid(value) { return PMID_PATTERN.test(text(value)) }
-export function isValidDoi(value) { return DOI_PATTERN.test(normalizeDoi(value)) }
-export function normalizeDoi(value) {
-  return text(value).replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '').replace(/^doi:\s*/i, '').trim()
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function text(value) {
+  return String(value ?? '').trim()
 }
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isValidPmid(value) {
+  return PMID_PATTERN.test(text(value))
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isValidDoi(value) {
+  return DOI_PATTERN.test(normalizeDoi(value))
+}
+
+/**
+ * Strip the resolver prefixes a DOI arrives with.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeDoi(value) {
+  return text(value)
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .replace(/^doi:\s*/i, '')
+    .trim()
+}
+
+/**
+ * Every valid PubMed ID in a value, in order, de-duplicated.
+ *
+ * A cell holding `"15070181; 22167571"` describes two studies and returns two
+ * identifiers. Values that are not valid PMIDs are dropped rather than passed
+ * through, because a malformed identifier renders as a dead citation link.
+ *
+ * @param {unknown} value
+ * @returns {string[]}
+ */
 export function normalizePmidList(value) {
   const raw = text(value)
   if (!raw) return []
+
   const seen = new Set()
   for (const part of raw.split(IDENTIFIER_SEPARATOR)) {
-    const candidate = part.trim().replace(/^pmid:?\s*/i, '').replace(/^https?:\/\/pubmed\.ncbi\.nlm\.nih\.gov\//i, '').replace(/\/$/, '').trim()
+    const candidate = part
+      .trim()
+      .replace(/^pmid:?\s*/i, '')
+      .replace(/^https?:\/\/pubmed\.ncbi\.nlm\.nih\.gov\//i, '')
+      .replace(/\/$/, '')
+      .trim()
     if (isValidPmid(candidate)) seen.add(candidate)
   }
   return [...seen]
 }
+
+/**
+ * Return every stable identifier that names a citation, in canonical form.
+ * DOI is listed first because it is the preferred resolver. A packed PMID cell
+ * can return more than one PMID because those values name distinct studies;
+ * callers must not assume every returned identifier is an alias of one study.
+ *
+ * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }} source
+ * @returns {string[]}
+ */
 export function citationIdentifiers(source) {
   const identifiers = []
   const doi = normalizeDoi(source?.doi)
   if (isValidDoi(doi)) identifiers.push(`doi:${doi.toLowerCase()}`)
-  for (const pmid of normalizePmidList(source?.pmid ?? source?.pubmedId)) identifiers.push(`pmid:${pmid}`)
+  for (const pmid of normalizePmidList(source?.pmid ?? source?.pubmedId)) {
+    identifiers.push(`pmid:${pmid}`)
+  }
   return identifiers
 }
+
 function createIdentifierUnion() {
   const parent = new Map()
   const find = (value) => {
     const current = parent.get(value) ?? value
-    if (current === value) { parent.set(value, value); return value }
-    const root = find(current); parent.set(value, root); return root
+    if (current === value) {
+      parent.set(value, value)
+      return value
+    }
+    const root = find(current)
+    parent.set(value, root)
+    return root
   }
   const union = (left, right) => {
-    const leftRoot = find(left), rightRoot = find(right)
+    const leftRoot = find(left)
+    const rightRoot = find(right)
     if (leftRoot === rightRoot) return
-    const [keep, merge] = [leftRoot, rightRoot].sort(); parent.set(merge, keep)
+    const [keep, merge] = [leftRoot, rightRoot].sort()
+    parent.set(merge, keep)
   }
   return { parent, find, union }
 }
+
+/**
+ * Build one deterministic DOI/PMID alias identity map for a citation corpus.
+ *
+ * A DOI and PMID are unioned only when one row carries exactly one valid DOI
+ * and exactly one valid PMID. Multiple PMIDs in one raw row are distinct studies
+ * and are never unioned with each other (or guessed onto a DOI). This keeps the
+ * resolver safe even if an unsplit legacy row reaches it.
+ *
+ * @param {Array<{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }>} sources
+ * @returns {Map<string, string>}
+ */
 export function buildCitationIdentifierIdentityMap(sources = []) {
   const { parent, find, union } = createIdentifierUnion()
+
   for (const source of sources) {
     const identifiers = citationIdentifiers(source)
     for (const identifier of identifiers) find(identifier)
-    const dois = identifiers.filter(identifier => identifier.startsWith('doi:'))
-    const pmids = identifiers.filter(identifier => identifier.startsWith('pmid:'))
-    if (dois.length === 1 && pmids.length === 1) union(dois[0], pmids[0])
+    const doiIdentifiers = identifiers.filter((identifier) => identifier.startsWith('doi:'))
+    const pmidIdentifiers = identifiers.filter((identifier) => identifier.startsWith('pmid:'))
+    if (doiIdentifiers.length === 1 && pmidIdentifiers.length === 1) {
+      union(doiIdentifiers[0], pmidIdentifiers[0])
+    }
   }
+
   const identities = new Map()
   for (const identifier of parent.keys()) identities.set(identifier, find(identifier))
   return identities
 }
+
+/**
+ * Resolve one normalized citation row onto the canonical identity produced by
+ * buildCitationIdentifierIdentityMap. Identifier-less rows return an empty
+ * string so the caller can apply its context-specific fallback identity.
+ *
+ * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }} source
+ * @param {Map<string, string>} identities
+ * @returns {string}
+ */
 export function canonicalCitationIdentifier(source, identities) {
   for (const identifier of citationIdentifiers(source)) {
     const canonical = identities.get(identifier)
@@ -74,9 +178,22 @@ export function canonicalCitationIdentifier(source, identities) {
   }
   return ''
 }
+
+/**
+ * Every usable full URL in a value, in order, de-duplicated.
+ *
+ * Some legacy workbook cells contain multiple complete links separated by a
+ * pipe. A browser cannot navigate to the packed string, so keep the first
+ * valid link as the canonical href while leaving identifier fields available
+ * for additional study counting.
+ *
+ * @param {unknown} value
+ * @returns {string[]}
+ */
 export function normalizeCitationUrlList(value) {
   const raw = text(value)
   if (!raw) return []
+
   const seen = new Set()
   for (const part of raw.split(URL_SEPARATOR)) {
     const candidate = part.trim()
@@ -85,28 +202,63 @@ export function normalizeCitationUrlList(value) {
   }
   return [...seen]
 }
+
+/**
+ * The identifier a citation should link to, preferring a direct URL when one
+ * is usable, then DOI, then PMID.
+ *
+ * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown, url?: unknown }} source
+ * @returns {string}
+ */
 export function citationUrl(source) {
   const [direct] = normalizeCitationUrlList(source?.url)
   if (direct) return direct
+
   const doi = normalizeDoi(source?.doi)
   if (isValidDoi(doi)) return `https://doi.org/${doi}`
+
   const [pmid] = normalizePmidList(source?.pmid ?? source?.pubmedId)
   if (pmid) return `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`
+
   return ''
 }
-const PLACEHOLDER_TITLE_PATTERNS = [/minimal citation row/i,/metadata extraction required/i,/abstract unavailable/i,/^pubmed\s+pmid\s+\d+\.?$/i,/^(?:doi|pmid)\s+\S+$/i,/\bplaceholder\b/i,/\bto be (?:added|filled|completed)\b/i]
+
+/**
+ * Titles that record the absence of metadata rather than naming a study.
+ */
+const PLACEHOLDER_TITLE_PATTERNS = [
+  /minimal citation row/i,
+  /metadata extraction required/i,
+  /abstract unavailable/i,
+  /^pubmed\s+pmid\s+\d+\.?$/i,
+  /^(?:doi|pmid)\s+\S+$/i,
+  /\bplaceholder\b/i,
+  /\bto be (?:added|filled|completed)\b/i,
+]
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
 export function isPlaceholderCitationTitle(value) {
   const title = text(value)
   if (!title) return true
-  return PLACEHOLDER_TITLE_PATTERNS.some(pattern => pattern.test(title))
+  return PLACEHOLDER_TITLE_PATTERNS.some((pattern) => pattern.test(title))
 }
+
+/**
+ * @param {Record<string, unknown>} source
+ * @returns {{ complete: boolean, missing: string[], identifier: string }}
+ */
 export function citationCompleteness(source) {
   const missing = []
   const [identifier = ''] = citationIdentifiers(source)
+
   if (!identifier) missing.push('identifier')
   if (isPlaceholderCitationTitle(source?.title)) missing.push('title')
   if (!text(source?.year)) missing.push('year')
   if (!text(source?.authors ?? source?.author_or_label)) missing.push('authors')
   if (!text(source?.journal)) missing.push('journal')
+
   return { complete: missing.length === 0, missing, identifier }
 }

--- a/lib/citation-identifiers.mjs
+++ b/lib/citation-identifiers.mjs
@@ -13,118 +13,70 @@
  * from how many independent sources back a claim.
  */
 
-/**
- * PubMed IDs are positive integers, currently 8 digits and growing. No leading
- * zero has ever been issued, so one signals a malformed or truncated value.
- */
 export const PMID_PATTERN = /^[1-9]\d{0,8}$/
-
-/** DOIs are a `10.` registrant prefix and a non-empty suffix. */
 export const DOI_PATTERN = /^10\.\d{4,9}\/\S+$/
-
-/** Separators seen between identifiers packed into one cell. */
 const IDENTIFIER_SEPARATOR = /[;,]|\s+and\s+|\s{2,}/i
-
-/** Separators seen between full URLs packed into one workbook cell. */
 const URL_SEPARATOR = /\s*\|\s*|\r?\n+/
-
-/**
- * @param {unknown} value
- * @returns {string}
- */
-function text(value) {
-  return String(value ?? '').trim()
-}
-
-/**
- * @param {unknown} value
- * @returns {boolean}
- */
-export function isValidPmid(value) {
-  return PMID_PATTERN.test(text(value))
-}
-
-/**
- * @param {unknown} value
- * @returns {boolean}
- */
-export function isValidDoi(value) {
-  return DOI_PATTERN.test(normalizeDoi(value))
-}
-
-/**
- * Strip the resolver prefixes a DOI arrives with.
- *
- * @param {unknown} value
- * @returns {string}
- */
+function text(value) { return String(value ?? '').trim() }
+export function isValidPmid(value) { return PMID_PATTERN.test(text(value)) }
+export function isValidDoi(value) { return DOI_PATTERN.test(normalizeDoi(value)) }
 export function normalizeDoi(value) {
-  return text(value)
-    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
-    .replace(/^doi:\s*/i, '')
-    .trim()
+  return text(value).replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '').replace(/^doi:\s*/i, '').trim()
 }
-
-/**
- * Every valid PubMed ID in a value, in order, de-duplicated.
- *
- * A cell holding `"15070181; 22167571"` describes two studies and returns two
- * identifiers. Values that are not valid PMIDs are dropped rather than passed
- * through, because a malformed identifier renders as a dead citation link.
- *
- * @param {unknown} value
- * @returns {string[]}
- */
 export function normalizePmidList(value) {
   const raw = text(value)
   if (!raw) return []
-
   const seen = new Set()
   for (const part of raw.split(IDENTIFIER_SEPARATOR)) {
-    const candidate = part
-      .trim()
-      .replace(/^pmid:?\s*/i, '')
-      .replace(/^https?:\/\/pubmed\.ncbi\.nlm\.nih\.gov\//i, '')
-      .replace(/\/$/, '')
-      .trim()
+    const candidate = part.trim().replace(/^pmid:?\s*/i, '').replace(/^https?:\/\/pubmed\.ncbi\.nlm\.nih\.gov\//i, '').replace(/\/$/, '').trim()
     if (isValidPmid(candidate)) seen.add(candidate)
   }
   return [...seen]
 }
-
-/**
- * Return every stable identifier that names a citation, in canonical form.
- * DOI is listed first because it is the preferred resolver; PMIDs remain
- * aliases for identity/deduplication even when a DOI is present.
- *
- * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown }} source
- * @returns {string[]}
- */
 export function citationIdentifiers(source) {
   const identifiers = []
   const doi = normalizeDoi(source?.doi)
   if (isValidDoi(doi)) identifiers.push(`doi:${doi.toLowerCase()}`)
-  for (const pmid of normalizePmidList(source?.pmid ?? source?.pubmedId)) {
-    identifiers.push(`pmid:${pmid}`)
-  }
+  for (const pmid of normalizePmidList(source?.pmid ?? source?.pubmedId)) identifiers.push(`pmid:${pmid}`)
   return identifiers
 }
-
-/**
- * Every usable full URL in a value, in order, de-duplicated.
- *
- * Some legacy workbook cells contain multiple complete links separated by a
- * pipe. A browser cannot navigate to the packed string, so keep the first
- * valid link as the canonical href while leaving identifier fields available
- * for additional study counting.
- *
- * @param {unknown} value
- * @returns {string[]}
- */
+function createIdentifierUnion() {
+  const parent = new Map()
+  const find = (value) => {
+    const current = parent.get(value) ?? value
+    if (current === value) { parent.set(value, value); return value }
+    const root = find(current); parent.set(value, root); return root
+  }
+  const union = (left, right) => {
+    const leftRoot = find(left), rightRoot = find(right)
+    if (leftRoot === rightRoot) return
+    const [keep, merge] = [leftRoot, rightRoot].sort(); parent.set(merge, keep)
+  }
+  return { parent, find, union }
+}
+export function buildCitationIdentifierIdentityMap(sources = []) {
+  const { parent, find, union } = createIdentifierUnion()
+  for (const source of sources) {
+    const identifiers = citationIdentifiers(source)
+    for (const identifier of identifiers) find(identifier)
+    const dois = identifiers.filter(identifier => identifier.startsWith('doi:'))
+    const pmids = identifiers.filter(identifier => identifier.startsWith('pmid:'))
+    if (dois.length === 1 && pmids.length === 1) union(dois[0], pmids[0])
+  }
+  const identities = new Map()
+  for (const identifier of parent.keys()) identities.set(identifier, find(identifier))
+  return identities
+}
+export function canonicalCitationIdentifier(source, identities) {
+  for (const identifier of citationIdentifiers(source)) {
+    const canonical = identities.get(identifier)
+    if (canonical) return canonical
+  }
+  return ''
+}
 export function normalizeCitationUrlList(value) {
   const raw = text(value)
   if (!raw) return []
-
   const seen = new Set()
   for (const part of raw.split(URL_SEPARATOR)) {
     const candidate = part.trim()
@@ -133,65 +85,28 @@ export function normalizeCitationUrlList(value) {
   }
   return [...seen]
 }
-
-/**
- * The identifier a citation should link to, preferring a direct URL when one
- * is usable, then DOI, then PMID.
- *
- * @param {{ doi?: unknown, pmid?: unknown, pubmedId?: unknown, url?: unknown }} source
- * @returns {string}
- */
 export function citationUrl(source) {
   const [direct] = normalizeCitationUrlList(source?.url)
   if (direct) return direct
-
   const doi = normalizeDoi(source?.doi)
   if (isValidDoi(doi)) return `https://doi.org/${doi}`
-
   const [pmid] = normalizePmidList(source?.pmid ?? source?.pubmedId)
   if (pmid) return `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`
-
   return ''
 }
-
-/**
- * Titles that record the absence of metadata rather than naming a study.
- */
-const PLACEHOLDER_TITLE_PATTERNS = [
-  /minimal citation row/i,
-  /metadata extraction required/i,
-  /abstract unavailable/i,
-  /^pubmed\s+pmid\s+\d+\.?$/i,
-  /^(?:doi|pmid)\s+\S+$/i,
-  /\bplaceholder\b/i,
-  /\bto be (?:added|filled|completed)\b/i,
-]
-
-/**
- * @param {unknown} value
- * @returns {boolean}
- */
+const PLACEHOLDER_TITLE_PATTERNS = [/minimal citation row/i,/metadata extraction required/i,/abstract unavailable/i,/^pubmed\s+pmid\s+\d+\.?$/i,/^(?:doi|pmid)\s+\S+$/i,/\bplaceholder\b/i,/\bto be (?:added|filled|completed)\b/i]
 export function isPlaceholderCitationTitle(value) {
   const title = text(value)
   if (!title) return true
-  return PLACEHOLDER_TITLE_PATTERNS.some((pattern) => pattern.test(title))
+  return PLACEHOLDER_TITLE_PATTERNS.some(pattern => pattern.test(title))
 }
-
-/**
- * Which of the fields a reader needs are present on a citation.
- *
- * @param {Record<string, unknown>} source
- * @returns {{ complete: boolean, missing: string[], identifier: string }}
- */
 export function citationCompleteness(source) {
   const missing = []
   const [identifier = ''] = citationIdentifiers(source)
-
   if (!identifier) missing.push('identifier')
   if (isPlaceholderCitationTitle(source?.title)) missing.push('title')
   if (!text(source?.year)) missing.push('year')
   if (!text(source?.authors ?? source?.author_or_label)) missing.push('authors')
   if (!text(source?.journal)) missing.push('journal')
-
   return { complete: missing.length === 0, missing, identifier }
 }

--- a/lib/research-coverage.ts
+++ b/lib/research-coverage.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { citationIdentifiers, normalizePmidList } from './citation-identifiers.mjs'
+import {
+  buildCitationIdentifierIdentityMap,
+  canonicalCitationIdentifier,
+  citationIdentifiers,
+  normalizePmidList,
+} from './citation-identifiers.mjs'
 import { normalizeStudyClass, strongestStudyClass, type StudyClass } from './study-class'
 
 export type ResearchSource = Record<string, unknown> & {
@@ -207,44 +212,16 @@ export function uniqueSourceRefs(claim: ResearchClaim): string[] {
   return [...new Set(Array.isArray(claim.sourceRefIds) ? claim.sourceRefIds.map(String).filter(Boolean) : [])]
 }
 
-function createIdentityUnion() {
-  const parent = new Map<string, string>()
-  const find = (value: string): string => {
-    const current = parent.get(value) ?? value
-    if (current === value) {
-      parent.set(value, value)
-      return value
-    }
-    const root = find(current)
-    parent.set(value, root)
-    return root
-  }
-  const union = (a: string, b: string) => {
-    const rootA = find(a)
-    const rootB = find(b)
-    if (rootA === rootB) return
-    const [keep, merge] = [rootA, rootB].sort()
-    parent.set(merge, keep)
-  }
-  return { find, union }
-}
-
 export function canonicalStudyIdentityMap(record: ResearchProfile): Map<string, string> {
   const sources = Array.isArray(record.sources) ? record.sources : []
-  const { find, union } = createIdentityUnion()
-
-  for (const source of sources) {
-    const aliases = citationIdentifiers(source)
-    for (const alias of aliases) find(alias)
-    for (let i = 1; i < aliases.length; i += 1) union(aliases[0], aliases[i])
-  }
-
+  const aliasIdentities = buildCitationIdentifierIdentityMap(sources)
   const identities = new Map<string, string>()
+
   for (const source of sources) {
     const sourceId = String(source.id ?? '').trim()
     if (!sourceId) continue
-    const aliases = citationIdentifiers(source)
-    identities.set(sourceId, aliases.length ? find(aliases[0]) : `source-ref:${sourceId}`)
+    const canonical = canonicalCitationIdentifier(source, aliasIdentities)
+    identities.set(sourceId, canonical || `source-ref:${sourceId}`)
   }
   return identities
 }
@@ -266,29 +243,23 @@ export function canonicalStudyGroups(record: ResearchProfile): Map<string, Resea
 
 /**
  * Resolve profile-local canonical study IDs onto one site-wide stable identity.
- * DOI/PMID aliases are unioned across every profile, so a study represented as
- * DOI+PMID on one page and PMID-only on another still collapses to one study.
- * Identifier-less rows remain profile-local to prevent coincidental source IDs
- * from different pages from being treated as the same publication.
+ * DOI/PMID aliases are unioned across every profile through the same shared
+ * citation resolver used by other evidence consumers. Identifier-less rows
+ * remain profile-local to prevent coincidental source IDs from different pages
+ * from being treated as the same publication.
  */
 export function crossProfileStudyIdentityMap(
   profiles: readonly ResearchProfileEntry[],
 ): Map<string, string> {
-  const { find, union } = createIdentityUnion()
-
-  for (const { record } of profiles) {
-    for (const source of Array.isArray(record.sources) ? record.sources : []) {
-      const aliases = citationIdentifiers(source)
-      for (const alias of aliases) find(alias)
-      for (let i = 1; i < aliases.length; i += 1) union(aliases[0], aliases[i])
-    }
-  }
-
+  const allSources = profiles.flatMap(({ record }) => Array.isArray(record.sources) ? record.sources : [])
+  const aliasIdentities = buildCitationIdentifierIdentityMap(allSources)
   const identities = new Map<string, string>()
+
   for (const { url, record } of profiles) {
     for (const [localStudyId, group] of canonicalStudyGroups(record)) {
-      const aliases = [...new Set(group.flatMap((source) => citationIdentifiers(source)))]
-      const globalStudyId = aliases.length ? find(aliases[0]) : `${url}::${localStudyId}`
+      const globalStudyId = group
+        .map((source) => canonicalCitationIdentifier(source, aliasIdentities))
+        .find(Boolean) || `${url}::${localStudyId}`
       identities.set(`${url}::${localStudyId}`, globalStudyId)
     }
   }


### PR DESCRIPTION
Adds one conservative DOI/PMID alias resolver, migrates profile-local and cross-profile research identity to it, removes the duplicate research union implementation, and adds regressions for bridge collapse plus packed-PMID safety.