### PR TITLE
fix(evidence-report): stabilize relationship export identity

### DIFF
--- a/lib/__tests__/public-evidence-export-determinism.test.ts
+++ b/lib/__tests__/public-evidence-export-determinism.test.ts
@@ -100,4 +100,37 @@ describe('public evidence export determinism', () => {
     expect(normalizedFirst.studies[1].conditions).toEqual(['Sleep', 'Stress'])
     expect(normalizedFirst.studies[1].relationships.map((item) => item.ingredientSlug)).toEqual(['a', 'z'])
   })
+
+  it('stabilizes relationship ordering when herb and compound identities share a slug', () => {
+    const sharedContext = {
+      ingredientSlug: 'shared',
+      ingredientName: 'Shared',
+      evidenceGrade: 'B',
+      relationship: 'supports' as const,
+      outcome: 'Same endpoint',
+    }
+    const herbRelationship = {
+      ...sharedContext,
+      ingredientType: 'herb' as const,
+      ingredientPath: '/herbs/shared/',
+    }
+    const compoundRelationship = {
+      ...sharedContext,
+      ingredientType: 'compound' as const,
+      ingredientPath: '/compounds/shared/',
+    }
+
+    const first = normalizePublicEvidenceDatasetForExport(dataset([
+      study({ relationships: [herbRelationship, compoundRelationship] }),
+    ]))
+    const second = normalizePublicEvidenceDatasetForExport(dataset([
+      study({ relationships: [compoundRelationship, herbRelationship] }),
+    ]))
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+    expect(first.studies[0].relationships.map((item) => item.ingredientPath)).toEqual([
+      '/compounds/shared/',
+      '/herbs/shared/',
+    ])
+  })
 })

--- a/lib/public-evidence-export.ts
+++ b/lib/public-evidence-export.ts
@@ -10,6 +10,10 @@ function clean(value: unknown): string {
 function relationshipSortKey(relationship: PublicStudyRelationship): string {
   return JSON.stringify([
     clean(relationship.ingredientSlug),
+    clean(relationship.ingredientType),
+    clean(relationship.ingredientPath),
+    clean(relationship.ingredientName),
+    clean(relationship.evidenceGrade),
     clean(relationship.relationship),
     clean(relationship.outcome),
     clean(relationship.result),


### PR DESCRIPTION
## Summary
- make public evidence relationship export sorting distinguish same-slug herb/compound identities
- include type/path/name/grade in the deterministic sort key
- add regression proving reversed input produces identical output for a cross-type slug collision

## Why
PR #3852 made public dataset exports deterministic, but relationships with the same slug and identical study context could still compare equal when their ingredient types/paths differed. This closes that remaining input-order dependency.