### PR TITLE
refactor(theme): align resonant lighting with graphite brass

### DIFF
--- a/styles/resonant-theme-lighting.css
+++ b/styles/resonant-theme-lighting.css
@@ -1,56 +1,44 @@
 /*
   Resonant theme lighting layer.
-  Adds restrained brass warmth, indigo resonance, and soft editorial depth
-  without changing content or data. This is intentionally not a botanical-green
-  brand layer; green remains available only where it communicates semantics.
+  Adds restrained brass warmth, graphite depth, and soft editorial sheen
+  without changing content or data. Semantic evidence and safety colors remain
+  owned by their dedicated components and tokens.
 */
 
 :root {
-  --resonance-indigo: rgba(111, 102, 168, 0.16);
-  --resonance-indigo-strong: rgba(81, 68, 117, 0.22);
-  --resonance-gold: rgba(169, 119, 47, 0.16);
-  --resonance-violet: rgba(125, 111, 187, 0.12);
-  --resonance-rose: rgba(190, 91, 108, 0.07);
+  --resonance-graphite: rgba(46, 44, 40, 0.12);
+  --resonance-graphite-strong: rgba(46, 44, 40, 0.20);
+  --resonance-brass: rgba(177, 132, 73, 0.16);
   --resonance-sheen: rgba(255, 255, 255, 0.58);
-  --resonance-card-shadow: 0 20px 54px rgba(49, 42, 52, 0.085), 0 1px 0 rgba(255, 255, 255, 0.64) inset;
-  --resonance-card-shadow-hover: 0 26px 72px rgba(49, 42, 52, 0.12), 0 1px 0 rgba(255, 255, 255, 0.74) inset;
-  --resonance-button-glow: 0 12px 34px rgba(64, 54, 91, 0.22);
+  --resonance-card-shadow: 0 20px 54px rgba(46, 44, 40, 0.085), 0 1px 0 rgba(255, 255, 255, 0.64) inset;
+  --resonance-card-shadow-hover: 0 26px 72px rgba(46, 44, 40, 0.12), 0 1px 0 rgba(255, 255, 255, 0.74) inset;
+  --resonance-button-glow: 0 12px 34px rgba(177, 132, 73, 0.18);
 }
 
 html.dark {
-  --resonance-indigo: rgba(168, 157, 204, 0.15);
-  --resonance-indigo-strong: rgba(192, 181, 215, 0.20);
-  --resonance-gold: rgba(213, 173, 108, 0.15);
-  --resonance-violet: rgba(184, 174, 207, 0.14);
-  --resonance-rose: rgba(252, 165, 165, 0.065);
+  --resonance-graphite: rgba(227, 211, 181, 0.08);
+  --resonance-graphite-strong: rgba(227, 211, 181, 0.14);
+  --resonance-brass: rgba(208, 163, 91, 0.16);
   --resonance-sheen: rgba(255, 255, 255, 0.065);
   --resonance-card-shadow: 0 22px 64px rgba(0, 0, 0, 0.30), 0 1px 0 rgba(255, 255, 255, 0.045) inset;
   --resonance-card-shadow-hover: 0 28px 82px rgba(0, 0, 0, 0.36), 0 1px 0 rgba(255, 255, 255, 0.075) inset;
-  --resonance-button-glow: 0 14px 42px rgba(213, 173, 108, 0.18);
-}
-
-body {
-  background: #fffaf3;
-}
-
-html.dark body {
-  background: #151319;
+  --resonance-button-glow: 0 14px 42px rgba(208, 163, 91, 0.18);
 }
 
 .hero-shell {
   position: relative;
   overflow: hidden;
-  border-color: color-mix(in srgb, var(--border-soft) 72%, var(--resonance-indigo-strong));
+  border-color: color-mix(in srgb, var(--border-soft) 72%, var(--resonance-graphite-strong));
   background:
-    radial-gradient(circle at 100% 0%, rgba(169, 119, 47, 0.07), transparent 18rem),
-    linear-gradient(180deg, rgba(255, 250, 243, 0.94), rgba(248, 242, 232, 0.90));
+    radial-gradient(circle at 100% 0%, rgba(177, 132, 73, 0.08), transparent 18rem),
+    linear-gradient(180deg, rgba(255, 253, 248, 0.95), rgba(243, 240, 233, 0.91));
   box-shadow: var(--resonance-card-shadow);
 }
 
 html.dark .hero-shell {
   background:
-    radial-gradient(circle at 100% 0%, rgba(168, 157, 204, 0.10), transparent 18rem),
-    linear-gradient(180deg, rgba(44, 40, 51, 0.97), rgba(30, 28, 35, 0.95));
+    radial-gradient(circle at 100% 0%, rgba(208, 163, 91, 0.10), transparent 18rem),
+    linear-gradient(180deg, rgba(32, 35, 38, 0.98), rgba(20, 23, 25, 0.96));
 }
 
 .hero-shell::before {
@@ -75,7 +63,7 @@ html.dark .hero-shell::before {
 
 .goal-link-card:hover,
 .goal-mini-card:hover {
-  border-color: color-mix(in srgb, var(--border-strong) 60%, var(--resonance-gold));
+  border-color: color-mix(in srgb, var(--border-strong) 60%, var(--resonance-brass));
   box-shadow: var(--resonance-card-shadow-hover);
 }
 
@@ -83,7 +71,7 @@ html.dark .hero-shell::before {
 .section-label,
 .identity-kicker,
 .identity-meta {
-  color: #655391;
+  color: #8a6536;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.38);
 }
 
@@ -91,8 +79,8 @@ html.dark .eyebrow-label,
 html.dark .section-label,
 html.dark .identity-kicker,
 html.dark .identity-meta {
-  color: #d5cce5;
-  text-shadow: 0 0 18px rgba(168, 157, 204, 0.15);
+  color: #d0a35b;
+  text-shadow: 0 0 18px rgba(208, 163, 91, 0.14);
 }
 
 a.rounded-full.bg-brand-950,
@@ -102,7 +90,6 @@ button.rounded-full.bg-brand-850 {
   box-shadow: var(--resonance-button-glow);
 }
 
-.button-primary:hover,
 a.rounded-full.bg-brand-950:hover,
 a.rounded-full.bg-brand-850:hover,
 button.rounded-full.bg-brand-950:hover,
@@ -110,26 +97,15 @@ button.rounded-full.bg-brand-850:hover {
   filter: saturate(1.04) brightness(1.02);
 }
 
-.button-secondary,
-a.rounded-full.border,
-button.rounded-full.border {
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-}
-
 @media (max-width: 768px) {
   :root {
-    --resonance-card-shadow: 0 14px 34px rgba(49, 42, 52, 0.07), 0 1px 0 rgba(255, 255, 255, 0.58) inset;
-    --resonance-card-shadow-hover: 0 18px 44px rgba(49, 42, 52, 0.095), 0 1px 0 rgba(255, 255, 255, 0.64) inset;
+    --resonance-card-shadow: 0 14px 34px rgba(46, 44, 40, 0.07), 0 1px 0 rgba(255, 255, 255, 0.58) inset;
+    --resonance-card-shadow-hover: 0 18px 44px rgba(46, 44, 40, 0.095), 0 1px 0 rgba(255, 255, 255, 0.64) inset;
   }
 
   html.dark {
     --resonance-card-shadow: 0 16px 40px rgba(0, 0, 0, 0.25), 0 1px 0 rgba(255, 255, 255, 0.04) inset;
     --resonance-card-shadow-hover: 0 20px 52px rgba(0, 0, 0, 0.31), 0 1px 0 rgba(255, 255, 255, 0.06) inset;
-  }
-
-  body {
-    background-size: auto;
   }
 
   .hero-shell::before {


### PR DESCRIPTION
Keep the resonant hero sheen/depth layer but remove its competing violet identity and stale ownership. Replaces indigo/violet ambient color with graphite + brass, deletes unused violet/rose tokens, removes body background rules now owned by the final token layer, and drops a dead secondary-button blur override. No content or interaction logic changes.