### PR TITLE
SEO: link legacy FAQ answers to source ledger

### DIFF
--- a/components/LegacyGuideFAQ.tsx
+++ b/components/LegacyGuideFAQ.tsx
@@ -35,6 +35,9 @@ export default function LegacyGuideFAQ({ questions, pagePath }: LegacyGuideFAQPr
             </div>
           ))}
         </div>
+        <a href="#references" data-citation-sources="true" className="text-xs font-semibold text-brand-800 hover:underline">
+          Verify sources →
+        </a>
         <a href="#frequently-asked-questions" className="sr-only">Permanent link to frequently asked questions</a>
       </section>
     </>


### PR DESCRIPTION
Refs #3785

## Summary
- adds one visible `Verify sources →` link to the shared `LegacyGuideFAQ` boundary
- links directly to the canonical `#references` ledger already present on all five legacy guides
- marks the source-verification link with `data-citation-sources="true"`
- automatically upgrades all five migrated guides through the shared component
- changes no FAQ questions, answers, schema payloads, reference entries, or page files

## Before → after
- legacy FAQ sections with durable source-ledger verification: 0/5 → 5/5
- page-specific changes: 0
- FAQ prose changes: 0

## Validation
- `npx eslint components/LegacyGuideFAQ.tsx --max-warnings=0`
- `npm run audit:ai-citations`
- `npm run typecheck`
- AI search quality check / Atomic upgrade gate

## Trust / extraction impact
FAQ answers that contain ordinal citations now expose an explicit, machine-readable path to the source ledger rather than relying on citation numbers alone.