### PR TITLE
refactor(theme): narrow premium surface ownership

### DIFF
--- a/styles/premium-surface-details.css
+++ b/styles/premium-surface-details.css
@@ -1,159 +1,42 @@
 /*
   Premium surface detail layer.
-  Extends the research-folio visual language into navigation, forms, tables,
-  chips, FAQ/detail elements, and dense legacy utility surfaces.
-
-  This file also acts as the compatibility bridge for older Tailwind `brand-*`
-  classes. Generic brand color is indigo/charcoal; botanical green remains
-  available through semantic emerald/evidence/safety classes only.
+  Owns dense utility surfaces only: tables, forms, details, chips, and semantic
+  callout rails. Global palette, navigation, buttons, and selection styling are
+  owned by the later canonical visual-system layers.
 */
 
 :root {
-  /* Legacy Tailwind brand palette -> premium indigo. */
-  --color-brand-50: #f3f0f8;
-  --color-brand-100: #e7e1f1;
-  --color-brand-200: #d3c9e5;
-  --color-brand-300: #b8aad4;
-  --color-brand-400: #9b8bc1;
-  --color-brand-500: #7d6da9;
-  --color-brand-600: #66558f;
-  --color-brand-700: #514475;
-  --color-brand-800: #40365b;
-  --color-brand-900: #302a43;
-  --color-brand-950: #211d2f;
-  --color-brand: #40365b;
-
-  /* Legacy theme variables used by older components. */
-  --color-background: #fffaf3;
-  --color-surface: #f8f2e8;
-  --color-ink: #29272f;
-  --color-muted: #625e68;
-  --bg: #fbf7f1;
-  --surface: #f8f2e8;
-  --surface-elevated: #fffaf3;
-  --text-primary: #29272f;
-  --text-secondary: #514d59;
-  --text-muted: #625e68;
-  --border-soft: rgba(45, 42, 52, 0.11);
-  --border-strong: rgba(45, 42, 52, 0.19);
-  --border-default: var(--border-soft);
-  --surface-card: rgba(255, 250, 243, 0.90);
-  --surface-card-strong: rgba(255, 250, 243, 0.97);
-  --surface-1: var(--surface);
-  --surface-2: var(--surface-card);
-  --surface-subtle: rgba(243, 238, 246, 0.76);
-  --surface-code: #f3eff5;
-  --surface-neutral: rgba(248, 245, 249, 0.9);
-  --ring-brand: rgba(81, 68, 117, 0.28);
-  --accent-primary: #514475;
-  --accent-secondary: #6f66a8;
-  --accent-teal: #6f66a8;
-
-  --surface-detail-border: rgba(45, 42, 52, 0.13);
-  --surface-detail-border-strong: rgba(45, 42, 52, 0.23);
-  --surface-detail-bg: rgba(255, 250, 243, 0.70);
-  --surface-detail-bg-strong: rgba(255, 250, 243, 0.94);
-  --surface-detail-glow: rgba(169, 119, 47, 0.15);
-  --surface-detail-focus: rgba(111, 102, 168, 0.24);
-  --surface-detail-text: #29272f;
-  --surface-detail-muted: #625e68;
+  --surface-detail-border: rgba(46, 44, 40, 0.13);
+  --surface-detail-border-strong: rgba(46, 44, 40, 0.23);
+  --surface-detail-bg-strong: rgba(255, 253, 248, 0.95);
+  --surface-detail-focus: rgba(177, 132, 73, 0.28);
+  --surface-detail-text: #1d1d1f;
+  --surface-detail-muted: #6c6862;
 }
 
 html.dark {
-  --color-brand-50: #24212b;
-  --color-brand-100: #2f2a39;
-  --color-brand-200: #3d364b;
-  --color-brand-300: #50465f;
-  --color-brand-400: #6d6084;
-  --color-brand-500: #8b7ca8;
-  --color-brand-600: #a89ac4;
-  --color-brand-700: #c0b5d7;
-  --color-brand-800: #d5cce5;
-  --color-brand-900: #e8e1f0;
-  --color-brand-950: #f5f0f8;
-  --color-brand: #c0b5d7;
-
-  --color-background: #151319;
-  --color-surface: #201e25;
-  --color-ink: #f5f0e8;
-  --color-muted: #c4bec9;
-  --bg: #151319;
-  --surface: #201e25;
-  --surface-elevated: #292630;
-  --text-primary: #f5f0e8;
-  --text-secondary: #d5cedb;
-  --text-muted: #c4bec9;
-  --border-soft: rgba(225, 217, 232, 0.13);
-  --border-strong: rgba(225, 217, 232, 0.24);
-  --border-default: var(--border-soft);
-  --surface-card: rgba(32, 30, 37, 0.94);
-  --surface-card-strong: rgba(41, 38, 48, 0.98);
-  --surface-1: var(--surface);
-  --surface-2: var(--surface-card);
-  --surface-subtle: rgba(61, 54, 75, 0.52);
-  --surface-code: rgba(38, 34, 46, 0.92);
-  --surface-neutral: rgba(44, 40, 51, 0.90);
-  --ring-brand: rgba(192, 181, 215, 0.28);
-  --accent-primary: #c0b5d7;
-  --accent-secondary: #a89dcc;
-  --accent-teal: #9a90cf;
-
-  --surface-detail-border: rgba(225, 217, 232, 0.13);
-  --surface-detail-border-strong: rgba(225, 217, 232, 0.24);
-  --surface-detail-bg: rgba(255, 255, 255, 0.045);
-  --surface-detail-bg-strong: rgba(41, 38, 48, 0.88);
-  --surface-detail-glow: rgba(213, 173, 108, 0.13);
-  --surface-detail-focus: rgba(168, 157, 204, 0.24);
-  --surface-detail-text: #f5f0e8;
-  --surface-detail-muted: #c4bec9;
+  --surface-detail-border: rgba(227, 211, 181, 0.13);
+  --surface-detail-border-strong: rgba(227, 211, 181, 0.24);
+  --surface-detail-bg-strong: rgba(28, 31, 33, 0.94);
+  --surface-detail-focus: rgba(208, 163, 91, 0.30);
+  --surface-detail-text: #f3eee4;
+  --surface-detail-muted: #aaa49a;
 }
 
