### PR TITLE
fix(evidence-report): preserve multiple contexts from one publication

### DIFF
--- a/lib/__tests__/citation-context-extraction.test.ts
+++ b/lib/__tests__/citation-context-extraction.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractCitationContextsFromRecord,
+  extractCitationsFromRecord,
+} from '@/lib/citations'
+import { buildPublicEvidenceDatasetFromRecords } from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'example',
+    name: 'Example',
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('citation context extraction', () => {
+  const sources = [
+    {
+      title: 'One publication, multiple endpoints',
+      doi: '10.1000/multi-endpoint',
+      year: 2022,
+      study_type: 'randomized controlled trial',
+      outcome: 'Stress score',
+      result: 'Stress improved',
+      dose: '300 mg/day',
+      relationship: 'supports',
+    },
+    {
+      title: 'One publication, multiple endpoints',
+      doi: '10.1000/multi-endpoint',
+      year: 2022,
+      study_type: 'randomized controlled trial',
+      outcome: 'Sleep score',
+      result: 'Sleep unchanged',
+      dose: '300 mg/day',
+      relationship: 'no_clear_effect',
+    },
+  ]
+
+  it('keeps the existing publication-level extractor contract', () => {
+    expect(extractCitationsFromRecord({ sources })).toHaveLength(1)
+  })
+
+  it('preserves distinct structured contexts while collapsing exact duplicates', () => {
+    const contexts = extractCitationContextsFromRecord({ sources: [...sources, { ...sources[0] }] })
+    expect(contexts).toHaveLength(2)
+    expect(contexts.map(item => item.outcome).sort()).toEqual(['Sleep score', 'Stress score'])
+  })
+
+  it('keeps both endpoint relationships under one public canonical study', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({ slug: 'alpha', sources }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].relationships).toHaveLength(2)
+    expect(dataset.studies[0].relationships).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        ingredientSlug: 'alpha',
+        outcome: 'Stress score',
+        result: 'Stress improved',
+        relationship: 'supports',
+      }),
+      expect.objectContaining({
+        ingredientSlug: 'alpha',
+        outcome: 'Sleep score',
+        result: 'Sleep unchanged',
+        relationship: 'no_clear_effect',
+      }),
+    ]))
+    expect(dataset.studies[0].outcome).toBeUndefined()
+    expect(dataset.studies[0].result).toBeUndefined()
+    expect(dataset.studies[0].relationshipSummary).toBe('mixed')
+    expect(dataset.metrics.supportingRelationships).toBe(1)
+    expect(dataset.metrics.noClearEffectRelationships).toBe(1)
+  })
+})

--- a/lib/citations.ts
+++ b/lib/citations.ts
@@ -156,13 +156,46 @@ function citationKey(citation: Citation): string {
         : `title:${citation.title.trim().toLowerCase()}`)
 }
 
-export function extractCitationsFromRecord(record: Record<string, unknown>): Citation[] {
+function normalizedContextValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(item => String(item).trim()).filter(Boolean).sort()
+  if (typeof value === 'string') return value.trim().replace(/\s+/g, ' ').toLowerCase()
+  return value ?? null
+}
+
+function citationContextKey(citation: Citation): string {
+  return JSON.stringify([
+    citationKey(citation),
+    normalizedContextValue(citation.year),
+    normalizedContextValue(citation.authors),
+    normalizedContextValue(citation.journal),
+    normalizedContextValue(citation.studyType),
+    normalizedContextValue(citation.evidenceClass),
+    normalizedContextValue(citation.sampleSize),
+    normalizedContextValue(citation.dose),
+    normalizedContextValue(citation.duration),
+    normalizedContextValue(citation.population),
+    normalizedContextValue(citation.outcome),
+    normalizedContextValue(citation.result),
+    normalizedContextValue(citation.limitation),
+    normalizedContextValue(citation.relationship),
+    normalizedContextValue(citation.confidence),
+    normalizedContextValue(citation.statisticalConsistency),
+    normalizedContextValue(citation.extractName),
+    normalizedContextValue(citation.conditions),
+    normalizedContextValue(citation.safetyOutcome),
+  ])
+}
+
+function extractCitations(
+  record: Record<string, unknown>,
+  keyForCitation: (citation: Citation) => string,
+): Citation[] {
   const results: Citation[] = []
   const seen = new Set<string>()
 
   const pushCitation = (citation: Citation) => {
     if (!citation.title && !citation.pmid && !citation.doi && !citation.url) return
-    const key = citationKey(citation)
+    const key = keyForCitation(citation)
     if (seen.has(key)) return
     seen.add(key)
     results.push(citation)
@@ -211,4 +244,18 @@ export function extractCitationsFromRecord(record: Record<string, unknown>): Cit
   }
 
   return results
+}
+
+/** Publication-level citation inventory for reader-facing citation lists. */
+export function extractCitationsFromRecord(record: Record<string, unknown>): Citation[] {
+  return extractCitations(record, citationKey)
+}
+
+/**
+ * Citation rows for evidence-data consumers that need distinct endpoint or
+ * ingredient contexts from the same publication. Exact duplicate contexts are
+ * collapsed, but rows that differ in structured metadata are preserved.
+ */
+export function extractCitationContextsFromRecord(record: Record<string, unknown>): Citation[] {
+  return extractCitations(record, citationContextKey)
 }

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -2,7 +2,7 @@ import {
   buildCitationIdentifierIdentityMap,
   canonicalCitationIdentifier,
 } from '@/lib/citation-identifiers.mjs'
