### PR TITLE
feat(evidence-report): export per-study ambiguity flags

### DIFF
--- a/lib/__tests__/public-evidence-ambiguity-flags.test.ts
+++ b/lib/__tests__/public-evidence-ambiguity-flags.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPublicEvidenceDatasetFromRecords,
+  publicEvidenceDatasetToCsv,
+} from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence ambiguity flags', () => {
+  it('exports canonical study-class and participant-count ambiguity per study', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'first-alias',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/ambiguous-study',
+            study_type: 'randomized controlled trial',
+            n: 100,
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'second-alias',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/ambiguous-study',
+            pmid: '34559859',
+            study_type: 'systematic review',
+            n: 120,
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0]).toMatchObject({
+      id: 'doi:10.1000/ambiguous-study',
+      evidenceClass: 'other',
+      studyClassAmbiguous: true,
+      participantCountAmbiguous: true,
+    })
+    expect(dataset.metrics.studyClassAmbiguityStudyCount).toBe(1)
+    expect(dataset.metrics.participantCountAmbiguityStudyCount).toBe(1)
+    expect(dataset.metrics.humanTrialCount).toBe(0)
+    expect(dataset.metrics.approximateParticipants).toBe(0)
+    expect(dataset.metrics.participantCountCoverage).toBe(0)
+
+    const csv = publicEvidenceDatasetToCsv(dataset)
+    expect(csv).toContain('study_class,study_class_ambiguous,sample_size,participant_count_ambiguous')
+    expect(csv).toContain('other,true,100,true')
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -62,7 +62,9 @@ export type PublicStudyEntity = {
   url?: string
   studyType?: string
   evidenceClass: EvidenceStudyClass
+  studyClassAmbiguous?: boolean
   sampleSize?: number | string
+  participantCountAmbiguous?: boolean
   dose?: string
   duration?: string
   population?: string
@@ -401,25 +403,35 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       .filter(([, classes]) => classes.size > 1)
       .map(([studyId]) => studyId),
   )
+  const ambiguousParticipantStudyIds = new Set(
+    [...participantCountsByStudyId.entries()]
+      .filter(([, counts]) => counts.size > 1)
+      .map(([studyId]) => studyId),
+  )
   const studies = [...studiesById.values()]
     .map((study) => {
       const classes = evidenceClassesByStudyId.get(study.id)
-      if (!classes?.size) return study
-      if (classes.size === 1) return { ...study, evidenceClass: [...classes][0] }
-      return { ...study, evidenceClass: 'other' as const }
+      const studyClassAmbiguous = ambiguousStudyClassIds.has(study.id)
+      const participantCountAmbiguous = ambiguousParticipantStudyIds.has(study.id)
+      const evidenceClass = !classes?.size
+        ? study.evidenceClass
+        : classes.size === 1
+          ? [...classes][0]
+          : 'other'
+      return {
+        ...study,
+        evidenceClass,
+        studyClassAmbiguous,
+        participantCountAmbiguous,
+      }
     })
     .sort((a, b) => {
       const yearDiff = Number(b.year || 0) - Number(a.year || 0)
       if (yearDiff !== 0) return yearDiff
       return a.title.localeCompare(b.title)
     })
-  const ambiguousParticipantStudyIds = new Set(
-    [...participantCountsByStudyId.entries()]
-      .filter(([, counts]) => counts.size > 1)
-      .map(([studyId]) => studyId),
-  )
   const studyMetrics = summarizeEvidenceStudies(studies.map((study) =>
-    toStudyRecord(ambiguousParticipantStudyIds.has(study.id) ? { ...study, sampleSize: undefined } : study),
+    toStudyRecord(study.participantCountAmbiguous ? { ...study, sampleSize: undefined } : study),
   ))
   const categoryBySlug = new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient.category] as const))
 
@@ -485,8 +497,8 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     humanTrialCount: studyMetrics.humanTrials,
     approximateParticipants: studyMetrics.approximateParticipants,
     participantCountCoverage: studyMetrics.studiesWithParticipantCounts,
-    participantCountAmbiguityStudyCount: ambiguousParticipantStudyIds.size,
-    studyClassAmbiguityStudyCount: ambiguousStudyClassIds.size,
+    participantCountAmbiguityStudyCount: studies.filter(study => study.participantCountAmbiguous).length,
+    studyClassAmbiguityStudyCount: studies.filter(study => study.studyClassAmbiguous).length,
     strongOrModerateIngredients: ingredients.filter(item => item.evidenceGrade === 'A' || item.evidenceGrade === 'B').length,
     preliminaryOrInsufficientIngredients: ingredients.filter(item => item.evidenceGrade === 'C' || item.evidenceGrade === 'D' || item.evidenceGrade === 'Avoid/Insufficient').length,
     unassignedIngredients: ingredients.filter(item => item.evidenceGrade === 'Unassigned').length,
@@ -608,9 +620,9 @@ function csvEscape(value: unknown): string {
 
 export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): string {
   const headers = [
-    'study_id', 'title', 'authors', 'journal', 'year', 'pmid', 'doi', 'study_class', 'sample_size',
-    'dose', 'duration', 'population', 'outcome', 'result', 'limitation', 'relationship_summary',
-    'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
+    'study_id', 'title', 'authors', 'journal', 'year', 'pmid', 'doi', 'study_class', 'study_class_ambiguous',
+    'sample_size', 'participant_count_ambiguous', 'dose', 'duration', 'population', 'outcome', 'result', 'limitation',
+    'relationship_summary', 'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
   ]
 
   const rows = dataset.studies.map(study => [
@@ -622,7 +634,9 @@ export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): stri
     study.pmid,
     study.doi,
     study.evidenceClass,
+    Boolean(study.studyClassAmbiguous),
     parseSampleSize(study.sampleSize) ?? study.sampleSize,
+    Boolean(study.participantCountAmbiguous),
     study.dose,
     study.duration,
     study.population,


### PR DESCRIPTION
Expose studyClassAmbiguous and participantCountAmbiguous on each public study entity, derive summary counts from those rows, and add matching CSV columns. Includes regression coverage for a canonical publication with both ambiguity types.