### PR TITLE
fix(evidence-report): canonical citation identity

### DIFF
--- a/lib/__tests__/public-evidence-canonical-citation-identity.test.ts
+++ b/lib/__tests__/public-evidence-canonical-citation-identity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPublicEvidenceDatasetFromRecords } from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence canonical citation identity', () => {
+  it('collapses DOI-only and PMID-only rows when a DOI+PMID bridge proves one publication', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'doi-only',
+          sources: [{ title: 'Shared via DOI', doi: '10.1000/shared-study', relationship: 'supports' }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'bridge',
+          sources: [{ title: 'Bridge', doi: 'https://doi.org/10.1000/shared-study', pmid: '34559859', relationship: 'mixed' }],
+        }),
+      },
+      {
+        type: 'herb',
+        record: record({
+          slug: 'pmid-only',
+          sources: [{ title: 'Shared via PMID', pmid: '34559859', relationship: 'contradicts' }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].id).toBe('doi:10.1000/shared-study')
+    expect(dataset.studies[0]).toMatchObject({ doi: '10.1000/shared-study', pmid: '34559859' })
+    expect(dataset.studies[0].relationships.map(item => item.ingredientSlug).sort()).toEqual([
+      'bridge',
+      'doi-only',
+      'pmid-only',
+    ])
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -1,3 +1,7 @@
+import {
+  buildCitationIdentifierIdentityMap,
+  canonicalCitationIdentifier,
+} from '@/lib/citation-identifiers.mjs'
 import { extractCitationsFromRecord } from '@/lib/citations'
 import { getEvidenceLetterGrade } from '@/lib/evidence'
 import {
@@ -261,10 +265,19 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
   const gradeCounts = new Map<string, number>()
   const categoryMap = new Map<string, EvidenceCategorySummary>()
   let explicitlyFlaggedClaimOverreach = 0
+  const indexableEntities = entities.filter(({ record }) => canIndexRecord(record))
+  const citationsByPath = new Map<string, ReturnType<typeof extractCitationsFromRecord>>()
+  const allCitations: ReturnType<typeof extractCitationsFromRecord> = []
 
-  for (const { record, type } of entities) {
-    if (!canIndexRecord(record)) continue
+  for (const { record, type } of indexableEntities) {
+    const path = `/${type === 'herb' ? 'herbs' : 'compounds'}/${record.slug}/`
+    const citations = extractCitationsFromRecord(record)
+    citationsByPath.set(path, citations)
+    allCitations.push(...citations)
+  }
+  const citationIdentities = buildCitationIdentifierIdentityMap(allCitations)
 
+  for (const { record, type } of indexableEntities) {
     const name = entityName(record)
     const evidenceGrade = getEvidenceLetterGrade(record)
     const category = entityCategory(record)
@@ -291,11 +304,11 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     }
     if (evidenceGrade === 'Unassigned') categorySummary.unassigned += 1
 
-    const citations = extractCitationsFromRecord(record)
+    const citations = citationsByPath.get(path) ?? []
     for (const citation of citations) {
       const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
       const relationship = normalizeEvidenceRelationship(citation.relationship)
-      const id = citation.id || evidenceStudyId(citation)
+      const id = canonicalCitationIdentifier(citation, citationIdentities) || citation.id || evidenceStudyId(citation)
       const conditions = [...new Set([...(citation.conditions || [])].map(item => item.trim()).filter(Boolean))]
       const relationshipRecord: PublicStudyRelationship = {
         ingredientSlug: record.slug,


### PR DESCRIPTION
Use the shared citation identity resolver in the public evidence dataset and add regression coverage.