### PR TITLE
fix(evidence-report): dedupe category study counts

### DIFF
--- a/app/evidence/evidence-report/EvidenceReportClient.tsx
+++ b/app/evidence/evidence-report/EvidenceReportClient.tsx
@@ -160,7 +160,7 @@ export default function EvidenceReportClient({ datasetVersion, citationText, met
         <p className="eyebrow-label">Category comparison</p>
         <h2 className="mt-2 text-2xl font-semibold text-ink">Where the current library has stronger human-evidence coverage</h2>
         <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
-          Categories are ranked by the share of indexable ingredients currently graded A/B, then by structured human-trial record coverage. These are source/publication-level counts rather than proven-independent underlying-study counts. Category names come from canonical runtime records; small categories can be volatile.
+          Categories are ranked by the share of indexable ingredients currently graded A/B, then by structured human-trial record coverage. Human source and trial counts are deduplicated publication entities within each category, not citation incidences or proven-independent underlying studies. Category names come from canonical runtime records; small categories can be volatile.
         </p>
         <div className="mt-6 overflow-x-auto">
           <table className="w-full min-w-[900px] border-collapse text-left text-sm">

--- a/lib/__tests__/public-evidence-category-study-counts.test.ts
+++ b/lib/__tests__/public-evidence-category-study-counts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPublicEvidenceDatasetFromRecords } from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence category study counts', () => {
+  it('counts one deduplicated human trial once when reused by multiple ingredients in the same category', () => {
+    const sharedTrial = {
+      title: 'Shared trial',
+      pmid: '12345678',
+      study_type: 'randomized controlled trial',
+      relationship: 'supports',
+    }
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      { type: 'herb', record: record({ slug: 'alpha', sources: [sharedTrial] }) },
+      { type: 'compound', record: record({ slug: 'beta', sources: [sharedTrial] }) },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.metrics.categories).toEqual([
+      expect.objectContaining({ category: 'Stress', humanStudies: 1, humanTrials: 1 }),
+    ])
+  })
+
+  it('counts one shared trial once in each distinct category it supports', () => {
+    const sharedTrial = {
+      title: 'Cross-category trial',
+      pmid: '87654321',
+      study_type: 'randomized controlled trial',
+      relationship: 'supports',
+    }
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      { type: 'herb', record: record({ slug: 'alpha', category: 'Stress', sources: [sharedTrial] }) },
+      { type: 'compound', record: record({ slug: 'beta', category: 'Sleep', sources: [sharedTrial] }) },
+    ])
+
+    const counts = new Map(dataset.metrics.categories.map(category => [category.category, category]))
+    expect(counts.get('Stress')).toMatchObject({ humanStudies: 1, humanTrials: 1 })
+    expect(counts.get('Sleep')).toMatchObject({ humanStudies: 1, humanTrials: 1 })
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -376,9 +376,6 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
         }
         existing.relationshipSummary = aggregateRelationship(existing.relationships)
       }
-
-      if (isHumanEvidenceClass(evidenceClass)) categorySummary.humanStudies += 1
-      if (isHumanTrialClass(evidenceClass)) categorySummary.humanTrials += 1
     }
 
     categoryMap.set(category, categorySummary)
@@ -390,6 +387,21 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     return a.title.localeCompare(b.title)
   })
   const studyMetrics = summarizeEvidenceStudies(studies.map(toStudyRecord))
+  const categoryBySlug = new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient.category] as const))
+
+  for (const study of studies) {
+    const studyCategories = new Set(
+      study.relationships
+        .map((relationship) => categoryBySlug.get(relationship.ingredientSlug))
+        .filter((category): category is string => Boolean(category)),
+    )
+    for (const category of studyCategories) {
+      const summary = categoryMap.get(category)
+      if (!summary) continue
+      if (isHumanEvidenceClass(study.evidenceClass)) summary.humanStudies += 1
+      if (isHumanTrialClass(study.evidenceClass)) summary.humanTrials += 1
+    }
+  }
 
   let supportingRelationships = 0
   let mixedRelationships = 0


### PR DESCRIPTION
Count deduplicated study entities once per category instead of once per ingredient-citation incidence, with regressions for same-category reuse and cross-category reuse. Clarifies the category table denominator.