### PR TITLE
feat(evidence-report): quantify metadata ambiguity magnitude

### DIFF
--- a/app/evidence/evidence-report/AmbiguityMagnitudePanel.tsx
+++ b/app/evidence/evidence-report/AmbiguityMagnitudePanel.tsx
@@ -1,0 +1,50 @@
+import { analyzePublicEvidenceAmbiguity } from '@/lib/public-evidence-ambiguity-analysis'
+import type { PublicStudyEntity } from '@/lib/public-evidence-dataset'
+
+type Props = {
+  studies: PublicStudyEntity[]
+}
+
+function formatRatio(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0×'
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')}×`
+}
+
+export default function AmbiguityMagnitudePanel({ studies }: Props) {
+  const { summary } = analyzePublicEvidenceAmbiguity(studies)
+  if (summary.studiesWithAnyAmbiguity === 0) return null
+
+  return (
+    <section className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8" aria-labelledby="ambiguity-magnitude-title">
+      <div className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+        <p className="eyebrow-label">Metadata reconciliation</p>
+        <h2 id="ambiguity-magnitude-title" className="mt-2 text-2xl font-semibold text-ink">How large are the unresolved metadata conflicts?</h2>
+        <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
+          These are raw conflict magnitudes, not subjective severity scores. Candidate values remain available in the downloadable dataset so discrepancies can be reconciled at the source level.
+        </p>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+            <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Ambiguous studies</p>
+            <p className="mt-2 text-2xl font-bold text-ink">{summary.studiesWithAnyAmbiguity.toLocaleString()}</p>
+            <p className="mt-1 text-xs leading-5 text-muted">Canonical publications with a year, participant-count, or concrete study-class conflict.</p>
+          </div>
+          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+            <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Cross-family class conflicts</p>
+            <p className="mt-2 text-2xl font-bold text-ink">{summary.crossFamilyStudyClassConflictCount.toLocaleString()}</p>
+            <p className="mt-1 text-xs leading-5 text-muted">Class disagreements that cross evidence families rather than staying within one design family.</p>
+          </div>
+          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+            <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Largest year span</p>
+            <p className="mt-2 text-2xl font-bold text-ink">{summary.largestPublicationYearSpan.toLocaleString()} yr</p>
+            <p className="mt-1 text-xs leading-5 text-muted">Maximum difference between observed publication-year candidates for one canonical study.</p>
+          </div>
+          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+            <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Largest participant mismatch</p>
+            <p className="mt-2 text-2xl font-bold text-ink">{formatRatio(summary.largestParticipantCountRatio)}</p>
+            <p className="mt-1 text-xs leading-5 text-muted">Largest ratio between conflicting structured participant-count candidates; maximum absolute spread is {summary.largestParticipantCountAbsoluteSpread.toLocaleString()}.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/evidence/evidence-report/page.tsx
+++ b/app/evidence/evidence-report/page.tsx
@@ -4,6 +4,7 @@ import { buildPageMetadata } from '@/src/lib/seo'
 import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
 import { evidenceGradeHistory } from '@/data/editorial/evidence-grade-history'
 import EvidenceReportClient from './EvidenceReportClient'
+import AmbiguityMagnitudePanel from './AmbiguityMagnitudePanel'
 import CategoryEvidenceMixPanel from './CategoryEvidenceMixPanel'
 import UnderlyingStudyIndependencePanel from './UnderlyingStudyIndependencePanel'
 import UnassignedEvidenceStatusPanel from './UnassignedEvidenceStatusPanel'
@@ -26,6 +27,7 @@ export default async function EvidenceReportPage() {
         metrics={dataset.metrics}
         changeHistory={evidenceGradeHistory}
       />
+      <AmbiguityMagnitudePanel studies={dataset.studies} />
       <UnderlyingStudyIndependencePanel metrics={dataset.metrics} />
       <UnassignedEvidenceStatusPanel dataset={dataset} />
       <CategoryEvidenceMixPanel dataset={dataset} />

--- a/lib/__tests__/public-evidence-ambiguity-analysis.test.ts
+++ b/lib/__tests__/public-evidence-ambiguity-analysis.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  analyzePublicEvidenceAmbiguity,
+  analyzePublicStudyAmbiguity,
+} from '@/lib/public-evidence-ambiguity-analysis'
+import type { PublicStudyEntity } from '@/lib/public-evidence-dataset'
+
+function study(overrides: Partial<PublicStudyEntity>): PublicStudyEntity {
+  return {
+    id: 'doi:10.1000/example',
+    title: 'Example publication',
+    evidenceClass: 'other',
+    confidence: 'unknown',
+    conditions: [],
+    relationships: [],
+    relationshipSummary: 'background',
+    ...overrides,
+  }
+}
+
+describe('public evidence ambiguity magnitude', () => {
+  it('derives objective spans and cross-family class conflict without severity thresholds', () => {
+    const result = analyzePublicStudyAmbiguity(study({
+      publicationYearCandidates: [2020, 2023],
+      publicationYearAmbiguous: true,
+      participantCountCandidates: [100, 250],
+      participantCountAmbiguous: true,
+      studyClassCandidates: ['randomized_controlled_trial', 'systematic_review'],
+      studyClassAmbiguous: true,
+    }))
+
+    expect(result).toEqual({
+      publicationYearSpan: 3,
+      participantCountAbsoluteSpread: 150,
+      participantCountRatio: 2.5,
+      studyClassFamilies: ['primary-human-trial', 'synthesis'],
+      crossFamilyStudyClassConflict: true,
+    })
+  })
+
+  it('keeps same-family design ambiguity distinct from cross-family conflict', () => {
+    const result = analyzePublicStudyAmbiguity(study({
+      studyClassCandidates: ['randomized_controlled_trial', 'controlled_trial'],
+      studyClassAmbiguous: true,
+    }))
+
+    expect(result.studyClassFamilies).toEqual(['primary-human-trial'])
+    expect(result.crossFamilyStudyClassConflict).toBe(false)
+    expect(result.publicationYearSpan).toBeNull()
+    expect(result.participantCountAbsoluteSpread).toBeNull()
+    expect(result.participantCountRatio).toBeNull()
+  })
+
+  it('summarizes the largest observed conflict magnitudes across the public study inventory', () => {
+    const analysis = analyzePublicEvidenceAmbiguity([
+      study({
+        id: 'doi:10.1000/one',
+        publicationYearCandidates: [2020, 2021],
+        publicationYearAmbiguous: true,
+        participantCountCandidates: [100, 120],
+        participantCountAmbiguous: true,
+        studyClassCandidates: ['randomized_controlled_trial', 'controlled_trial'],
+        studyClassAmbiguous: true,
+      }),
+      study({
+        id: 'doi:10.1000/two',
+        publicationYearCandidates: [2018, 2023],
+        publicationYearAmbiguous: true,
+        participantCountCandidates: [50, 200],
+        participantCountAmbiguous: true,
+        studyClassCandidates: ['animal', 'randomized_controlled_trial'],
+        studyClassAmbiguous: true,
+      }),
+      study({ id: 'doi:10.1000/clean' }),
+    ])
+
+    expect(analysis.summary).toEqual({
+      studiesAnalyzed: 3,
+      studiesWithAnyAmbiguity: 2,
+      crossFamilyStudyClassConflictCount: 1,
+      largestPublicationYearSpan: 5,
+      largestParticipantCountAbsoluteSpread: 150,
+      largestParticipantCountRatio: 4,
+    })
+  })
+})

--- a/lib/public-evidence-ambiguity-analysis.ts
+++ b/lib/public-evidence-ambiguity-analysis.ts
@@ -1,0 +1,92 @@
+import type { EvidenceStudyClass } from '@/lib/evidence-study'
+import type { PublicStudyEntity } from '@/lib/public-evidence-dataset'
+
+export type PublicEvidenceStudyClassFamily =
+  | 'synthesis'
+  | 'primary-human-trial'
+  | 'other-human'
+  | 'narrative'
+  | 'preclinical'
+  | 'other'
+
+export type PublicStudyAmbiguityMagnitude = {
+  publicationYearSpan: number | null
+  participantCountAbsoluteSpread: number | null
+  participantCountRatio: number | null
+  studyClassFamilies: PublicEvidenceStudyClassFamily[]
+  crossFamilyStudyClassConflict: boolean
+}
+
+export type PublicEvidenceAmbiguityAnalysis = {
+  studies: Array<{
+    studyId: string
+    magnitude: PublicStudyAmbiguityMagnitude
+  }>
+  summary: {
+    studiesAnalyzed: number
+    studiesWithAnyAmbiguity: number
+    crossFamilyStudyClassConflictCount: number
+    largestPublicationYearSpan: number
+    largestParticipantCountAbsoluteSpread: number
+    largestParticipantCountRatio: number
+  }
+}
+
+function studyClassFamily(studyClass: EvidenceStudyClass): PublicEvidenceStudyClassFamily {
+  if (studyClass === 'meta_analysis' || studyClass === 'systematic_review') return 'synthesis'
+  if (studyClass === 'randomized_controlled_trial' || studyClass === 'controlled_trial') return 'primary-human-trial'
+  if (studyClass === 'observational' || studyClass === 'case_report') return 'other-human'
+  if (studyClass === 'narrative_review') return 'narrative'
+  if (studyClass === 'animal' || studyClass === 'in_vitro' || studyClass === 'mechanistic') return 'preclinical'
+  return 'other'
+}
+
+function span(values: number[]): number | null {
+  if (values.length < 2) return null
+  return values[values.length - 1] - values[0]
+}
+
+export function analyzePublicStudyAmbiguity(study: PublicStudyEntity): PublicStudyAmbiguityMagnitude {
+  const yearCandidates = [...(study.publicationYearCandidates ?? [])].sort((a, b) => a - b)
+  const participantCandidates = [...(study.participantCountCandidates ?? [])].sort((a, b) => a - b)
+  const studyClassFamilies = [...new Set(
+    (study.studyClassCandidates ?? []).map(studyClassFamily),
+  )].sort() as PublicEvidenceStudyClassFamily[]
+  const participantCountAbsoluteSpread = span(participantCandidates)
+  const minParticipantCount = participantCandidates[0]
+  const maxParticipantCount = participantCandidates[participantCandidates.length - 1]
+  const participantCountRatio = participantCandidates.length >= 2 && minParticipantCount > 0
+    ? maxParticipantCount / minParticipantCount
+    : null
+
+  return {
+    publicationYearSpan: span(yearCandidates),
+    participantCountAbsoluteSpread,
+    participantCountRatio,
+    studyClassFamilies,
+    crossFamilyStudyClassConflict: studyClassFamilies.length > 1,
+  }
+}
+
+export function analyzePublicEvidenceAmbiguity(studies: PublicStudyEntity[]): PublicEvidenceAmbiguityAnalysis {
+  const analyzed = studies.map((study) => ({
+    studyId: study.id,
+    magnitude: analyzePublicStudyAmbiguity(study),
+  }))
+
+  const studiesWithAnyAmbiguity = studies.filter((study) =>
+    study.publicationYearAmbiguous || study.participantCountAmbiguous || study.studyClassAmbiguous,
+  ).length
+
+  return {
+    studies: analyzed,
+    summary: {
+      studiesAnalyzed: studies.length,
+      studiesWithAnyAmbiguity,
+      crossFamilyStudyClassConflictCount: analyzed.filter((item) => item.magnitude.crossFamilyStudyClassConflict).length,
+      largestPublicationYearSpan: Math.max(0, ...analyzed.map((item) => item.magnitude.publicationYearSpan ?? 0)),
+      largestParticipantCountAbsoluteSpread: Math.max(0, ...analyzed.map((item) => item.magnitude.participantCountAbsoluteSpread ?? 0)),
+      largestParticipantCountRatio: Math.max(0, ...analyzed.map((item) => item.magnitude.participantCountRatio ?? 0)),
+    },
+  }
+}


### PR DESCRIPTION
Derive objective ambiguity magnitude from the canonical candidate arrays: publication-year span, participant-count absolute spread and ratio, and same-family versus cross-family study-class conflict. Surface a server-rendered summary panel in the evidence report. No subjective severity thresholds and no second source of truth; all values are derived from exported study candidates.