### PR TITLE
refactor(visual): polish navigation chrome

### DIFF
--- a/styles/navigation-responsive.css
+++ b/styles/navigation-responsive.css
@@ -16,3 +16,83 @@
 [data-global-breadcrumb] + main nav[aria-label='Breadcrumb'] {
   display: none;
 }
+
+/* Premium navigation chrome. The header should behave like quiet hardware,
+   not a green content card. */
+nav[aria-label='Primary'] {
+  border-color: var(--border-soft) !important;
+  background: color-mix(in srgb, var(--surface-elevated) 88%, transparent) !important;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.45) inset;
+  backdrop-filter: blur(18px) saturate(115%);
+}
+
+html.dark nav[aria-label='Primary'] {
+  background: rgba(14, 16, 17, 0.90) !important;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.025) inset;
+}
+
+nav[aria-label='Primary'] a {
+  color: var(--text-secondary) !important;
+}
+
+nav[aria-label='Primary'] a:hover,
+nav[aria-label='Primary'] a[aria-current='page'],
+nav[aria-label='Primary'] a[aria-label='The Hippie Scientist home'] {
+  color: var(--text-primary) !important;
+}
+
+nav[aria-label='Primary'] a[aria-current='page']::after {
+  background: var(--hs-gold) !important;
+}
+
+nav[aria-label='Primary'] a[aria-label='The Hippie Scientist home'] svg {
+  color: var(--hs-gold) !important;
+}
+
+nav[aria-label='Primary'] button {
+  border-color: var(--border-soft) !important;
+  background: color-mix(in srgb, var(--surface-card) 90%, transparent) !important;
+  color: var(--text-primary) !important;
+  box-shadow: none !important;
+}
+
+nav[aria-label='Primary'] button:hover {
+  border-color: color-mix(in srgb, var(--hs-gold) 38%, var(--border-soft)) !important;
+  background: var(--surface-card-strong) !important;
+}
+
+#mobile-nav > div[aria-hidden='true'] {
+  background: rgba(6, 7, 8, 0.62) !important;
+  backdrop-filter: blur(6px);
+}
+
+#mobile-nav [role='dialog'] {
+  border-color: var(--border-soft) !important;
+  background: var(--surface-elevated) !important;
+  box-shadow: -18px 0 54px rgba(0, 0, 0, 0.28) !important;
+}
+
+html.dark #mobile-nav [role='dialog'] {
+  background: #151719 !important;
+  box-shadow: -20px 0 64px rgba(0, 0, 0, 0.72) !important;
+}
+
+#mobile-nav a {
+  color: var(--text-secondary) !important;
+}
+
+#mobile-nav a:hover,
+#mobile-nav a[aria-current='page'] {
+  color: var(--text-primary) !important;
+}
+
+#mobile-nav a[aria-current='page'] {
+  border-color: color-mix(in srgb, var(--hs-gold) 24%, transparent) !important;
+  background: color-mix(in srgb, var(--hs-gold) 8%, var(--surface-card)) !important;
+  box-shadow: none !important;
+}
+
+#mobile-nav nav > div:last-child {
+  border-color: var(--border-soft) !important;
+  background: var(--surface-subtle) !important;
+}


### PR DESCRIPTION
Aligns the sticky header and mobile drawer with the new graphite/ivory/brass visual system. Removes the remaining green/purple feel from navigation surfaces, uses brass only for active/focus signals, neutralizes drawer backgrounds, and makes mobile navigation feel like polished UI hardware rather than another content card.