### PR TITLE
feat(evidence-report): track within-ingredient directional heterogeneity

### DIFF
--- a/lib/__tests__/public-evidence-within-ingredient-heterogeneity.test.ts
+++ b/lib/__tests__/public-evidence-within-ingredient-heterogeneity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPublicEvidenceDatasetFromRecords } from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(slug: string, sources: Array<Record<string, unknown>>): RuntimeRecord {
+  return {
+    slug,
+    name: slug,
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    sources,
+  } as RuntimeRecord
+}
+
+function source(outcome: string, relationship: string) {
+  return {
+    title: 'Shared publication',
+    doi: '10.1000/heterogeneity',
+    study_type: 'randomized controlled trial',
+    outcome,
+    relationship,
+  }
+}
+
+describe('within-ingredient directional heterogeneity', () => {
+  it('does not call cross-ingredient directional variation within-ingredient heterogeneity', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record('alpha', [source('Alpha endpoint', 'supports')]),
+      },
+      {
+        type: 'compound',
+        record: record('beta', [source('Beta endpoint', 'no_clear_effect')]),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].relationshipSummary).toBe('mixed')
+    expect(dataset.metrics.disagreementStudyCount).toBe(1)
+    expect(dataset.metrics.withinIngredientDirectionalHeterogeneityStudyCount).toBe(0)
+  })
+
+  it('flags multiple directional endpoint states for the same ingredient', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record('alpha', [
+          source('Primary endpoint', 'supports'),
+          source('Secondary endpoint', 'no_clear_effect'),
+        ]),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].relationshipSummary).toBe('mixed')
+    expect(dataset.metrics.disagreementStudyCount).toBe(1)
+    expect(dataset.metrics.withinIngredientDirectionalHeterogeneityStudyCount).toBe(1)
+  })
+
+  it('counts an explicitly mixed relationship as within-ingredient heterogeneity', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record('alpha', [source('Composite endpoint', 'mixed')]),
+      },
+    ])
+
+    expect(dataset.metrics.disagreementStudyCount).toBe(1)
+    expect(dataset.metrics.withinIngredientDirectionalHeterogeneityStudyCount).toBe(1)
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -121,6 +121,7 @@ export type PublicEvidenceReportMetrics = {
   contradictingRelationships: number
   noClearEffectRelationships: number
   disagreementStudyCount: number
+  withinIngredientDirectionalHeterogeneityStudyCount: number
   /** Null for synthetic/pure builders that do not execute canonical topology. */
   underlyingStudyMetricsSource: 'canonical-research-topology' | null
   /** Public/indexable profiles requested from and matched by the canonical research topology. */
@@ -246,6 +247,16 @@ function aggregateRelationship(relationships: PublicStudyRelationship[]): Eviden
   if (directional.size === 0) return 'background'
   if (directional.has('mixed') || directional.size > 1) return 'mixed'
   return [...directional][0]
+}
+
+function hasWithinIngredientDirectionalHeterogeneity(study: PublicStudyEntity): boolean {
+  const byIngredient = new Map<string, PublicStudyRelationship[]>()
+  for (const relationship of study.relationships) {
+    const values = byIngredient.get(relationship.ingredientSlug) ?? []
+    values.push(relationship)
+    byIngredient.set(relationship.ingredientSlug, values)
+  }
+  return [...byIngredient.values()].some((relationships) => aggregateRelationship(relationships) === 'mixed')
 }
 
 function relationshipContextKey(relationship: PublicStudyRelationship): string {
@@ -596,6 +607,7 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     contradictingRelationships,
     noClearEffectRelationships,
     disagreementStudyCount: studies.filter(study => study.relationshipSummary === 'mixed').length,
+    withinIngredientDirectionalHeterogeneityStudyCount: studies.filter(hasWithinIngredientDirectionalHeterogeneity).length,
     underlyingStudyMetricsSource: null,
     researchTopologyRequestedProfiles: null,
     researchTopologyMatchedProfiles: null,


### PR DESCRIPTION
Add a dedicated count for canonical studies whose directional contexts are mixed within the same ingredient, while retaining the broader mixed-study count. This prevents cross-ingredient variation from masquerading as within-ingredient endpoint heterogeneity.