-/* Top navigation: restrained ivory/charcoal glass, not botanical green. */
-header nav,
-header [role='navigation'] {
-  border-color: var(--surface-detail-border) !important;
-  background: color-mix(in srgb, var(--hs-surface, #fffaf3) 94%, transparent) !important;
-  box-shadow: 0 1px 3px rgba(49, 42, 52, 0.055);
-}
-
-html.dark header nav,
-html.dark header [role='navigation'] {
-  background:
-    linear-gradient(180deg, rgba(38, 35, 44, 0.96), rgba(27, 25, 32, 0.96)) !important;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.26);
-}
-
-header nav a,
-header [role='navigation'] a {
-  text-underline-offset: 0.26em;
-}
-
-header nav a:hover,
-header [role='navigation'] a:hover {
-  text-shadow: 0 0 18px rgba(111, 102, 168, 0.15);
-}
-
-html.dark header nav a:hover,
-html.dark header [role='navigation'] a:hover {
-  text-shadow: 0 0 20px rgba(192, 181, 215, 0.17);
-}
-
-/* Tables: publication-like indigo signal and warm neutral rows. */
+/* Tables: neutral publication surfaces with restrained brass interaction. */
 main table {
   border-radius: 1rem;
   overflow: hidden;
 }
 
 main thead th {
-  background:
-    linear-gradient(180deg, rgba(243, 239, 248, 0.94), rgba(235, 229, 241, 0.78)) !important;
-  color: #302a3a !important;
+  background: linear-gradient(180deg, rgba(246, 243, 237, 0.96), rgba(235, 231, 222, 0.82)) !important;
+  color: #2e2c28 !important;
 }
 
 html.dark main thead th {
-  background:
-    linear-gradient(180deg, rgba(69, 61, 83, 0.88), rgba(49, 44, 59, 0.84)) !important;
-  color: #f5f0e8 !important;
+  background: linear-gradient(180deg, rgba(35, 38, 40, 0.94), rgba(25, 28, 30, 0.90)) !important;
+  color: #f3eee4 !important;
 }
 
 main tbody tr {
@@ -161,11 +44,11 @@ main tbody tr {
 }
 
 main tbody tr:hover {
-  background-color: rgba(111, 102, 168, 0.05) !important;
+  background-color: rgba(177, 132, 73, 0.055) !important;
 }
 
 html.dark main tbody tr:hover {
-  background-color: rgba(168, 157, 204, 0.07) !important;
+  background-color: rgba(208, 163, 91, 0.075) !important;
 }
 
 /* Forms and search fields: designed, neutral editorial controls. */
@@ -175,7 +58,7 @@ main textarea {
   border-color: var(--surface-detail-border) !important;
   background: var(--surface-detail-bg-strong) !important;
   color: var(--surface-detail-text) !important;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.42), 0 8px 22px rgba(49, 42, 52, 0.045);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.42), 0 8px 22px rgba(46, 44, 40, 0.045);
 }
 
 main input::placeholder,
