### PR TITLE
polish(mobile): remove stale consent offset

### DIFF
--- a/src/components/ConsentBanner.tsx
+++ b/src/components/ConsentBanner.tsx
@@ -26,7 +26,7 @@ export default function ConsentBanner() {
   const dnt = getSystemNoTracking()
 
   return (
-    <div className='fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+5.25rem)] z-[100] px-3 md:bottom-0 md:px-4 md:pb-4'>
+    <div className='fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] z-[100] px-3 md:bottom-0 md:px-4 md:pb-4'>
       <div
         role='region'
         aria-label='Privacy notice'


### PR DESCRIPTION
Remove the obsolete 5.25rem mobile bottom reservation from the consent banner now that the floating mobile navigation has been deleted. The banner still respects the device safe area; desktop placement and consent behavior are unchanged.