### PR TITLE
feat(research): surface participant count ambiguity

### DIFF
--- a/lib/__tests__/research-participant-count-ambiguity.test.ts
+++ b/lib/__tests__/research-participant-count-ambiguity.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildResearchMetadataIntegrity } from '@/lib/research-metadata-integrity'
+import { analyzeStudyParticipantCountAmbiguities } from '@/lib/research-participant-count-ambiguity'
+import type { ResearchQualityAnalysis } from '@/lib/research-quality-analysis'
+import {
+  buildAggregatedTopologyGapSignals,
+  type AggregatedTopologyGapWeights,
+} from '@/lib/research-quality-policy-topology-signals'
+import type { ResearchQualityTopology } from '@/lib/research-quality-topology'
+
+const weights = {
+  narrowCrossProfileEvidenceBundle: 12,
+  semanticMismatch: 18,
+  highConfidenceSemanticMismatchBonus: 10,
+  semanticSingleSource: 12,
+  semanticSupportConcentration: 8,
+  highConfidenceSemanticConcentrationBonus: 6,
+  semanticMetadataCoverageGap: 6,
+  highConfidenceSemanticCoverageGapBonus: 4,
+  causalWithoutControlledOrSynthesis: 18,
+  causalWithoutDirectControlled: 10,
+  synthesisOnlyCausalSupport: 7,
+  highConfidenceCausalLanguageBonus: 8,
+  metadataIntegrity: 6,
+  highConfidenceMetadataIntegrityBonus: 4,
+  provenanceNarrowMultiStudySupport: 8,
+  highConfidenceProvenanceNarrowBonus: 4,
+  pseudoMultiSourceSupport: 9,
+  underlyingStudyPublicationReuse: 12,
+  highConfidenceUnderlyingStudyPublicationReuseBonus: 6,
+  independenceMetadataGap: 8,
+  highConfidenceIndependenceMetadataBonus: 6,
+  severeStudyClassConflict: 100,
+} satisfies AggregatedTopologyGapWeights
+
+function analysisFixture(): ResearchQualityAnalysis {
+  return {
+    cache: {},
+    profiles: [{
+      kind: 'herbs',
+      url: '/herbs/example/',
+      file: 'example.json',
+      record: {
+        slug: 'example',
+        sources: [
+          { id: 'doi', doi: '10.1000/shared', n: 100 },
+          { id: 'bridge', doi: '10.1000/shared', pmid: '34559859', sample_size: 'N=120' },
+        ],
+        claimMap: [],
+      },
+    }],
+    profileAnalyses: [],
+    claimAnalyses: [],
+    structuredClaimAnalyses: [],
+  } as unknown as ResearchQualityAnalysis
+}
+
+describe('participant-count ambiguity', () => {
+  it('preserves conflicting explicit N values on one canonical publication', () => {
+    const ambiguities = analyzeStudyParticipantCountAmbiguities(analysisFixture())
+
+    expect(ambiguities).toEqual([{
+      url: '/herbs/example/',
+      studyId: 'doi:10.1000/shared',
+      participantCounts: [100, 120],
+      minParticipantCount: 100,
+      maxParticipantCount: 120,
+      spread: 20,
+    }])
+  })
+
+  it('rolls ambiguity into the existing metadata-integrity remediation reason', () => {
+    const ambiguities = analyzeStudyParticipantCountAmbiguities(analysisFixture())
+    const metadataIntegrity = buildResearchMetadataIntegrity({
+      studyYearConflicts: [],
+      participantCountAmbiguities: ambiguities,
+      provenanceConflicts: [],
+      studyClassConflicts: { conflicts: [], severeConflicts: [] } as never,
+      claimCitationMetadata: { lowCoverageClaims: [], highConfidenceLowCoverageClaims: [] } as never,
+    })
+
+    expect(metadataIntegrity.profiles[0]).toMatchObject({
+      url: '/herbs/example/',
+      participantCountAmbiguities: 1,
+      issueCount: 1,
+    })
+
+    const topology = {
+      narrowCrossProfileEvidenceBundles: [],
+      semanticAlignment: { findings: [], concentrationFindings: [], coverageGapFindings: [] },
+      claimBreadth: { findings: [] },
+      effectCertainty: { findings: [] },
+      directionalConsistency: { findings: [] },
+      outcomeReportingIntegrity: { claims: [] },
+      claimLanguageCalibration: { directEvidenceFindings: [] },
+      metadataIntegrity,
+      provenanceNarrowMultiStudyClaims: [],
+      edgeCardinality: { pseudoMultiSourceClaims: [] },
+      underlyingStudyIndependence: { newlyOverDependentProfiles: [], reducedClaims: [], profiles: [] },
+      evidenceIndependenceCoverage: { unresolvedClaims: [] },
+      studyClassConflicts: { severeConflicts: [] },
+    } as unknown as ResearchQualityTopology
+
+    const signals = buildAggregatedTopologyGapSignals(topology, weights)
+    expect(signals).toHaveLength(1)
+    expect(signals[0]).toMatchObject({
+      url: '/herbs/example/',
+      kind: 'research-metadata-integrity',
+      weight: 6,
+    })
+    expect(signals[0].detail).toContain('1 participant-count ambiguity finding(s)')
+  })
+})

