### PR TITLE
fix(evidence-report): use path-scoped ingredient identity

### DIFF
--- a/lib/__tests__/public-evidence-entity-path-identity.test.ts
+++ b/lib/__tests__/public-evidence-entity-path-identity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPublicEvidenceDatasetFromRecords } from '@/lib/public-evidence-dataset'
+import type { RuntimeRecord } from '@/src/types/content'
+
+function record(overrides: Partial<RuntimeRecord>): RuntimeRecord {
+  return {
+    slug: 'shared',
+    name: 'Shared',
+    category: 'Stress',
+    indexability_status: 'PUBLISH',
+    evidence_grade: 'B',
+    summary_quality: 'strong',
+    profile_status: 'complete',
+    ...overrides,
+  } as RuntimeRecord
+}
+
+describe('public evidence entity path identity', () => {
+  it('keeps same-slug herb and compound relationships distinct for metrics and context', () => {
+    const dataset = buildPublicEvidenceDatasetFromRecords([
+      {
+        type: 'herb',
+        record: record({
+          category: 'Stress',
+          sources: [{
+            title: 'Shared clinical trial',
+            doi: '10.1000/same-slug-shared-study',
+            study_type: 'randomized controlled trial',
+            relationship: 'supports',
+            outcome: 'Shared endpoint',
+          }],
+        }),
+      },
+      {
+        type: 'compound',
+        record: record({
+          category: 'Sleep',
+          sources: [{
+            title: 'Shared clinical trial',
+            doi: '10.1000/same-slug-shared-study',
+            study_type: 'randomized controlled trial',
+            relationship: 'no_clear_effect',
+            outcome: 'Shared endpoint',
+          }],
+        }),
+      },
+    ])
+
+    expect(dataset.studies).toHaveLength(1)
+    expect(dataset.studies[0].relationships.map((relationship) => relationship.ingredientPath).sort()).toEqual([
+      '/compounds/shared/',
+      '/herbs/shared/',
+    ])
+    expect(dataset.studies[0].relationshipSummary).toBe('mixed')
+    expect(dataset.metrics.withinIngredientDirectionalHeterogeneityStudyCount).toBe(0)
+
+    const stress = dataset.metrics.categories.find((category) => category.category === 'Stress')
+    const sleep = dataset.metrics.categories.find((category) => category.category === 'Sleep')
+    expect(stress).toMatchObject({ humanStudies: 1, humanTrials: 1 })
+    expect(sleep).toMatchObject({ humanStudies: 1, humanTrials: 1 })
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -255,16 +255,16 @@ function aggregateRelationship(relationships: PublicStudyRelationship[]): Eviden
 function hasWithinIngredientDirectionalHeterogeneity(study: PublicStudyEntity): boolean {
   const byIngredient = new Map<string, PublicStudyRelationship[]>()
   for (const relationship of study.relationships) {
-    const values = byIngredient.get(relationship.ingredientSlug) ?? []
+    const values = byIngredient.get(relationship.ingredientPath) ?? []
     values.push(relationship)
-    byIngredient.set(relationship.ingredientSlug, values)
+    byIngredient.set(relationship.ingredientPath, values)
   }
   return [...byIngredient.values()].some((relationships) => aggregateRelationship(relationships) === 'mixed')
 }
 
 function relationshipContextKey(relationship: PublicStudyRelationship): string {
   return JSON.stringify([
-    relationship.ingredientSlug,
+    relationship.ingredientPath,
     relationship.relationship,
     cleanString(relationship.dose).toLowerCase(),
     cleanString(relationship.duration).toLowerCase(),
@@ -522,12 +522,12 @@ export function buildPublicEvidenceDatasetFromRecords(entities: EntityRecord[]):
       return a.title.localeCompare(b.title)
     })
   const studyMetrics = summarizeEvidenceStudies(studies.map(toStudyRecord))
-  const categoryBySlug = new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient.category] as const))
+  const categoryByPath = new Map(ingredients.map((ingredient) => [ingredient.path, ingredient.category] as const))
 
   for (const study of studies) {
     const studyCategories = new Set(
       study.relationships
-        .map((relationship) => categoryBySlug.get(relationship.ingredientSlug))
+        .map((relationship) => categoryByPath.get(relationship.ingredientPath))
         .filter((category): category is string => Boolean(category)),
     )
     for (const category of studyCategories) {


### PR DESCRIPTION
Fix same-slug herb/compound collisions in the public evidence builder by using canonical ingredient paths for relationship dedupe, within-ingredient endpoint heterogeneity grouping, and category attribution. Adds a regression where a herb and compound share a slug and publication but must remain distinct entities.