### PR TITLE
fix(evidence-report): surface publication year ambiguity

### DIFF
--- a/lib/__tests__/public-evidence-publication-year-ambiguity.test.ts
+++ b/lib/__tests__/public-evidence-publication-year-ambiguity.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPublicEvidenceDatasetFromRecords,
+  publicEvidenceDatasetToCsv,
+} from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence publication-year ambiguity', () => {
+  it('does not choose one conflicting canonical publication year silently', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'year-2020',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/year-conflict',
+            year: 2020,
+            study_type: 'randomized controlled trial',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'year-2021',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/year-conflict',
+            pmid: '34559859',
+            year: 2021,
+            study_type: 'randomized controlled trial',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].year).toBeUndefined()
+    expect(dataset.studies[0].publicationYearAmbiguous).toBe(true)
+    expect(dataset.metrics.publicationYearAmbiguityStudyCount).toBe(1)
+
+    const csv = publicEvidenceDatasetToCsv(dataset)
+    expect(csv).toContain('year,year_ambiguous')
+    expect(csv).toContain('true,34559859')
+  })
+
+  it('uses one valid year over missing year metadata regardless of order', () => {
+    const missing = {
+      type: 'herb' as const,
+      record: record({
+        slug: 'missing-year',
+        sources: [{
+          title: 'Shared publication',
+          doi: '10.1000/year-known',
+          study_type: 'randomized controlled trial',
+        }],
+      }),
+    }
+    const known = {
+      type: 'compound' as const,
+      record: record({
+        slug: 'known-year',
+        sources: [{
+          title: 'Shared publication',
+          doi: '10.1000/year-known',
+          pmid: '34559859',
+          year: 2022,
+          study_type: 'randomized controlled trial',
+        }],
+      }),
+    }
+
+    for (const entities of [[missing, known], [known, missing]]) {
+      const dataset = buildPublicEvidenceDatasetFromRecords(entities)
+      expect(dataset.studies).toHaveLength(1)
+      expect(dataset.studies[0].year).toBe(2022)
+      expect(dataset.studies[0].publicationYearAmbiguous).toBe(false)
+      expect(dataset.metrics.publicationYearAmbiguityStudyCount).toBe(0)
+    }
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -57,6 +57,7 @@ export type PublicStudyEntity = {
   authors?: string
   journal?: string
   year?: number | string
+  publicationYearAmbiguous?: boolean
   pmid?: string
   doi?: string
   url?: string
@@ -99,6 +100,7 @@ export type PublicEvidenceReportMetrics = {
   participantCountCoverage: number
   participantCountAmbiguityStudyCount: number
   studyClassAmbiguityStudyCount: number
+  publicationYearAmbiguityStudyCount: number
   strongOrModerateIngredients: number
   preliminaryOrInsufficientIngredients: number
   unassignedIngredients: number
@@ -169,6 +171,12 @@ function cleanList(value: unknown): string[] {
   const text = cleanString(value)
   if (!text) return []
   return text.split(/[|;,]/).map(item => item.trim()).filter(Boolean)
+}
+
+function parsePublicationYear(value: unknown): number | null {
+  const year = Number(String(value ?? '').trim())
+  const currentYear = new Date().getFullYear()
+  return Number.isInteger(year) && year >= 1800 && year <= currentYear + 1 ? year : null
 }
 
 function canIndexRecord(record: RuntimeRecord): boolean {
@@ -266,6 +274,7 @@ function mergeStudyField<T>(current: T | undefined, incoming: T | undefined): T 
 export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]): PublicEvidenceDataset {
   const ingredients: PublicEvidenceIngredient[] = []
   const studiesById = new Map<string, PublicStudyEntity>()
+  const publicationYearsByStudyId = new Map<string, Set<number>>()
   const participantCountsByStudyId = new Map<string, Set<number>>()
   const evidenceClassesByStudyId = new Map<string, Set<EvidenceStudyClass>>()
   const gradeCounts = new Map<string, number>()
@@ -315,6 +324,12 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       const evidenceClass = citation.evidenceClass || normalizeEvidenceStudyClass(citation.studyType)
       const relationship = normalizeEvidenceRelationship(citation.relationship)
       const id = canonicalCitationIdentifier(citation, citationIdentities) || citation.id || evidenceStudyId(citation)
+      const publicationYear = parsePublicationYear(citation.year)
+      if (publicationYear !== null) {
+        const years = publicationYearsByStudyId.get(id) ?? new Set<number>()
+        years.add(publicationYear)
+        publicationYearsByStudyId.set(id, years)
+      }
       if (evidenceClass !== 'other') {
         const classes = evidenceClassesByStudyId.get(id) ?? new Set<EvidenceStudyClass>()
         classes.add(evidenceClass)
@@ -408,18 +423,32 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       .filter(([, counts]) => counts.size > 1)
       .map(([studyId]) => studyId),
   )
+  const ambiguousPublicationYearStudyIds = new Set(
+    [...publicationYearsByStudyId.entries()]
+      .filter(([, years]) => years.size > 1)
+      .map(([studyId]) => studyId),
+  )
   const studies = [...studiesById.values()]
     .map((study) => {
       const classes = evidenceClassesByStudyId.get(study.id)
+      const years = publicationYearsByStudyId.get(study.id)
       const studyClassAmbiguous = ambiguousStudyClassIds.has(study.id)
       const participantCountAmbiguous = ambiguousParticipantStudyIds.has(study.id)
+      const publicationYearAmbiguous = ambiguousPublicationYearStudyIds.has(study.id)
       const evidenceClass = !classes?.size
         ? study.evidenceClass
         : classes.size === 1
           ? [...classes][0]
           : 'other'
+      const year = !years?.size
+        ? study.year
+        : years.size === 1
+          ? [...years][0]
+          : undefined
       return {
         ...study,
+        year,
+        publicationYearAmbiguous,
         evidenceClass,
         studyClassAmbiguous,
         participantCountAmbiguous,
@@ -499,6 +528,7 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     participantCountCoverage: studyMetrics.studiesWithParticipantCounts,
     participantCountAmbiguityStudyCount: studies.filter(study => study.participantCountAmbiguous).length,
     studyClassAmbiguityStudyCount: studies.filter(study => study.studyClassAmbiguous).length,
+    publicationYearAmbiguityStudyCount: studies.filter(study => study.publicationYearAmbiguous).length,
     strongOrModerateIngredients: ingredients.filter(item => item.evidenceGrade === 'A' || item.evidenceGrade === 'B').length,
     preliminaryOrInsufficientIngredients: ingredients.filter(item => item.evidenceGrade === 'C' || item.evidenceGrade === 'D' || item.evidenceGrade === 'Avoid/Insufficient').length,
     unassignedIngredients: ingredients.filter(item => item.evidenceGrade === 'Unassigned').length,
@@ -620,7 +650,7 @@ function csvEscape(value: unknown): string {
 
 export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): string {
   const headers = [
-    'study_id', 'title', 'authors', 'journal', 'year', 'pmid', 'doi', 'study_class', 'study_class_ambiguous',
+    'study_id', 'title', 'authors', 'journal', 'year', 'year_ambiguous', 'pmid', 'doi', 'study_class', 'study_class_ambiguous',
     'sample_size', 'participant_count_ambiguous', 'dose', 'duration', 'population', 'outcome', 'result', 'limitation',
     'relationship_summary', 'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
   ]
@@ -631,6 +661,7 @@ export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): stri
     study.authors,
     study.journal,
     study.year,
+    Boolean(study.publicationYearAmbiguous),
     study.pmid,
     study.doi,
     study.evidenceClass,


### PR DESCRIPTION
Resolve canonical publication years deterministically in the public evidence dataset. One valid year wins over missing metadata; conflicting valid years are left blank and marked publicationYearAmbiguous, with a summary metric and CSV flag. Includes order-invariance regressions.