### PR TITLE
refactor(evidence-report): preserve relationship-specific study context

### DIFF
--- a/lib/__tests__/public-evidence-relationship-context.test.ts
+++ b/lib/__tests__/public-evidence-relationship-context.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPublicEvidenceDatasetFromRecords,
+  publicEvidenceDatasetToCsv,
+} from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence relationship-specific context', () => {
+  it('preserves differing ingredient contexts without selecting one at study level', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'alpha',
+          name: 'Alpha',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/relationship-context',
+            year: 2022,
+            study_type: 'randomized controlled trial',
+            dose: '300 mg/day',
+            duration: '8 weeks',
+            population: 'Adults with stress',
+            outcome: 'Stress score',
+            result: 'Stress score improved',
+            limitation: 'Small sample',
+            confidence: 'high',
+            statistical_consistency: 'consistent',
+            extract: 'Extract A',
+            conditions: ['stress'],
+            safety_outcome: 'No serious adverse events',
+            relationship: 'supports',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'beta',
+          name: 'Beta',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/relationship-context',
+            pmid: '34559859',
+            year: 2022,
+            study_type: 'randomized controlled trial',
+            dose: '600 mg/day',
+            duration: '8 weeks',
+            population: 'Adults with stress',
+            outcome: 'Sleep score',
+            result: 'Sleep score unchanged',
+            limitation: 'Secondary endpoint',
+            confidence: 'moderate',
+            statistical_consistency: 'mixed',
+            extract: 'Extract B',
+            conditions: ['sleep'],
+            safety_outcome: 'Mild gastrointestinal events',
+            relationship: 'no_clear_effect',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    const study = dataset.studies[0]
+    expect(study.relationships).toHaveLength(2)
+    expect(study.dose).toBeUndefined()
+    expect(study.outcome).toBeUndefined()
+    expect(study.result).toBeUndefined()
+    expect(study.limitation).toBeUndefined()
+    expect(study.extractName).toBeUndefined()
+    expect(study.safetyOutcome).toBeUndefined()
+    expect(study.statisticalConsistency).toBeUndefined()
+    expect(study.confidence).toBe('unknown')
+    expect(study.duration).toBe('8 weeks')
+    expect(study.population).toBe('Adults with stress')
+    expect(study.conditions.sort()).toEqual(['sleep', 'stress'])
+
+    expect(study.relationships.find(item => item.ingredientSlug === 'alpha')).toMatchObject({
+      dose: '300 mg/day',
+      outcome: 'Stress score',
+      result: 'Stress score improved',
+      confidence: 'high',
+      extractName: 'Extract A',
+      conditions: ['stress'],
+    })
+    expect(study.relationships.find(item => item.ingredientSlug === 'beta')).toMatchObject({
+      dose: '600 mg/day',
+      outcome: 'Sleep score',
+      result: 'Sleep score unchanged',
+      confidence: 'moderate',
+      extractName: 'Extract B',
+      conditions: ['sleep'],
+    })
+
+    const csv = publicEvidenceDatasetToCsv(dataset)
+    expect(csv.split('\n')[0]).toContain('relationships_json')
+    expect(csv).toContain('Stress score improved')
+    expect(csv).toContain('Sleep score unchanged')
+    expect(csv).toContain('300 mg/day')
+    expect(csv).toContain('600 mg/day')
+  })
+
+  it('retains a study-level shortcut when all relationship contexts agree', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          slug: 'alpha',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/consensus-context',
+            study_type: 'randomized controlled trial',
+            dose: '300 mg/day',
+            outcome: 'Stress score',
+            result: 'Improved versus placebo',
+            confidence: 'high',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          slug: 'beta',
+          sources: [{
+            title: 'Shared publication',
+            doi: '10.1000/consensus-context',
+            pmid: '34559859',
+            study_type: 'randomized controlled trial',
+            dose: '300 mg/day',
+            outcome: 'Stress score',
+            result: 'Improved versus placebo',
+            confidence: 'high',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies[0]).toMatchObject({
+      dose: '300 mg/day',
+      outcome: 'Stress score',
+      result: 'Improved versus placebo',
+      confidence: 'high',
+    })
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -48,7 +48,17 @@ export type PublicStudyRelationship = {
   ingredientPath: string
   evidenceGrade: string
   relationship: EvidenceRelationship
+  dose?: string
+  duration?: string
+  population?: string
   outcome?: string
+  result?: string
+  limitation?: string
+  confidence?: EvidenceConfidence
+  statisticalConsistency?: string
+  extractName?: string
+  conditions?: string[]
+  safetyOutcome?: string
 }
 
 export type PublicStudyEntity = {
@@ -238,6 +248,27 @@ function aggregateRelationship(relationships: PublicStudyRelationship[]): Eviden
   return 'background'
 }
 
+function consensusRelationshipString(
+  relationships: PublicStudyRelationship[],
+  field: 'dose' | 'duration' | 'population' | 'outcome' | 'result' | 'limitation' | 'statisticalConsistency' | 'extractName' | 'safetyOutcome',
+): string | undefined {
+  const values = relationships
+    .map((relationship) => cleanString(relationship[field]))
+    .filter(Boolean)
+  const normalized = new Map<string, string>()
+  for (const value of values) normalized.set(value.toLowerCase().replace(/\s+/g, ' '), value)
+  return normalized.size === 1 ? [...normalized.values()][0] : undefined
+}
+
+function consensusRelationshipConfidence(relationships: PublicStudyRelationship[]): EvidenceConfidence {
+  const values = new Set(
+    relationships
+      .map((relationship) => relationship.confidence)
+      .filter((value): value is EvidenceConfidence => Boolean(value) && value !== 'unknown'),
+  )
+  return values.size === 1 ? [...values][0] : 'unknown'
+}
+
 function toStudyRecord(study: PublicStudyEntity): EvidenceStudyRecord {
   return {
     id: study.id,
@@ -349,7 +380,17 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
         ingredientPath: path,
         evidenceGrade,
         relationship,
+        dose: citation.dose,
+        duration: citation.duration,
+        population: citation.population,
         outcome: citation.outcome,
+        result: citation.result,
+        limitation: citation.limitation,
+        confidence: normalizeEvidenceConfidence(citation.confidence),
+        statisticalConsistency: citation.statisticalConsistency,
+        extractName: citation.extractName,
+        conditions,
+        safetyOutcome: citation.safetyOutcome,
       }
 
       const existing = studiesById.get(id)
@@ -389,15 +430,6 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
         existing.url = mergeStudyField(existing.url, citation.url)
         existing.studyType = mergeStudyField(existing.studyType, citation.studyType)
         existing.sampleSize = mergeStudyField(existing.sampleSize, citation.sampleSize)
-        existing.dose = mergeStudyField(existing.dose, citation.dose)
-        existing.duration = mergeStudyField(existing.duration, citation.duration)
-        existing.population = mergeStudyField(existing.population, citation.population)
-        existing.outcome = mergeStudyField(existing.outcome, citation.outcome)
-        existing.result = mergeStudyField(existing.result, citation.result)
-        existing.limitation = mergeStudyField(existing.limitation, citation.limitation)
-        existing.statisticalConsistency = mergeStudyField(existing.statisticalConsistency, citation.statisticalConsistency)
-        existing.extractName = mergeStudyField(existing.extractName, citation.extractName)
-        existing.safetyOutcome = mergeStudyField(existing.safetyOutcome, citation.safetyOutcome)
         existing.conditions = [...new Set([...existing.conditions, ...conditions])]
         if (!existing.relationships.some(item =>
           item.ingredientSlug === relationshipRecord.ingredientSlug &&
@@ -452,6 +484,16 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
         evidenceClass,
         studyClassAmbiguous,
         participantCountAmbiguous,
+        dose: consensusRelationshipString(study.relationships, 'dose'),
+        duration: consensusRelationshipString(study.relationships, 'duration'),
+        population: consensusRelationshipString(study.relationships, 'population'),
+        outcome: consensusRelationshipString(study.relationships, 'outcome'),
+        result: consensusRelationshipString(study.relationships, 'result'),
+        limitation: consensusRelationshipString(study.relationships, 'limitation'),
+        confidence: consensusRelationshipConfidence(study.relationships),
+        statisticalConsistency: consensusRelationshipString(study.relationships, 'statisticalConsistency'),
+        extractName: consensusRelationshipString(study.relationships, 'extractName'),
+        safetyOutcome: consensusRelationshipString(study.relationships, 'safetyOutcome'),
       }
     })
     .sort((a, b) => {
@@ -653,6 +695,7 @@ export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): stri
     'study_id', 'title', 'authors', 'journal', 'year', 'year_ambiguous', 'pmid', 'doi', 'study_class', 'study_class_ambiguous',
     'sample_size', 'participant_count_ambiguous', 'dose', 'duration', 'population', 'outcome', 'result', 'limitation',
     'relationship_summary', 'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
+    'relationships_json',
   ]
 
   const rows = dataset.studies.map(study => [
@@ -680,6 +723,7 @@ export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): stri
     study.relationships.map(item => item.ingredientSlug).join('|'),
     study.relationships.map(item => item.ingredientName).join('|'),
     study.relationships.map(item => item.evidenceGrade).join('|'),
+    JSON.stringify(study.relationships),
   ].map(csvEscape).join(','))
 
   return `${headers.join(',')}\n${rows.join('\n')}\n`


### PR DESCRIPTION
Move ingredient-specific dose, duration, population, outcome/result, limitation, confidence, extract, conditions, and safety context onto each public study relationship. Keep study-level context only when relationship rows agree, and export the full relationship payload as relationships_json in CSV. Includes disagreement and consensus regressions.