@@ -190,7 +73,7 @@ main textarea:focus {
   border-color: var(--surface-detail-border-strong) !important;
   outline: 3px solid var(--surface-detail-focus) !important;
   outline-offset: 2px;
-  box-shadow: 0 0 0 1px var(--surface-detail-border-strong), 0 14px 32px rgba(49, 42, 52, 0.07);
+  box-shadow: 0 0 0 1px var(--surface-detail-border-strong), 0 14px 32px rgba(46, 44, 40, 0.07);
 }
 
 html.dark main input,
@@ -203,15 +86,15 @@ html.dark main textarea {
 main details {
   border-color: var(--surface-detail-border) !important;
   background:
-    radial-gradient(circle at 100% 0%, rgba(111, 102, 168, 0.075), transparent 10rem),
-    linear-gradient(180deg, rgba(255, 250, 243, 0.92), rgba(248, 242, 232, 0.80)) !important;
-  box-shadow: 0 12px 32px rgba(49, 42, 52, 0.055), inset 0 1px 0 rgba(255, 255, 255, 0.58);
+    radial-gradient(circle at 100% 0%, rgba(177, 132, 73, 0.075), transparent 10rem),
+    linear-gradient(180deg, rgba(255, 253, 248, 0.94), rgba(243, 240, 233, 0.84)) !important;
+  box-shadow: 0 12px 32px rgba(46, 44, 40, 0.055), inset 0 1px 0 rgba(255, 255, 255, 0.58);
 }
 
 html.dark main details {
   background:
-    radial-gradient(circle at 100% 0%, rgba(168, 157, 204, 0.09), transparent 10rem),
-    linear-gradient(180deg, rgba(45, 41, 53, 0.90), rgba(31, 29, 36, 0.86)) !important;
+    radial-gradient(circle at 100% 0%, rgba(208, 163, 91, 0.085), transparent 10rem),
+    linear-gradient(180deg, rgba(31, 34, 36, 0.92), rgba(22, 25, 27, 0.88)) !important;
   box-shadow: 0 14px 36px rgba(0, 0, 0, 0.26), inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
@@ -224,7 +107,7 @@ main summary {
   text-wrap: pretty;
 }
 
-/* Chips, pills, badges: preserve local semantic fills while unifying borders. */
+/* Chips and badges preserve local semantic fills while sharing border treatment. */
 .evidence-pill-strong,
 .evidence-pill-moderate,
 main :is([class*='rounded-full'][class*='text-']) {
@@ -238,8 +121,7 @@ html.dark main :is([class*='rounded-full'][class*='text-']) {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.055);
 }
 
-/* Semantic callouts keep their own caution/safety fill; the shared light rail is
-   brass -> indigo instead of brass -> botanical green. */
+/* Semantic callouts keep their severity fill; the decorative rail stays neutral/brass. */
 .safety-block,
 main :is(.bg-amber-50\/80, .bg-amber-50\/85, .bg-rose-50, .bg-red-50, .bg-emerald-50) {
   position: relative;
@@ -252,26 +134,16 @@ main :is(.bg-amber-50\/80, .bg-amber-50\/85, .bg-rose-50, .bg-red-50, .bg-emeral
   position: absolute;
   inset: 0 auto 0 0;
   width: 3px;
-  background: linear-gradient(180deg, rgba(169, 119, 47, 0.78), rgba(111, 102, 168, 0.48));
+  background: linear-gradient(180deg, rgba(177, 132, 73, 0.82), rgba(46, 44, 40, 0.42));
   pointer-events: none;
 }
 
-::selection {
-  background: rgba(169, 119, 47, 0.26);
-  color: #29272f;
-}
-
-html.dark ::selection {
-  background: rgba(168, 157, 204, 0.28);
-  color: #f5f0e8;
+html.dark .safety-block::before,
+html.dark main :is(.bg-amber-50\/80, .bg-amber-50\/85, .bg-rose-50, .bg-red-50, .bg-emerald-50)::before {
+  background: linear-gradient(180deg, rgba(208, 163, 91, 0.86), rgba(227, 211, 181, 0.28));
 }
 
 @media (max-width: 768px) {
-  header nav,
-  header [role='navigation'] {
-    box-shadow: 0 8px 24px rgba(49, 42, 52, 0.055);
-  }
-
   main details,
   main input,
   main select,


### PR DESCRIPTION
Reduce premium-surface-details.css to its unique responsibilities only: tables, forms, details, chips, and semantic callout rails. Remove obsolete global palette definitions, navigation styling, and selection styling now owned by later canonical layers, and align the remaining unique surfaces to graphite/brass. No content or interaction logic changes.