--- a/lib/research-metadata-integrity.ts
+++ b/lib/research-metadata-integrity.ts
@@ -1,11 +1,13 @@
 import type { ClaimCitationMetadataAnalysis } from './research-claim-citation-metadata'
 import type { StudyYearConflict } from './research-evidence-age'
+import type { StudyParticipantCountAmbiguity } from './research-participant-count-ambiguity'
 import type { StudyProvenanceConflict } from './research-provenance-concentration'
 import type { StudyClassConflictAnalysis } from './research-study-class-conflicts'
 
 export type ResearchMetadataIntegrityProfile = {
   url: string
   yearConflicts: number
+  participantCountAmbiguities: number
   provenanceConflicts: number
   studyClassConflicts: number
   severeStudyClassConflicts: number
@@ -21,6 +23,7 @@ export type ResearchMetadataIntegrity = {
     profilesWithIssues: number
     profilesWithSevereIssues: number
     yearConflicts: number
+    participantCountAmbiguities: number
     provenanceConflicts: number
     studyClassConflicts: number
     severeStudyClassConflicts: number
@@ -31,6 +34,7 @@ export type ResearchMetadataIntegrity = {
 
 type MetadataIntegrityInputs = {
   studyYearConflicts: readonly StudyYearConflict[]
+  participantCountAmbiguities: readonly StudyParticipantCountAmbiguity[]
   provenanceConflicts: readonly StudyProvenanceConflict[]
   studyClassConflicts: StudyClassConflictAnalysis
   claimCitationMetadata: ClaimCitationMetadataAnalysis
@@ -42,6 +46,7 @@ function emptyProfile(url: string): MutableProfile {
   return {
     url,
     yearConflicts: 0,
+    participantCountAmbiguities: 0,
     provenanceConflicts: 0,
     studyClassConflicts: 0,
     severeStudyClassConflicts: 0,
@@ -64,6 +69,7 @@ export function buildResearchMetadataIntegrity(inputs: MetadataIntegrityInputs):
   }
 
   for (const conflict of inputs.studyYearConflicts) profile(conflict.url).yearConflicts += 1
+  for (const ambiguity of inputs.participantCountAmbiguities) profile(ambiguity.url).participantCountAmbiguities += 1
   for (const conflict of inputs.provenanceConflicts) profile(conflict.url).provenanceConflicts += 1
   for (const conflict of inputs.studyClassConflicts.conflicts) {
     const value = profile(conflict.url)
@@ -78,6 +84,7 @@ export function buildResearchMetadataIntegrity(inputs: MetadataIntegrityInputs):
   const profiles = [...byUrl.values()]
     .map((value): ResearchMetadataIntegrityProfile => {
       const issueCount = value.yearConflicts
+        + value.participantCountAmbiguities
         + value.provenanceConflicts
         + value.studyClassConflicts
         + value.lowCitationMetadataClaims
@@ -97,6 +104,7 @@ export function buildResearchMetadataIntegrity(inputs: MetadataIntegrityInputs):
       profilesWithIssues: profiles.length,
       profilesWithSevereIssues: profiles.filter((value) => value.severeIssueCount > 0).length,
       yearConflicts: inputs.studyYearConflicts.length,
+      participantCountAmbiguities: inputs.participantCountAmbiguities.length,
       provenanceConflicts: inputs.provenanceConflicts.length,
       studyClassConflicts: inputs.studyClassConflicts.conflicts.length,
       severeStudyClassConflicts: inputs.studyClassConflicts.severeConflicts.length,

--- a/lib/research-participant-count-ambiguity.ts
+++ b/lib/research-participant-count-ambiguity.ts
@@ -1,0 +1,70 @@
+import { parseSampleSize } from './evidence-study'
+import { canonicalStudyGroups, type ResearchSource } from './research-coverage'
+import type { ResearchQualityAnalysis } from './research-quality-analysis'
+
+export type StudyParticipantCountAmbiguity = {
+  url: string
+  studyId: string
+  participantCounts: number[]
+  minParticipantCount: number
+  maxParticipantCount: number
+  spread: number
+}
+
+function explicitParticipantCounts(source: ResearchSource): number[] {
+  const candidates = [
+    source.sampleSize,
+    source.sample_size,
+    source.n,
+    source.participantCount,
+    source.participant_count,
+    source.participants_n,
+  ]
+  const participants = source.participants
+  if (typeof participants === 'number' || /^\s*n\s*=/.test(String(participants ?? ''))) {
+    candidates.push(participants)
+  }
+
+  return [...new Set(
+    candidates
+      .map(parseSampleSize)
+      .filter((value): value is number => value !== null),
+  )].sort((a, b) => a - b)
+}
+
+/**
+ * Preserve conflicting explicit participant-count metadata on one canonical
+ * publication instead of silently letting source order choose which N wins.
+ *
+ * This is advisory metadata ambiguity, not proof that either value is wrong:
+ * a publication can legitimately report enrolled, randomized, analyzed, or
+ * per-protocol populations. Editorial review should reconcile the intended N.
+ */
+export function analyzeStudyParticipantCountAmbiguities(
+  analysis: ResearchQualityAnalysis,
+): StudyParticipantCountAmbiguity[] {
+  const ambiguities: StudyParticipantCountAmbiguity[] = []
+
+  for (const { url, record } of analysis.profiles) {
+    for (const [studyId, group] of canonicalStudyGroups(record)) {
+      const participantCounts = [...new Set(group.flatMap(explicitParticipantCounts))].sort((a, b) => a - b)
+      if (participantCounts.length < 2) continue
+      const minParticipantCount = participantCounts[0]
+      const maxParticipantCount = participantCounts.at(-1) ?? minParticipantCount
+      ambiguities.push({
+        url,
+        studyId,
+        participantCounts,
+        minParticipantCount,
+        maxParticipantCount,
+        spread: maxParticipantCount - minParticipantCount,
+      })
+    }
+  }
+
+  return ambiguities.sort((a, b) =>
+    b.spread - a.spread
+    || a.url.localeCompare(b.url)
+    || a.studyId.localeCompare(b.studyId),
+  )
+}

--- a/lib/research-quality-policy-topology-signals.ts
+++ b/lib/research-quality-policy-topology-signals.ts
@@ -194,7 +194,9 @@ export function buildAggregatedTopologyGapSignals(
 
   for (const item of topology.metadataIntegrity.profiles) {
     const advisoryStudyClassConflicts = Math.max(0, item.studyClassConflicts - item.severeStudyClassConflicts)
+    const participantCountAmbiguities = item.participantCountAmbiguities ?? 0
     const advisoryIssueCount = item.yearConflicts
+      + participantCountAmbiguities
       + item.provenanceConflicts
       + advisoryStudyClassConflicts
       + item.lowCitationMetadataClaims
@@ -206,7 +208,7 @@ export function buildAggregatedTopologyGapSignals(
       weight: weights.metadataIntegrity
         + Math.min(12, Math.max(0, advisoryIssueCount - 1) * 2)
         + (highConfidence ? weights.highConfidenceMetadataIntegrityBonus : 0),
-      detail: `${advisoryIssueCount} advisory metadata integrity issue(s): ${item.yearConflicts} publication-year conflict(s), ${item.provenanceConflicts} provenance alias conflict(s), ${advisoryStudyClassConflicts} advisory study-class ambiguity, ${item.lowCitationMetadataClaims} low-completeness claim(s); ${item.highConfidenceLowCitationMetadataClaims} high-confidence citation gap(s)`,
+      detail: `${advisoryIssueCount} advisory metadata integrity issue(s): ${item.yearConflicts} publication-year conflict(s), ${participantCountAmbiguities} participant-count ambiguity finding(s), ${item.provenanceConflicts} provenance alias conflict(s), ${advisoryStudyClassConflicts} advisory study-class ambiguity, ${item.lowCitationMetadataClaims} low-completeness claim(s); ${item.highConfidenceLowCitationMetadataClaims} high-confidence citation gap(s)`,
     })
   }
 

--- a/lib/research-quality-topology.ts
+++ b/lib/research-quality-topology.ts
@@ -17,6 +17,7 @@ import { analyzeOutcomeMetadataCoverage } from './research-outcome-metadata-cove
 import { analyzeOutcomeRegistrationAlignment } from './research-outcome-registration-alignment'
 import { analyzeOutcomeReportingIntegrity } from './research-outcome-reporting-integrity'
 import { buildOutcomeReviewQueue } from './research-outcome-review-queue'
+import { analyzeStudyParticipantCountAmbiguities } from './research-participant-count-ambiguity'
 import { analyzeProvenanceConcentration, analyzeStudyProvenanceConflicts } from './research-provenance-concentration'
 import type { ResearchQualityAnalysis } from './research-quality-analysis'
 import { analyzeResearchSemanticAlignment } from './research-semantic-alignment'
@@ -50,6 +51,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const claimEvidenceAge = analyzeClaimEvidenceAge(analysis)
   const evidenceAgeSummary = summarizeEvidenceAge(claimEvidenceAge)
   const studyYearConflicts = analyzeStudyYearConflicts(analysis)
+  const participantCountAmbiguities = analyzeStudyParticipantCountAmbiguities(analysis)
   const legacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.allKnownEvidenceOlderThan10Years)
   const highConfidenceLegacyOnlyClaims = claimEvidenceAge.filter((claim) => claim.highConfidenceLegacyOnlyClaim)
   const studyIdentityCoverage = analyzeStudyIdentityCoverage(analysis)
@@ -104,6 +106,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
   const claimCitationMetadata = analyzeClaimCitationMetadata(analysis)
   const metadataIntegrity = buildResearchMetadataIntegrity({
     studyYearConflicts,
+    participantCountAmbiguities,
     provenanceConflicts,
     studyClassConflicts,
     claimCitationMetadata,
@@ -122,6 +125,7 @@ export function buildResearchQualityTopology(analysis: ResearchQualityAnalysis) 
     claimEvidenceAge,
     evidenceAgeSummary,
     studyYearConflicts,
+    participantCountAmbiguities,
     legacyOnlyClaims,
     highConfidenceLegacyOnlyClaims,
     studyIdentityCoverage,


### PR DESCRIPTION
Detect conflicting explicit participant counts on one canonical publication, roll them into the existing metadata-integrity summary, and route them through the existing remediation reason as advisory ambiguity. Includes end-to-end regression coverage.