### PR TITLE
polish(evidence-report): unify analysis panel surfaces

### DIFF
--- a/app/evidence/evidence-report/AmbiguityMagnitudePanel.tsx
+++ b/app/evidence/evidence-report/AmbiguityMagnitudePanel.tsx
@@ -10,35 +10,37 @@ function formatRatio(value: number): string {
   return `${value >= 10 ? value.toFixed(0) : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')}×`
 }
 
+const metricCardClass = 'rounded-xl border border-[var(--border-soft)] bg-[var(--surface-subtle)] p-4'
+
 export default function AmbiguityMagnitudePanel({ studies }: Props) {
   const { summary } = analyzePublicEvidenceAmbiguity(studies)
   if (summary.studiesWithAnyAmbiguity === 0) return null
 
   return (
     <section className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8" aria-labelledby="ambiguity-magnitude-title">
-      <div className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+      <div className="card-premium p-6 sm:p-8">
         <p className="eyebrow-label">Metadata reconciliation</p>
         <h2 id="ambiguity-magnitude-title" className="mt-2 text-2xl font-semibold text-ink">How large are the unresolved metadata conflicts?</h2>
         <p className="mt-3 max-w-4xl text-sm leading-7 text-muted">
           These are raw conflict magnitudes, not subjective severity scores. Candidate values remain available in the downloadable dataset so discrepancies can be reconciled at the source level.
         </p>
         <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <div className={metricCardClass}>
             <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Ambiguous studies</p>
             <p className="mt-2 text-2xl font-bold text-ink">{summary.studiesWithAnyAmbiguity.toLocaleString()}</p>
             <p className="mt-1 text-xs leading-5 text-muted">Canonical publications with a year, participant-count, or concrete study-class conflict.</p>
           </div>
-          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <div className={metricCardClass}>
             <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Cross-family class conflicts</p>
             <p className="mt-2 text-2xl font-bold text-ink">{summary.crossFamilyStudyClassConflictCount.toLocaleString()}</p>
             <p className="mt-1 text-xs leading-5 text-muted">Class disagreements that cross evidence families rather than staying within one design family.</p>
           </div>
-          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <div className={metricCardClass}>
             <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Largest year span</p>
             <p className="mt-2 text-2xl font-bold text-ink">{summary.largestPublicationYearSpan.toLocaleString()} yr</p>
             <p className="mt-1 text-xs leading-5 text-muted">Maximum difference between observed publication-year candidates for one canonical study.</p>
           </div>
-          <div className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+          <div className={metricCardClass}>
             <p className="text-xs font-bold uppercase tracking-[0.12em] text-brand-700">Largest participant mismatch</p>
             <p className="mt-2 text-2xl font-bold text-ink">{formatRatio(summary.largestParticipantCountRatio)}</p>
             <p className="mt-1 text-xs leading-5 text-muted">Largest ratio between conflicting structured participant-count candidates; maximum absolute spread is {summary.largestParticipantCountAbsoluteSpread.toLocaleString()}.</p>

--- a/app/evidence/evidence-report/CategoryEvidenceMixPanel.tsx
+++ b/app/evidence/evidence-report/CategoryEvidenceMixPanel.tsx
@@ -15,7 +15,7 @@ export default function CategoryEvidenceMixPanel({ dataset }: Props) {
 
   return (
     <section className="mx-auto mb-10 max-w-6xl px-4 sm:px-6 lg:px-8" aria-labelledby="category-evidence-mix-title">
-      <div className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+      <div className="card-premium p-6 sm:p-8">
         <p className="eyebrow-label">Evidence-design mix</p>
         <h2 id="category-evidence-mix-title" className="mt-2 text-2xl font-semibold text-ink">
           Which categories rely on direct human research, synthesis, or preclinical evidence?

--- a/app/evidence/evidence-report/UnassignedEvidenceStatusPanel.tsx
+++ b/app/evidence/evidence-report/UnassignedEvidenceStatusPanel.tsx
@@ -18,7 +18,7 @@ export default function UnassignedEvidenceStatusPanel({ dataset }: Props) {
 
   return (
     <section className="mx-auto mb-10 max-w-6xl px-4 sm:px-6 lg:px-8" aria-labelledby="unassigned-evidence-status-title">
-      <div className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8">
+      <div className="card-premium p-6 sm:p-8">
         <p className="eyebrow-label">Grade accounting</p>
         <h2 id="unassigned-evidence-status-title" className="mt-2 text-2xl font-semibold text-ink">
           Unassigned means no single evidence grade is being claimed

--- a/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
+++ b/app/evidence/evidence-report/UnderlyingStudyIndependencePanel.tsx
@@ -12,6 +12,9 @@ function pct(value: number | null): string {
   return value === null ? '—' : `${Math.round(value * 100)}%`
 }
 
+const metricCardClass = 'rounded-xl border border-[var(--border-soft)] bg-[var(--surface-subtle)] p-4'
+const warningCardClass = 'rounded-xl border border-amber-500/25 bg-[var(--surface-warning)] p-4 text-sm leading-6 text-amber-950 dark:text-amber-100'
+
 export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
   const available = metrics.underlyingStudyMetricsSource === 'canonical-research-topology'
     && metrics.globalPrimaryHumanPublicationCount !== null
@@ -29,7 +32,7 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
   const topologyMissing = metrics.researchTopologyMissingProfiles ?? 0
 
   return (
-    <section className="rounded-2xl border border-brand-900/10 bg-white p-6 shadow-sm sm:p-8" aria-labelledby="underlying-study-independence-heading">
+    <section className="card-premium p-6 sm:p-8" aria-labelledby="underlying-study-independence-heading">
       <p className="eyebrow-label">Evidence independence</p>
       <h2 id="underlying-study-independence-heading" className="mt-2 text-2xl font-semibold text-ink">
         Independence-adjusted counts, not assumed independence
@@ -39,29 +42,29 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
       </p>
 
       {topologyMissing > 0 ? (
-        <div className="mt-5 rounded-xl border border-amber-900/15 bg-amber-50/70 p-4 text-sm leading-6 text-amber-950">
+        <div className={`mt-5 ${warningCardClass}`}>
           <strong>Research-topology coverage is {topologyMatched} of {topologyRequested} public profiles ({pct(metrics.researchTopologyProfileCoverage)}).</strong>{' '}
           {topologyMissing} public profile{topologyMissing === 1 ? '' : 's'} currently lack a matching canonical research-detail profile, so the independence-adjusted counts below cover only the matched subset. Ingredient, grade, and public source-record metrics elsewhere in this report still use the full indexable dataset.
         </div>
       ) : null}
 
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+        <article className={metricCardClass}>
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Primary-human publications</p>
           <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalPrimaryHumanPublicationCount)}</p>
           <p className="mt-2 text-xs leading-5 text-muted">Unique publication identities within the matched public research-profile scope, classified as primary human research.</p>
         </article>
-        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+        <article className={metricCardClass}>
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Independence-adjusted human units</p>
           <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalPrimaryHumanUnderlyingStudyCount)}</p>
           <p className="mt-2 text-xs leading-5 text-muted">Primary-human evidence units remaining after explicitly proven cross-publication dependence is collapsed.</p>
         </article>
-        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+        <article className={metricCardClass}>
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Human publications collapsed</p>
           <p className="mt-2 text-3xl font-bold text-ink">{value(metrics.globalCollapsedPrimaryHumanPublicationCount)}</p>
           <p className="mt-2 text-xs leading-5 text-muted">Publication identities removed from the adjusted count because shared underlying-study identity was positively established.</p>
         </article>
-        <article className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
+        <article className={metricCardClass}>
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700">Primary-human metadata coverage</p>
           <p className="mt-2 text-3xl font-bold text-ink">{pct(metrics.globalPrimaryHumanIndependenceMetadataCoverage)}</p>
           <p className="mt-2 text-xs leading-5 text-muted">Share of unique primary-human publications with explicit registry, cohort, dataset, parent-study, or same-trial metadata available for independence assessment.</p>
@@ -69,14 +72,14 @@ export default function UnderlyingStudyIndependencePanel({ metrics }: Props) {
       </div>
 
       {primaryHumanMissingMetadata > 0 ? (
-        <div className="mt-5 rounded-xl border border-amber-900/15 bg-amber-50/70 p-4 text-sm leading-6 text-amber-950">
+        <div className={`mt-5 ${warningCardClass}`}>
           <strong>{primaryHumanMissingMetadata} unique primary-human publication{primaryHumanMissingMetadata === 1 ? '' : 's'} currently lack explicit independence metadata.</strong>{' '}
           Those publications remain separate in the adjusted count unless and until the canonical research graph positively establishes shared underlying-study identity.
         </div>
       ) : null}
 
       {multiStudy > 0 ? (
-        <div className="mt-4 rounded-xl border border-brand-900/10 bg-brand-50/50 p-4 text-sm leading-6 text-muted">
+        <div className="mt-4 rounded-xl border border-[var(--border-soft)] bg-[var(--surface-subtle)] p-4 text-sm leading-6 text-muted">
           <strong className="text-ink">Approved-claim diagnostic:</strong>{' '}
           independence remains unresolved for {unresolved} of {multiStudy} approved claims supported by multiple publication-level studies; {highConfidenceUnresolved} of those unresolved claims are high-confidence. Mean claim-level explicit lineage coverage is {pct(metrics.meanIndependenceCoverage)}.
         </div>


### PR DESCRIPTION
Normalize the four server-rendered evidence-report analysis panels onto the canonical card/surface system. This is presentation-only: metrics, calculations, labels, and report copy are unchanged. The independence panel also reuses one metric-card style and one semantic warning style instead of duplicating light-only classes.