### PR TITLE
polish(legacy-guide): normalize quick answer actions

### DIFF
--- a/components/LegacyGuideQuickAnswer.tsx
+++ b/components/LegacyGuideQuickAnswer.tsx
@@ -16,6 +16,9 @@ export default function LegacyGuideQuickAnswer({
   children,
   referencesHref,
 }: LegacyGuideQuickAnswerProps) {
+  const actionClass =
+    'inline-flex min-h-11 items-center rounded-lg text-xs font-semibold text-brand-700 underline-offset-4 transition hover:text-brand-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 focus-visible:ring-offset-2 dark:text-brand-200 dark:hover:text-brand-100'
+
   return (
     <section
       id="quick-answer"
@@ -28,11 +31,7 @@ export default function LegacyGuideQuickAnswer({
         <h2 id="quick-answer-heading" className="text-2xl font-semibold">
           Quick answer
         </h2>
-        <a
-          href="#quick-answer"
-          aria-label="Permanent link to quick answer"
-          className="text-xs font-semibold text-brand-700 underline-offset-4 hover:underline"
-        >
+        <a href="#quick-answer" aria-label="Permanent link to quick answer" className={actionClass}>
           Permanent link
         </a>
       </div>
@@ -40,11 +39,7 @@ export default function LegacyGuideQuickAnswer({
       <div className="text-sm leading-7 text-muted">{children}</div>
 
       {referencesHref ? (
-        <a
-          href={referencesHref}
-          data-citation-sources="true"
-          className="inline-flex text-xs font-bold text-brand-700 hover:text-brand-900 hover:underline"
-        >
+        <a href={referencesHref} data-citation-sources="true" className={`${actionClass} font-bold`}>
           Verify sources ↓
         </a>
       ) : null}


### PR DESCRIPTION
Raise the Quick Answer permanent/source actions to the 44px touch-target standard, add focus/dark states, and consolidate their duplicated link styling. Answer content and source semantics are unchanged.