-import { extractCitationsFromRecord } from '@/lib/citations'
+import { extractCitationContextsFromRecord } from '@/lib/citations'
 import { getEvidenceLetterGrade } from '@/lib/evidence'
 import {
   evidenceStudyId,
@@ -248,6 +248,24 @@ function aggregateRelationship(relationships: PublicStudyRelationship[]): Eviden
   return 'background'
 }
 
+function relationshipContextKey(relationship: PublicStudyRelationship): string {
+  return JSON.stringify([
+    relationship.ingredientSlug,
+    relationship.relationship,
+    cleanString(relationship.dose).toLowerCase(),
+    cleanString(relationship.duration).toLowerCase(),
+    cleanString(relationship.population).toLowerCase(),
+    cleanString(relationship.outcome).toLowerCase(),
+    cleanString(relationship.result).toLowerCase(),
+    cleanString(relationship.limitation).toLowerCase(),
+    relationship.confidence ?? 'unknown',
+    cleanString(relationship.statisticalConsistency).toLowerCase(),
+    cleanString(relationship.extractName).toLowerCase(),
+    [...(relationship.conditions ?? [])].map(item => item.trim().toLowerCase()).filter(Boolean).sort(),
+    cleanString(relationship.safetyOutcome).toLowerCase(),
+  ])
+}
+
 function consensusRelationshipString(
   relationships: PublicStudyRelationship[],
   field: 'dose' | 'duration' | 'population' | 'outcome' | 'result' | 'limitation' | 'statisticalConsistency' | 'extractName' | 'safetyOutcome',
@@ -312,12 +330,12 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
   const categoryMap = new Map<string, EvidenceCategorySummary>()
   let explicitlyFlaggedClaimOverreach = 0
   const indexableEntities = entities.filter(({ record }) => canIndexRecord(record))
-  const citationsByPath = new Map<string, ReturnType<typeof extractCitationsFromRecord>>()
-  const allCitations: ReturnType<typeof extractCitationsFromRecord> = []
+  const citationsByPath = new Map<string, ReturnType<typeof extractCitationContextsFromRecord>>()
+  const allCitations: ReturnType<typeof extractCitationContextsFromRecord> = []
 
   for (const { record, type } of indexableEntities) {
     const path = `/${type === 'herb' ? 'herbs' : 'compounds'}/${record.slug}/`
-    const citations = extractCitationsFromRecord(record)
+    const citations = extractCitationContextsFromRecord(record)
     citationsByPath.set(path, citations)
     allCitations.push(...citations)
   }
@@ -431,11 +449,8 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
         existing.studyType = mergeStudyField(existing.studyType, citation.studyType)
         existing.sampleSize = mergeStudyField(existing.sampleSize, citation.sampleSize)
         existing.conditions = [...new Set([...existing.conditions, ...conditions])]
-        if (!existing.relationships.some(item =>
-          item.ingredientSlug === relationshipRecord.ingredientSlug &&
-          item.relationship === relationshipRecord.relationship &&
-          item.outcome === relationshipRecord.outcome,
-        )) {
+        const contextKey = relationshipContextKey(relationshipRecord)
+        if (!existing.relationships.some(item => relationshipContextKey(item) === contextKey)) {
           existing.relationships.push(relationshipRecord)
         }
         existing.relationshipSummary = aggregateRelationship(existing.relationships)


### PR DESCRIPTION
Add a context-preserving citation extractor without changing the existing publication-level extractor, use it only in the public evidence dataset, and dedupe public relationships by full structured context. This preserves multiple endpoints from the same publication on one ingredient while collapsing exact duplicate rows.