### PR TITLE
fix(evidence-report): reconcile exported ambiguity flags

### DIFF
--- a/lib/__tests__/public-evidence-export-determinism.test.ts
+++ b/lib/__tests__/public-evidence-export-determinism.test.ts
@@ -133,4 +133,38 @@ describe('public evidence export determinism', () => {
       '/herbs/shared/',
     ])
   })
+
+  it('recomputes exported ambiguity flags from authoritative candidate sets', () => {
+    const normalized = normalizePublicEvidenceDatasetForExport(dataset([
+      study({
+        id: 'doi:10.1000/conflict',
+        publicationYearCandidates: [2020, 2021],
+        publicationYearAmbiguous: false,
+        participantCountCandidates: [100],
+        participantCountAmbiguous: true,
+        studyClassCandidates: ['controlled_trial', 'randomized_controlled_trial'],
+        studyClassAmbiguous: false,
+      }),
+      study({
+        id: 'doi:10.1000/no-candidates',
+        publicationYearAmbiguous: true,
+        participantCountAmbiguous: true,
+        studyClassAmbiguous: true,
+      }),
+    ]))
+
+    const conflict = normalized.studies.find((item) => item.id === 'doi:10.1000/conflict')
+    expect(conflict).toMatchObject({
+      publicationYearAmbiguous: true,
+      participantCountAmbiguous: false,
+      studyClassAmbiguous: true,
+    })
+
+    const noCandidates = normalized.studies.find((item) => item.id === 'doi:10.1000/no-candidates')
+    expect(noCandidates).toMatchObject({
+      publicationYearAmbiguous: false,
+      participantCountAmbiguous: false,
+      studyClassAmbiguous: false,
+    })
+  })
 })

--- a/lib/public-evidence-export.ts
+++ b/lib/public-evidence-export.ts
@@ -35,21 +35,36 @@ export function normalizePublicEvidenceDatasetForExport(dataset: PublicEvidenceD
     .sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path))
 
   const studies = dataset.studies
-    .map((study) => ({
-      ...study,
-      publicationYearCandidates: study.publicationYearCandidates ? [...study.publicationYearCandidates].sort((a, b) => a - b) : undefined,
-      studyClassCandidates: study.studyClassCandidates ? [...study.studyClassCandidates].sort() : undefined,
-      participantCountCandidates: study.participantCountCandidates ? [...study.participantCountCandidates].sort((a, b) => a - b) : undefined,
-      conditions: [...study.conditions].sort((a, b) => a.localeCompare(b)),
-      relationships: study.relationships
-        .map((relationship) => ({
-          ...relationship,
-          conditions: relationship.conditions
-            ? [...relationship.conditions].sort((a, b) => a.localeCompare(b))
-            : undefined,
-        }))
-        .sort((a, b) => relationshipSortKey(a).localeCompare(relationshipSortKey(b))),
-    }))
+    .map((study) => {
+      const publicationYearCandidates = study.publicationYearCandidates
+        ? [...study.publicationYearCandidates].sort((a, b) => a - b)
+        : undefined
+      const studyClassCandidates = study.studyClassCandidates
+        ? [...study.studyClassCandidates].sort()
+        : undefined
+      const participantCountCandidates = study.participantCountCandidates
+        ? [...study.participantCountCandidates].sort((a, b) => a - b)
+        : undefined
+
+      return {
+        ...study,
+        publicationYearCandidates,
+        publicationYearAmbiguous: publicationYearCandidates ? publicationYearCandidates.length > 1 : false,
+        studyClassCandidates,
+        studyClassAmbiguous: studyClassCandidates ? studyClassCandidates.length > 1 : false,
+        participantCountCandidates,
+        participantCountAmbiguous: participantCountCandidates ? participantCountCandidates.length > 1 : false,
+        conditions: [...study.conditions].sort((a, b) => a.localeCompare(b)),
+        relationships: study.relationships
+          .map((relationship) => ({
+            ...relationship,
+            conditions: relationship.conditions
+              ? [...relationship.conditions].sort((a, b) => a.localeCompare(b))
+              : undefined,
+          }))
+          .sort((a, b) => relationshipSortKey(a).localeCompare(relationshipSortKey(b))),
+      }
+    })
     .sort((a, b) => {
       const yearDiff = Number(b.year || 0) - Number(a.year || 0)
       if (yearDiff !== 0) return yearDiff


### PR DESCRIPTION
Make the public export normalizer recompute year, participant-count, and study-class ambiguity booleans from the authoritative candidate arrays. This prevents downloadable JSON/CSV from publishing contradictory candidate/flag combinations. Adds regression coverage for stale false flags, stale true flags, and missing candidate sets.