### PR TITLE
fix(evidence-report): neutralize ambiguous study classes

### DIFF
--- a/lib/__tests__/public-evidence-study-class-ambiguity.test.ts
+++ b/lib/__tests__/public-evidence-study-class-ambiguity.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPublicEvidenceDatasetFromRecords } from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence study-class ambiguity', () => {
+  it('neutralizes conflicting concrete classes for one canonical publication', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'rct-alias',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/class-conflict',
+            study_type: 'randomized controlled trial',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'review-alias',
+          sources: [{
+            title: 'Shared publication',
+            doi: 'https://doi.org/10.1000/class-conflict',
+            pmid: '34559859',
+            study_type: 'systematic review',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0]).toMatchObject({
+      id: 'doi:10.1000/class-conflict',
+      evidenceClass: 'other',
+    })
+    expect(dataset.metrics.studyClassAmbiguityStudyCount).toBe(1)
+    expect(dataset.metrics.humanStudyCount).toBe(0)
+    expect(dataset.metrics.humanTrialCount).toBe(0)
+    expect(dataset.metrics.categories[0].humanStudies).toBe(0)
+    expect(dataset.metrics.categories[0].humanTrials).toBe(0)
+  })
+
+  it('uses one concrete class over unknown aliases regardless of source order', () => {
+    const unknown = {
+      type: 'herb' as const,
+      record: record({
+        slug: 'unknown-alias',
+        sources: [{
+          title: 'Shared publication',
+          doi: '10.1000/class-known',
+          study_type: 'unclear publication type',
+        }],
+      }),
+    }
+    const rct = {
+      type: 'compound' as const,
+      record: record({
+        slug: 'rct-alias',
+        sources: [{
+          title: 'Shared publication',
+          doi: '10.1000/class-known',
+          pmid: '34559859',
+          study_type: 'randomized controlled trial',
+        }],
+      }),
+    }
+
+    for (const entities of [[unknown, rct], [rct, unknown]]) {
+      const dataset = buildPublicEvidenceDatasetFromRecords(entities)
+      expect(dataset.studies).toHaveLength(1)
+      expect(dataset.studies[0].evidenceClass).toBe('randomized_controlled_trial')
+      expect(dataset.metrics.studyClassAmbiguityStudyCount).toBe(0)
+      expect(dataset.metrics.humanStudyCount).toBe(1)
+      expect(dataset.metrics.humanTrialCount).toBe(1)
+    }
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -96,6 +96,7 @@ export type PublicEvidenceReportMetrics = {
   approximateParticipants: number
   participantCountCoverage: number
   participantCountAmbiguityStudyCount: number
+  studyClassAmbiguityStudyCount: number
   strongOrModerateIngredients: number
   preliminaryOrInsufficientIngredients: number
   unassignedIngredients: number
@@ -264,6 +265,7 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
   const ingredients: PublicEvidenceIngredient[] = []
   const studiesById = new Map<string, PublicStudyEntity>()
   const participantCountsByStudyId = new Map<string, Set<number>>()
+  const evidenceClassesByStudyId = new Map<string, Set<EvidenceStudyClass>>()
   const gradeCounts = new Map<string, number>()
   const categoryMap = new Map<string, EvidenceCategorySummary>()
   let explicitlyFlaggedClaimOverreach = 0
@@ -311,6 +313,11 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
       const relationship = normalizeEvidenceRelationship(citation.relationship)
       const id = canonicalCitationIdentifier(citation, citationIdentities) || citation.id || evidenceStudyId(citation)
+      if (evidenceClass !== 'other') {
+        const classes = evidenceClassesByStudyId.get(id) ?? new Set<EvidenceStudyClass>()
+        classes.add(evidenceClass)
+        evidenceClassesByStudyId.set(id, classes)
+      }
       const parsedParticipantCount = parseSampleSize(citation.sampleSize)
       if (parsedParticipantCount !== null) {
         const counts = participantCountsByStudyId.get(id) ?? new Set<number>()
@@ -389,11 +396,18 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     categoryMap.set(category, categorySummary)
   }
 
-  const studies = [...studiesById.values()].sort((a, b) => {
-    const yearDiff = Number(b.year || 0) - Number(a.year || 0)
-    if (yearDiff !== 0) return yearDiff
-    return a.title.localeCompare(b.title)
-  })
+  const ambiguousStudyClassIds = new Set(
+    [...evidenceClassesByStudyId.entries()]
+      .filter(([, classes]) => classes.size > 1)
+      .map(([studyId]) => studyId),
+  )
+  const studies = [...studiesById.values()]
+    .map((study) => ambiguousStudyClassIds.has(study.id) ? { ...study, evidenceClass: 'other' as const } : study)
+    .sort((a, b) => {
+      const yearDiff = Number(b.year || 0) - Number(a.year || 0)
+      if (yearDiff !== 0) return yearDiff
+      return a.title.localeCompare(b.title)
+    })
   const ambiguousParticipantStudyIds = new Set(
     [...participantCountsByStudyId.entries()]
       .filter(([, counts]) => counts.size > 1)
@@ -467,6 +481,7 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     approximateParticipants: studyMetrics.approximateParticipants,
     participantCountCoverage: studyMetrics.studiesWithParticipantCounts,
     participantCountAmbiguityStudyCount: ambiguousParticipantStudyIds.size,
+    studyClassAmbiguityStudyCount: ambiguousStudyClassIds.size,
     strongOrModerateIngredients: ingredients.filter(item => item.evidenceGrade === 'A' || item.evidenceGrade === 'B').length,
     preliminaryOrInsufficientIngredients: ingredients.filter(item => item.evidenceGrade === 'C' || item.evidenceGrade === 'D' || item.evidenceGrade === 'Avoid/Insufficient').length,
     unassignedIngredients: ingredients.filter(item => item.evidenceGrade === 'Unassigned').length,

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -402,7 +402,12 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       .map(([studyId]) => studyId),
   )
   const studies = [...studiesById.values()]
-    .map((study) => ambiguousStudyClassIds.has(study.id) ? { ...study, evidenceClass: 'other' as const } : study)
+    .map((study) => {
+      const classes = evidenceClassesByStudyId.get(study.id)
+      if (!classes?.size) return study
+      if (classes.size === 1) return { ...study, evidenceClass: [...classes][0] }
+      return { ...study, evidenceClass: 'other' as const }
+    })
     .sort((a, b) => {
       const yearDiff = Number(b.year || 0) - Number(a.year || 0)
       if (yearDiff !== 0) return yearDiff


### PR DESCRIPTION
Resolve public study class after canonical publication dedupe. One concrete class overrides unknown aliases; conflicting concrete classes become Other/unclear and increment an ambiguity metric so human/trial counts cannot depend on citation order. Includes order-invariance regressions.