### PR TITLE
fix(research): scope null outcome language to efficacy

### DIFF
--- a/lib/__tests__/research-outcome-metadata.test.ts
+++ b/lib/__tests__/research-outcome-metadata.test.ts
@@ -156,6 +156,44 @@ describe('canonical outcome metadata', () => {
     }
   })
 
+  it('does not treat unrelated safety significance language as a null primary efficacy result', () => {
+    const input = analysis(
+      [{ id: 's1', pmid: '123' }],
+      { '123': { abstract: 'The primary outcome favored treatment with no significant adverse events.' } },
+    )
+    const trialRegistrationIndependence = registration([{
+      url: '/herbs/example/',
+      studyId: 'pmid:123',
+      registryIds: [],
+      stableRegistryId: null,
+      ambiguous: false,
+    }])
+
+    const result = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+
+    expect(result.studies[0].primaryOutcomeStatus).toBe('met')
+    expect(result.summary.primaryOutcomeNotMet).toBe(0)
+  })
+
+  it('still recognizes an explicit no-significant-difference primary outcome as not met', () => {
+    const input = analysis(
+      [{ id: 's1', pmid: '123' }],
+      { '123': { abstract: 'The primary outcome showed no significant difference between groups with no serious adverse events.' } },
+    )
+    const trialRegistrationIndependence = registration([{
+      url: '/herbs/example/',
+      studyId: 'pmid:123',
+      registryIds: [],
+      stableRegistryId: null,
+      ambiguous: false,
+    }])
+
+    const result = analyzeOutcomeMetadata({ analysis: input, trialRegistrationIndependence })
+
+    expect(result.studies[0].primaryOutcomeStatus).toBe('not-met')
+    expect(result.summary.primaryOutcomeNotMet).toBe(1)
+  })
+
   it('keeps missing outcome metadata unknown', () => {
     const input = analysis([{ id: 's1', pmid: '123', title: 'Randomized clinical trial' }])
     const trialRegistrationIndependence = registration([{

--- a/lib/research-outcome-metadata.ts
+++ b/lib/research-outcome-metadata.ts
@@ -53,7 +53,7 @@ const STATUS_FIELDS = ['primaryOutcomeStatus', 'outcomeStatus'] as const
 const SWITCH_FIELDS = ['outcomeSwitch', 'outcomeSwitched', 'primaryOutcomeChanged'] as const
 const NON_REPORTING_FIELDS = ['registeredOutcomeNotReported', 'prespecifiedOutcomeNotReported'] as const
 
-const PRIMARY_NOT_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was not met|not met|failed to meet|did not meet|no significant|not statistically significant|non[- ]significant|not superior|(?:did not|does not|not) favou?r(?:ed|s|ing)?)\b/i
+const PRIMARY_NOT_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was not met|not met|failed to meet|did not meet|no significant (?:difference|effect|improvement|change|benefit|association)|not statistically significant|non[- ]significant|not superior|(?:did not|does not|not) favou?r(?:ed|s|ing)?)\b/i
 const PRIMARY_MET_TEXT = /\bprimary (?:outcome|endpoint)[^.]{0,180}(?:was met|met the|was statistically significant|was significantly (?:improved|reduced|increased|decreased)|favou?r(?:ed|s)|superior)\b/i
 const NEGATED_PRIMARY_POSITIVE_TEXT = /\b(?:not|never|did not|does not|failed to)\s+(?:statistically significant|significantly (?:improved|reduced|increased|decreased)|favou?r(?:ed|s|ing)?|superior)\b/gi
 const OUTCOME_SWITCH_TEXT = /\b(outcome switch(?:ing|ed)?|switched (?:the )?(?:primary )?(?:outcome|endpoint)|changed (?:the )?(?:primary )?(?:outcome|endpoint)|primary outcome (?:was )?changed|deviation from (?:the )?(?:registered|prespecified|protocol[- ]specified) outcome)\b/i


### PR DESCRIPTION
## Summary
- narrows prose-based `no significant` primary-outcome detection to efficacy-like objects such as difference, effect, improvement, change, benefit, or association
- prevents unrelated safety language such as `no significant adverse events` from creating a false null primary-outcome signal
- adds two-sided regressions proving positive efficacy + benign safety remains `met`, while `no significant difference` remains `not-met`

## Why
The canonical primary-outcome matcher previously treated any `no significant` phrase occurring later in the same primary-outcome sentence as evidence that the primary outcome was null. That could turn `The primary outcome favored treatment with no significant adverse events` into `mixed`, contaminating downstream outcome-integrity and editorial-priority logic.

## Regression contract
- positive primary efficacy + no significant adverse events => `met`
- no significant difference on the primary outcome => `not-met`
- existing negated significance/superiority/favorability protections remain intact