### PR TITLE
fix(evidence-report): exclude ambiguous participant counts

### DIFF
--- a/lib/__tests__/public-evidence-participant-count-ambiguity.test.ts
+++ b/lib/__tests__/public-evidence-participant-count-ambiguity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPublicEvidenceDatasetFromRecords } from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence participant-count ambiguity', () => {
+  it('excludes ambiguous N from aggregate participants while retaining clean studies', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'ambiguous-a',
+          sources: [{
+            title: 'Ambiguous shared trial',
+            pmid: '12345678',
+            study_type: 'randomized controlled trial',
+            n: 100,
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'ambiguous-b',
+          sources: [{
+            title: 'Ambiguous shared trial alias',
+            pmid: '12345678',
+            study_type: 'randomized controlled trial',
+            sample_size: 'N=120',
+          }],
+        }),
+      },
+      {
+        type: 'herb',
+        record: record({
+          slug: 'clean',
+          sources: [{
+            title: 'Clean trial',
+            pmid: '87654321',
+            study_type: 'randomized controlled trial',
+            n: 50,
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(2)
+    expect(dataset.metrics).toMatchObject({
+      humanTrialCount: 2,
+      approximateParticipants: 50,
+      participantCountCoverage: 1,
+      participantCountAmbiguityStudyCount: 1,
+    })
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -95,6 +95,7 @@ export type PublicEvidenceReportMetrics = {
   humanTrialCount: number
   approximateParticipants: number
   participantCountCoverage: number
+  participantCountAmbiguityStudyCount: number
   strongOrModerateIngredients: number
   preliminaryOrInsufficientIngredients: number
   unassignedIngredients: number
@@ -262,6 +263,7 @@ function mergeStudyField<T>(current: T | undefined, incoming: T | undefined): T 
 export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]): PublicEvidenceDataset {
   const ingredients: PublicEvidenceIngredient[] = []
   const studiesById = new Map<string, PublicStudyEntity>()
+  const participantCountsByStudyId = new Map<string, Set<number>>()
   const gradeCounts = new Map<string, number>()
   const categoryMap = new Map<string, EvidenceCategorySummary>()
   let explicitlyFlaggedClaimOverreach = 0
@@ -309,6 +311,12 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
       const relationship = normalizeEvidenceRelationship(citation.relationship)
       const id = canonicalCitationIdentifier(citation, citationIdentities) || citation.id || evidenceStudyId(citation)
+      const parsedParticipantCount = parseSampleSize(citation.sampleSize)
+      if (parsedParticipantCount !== null) {
+        const counts = participantCountsByStudyId.get(id) ?? new Set<number>()
+        counts.add(parsedParticipantCount)
+        participantCountsByStudyId.set(id, counts)
+      }
       const conditions = [...new Set([...(citation.conditions || [])].map(item => item.trim()).filter(Boolean))]
       const relationshipRecord: PublicStudyRelationship = {
         ingredientSlug: record.slug,
@@ -386,7 +394,14 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     if (yearDiff !== 0) return yearDiff
     return a.title.localeCompare(b.title)
   })
-  const studyMetrics = summarizeEvidenceStudies(studies.map(toStudyRecord))
+  const ambiguousParticipantStudyIds = new Set(
+    [...participantCountsByStudyId.entries()]
+      .filter(([, counts]) => counts.size > 1)
+      .map(([studyId]) => studyId),
+  )
+  const studyMetrics = summarizeEvidenceStudies(studies.map((study) =>
+    toStudyRecord(ambiguousParticipantStudyIds.has(study.id) ? { ...study, sampleSize: undefined } : study),
+  ))
   const categoryBySlug = new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient.category] as const))
 
   for (const study of studies) {
@@ -451,6 +466,7 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     humanTrialCount: studyMetrics.humanTrials,
     approximateParticipants: studyMetrics.approximateParticipants,
     participantCountCoverage: studyMetrics.studiesWithParticipantCounts,
+    participantCountAmbiguityStudyCount: ambiguousParticipantStudyIds.size,
     strongOrModerateIngredients: ingredients.filter(item => item.evidenceGrade === 'A' || item.evidenceGrade === 'B').length,
     preliminaryOrInsufficientIngredients: ingredients.filter(item => item.evidenceGrade === 'C' || item.evidenceGrade === 'D' || item.evidenceGrade === 'Avoid/Insufficient').length,
     unassignedIngredients: ingredients.filter(item => item.evidenceGrade === 'Unassigned').length,


### PR DESCRIPTION
Track participant counts by canonical study identity and exclude studies with conflicting explicit N values from the aggregate participant estimate while retaining the study records. Adds regression coverage with ambiguous and clean studies.