### PR TITLE
fix(evidence-report): make public dataset exports deterministic

### DIFF
--- a/app/evidence/evidence-report/dataset.csv/route.ts
+++ b/app/evidence/evidence-report/dataset.csv/route.ts
@@ -2,11 +2,12 @@ import {
   getPublicEvidenceDataset,
   publicEvidenceDatasetToCsv,
 } from '@/lib/public-evidence-dataset'
+import { normalizePublicEvidenceDatasetForExport } from '@/lib/public-evidence-export'
 
 export const dynamic = 'force-static'
 
 export async function GET() {
-  const dataset = await getPublicEvidenceDataset()
+  const dataset = normalizePublicEvidenceDatasetForExport(await getPublicEvidenceDataset())
   return new Response(publicEvidenceDatasetToCsv(dataset), {
     headers: {
       'content-type': 'text/csv; charset=utf-8',

--- a/app/evidence/evidence-report/dataset.json/route.ts
+++ b/app/evidence/evidence-report/dataset.json/route.ts
@@ -1,9 +1,10 @@
 import { getPublicEvidenceDataset } from '@/lib/public-evidence-dataset'
+import { normalizePublicEvidenceDatasetForExport } from '@/lib/public-evidence-export'
 
 export const dynamic = 'force-static'
 
 export async function GET() {
-  const dataset = await getPublicEvidenceDataset()
+  const dataset = normalizePublicEvidenceDatasetForExport(await getPublicEvidenceDataset())
   return new Response(`${JSON.stringify(dataset, null, 2)}\n`, {
     headers: {
       'content-type': 'application/json; charset=utf-8',

--- a/lib/__tests__/public-evidence-export-determinism.test.ts
+++ b/lib/__tests__/public-evidence-export-determinism.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizePublicEvidenceDatasetForExport } from '@/lib/public-evidence-export'
+import type { PublicEvidenceDataset, PublicStudyEntity } from '@/lib/public-evidence-dataset'
+
+function study(overrides: Partial<PublicStudyEntity>): PublicStudyEntity {
+  return {
+    id: 'doi:10.1000/example',
+    title: 'Example publication',
+    evidenceClass: 'randomized_controlled_trial',
+    confidence: 'moderate',
+    conditions: ['Sleep', 'Stress'],
+    relationships: [],
+    relationshipSummary: 'supports',
+    ...overrides,
+  }
+}
+
+function dataset(studies: PublicStudyEntity[]): PublicEvidenceDataset {
+  return {
+    schemaVersion: 1,
+    datasetVersion: 'test',
+    title: 'Test dataset',
+    generatedFrom: 'current indexable runtime records',
+    methodologyPath: '/info/editorial-policy/',
+    citationExplorerPath: '/learn/citation-explorer/',
+    citationText: 'Test citation',
+    ingredients: [
+      { slug: 'z', name: 'Same', type: 'herb', path: '/herbs/z/', evidenceGrade: 'B', category: 'Stress', safetyCaution: false },
+      { slug: 'a', name: 'Same', type: 'compound', path: '/compounds/a/', evidenceGrade: 'B', category: 'Stress', safetyCaution: false },
+    ],
+    studies,
+    metrics: {} as PublicEvidenceDataset['metrics'],
+  }
+}
+
+describe('public evidence export determinism', () => {
+  it('normalizes semantically identical study and relationship ordering', () => {
+    const relationships = [
+      {
+        ingredientSlug: 'z',
+        ingredientName: 'Z',
+        ingredientType: 'herb' as const,
+        ingredientPath: '/herbs/z/',
+        evidenceGrade: 'B',
+        relationship: 'no_clear_effect' as const,
+        outcome: 'Sleep latency',
+        conditions: ['Stress', 'Sleep'],
+      },
+      {
+        ingredientSlug: 'a',
+        ingredientName: 'A',
+        ingredientType: 'compound' as const,
+        ingredientPath: '/compounds/a/',
+        evidenceGrade: 'B',
+        relationship: 'supports' as const,
+        outcome: 'Sleep quality',
+        conditions: ['Sleep', 'Stress'],
+      },
+    ]
+
+    const first = dataset([
+      study({
+        id: 'doi:10.1000/b',
+        title: 'Same title',
+        year: 2024,
+        publicationYearCandidates: [2024, 2023],
+        participantCountCandidates: [120, 100],
+        studyClassCandidates: ['systematic_review', 'randomized_controlled_trial'],
+        conditions: ['Stress', 'Sleep'],
+        relationships,
+      }),
+      study({ id: 'doi:10.1000/a', title: 'Same title', year: 2024 }),
+    ])
+
+    const second = dataset([
+      study({ id: 'doi:10.1000/a', title: 'Same title', year: 2024 }),
+      study({
+        id: 'doi:10.1000/b',
+        title: 'Same title',
+        year: 2024,
+        publicationYearCandidates: [2023, 2024],
+        participantCountCandidates: [100, 120],
+        studyClassCandidates: ['randomized_controlled_trial', 'systematic_review'],
+        conditions: ['Sleep', 'Stress'],
+        relationships: [...relationships].reverse().map((relationship) => ({
+          ...relationship,
+          conditions: [...(relationship.conditions ?? [])].reverse(),
+        })),
+      }),
+    ])
+
+    const normalizedFirst = normalizePublicEvidenceDatasetForExport(first)
+    const normalizedSecond = normalizePublicEvidenceDatasetForExport(second)
+
+    expect(JSON.stringify(normalizedFirst)).toBe(JSON.stringify(normalizedSecond))
+    expect(normalizedFirst.ingredients.map((item) => item.path)).toEqual(['/compounds/a/', '/herbs/z/'])
+    expect(normalizedFirst.studies.map((item) => item.id)).toEqual(['doi:10.1000/a', 'doi:10.1000/b'])
+    expect(normalizedFirst.studies[1].participantCountCandidates).toEqual([100, 120])
+    expect(normalizedFirst.studies[1].conditions).toEqual(['Sleep', 'Stress'])
+    expect(normalizedFirst.studies[1].relationships.map((item) => item.ingredientSlug)).toEqual(['a', 'z'])
+  })
+})

--- a/lib/public-evidence-export.ts
+++ b/lib/public-evidence-export.ts
@@ -1,0 +1,60 @@
+import type {
+  PublicEvidenceDataset,
+  PublicStudyRelationship,
+} from '@/lib/public-evidence-dataset'
+
+function clean(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+function relationshipSortKey(relationship: PublicStudyRelationship): string {
+  return JSON.stringify([
+    clean(relationship.ingredientSlug),
+    clean(relationship.relationship),
+    clean(relationship.outcome),
+    clean(relationship.result),
+    clean(relationship.dose),
+    clean(relationship.duration),
+    clean(relationship.population),
+    clean(relationship.limitation),
+    clean(relationship.confidence),
+    clean(relationship.statisticalConsistency),
+    clean(relationship.extractName),
+    [...(relationship.conditions ?? [])].map(clean).filter(Boolean).sort(),
+    clean(relationship.safetyOutcome),
+  ])
+}
+
+export function normalizePublicEvidenceDatasetForExport(dataset: PublicEvidenceDataset): PublicEvidenceDataset {
+  const ingredients = dataset.ingredients
+    .map((ingredient) => ({ ...ingredient }))
+    .sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path))
+
+  const studies = dataset.studies
+    .map((study) => ({
+      ...study,
+      publicationYearCandidates: study.publicationYearCandidates ? [...study.publicationYearCandidates].sort((a, b) => a - b) : undefined,
+      studyClassCandidates: study.studyClassCandidates ? [...study.studyClassCandidates].sort() : undefined,
+      participantCountCandidates: study.participantCountCandidates ? [...study.participantCountCandidates].sort((a, b) => a - b) : undefined,
+      conditions: [...study.conditions].sort((a, b) => a.localeCompare(b)),
+      relationships: study.relationships
+        .map((relationship) => ({
+          ...relationship,
+          conditions: relationship.conditions
+            ? [...relationship.conditions].sort((a, b) => a.localeCompare(b))
+            : undefined,
+        }))
+        .sort((a, b) => relationshipSortKey(a).localeCompare(relationshipSortKey(b))),
+    }))
+    .sort((a, b) => {
+      const yearDiff = Number(b.year || 0) - Number(a.year || 0)
+      if (yearDiff !== 0) return yearDiff
+      return a.title.localeCompare(b.title) || a.id.localeCompare(b.id)
+    })
+
+  return {
+    ...dataset,
+    ingredients,
+    studies,
+  }
+}


### PR DESCRIPTION
Normalize the public evidence snapshot at export time so semantically equivalent input ordering produces stable JSON/CSV output. Candidate arrays, study conditions, relationship conditions, relationships, ingredients, and same-year/title study ties are sorted deterministically. The core builder remains untouched; both download routes consume the canonical export normalizer.