### PR TITLE
feat(evidence-report): export ambiguity candidate values

### DIFF
--- a/lib/__tests__/public-evidence-ambiguity-flags.test.ts
+++ b/lib/__tests__/public-evidence-ambiguity-flags.test.ts
@@ -20,7 +20,7 @@ function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
 }
 
 describe('public evidence ambiguity flags', () => {
-  it('exports canonical study-class and participant-count ambiguity per study', () => {
+  it('exports canonical ambiguity flags and candidate values per study', () => {
     const dataset = buildPublicEvidenceDatasetFromRecords([
       {
         type: 'herb',
@@ -29,6 +29,7 @@ describe('public evidence ambiguity flags', () => {
           sources: [{
             title: 'Shared publication',
             doi: '10.1000/ambiguous-study',
+            year: 2020,
             study_type: 'randomized controlled trial',
             n: 100,
           }],
@@ -42,6 +43,7 @@ describe('public evidence ambiguity flags', () => {
             title: 'Shared publication',
             doi: '10.1000/ambiguous-study',
             pmid: '34559859',
+            year: 2021,
             study_type: 'systematic review',
             n: 120,
           }],
@@ -52,10 +54,17 @@ describe('public evidence ambiguity flags', () => {
     expect(dataset.studies).toHaveLength(1)
     expect(dataset.studies[0]).toMatchObject({
       id: 'doi:10.1000/ambiguous-study',
+      year: undefined,
+      publicationYearCandidates: [2020, 2021],
+      publicationYearAmbiguous: true,
       evidenceClass: 'other',
+      studyClassCandidates: ['randomized_controlled_trial', 'systematic_review'],
       studyClassAmbiguous: true,
+      sampleSize: undefined,
+      participantCountCandidates: [100, 120],
       participantCountAmbiguous: true,
     })
+    expect(dataset.metrics.publicationYearAmbiguityStudyCount).toBe(1)
     expect(dataset.metrics.studyClassAmbiguityStudyCount).toBe(1)
     expect(dataset.metrics.participantCountAmbiguityStudyCount).toBe(1)
     expect(dataset.metrics.humanTrialCount).toBe(0)
@@ -63,7 +72,11 @@ describe('public evidence ambiguity flags', () => {
     expect(dataset.metrics.participantCountCoverage).toBe(0)
 
     const csv = publicEvidenceDatasetToCsv(dataset)
-    expect(csv).toContain('study_class,study_class_ambiguous,sample_size,participant_count_ambiguous')
-    expect(csv).toContain('other,true,100,true')
+    expect(csv).toContain('year,year_candidates,year_ambiguous')
+    expect(csv).toContain('study_class,study_class_candidates,study_class_ambiguous')
+    expect(csv).toContain('sample_size,participant_count_candidates,participant_count_ambiguous')
+    expect(csv).toContain('2020|2021,true')
+    expect(csv).toContain('randomized_controlled_trial|systematic_review,true')
+    expect(csv).toContain(',100|120,true')
   })
 })

--- a/lib/__tests__/public-evidence-publication-year-ambiguity.test.ts
+++ b/lib/__tests__/public-evidence-publication-year-ambiguity.test.ts
@@ -51,12 +51,13 @@ describe('public evidence publication-year ambiguity', () => {
 
     expect(dataset.studies).toHaveLength(1)
     expect(dataset.studies[0].year).toBeUndefined()
+    expect(dataset.studies[0].publicationYearCandidates).toEqual([2020, 2021])
     expect(dataset.studies[0].publicationYearAmbiguous).toBe(true)
     expect(dataset.metrics.publicationYearAmbiguityStudyCount).toBe(1)
 
     const csv = publicEvidenceDatasetToCsv(dataset)
-    expect(csv).toContain('year,year_ambiguous')
-    expect(csv).toContain('true,34559859')
+    expect(csv).toContain('year,year_candidates,year_ambiguous')
+    expect(csv).toContain(',2020|2021,true,34559859')
   })
 
   it('uses one valid year over missing year metadata regardless of order', () => {
@@ -89,6 +90,7 @@ describe('public evidence publication-year ambiguity', () => {
       const dataset = buildPublicEvidenceDatasetFromRecords(entities)
       expect(dataset.studies).toHaveLength(1)
       expect(dataset.studies[0].year).toBe(2022)
+      expect(dataset.studies[0].publicationYearCandidates).toEqual([2022])
       expect(dataset.studies[0].publicationYearAmbiguous).toBe(false)
       expect(dataset.metrics.publicationYearAmbiguityStudyCount).toBe(0)
     }

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -67,14 +67,17 @@ export type PublicStudyEntity = {
   authors?: string
   journal?: string
   year?: number | string
+  publicationYearCandidates?: number[]
   publicationYearAmbiguous?: boolean
   pmid?: string
   doi?: string
   url?: string
   studyType?: string
   evidenceClass: EvidenceStudyClass
+  studyClassCandidates?: EvidenceStudyClass[]
   studyClassAmbiguous?: boolean
   sampleSize?: number | string
+  participantCountCandidates?: number[]
   participantCountAmbiguous?: boolean
   dose?: string
   duration?: string
@@ -471,44 +474,35 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
     categoryMap.set(category, categorySummary)
   }
 
-  const ambiguousStudyClassIds = new Set(
-    [...evidenceClassesByStudyId.entries()]
-      .filter(([, classes]) => classes.size > 1)
-      .map(([studyId]) => studyId),
-  )
-  const ambiguousParticipantStudyIds = new Set(
-    [...participantCountsByStudyId.entries()]
-      .filter(([, counts]) => counts.size > 1)
-      .map(([studyId]) => studyId),
-  )
-  const ambiguousPublicationYearStudyIds = new Set(
-    [...publicationYearsByStudyId.entries()]
-      .filter(([, years]) => years.size > 1)
-      .map(([studyId]) => studyId),
-  )
   const studies = [...studiesById.values()]
     .map((study) => {
-      const classes = evidenceClassesByStudyId.get(study.id)
-      const years = publicationYearsByStudyId.get(study.id)
-      const studyClassAmbiguous = ambiguousStudyClassIds.has(study.id)
-      const participantCountAmbiguous = ambiguousParticipantStudyIds.has(study.id)
-      const publicationYearAmbiguous = ambiguousPublicationYearStudyIds.has(study.id)
-      const evidenceClass = !classes?.size
+      const studyClassCandidates = [...(evidenceClassesByStudyId.get(study.id) ?? [])].sort()
+      const participantCountCandidates = [...(participantCountsByStudyId.get(study.id) ?? [])].sort((a, b) => a - b)
+      const publicationYearCandidates = [...(publicationYearsByStudyId.get(study.id) ?? [])].sort((a, b) => a - b)
+      const studyClassAmbiguous = studyClassCandidates.length > 1
+      const participantCountAmbiguous = participantCountCandidates.length > 1
+      const publicationYearAmbiguous = publicationYearCandidates.length > 1
+      const evidenceClass = studyClassCandidates.length === 0
         ? study.evidenceClass
-        : classes.size === 1
-          ? [...classes][0]
+        : studyClassCandidates.length === 1
+          ? studyClassCandidates[0]
           : 'other'
-      const year = !years?.size
+      const year = publicationYearCandidates.length === 0
         ? study.year
-        : years.size === 1
-          ? [...years][0]
+        : publicationYearCandidates.length === 1
+          ? publicationYearCandidates[0]
           : undefined
+      const sampleSize = participantCountAmbiguous ? undefined : study.sampleSize
       return {
         ...study,
         year,
+        publicationYearCandidates,
         publicationYearAmbiguous,
         evidenceClass,
+        studyClassCandidates,
         studyClassAmbiguous,
+        sampleSize,
+        participantCountCandidates,
         participantCountAmbiguous,
         dose: consensusRelationshipString(study.relationships, 'dose'),
         duration: consensusRelationshipString(study.relationships, 'duration'),
@@ -527,9 +521,7 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       if (yearDiff !== 0) return yearDiff
       return a.title.localeCompare(b.title)
     })
-  const studyMetrics = summarizeEvidenceStudies(studies.map((study) =>
-    toStudyRecord(study.participantCountAmbiguous ? { ...study, sampleSize: undefined } : study),
-  ))
+  const studyMetrics = summarizeEvidenceStudies(studies.map(toStudyRecord))
   const categoryBySlug = new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient.category] as const))
 
   for (const study of studies) {
@@ -719,8 +711,10 @@ function csvEscape(value: unknown): string {
 
 export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): string {
   const headers = [
-    'study_id', 'title', 'authors', 'journal', 'year', 'year_ambiguous', 'pmid', 'doi', 'study_class', 'study_class_ambiguous',
-    'sample_size', 'participant_count_ambiguous', 'dose', 'duration', 'population', 'outcome', 'result', 'limitation',
+    'study_id', 'title', 'authors', 'journal', 'year', 'year_candidates', 'year_ambiguous', 'pmid', 'doi',
+    'study_class', 'study_class_candidates', 'study_class_ambiguous',
+    'sample_size', 'participant_count_candidates', 'participant_count_ambiguous',
+    'dose', 'duration', 'population', 'outcome', 'result', 'limitation',
     'relationship_summary', 'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
     'relationships_json',
   ]
@@ -731,12 +725,15 @@ export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): stri
     study.authors,
     study.journal,
     study.year,
+    (study.publicationYearCandidates ?? []).join('|'),
     Boolean(study.publicationYearAmbiguous),
     study.pmid,
     study.doi,
     study.evidenceClass,
+    (study.studyClassCandidates ?? []).join('|'),
     Boolean(study.studyClassAmbiguous),
     parseSampleSize(study.sampleSize) ?? study.sampleSize,
+    (study.participantCountCandidates ?? []).join('|'),
     Boolean(study.participantCountAmbiguous),
     study.dose,
     study.duration,


### PR DESCRIPTION
Expose observed candidate values for publication year, concrete study class, and participant count on each canonical public study row. Conflicting participant counts now leave canonical sampleSize blank instead of preserving a first-row value. CSV exports candidate sets explicitly, and existing ambiguity regressions are updated to validate both candidate provenance and single-candidate resolution.