### PR TITLE
refactor(evidence-report): make ambiguity candidates authoritative

### DIFF
--- a/lib/__tests__/public-evidence-ambiguity-analysis.test.ts
+++ b/lib/__tests__/public-evidence-ambiguity-analysis.test.ts
@@ -36,6 +36,12 @@ describe('public evidence ambiguity magnitude', () => {
       participantCountRatio: 2.5,
       studyClassFamilies: ['primary-human-trial', 'synthesis'],
       crossFamilyStudyClassConflict: true,
+      candidateDerivedAmbiguity: {
+        publicationYear: true,
+        participantCount: true,
+        studyClass: true,
+      },
+      storedFlagMismatches: [],
     })
   })
 
@@ -47,9 +53,32 @@ describe('public evidence ambiguity magnitude', () => {
 
     expect(result.studyClassFamilies).toEqual(['primary-human-trial'])
     expect(result.crossFamilyStudyClassConflict).toBe(false)
+    expect(result.candidateDerivedAmbiguity.studyClass).toBe(true)
+    expect(result.storedFlagMismatches).toEqual([])
     expect(result.publicationYearSpan).toBeNull()
     expect(result.participantCountAbsoluteSpread).toBeNull()
     expect(result.participantCountRatio).toBeNull()
+  })
+
+  it('treats candidate sets as authoritative and diagnoses stale ambiguity flags', () => {
+    const analysis = analyzePublicEvidenceAmbiguity([
+      study({
+        id: 'doi:10.1000/candidates-win',
+        publicationYearCandidates: [2020, 2021],
+        publicationYearAmbiguous: false,
+      }),
+      study({
+        id: 'doi:10.1000/flag-only',
+        participantCountCandidates: [100],
+        participantCountAmbiguous: true,
+      }),
+    ])
+
+    expect(analysis.summary.studiesWithAnyAmbiguity).toBe(1)
+    expect(analysis.summary.ambiguityFlagMismatchStudyCount).toBe(2)
+    expect(analysis.summary.ambiguityFlagMismatchCount).toBe(2)
+    expect(analysis.studies[0].magnitude.storedFlagMismatches).toEqual(['publication-year'])
+    expect(analysis.studies[1].magnitude.storedFlagMismatches).toEqual(['participant-count'])
   })
 
   it('summarizes the largest observed conflict magnitudes across the public study inventory', () => {
@@ -78,6 +107,8 @@ describe('public evidence ambiguity magnitude', () => {
     expect(analysis.summary).toEqual({
       studiesAnalyzed: 3,
       studiesWithAnyAmbiguity: 2,
+      ambiguityFlagMismatchStudyCount: 0,
+      ambiguityFlagMismatchCount: 0,
       crossFamilyStudyClassConflictCount: 1,
       largestPublicationYearSpan: 5,
       largestParticipantCountAbsoluteSpread: 150,

--- a/lib/public-evidence-ambiguity-analysis.ts
+++ b/lib/public-evidence-ambiguity-analysis.ts
@@ -9,12 +9,23 @@ export type PublicEvidenceStudyClassFamily =
   | 'preclinical'
   | 'other'
 
+export type PublicEvidenceAmbiguityFlag =
+  | 'publication-year'
+  | 'participant-count'
+  | 'study-class'
+
 export type PublicStudyAmbiguityMagnitude = {
   publicationYearSpan: number | null
   participantCountAbsoluteSpread: number | null
   participantCountRatio: number | null
   studyClassFamilies: PublicEvidenceStudyClassFamily[]
   crossFamilyStudyClassConflict: boolean
+  candidateDerivedAmbiguity: {
+    publicationYear: boolean
+    participantCount: boolean
+    studyClass: boolean
+  }
+  storedFlagMismatches: PublicEvidenceAmbiguityFlag[]
 }
 
 export type PublicEvidenceAmbiguityAnalysis = {
@@ -25,6 +36,8 @@ export type PublicEvidenceAmbiguityAnalysis = {
   summary: {
     studiesAnalyzed: number
     studiesWithAnyAmbiguity: number
+    ambiguityFlagMismatchStudyCount: number
+    ambiguityFlagMismatchCount: number
     crossFamilyStudyClassConflictCount: number
     largestPublicationYearSpan: number
     largestParticipantCountAbsoluteSpread: number
@@ -49,8 +62,9 @@ function span(values: number[]): number | null {
 export function analyzePublicStudyAmbiguity(study: PublicStudyEntity): PublicStudyAmbiguityMagnitude {
   const yearCandidates = [...(study.publicationYearCandidates ?? [])].sort((a, b) => a - b)
   const participantCandidates = [...(study.participantCountCandidates ?? [])].sort((a, b) => a - b)
+  const studyClassCandidates = [...new Set(study.studyClassCandidates ?? [])]
   const studyClassFamilies = [...new Set(
-    (study.studyClassCandidates ?? []).map(studyClassFamily),
+    studyClassCandidates.map(studyClassFamily),
   )].sort() as PublicEvidenceStudyClassFamily[]
   const participantCountAbsoluteSpread = span(participantCandidates)
   const minParticipantCount = participantCandidates[0]
@@ -58,6 +72,21 @@ export function analyzePublicStudyAmbiguity(study: PublicStudyEntity): PublicStu
   const participantCountRatio = participantCandidates.length >= 2 && minParticipantCount > 0
     ? maxParticipantCount / minParticipantCount
     : null
+  const candidateDerivedAmbiguity = {
+    publicationYear: yearCandidates.length > 1,
+    participantCount: participantCandidates.length > 1,
+    studyClass: studyClassCandidates.length > 1,
+  }
+  const storedFlagMismatches: PublicEvidenceAmbiguityFlag[] = []
+  if (Boolean(study.publicationYearAmbiguous) !== candidateDerivedAmbiguity.publicationYear) {
+    storedFlagMismatches.push('publication-year')
+  }
+  if (Boolean(study.participantCountAmbiguous) !== candidateDerivedAmbiguity.participantCount) {
+    storedFlagMismatches.push('participant-count')
+  }
+  if (Boolean(study.studyClassAmbiguous) !== candidateDerivedAmbiguity.studyClass) {
+    storedFlagMismatches.push('study-class')
+  }
 
   return {
     publicationYearSpan: span(yearCandidates),
@@ -65,6 +94,8 @@ export function analyzePublicStudyAmbiguity(study: PublicStudyEntity): PublicStu
     participantCountRatio,
     studyClassFamilies,
     crossFamilyStudyClassConflict: studyClassFamilies.length > 1,
+    candidateDerivedAmbiguity,
+    storedFlagMismatches,
   }
 }
 
@@ -74,15 +105,20 @@ export function analyzePublicEvidenceAmbiguity(studies: PublicStudyEntity[]): Pu
     magnitude: analyzePublicStudyAmbiguity(study),
   }))
 
-  const studiesWithAnyAmbiguity = studies.filter((study) =>
-    study.publicationYearAmbiguous || study.participantCountAmbiguous || study.studyClassAmbiguous,
+  const studiesWithAnyAmbiguity = analyzed.filter(({ magnitude }) =>
+    magnitude.candidateDerivedAmbiguity.publicationYear
+    || magnitude.candidateDerivedAmbiguity.participantCount
+    || magnitude.candidateDerivedAmbiguity.studyClass,
   ).length
+  const mismatchStudies = analyzed.filter(({ magnitude }) => magnitude.storedFlagMismatches.length > 0)
 
   return {
     studies: analyzed,
     summary: {
       studiesAnalyzed: studies.length,
       studiesWithAnyAmbiguity,
+      ambiguityFlagMismatchStudyCount: mismatchStudies.length,
+      ambiguityFlagMismatchCount: mismatchStudies.reduce((sum, item) => sum + item.magnitude.storedFlagMismatches.length, 0),
       crossFamilyStudyClassConflictCount: analyzed.filter((item) => item.magnitude.crossFamilyStudyClassConflict).length,
       largestPublicationYearSpan: Math.max(0, ...analyzed.map((item) => item.magnitude.publicationYearSpan ?? 0)),
       largestParticipantCountAbsoluteSpread: Math.max(0, ...analyzed.map((item) => item.magnitude.participantCountAbsoluteSpread ?? 0)),


### PR DESCRIPTION
Derive public-evidence ambiguity from candidate sets rather than trusting duplicated stored booleans. Adds explicit diagnostics when stored ambiguity flags disagree with candidate cardinality, so stale flags cannot inflate or suppress ambiguity analysis. Regression coverage locks candidate-first behavior and mismatch accounting.