### PR TITLE
Trust: guard legacy FAQ source-ledger relationship

### DIFF
--- a/scripts/ci/audit-ai-answer-engine-readiness.mjs
+++ b/scripts/ci/audit-ai-answer-engine-readiness.mjs
@@ -95,7 +95,7 @@ function auditMachineReadable() {
       const parsed = JSON.parse(text(MANIFEST))
       const serialized = JSON.stringify(parsed)
       if (!serialized.includes('herb') || !serialized.includes('compound')) add('warn', 'entity-data', 'entity manifest may not expose both herb and compound collections')
-      if (statSync(MANIFEST).size < 100) add('error', 'entity-data', 'entity manifest is unexpectedly small')
+      if (statSync(MANIFEST).size < 100) add('error', 'entity-data', 'AI entity manifest is unexpectedly small')
     } catch {
       add('error', 'entity-data', 'AI entity manifest is not valid JSON')
     }
@@ -286,6 +286,8 @@ function auditLegacyGuideFaqPrimitives() {
     ['id="frequently-asked-questions"', 'stable visible FAQ anchor'],
     ['data-visible-faq="true"', 'visible FAQ marker'],
     ['questions.map((faq)', 'shared visible FAQ rendering'],
+    ['href="#references"', 'FAQ source-ledger verification target'],
+    ['data-citation-sources="true"', 'FAQ source-verification marker'],
     ['href="#frequently-asked-questions"', 'durable FAQ self-link'],
   ])
 


### PR DESCRIPTION
Fixes #3785

## Summary
- extends the existing canonical AI answer-engine audit with the FAQ source-ledger contract
- requires `LegacyGuideFAQ` to contain a durable `href="#references"` verification target
- requires the source link to carry `data-citation-sources="true"`
- relies on the existing legacy-guide requirement that every page exposes `id="references"`
- adds no page-specific props, validators, workflows, or duplicate source models

## Acceptance criteria
- all five legacy FAQ sections retain a direct source-verification path
- the verification path remains machine-readable
- removing either the references target or citation-source marker fails the canonical audit

## Before → after
- FAQ source-ledger relationship: 5/5 → 5/5
- regression governance: 0/5 → 5/5
- new validation pipelines: 0

## Validation
- `npm run audit:ai-citations`
- `npx eslint scripts/ci/audit-ai-answer-engine-readiness.mjs --max-warnings=0`
- `npm run typecheck`
- AI search quality check / Atomic upgrade gate

## Trust impact
FAQ answers with ordinal citations remain explicitly connected to the ledger readers and answer systems can use to verify them.