### PR TITLE
Trust: guard legacy FAQ schema-visible alignment

### DIFF
--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -17,6 +17,7 @@ const GOAL_CLUSTER_ARTICLE = path.join(ROOT, 'components', 'articles', 'GoalClus
 const RHABDO_PAGE = path.join(ROOT, 'app', 'learn', 'rhabdomyolysis', 'page.tsx')
 const LEGACY_GUIDE_REFERENCE = path.join(ROOT, 'components', 'LegacyGuideReference.tsx')
 const LEGACY_GUIDE_QUICK_ANSWER = path.join(ROOT, 'components', 'LegacyGuideQuickAnswer.tsx')
+const LEGACY_GUIDE_FAQ = path.join(ROOT, 'components', 'LegacyGuideFAQ.tsx')
 const LEGACY_GUIDE_PAGES = [
   ['prebiotics', path.join(ROOT, 'app', 'guides', 'other', 'prebiotics', 'page.tsx')],
   ['greens-powders', path.join(ROOT, 'app', 'guides', 'other', 'greens-powders', 'page.tsx')],
@@ -278,6 +279,33 @@ function auditLegacyGuideQuickAnswerPrimitives() {
   }
 }
 
+function auditLegacyGuideFaqPrimitives() {
+  requireSignals(LEGACY_GUIDE_FAQ, 'legacy-guide-faq', 'LegacyGuideFAQ', [
+    ["import FAQSchema from '@/components/seo/FAQSchema'", 'FAQ schema boundary'],
+    ['<FAQSchema pagePath={pagePath} questions={questions} />', 'shared structured FAQ rendering'],
+    ['id="frequently-asked-questions"', 'stable visible FAQ anchor'],
+    ['data-visible-faq="true"', 'visible FAQ marker'],
+    ['questions.map((faq)', 'shared visible FAQ rendering'],
+    ['href="#frequently-asked-questions"', 'durable FAQ self-link'],
+  ])
+
+  for (const [slug, file] of LEGACY_GUIDE_PAGES) {
+    requireSignals(file, 'legacy-guide-faq', `${slug} guide`, [
+      ["import LegacyGuideFAQ from '@/components/LegacyGuideFAQ'", 'shared legacy FAQ import'],
+      ['<LegacyGuideFAQ', 'shared FAQ boundary usage'],
+      ['questions={FAQS}', 'FAQ source-array binding'],
+    ])
+
+    const source = text(file)
+    if (source.includes("import FAQSchema from '@/components/seo/FAQSchema'") || source.includes('<FAQSchema ')) {
+      add('error', 'legacy-guide-faq', `${slug} guide reintroduced standalone FAQ schema outside LegacyGuideFAQ`)
+    }
+    if (/FAQS\.map\s*\(/.test(source)) {
+      add('error', 'legacy-guide-faq', `${slug} guide reintroduced page-local FAQ rendering outside LegacyGuideFAQ`)
+    }
+  }
+}
+
 function auditLegacyGuideTablePrimitives() {
   for (const [slug, file] of LEGACY_GUIDE_PAGES) {
     const source = text(file)
@@ -391,6 +419,7 @@ auditGoalClusterCitationPrimitives()
 auditRhabdoCitationPrimitives()
 auditLegacyGuideReferencePrimitives()
 auditLegacyGuideQuickAnswerPrimitives()
+auditLegacyGuideFaqPrimitives()
 auditLegacyGuideTablePrimitives()
 auditProfilePrimitives()
 auditExtractability()


### PR DESCRIPTION
Fixes #3766

## Summary
- extends the existing canonical AI answer-engine audit with a legacy FAQ alignment contract
- requires the shared `LegacyGuideFAQ` component to emit both `FAQSchema` and visible FAQ content
- requires all five legacy authority guides to import and use `LegacyGuideFAQ` with their existing `FAQS` arrays
- rejects standalone `FAQSchema` usage in those pages
- rejects page-local `FAQS.map(...)` rendering that could drift independently from structured data
- adds no new validator or workflow

## Acceptance criteria
- all five legacy guides use one FAQ rendering boundary
- visible and structured FAQs stay sourced from the same array
- schema-only FAQ regressions fail the canonical audit
- page-local duplicate FAQ renderers fail the canonical audit

## Before → after
- legacy guide FAQ schema/visible alignment: 5/5 → 5/5
- pages covered by regression governance: 0/5 → 5/5
- new validation pipelines: 0

## Validation
- `npm run audit:ai-citations`
- `npx eslint scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- AI search quality check / Atomic upgrade gate

## Trust impact
FAQ structured data is now structurally coupled to the FAQ content readers can actually see across the entire legacy-guide family.