### PR TITLE
refactor(theme): align editorial surfaces with graphite brass

### DIFF
--- a/styles/editorial-botanical-refresh.css
+++ b/styles/editorial-botanical-refresh.css
@@ -1,36 +1,35 @@
-/* Editorial specimen visual system
-   Warm paper, charcoal ink, muted indigo surfaces, and restrained brass accents.
-   Botanical geometry remains as a distinctive motif; green is reserved for
-   semantic evidence/safety states rather than generic brand chrome. */
+/* Editorial specimen visual system.
+   Botanical geometry remains distinctive, while shared surfaces now derive from
+   the canonical graphite, warm-paper, and brass tokens. Green remains semantic. */
 
 :root {
-  --editorial-paper: #fbf7f1;
-  --editorial-paper-strong: #fffaf3;
-  --editorial-cream: #f3ece4;
-  /* Legacy variable names retained for compatibility; values follow the new palette. */
-  --editorial-sage: #e8e2f0;
-  --editorial-sage-strong: #d5cce5;
-  --editorial-evergreen: #29272f;
-  --editorial-evergreen-soft: #514475;
-  --editorial-gold: #a9772f;
-  --editorial-gold-soft: #dfc59c;
-  --editorial-charcoal: #29272f;
-  --editorial-border: rgba(45, 42, 52, 0.12);
-  --editorial-shadow: 0 18px 48px rgba(49, 42, 52, 0.09);
-  --editorial-shadow-soft: 0 8px 28px rgba(49, 42, 52, 0.065);
+  --editorial-paper: var(--bg);
+  --editorial-paper-strong: var(--surface-elevated);
+  --editorial-cream: var(--surface);
+  /* Legacy names remain for component compatibility, but no longer imply sage. */
+  --editorial-sage: var(--surface-subtle);
+  --editorial-sage-strong: color-mix(in srgb, var(--surface) 82%, var(--text-primary));
+  --editorial-evergreen: var(--text-primary);
+  --editorial-evergreen-soft: var(--text-secondary);
+  --editorial-gold: var(--hs-gold);
+  --editorial-gold-soft: var(--hs-gold-soft);
+  --editorial-charcoal: var(--text-primary);
+  --editorial-border: var(--border-soft);
+  --editorial-shadow: var(--hs-lift);
+  --editorial-shadow-soft: 0 8px 28px rgba(46, 44, 40, 0.065);
 }
 
-html:not(.dark) body {
-  background: var(--editorial-paper);
+html.dark {
+  --editorial-shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.24);
 }
 
 .editorial-site-shell {
   position: relative;
   overflow: hidden;
   background:
-    radial-gradient(circle at 92% 5%, rgba(125, 111, 187, 0.18), transparent 22rem),
-    radial-gradient(circle at 4% 30%, rgba(223, 197, 156, 0.18), transparent 24rem),
-    linear-gradient(180deg, #fffaf3 0%, #fbf7f1 42%, #f5eee7 100%);
+    radial-gradient(circle at 92% 5%, color-mix(in srgb, var(--hs-gold) 10%, transparent), transparent 22rem),
+    radial-gradient(circle at 4% 30%, color-mix(in srgb, var(--text-primary) 4%, transparent), transparent 24rem),
+    linear-gradient(180deg, var(--surface-elevated) 0%, var(--bg) 42%, var(--surface) 100%);
 }
 
 .editorial-site-shell::before {
@@ -38,9 +37,8 @@ html:not(.dark) body {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  opacity: 0.30;
-  background-image:
-    radial-gradient(circle at 24px 24px, rgba(45, 42, 52, 0.045) 1px, transparent 1.5px);
+  opacity: 0.24;
+  background-image: radial-gradient(circle at 24px 24px, color-mix(in srgb, var(--text-primary) 5%, transparent) 1px, transparent 1.5px);
   background-size: 46px 46px;
   mask-image: linear-gradient(to bottom, #000 0%, transparent 48%);
 }
@@ -49,12 +47,12 @@ html:not(.dark) body {
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  border: 1px solid rgba(169, 119, 47, 0.20);
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 20%, var(--border-soft));
   border-radius: clamp(1.5rem, 4vw, 2.5rem);
   background:
-    radial-gradient(circle at 82% 18%, rgba(255, 255, 255, 0.88), transparent 17rem),
-    radial-gradient(circle at 100% 100%, rgba(125, 111, 187, 0.10), transparent 20rem),
-    linear-gradient(135deg, rgba(255, 250, 243, 0.98), rgba(243, 236, 228, 0.94));
+    radial-gradient(circle at 82% 18%, color-mix(in srgb, var(--surface-elevated) 88%, transparent), transparent 17rem),
+    radial-gradient(circle at 100% 100%, color-mix(in srgb, var(--hs-gold) 7%, transparent), transparent 20rem),
+    linear-gradient(135deg, var(--surface-elevated), color-mix(in srgb, var(--surface) 88%, var(--surface-elevated)));
   box-shadow: var(--editorial-shadow);
 }
 
@@ -65,7 +63,7 @@ html:not(.dark) body {
   z-index: -1;
   pointer-events: none;
   border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, rgba(111, 102, 168, 0.17), rgba(213, 204, 229, 0.07));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold) 18%, transparent), color-mix(in srgb, var(--text-primary) 4%, transparent));
   filter: blur(0.2px);
 }
 
@@ -91,7 +89,7 @@ html:not(.dark) body {
   bottom: -3.5rem;
   width: 16rem;
   height: 20rem;
-  opacity: 0.76;
+  opacity: 0.68;
   pointer-events: none;
 }
 
@@ -104,7 +102,7 @@ html:not(.dark) body {
   height: 18rem;
   transform: rotate(18deg);
   transform-origin: bottom;
-  background: linear-gradient(to top, rgba(81, 68, 117, 0.46), rgba(169, 119, 47, 0.08));
+  background: linear-gradient(to top, color-mix(in srgb, var(--text-secondary) 48%, transparent), color-mix(in srgb, var(--hs-gold) 12%, transparent));
 }
 
 .editorial-botanical-orbit span {
@@ -113,8 +111,8 @@ html:not(.dark) body {
   width: 5.5rem;
   height: 2.2rem;
   border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, rgba(111, 102, 168, 0.50), rgba(213, 204, 229, 0.30));
-  box-shadow: inset 0 0 0 1px rgba(45, 42, 52, 0.08);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold) 42%, transparent), color-mix(in srgb, var(--text-secondary) 15%, transparent));
+  box-shadow: inset 0 0 0 1px var(--border-soft);
 }
 
 .editorial-botanical-orbit span:nth-child(1) { right: 6.7rem; bottom: 4rem; transform: rotate(15deg); }
@@ -139,73 +137,83 @@ html:not(.dark) body {
 }
 
 .editorial-cta {
-  border: 1px solid rgba(223, 197, 156, 0.70);
-  background: linear-gradient(135deg, #4b4558, #302c39);
-  color: #fffaf3;
-  box-shadow: 0 12px 28px rgba(49, 42, 52, 0.20), inset 0 0 0 1px rgba(255, 255, 255, 0.07);
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 38%, var(--border-strong));
+  background: linear-gradient(135deg, #3b3b3d, #242426);
+  color: #fffdf8;
+  box-shadow: 0 12px 28px rgba(29, 29, 31, 0.20), inset 0 0 0 1px rgba(255, 255, 255, 0.07);
 }
 
 .editorial-cta:hover {
   transform: translateY(-2px);
-  background: linear-gradient(135deg, #5d527d, #3a3348);
-  box-shadow: 0 16px 36px rgba(49, 42, 52, 0.24), inset 0 0 0 1px rgba(255, 255, 255, 0.09);
+  background: linear-gradient(135deg, #49494b, #2d2d2f);
+  box-shadow: 0 16px 36px rgba(29, 29, 31, 0.24), inset 0 0 0 1px rgba(255, 255, 255, 0.09);
+}
+
+.dark .editorial-cta {
+  border-color: var(--hs-gold);
+  background: linear-gradient(135deg, var(--hs-gold-bright), var(--hs-gold));
+  color: #0e1011;
+}
+
+.dark .editorial-cta:hover {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold-bright) 88%, white), var(--hs-gold-bright));
 }
 
 .editorial-card {
   border: 1px solid var(--editorial-border);
-  background: rgba(255, 250, 243, 0.88);
+  background: color-mix(in srgb, var(--surface-card) 92%, transparent);
   box-shadow: var(--editorial-shadow-soft);
   backdrop-filter: blur(12px);
 }
 
 .editorial-card-strong {
-  border: 1px solid rgba(169, 119, 47, 0.20);
-  background: rgba(255, 250, 243, 0.96);
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 18%, var(--border-soft));
+  background: var(--surface-card-strong);
   box-shadow: var(--editorial-shadow);
 }
 
 .editorial-trust-strip {
-  border-top: 1px solid rgba(45, 42, 52, 0.09);
-  border-bottom: 1px solid rgba(45, 42, 52, 0.09);
-  background: rgba(255, 250, 243, 0.54);
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  background: color-mix(in srgb, var(--surface-card) 56%, transparent);
 }
 
 .editorial-icon-disc {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(45, 42, 52, 0.09);
+  border: 1px solid var(--border-soft);
   border-radius: 999px;
-  background: linear-gradient(145deg, rgba(232, 226, 240, 0.90), rgba(255, 250, 243, 0.92));
-  color: var(--editorial-evergreen-soft);
-  box-shadow: 0 4px 18px rgba(49, 42, 52, 0.055);
+  background: linear-gradient(145deg, color-mix(in srgb, var(--hs-gold-soft) 55%, var(--surface-card)), var(--surface-card));
+  color: var(--hs-gold-ink);
+  box-shadow: 0 4px 18px rgba(46, 44, 40, 0.055);
 }
 
 .editorial-link-tile {
-  border: 1px solid rgba(45, 42, 52, 0.09);
-  background: linear-gradient(145deg, rgba(243, 236, 228, 0.74), rgba(255, 250, 243, 0.96));
+  border: 1px solid var(--border-soft);
+  background: linear-gradient(145deg, var(--surface-subtle), var(--surface-card));
 }
 
 .editorial-link-tile:hover {
-  border-color: rgba(169, 119, 47, 0.32);
-  background: #fffaf3;
+  border-color: color-mix(in srgb, var(--hs-gold) 30%, var(--border-soft));
+  background: var(--surface-card-strong);
   transform: translateY(-2px);
   box-shadow: var(--editorial-shadow-soft);
 }
 
 .interaction-section-shell {
   border-radius: 2rem;
-  border: 1px solid rgba(169, 119, 47, 0.18);
-  background: linear-gradient(145deg, rgba(255, 250, 243, 0.98), rgba(243, 236, 228, 0.92));
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 18%, var(--border-soft));
+  background: linear-gradient(145deg, var(--surface-card-strong), var(--surface));
   box-shadow: var(--editorial-shadow);
 }
 
 .interaction-severity-card {
   overflow: hidden;
-  border: 1px solid rgba(45, 42, 52, 0.10);
+  border: 1px solid var(--border-soft);
   border-radius: 1.35rem;
-  background: rgba(255, 250, 243, 0.94);
-  box-shadow: 0 8px 26px rgba(49, 42, 52, 0.055);
+  background: var(--surface-card);
+  box-shadow: var(--editorial-shadow-soft);
 }
 
 .interaction-severity-card > summary {
@@ -224,26 +232,26 @@ html:not(.dark) body {
 }
 
 .interaction-chip {
-  border: 1px solid rgba(45, 42, 52, 0.08);
-  background: linear-gradient(145deg, rgba(232, 226, 240, 0.70), rgba(243, 236, 228, 0.88));
-  color: var(--editorial-evergreen);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.34);
+  border: 1px solid var(--border-soft);
+  background: linear-gradient(145deg, var(--surface-subtle), var(--surface-card));
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.20);
 }
 
 .interaction-chip:hover {
-  border-color: rgba(169, 119, 47, 0.30);
-  background: #fffaf3;
+  border-color: color-mix(in srgb, var(--hs-gold) 28%, var(--border-soft));
+  background: var(--surface-card-strong);
 }
 
 .editorial-footer {
   position: relative;
   overflow: hidden;
-  border-top: 1px solid rgba(169, 119, 47, 0.20);
+  border-top: 1px solid color-mix(in srgb, var(--hs-gold) 16%, var(--border-soft));
   background:
-    radial-gradient(circle at 94% 18%, rgba(125, 111, 187, 0.16), transparent 18rem),
-    radial-gradient(circle at 8% 90%, rgba(169, 119, 47, 0.08), transparent 20rem),
-    linear-gradient(180deg, #fbf7f1, #f2ebe4);
-  color: var(--editorial-evergreen);
+    radial-gradient(circle at 94% 18%, color-mix(in srgb, var(--hs-gold) 9%, transparent), transparent 18rem),
+    radial-gradient(circle at 8% 90%, color-mix(in srgb, var(--text-primary) 4%, transparent), transparent 20rem),
+    linear-gradient(180deg, var(--bg), var(--surface));
+  color: var(--text-primary);
 }
 
 .editorial-footer::after {
@@ -254,23 +262,29 @@ html:not(.dark) body {
   width: 18rem;
   height: 8rem;
   border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, rgba(111, 102, 168, 0.16), rgba(213, 204, 229, 0.07));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold) 12%, transparent), color-mix(in srgb, var(--text-primary) 3%, transparent));
   transform: rotate(-18deg);
   pointer-events: none;
 }
 
 .editorial-mobile-dock {
-  border: 1px solid rgba(45, 42, 52, 0.15);
-  background: rgba(255, 250, 243, 0.98);
-  box-shadow: 0 -6px 24px rgba(49, 42, 52, 0.09);
+  border: 1px solid var(--border-soft);
+  background: var(--surface-card-strong);
+  box-shadow: 0 -6px 24px rgba(46, 44, 40, 0.09);
   backdrop-filter: blur(14px);
 }
 
 .editorial-mobile-search {
-  border: 1px solid rgba(223, 197, 156, 0.72);
-  background: linear-gradient(145deg, #4b4558, #302c39);
-  color: #fffaf3;
-  box-shadow: 0 3px 10px rgba(49, 42, 52, 0.17);
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 38%, var(--border-strong));
+  background: linear-gradient(145deg, #3b3b3d, #242426);
+  color: #fffdf8;
+  box-shadow: 0 3px 10px rgba(29, 29, 31, 0.17);
+}
+
+.dark .editorial-mobile-search {
+  border-color: var(--hs-gold);
+  background: var(--hs-gold);
+  color: #0e1011;
 }
 
 @media (max-width: 767px) {
@@ -284,57 +298,9 @@ html:not(.dark) body {
   .editorial-botanical-orbit {
     right: -6rem;
     bottom: -5rem;
-    opacity: 0.46;
+    opacity: 0.42;
   }
-}
 
-.dark .editorial-site-shell {
-  background:
-    radial-gradient(circle at 90% 5%, rgba(125, 111, 187, 0.18), transparent 22rem),
-    radial-gradient(circle at 8% 90%, rgba(169, 119, 47, 0.06), transparent 22rem),
-    linear-gradient(180deg, #18161d, #121116 50%, #18161d);
-}
-
-.dark .editorial-hero,
-.dark .editorial-card,
-.dark .editorial-card-strong,
-.dark .interaction-section-shell,
-.dark .interaction-severity-card {
-  border-color: rgba(225, 217, 232, 0.15);
-  background: rgba(32, 30, 37, 0.94);
-}
-
-.dark .editorial-display,
-.dark .editorial-footer,
-.dark .interaction-chip {
-  color: #f5f0e8;
-}
-
-.dark .editorial-footer {
-  border-color: rgba(213, 173, 108, 0.18);
-  background:
-    radial-gradient(circle at 94% 18%, rgba(125, 111, 187, 0.15), transparent 18rem),
-    linear-gradient(180deg, #201e25, #151319);
-}
-
-.dark .interaction-chip,
-.dark .editorial-link-tile,
-.dark .editorial-mobile-dock {
-  border-color: rgba(225, 217, 232, 0.14);
-  background: rgba(41, 38, 48, 0.92);
-}
-
-.dark .editorial-trust-strip {
-  border-color: rgba(225, 217, 232, 0.13);
-  background: rgba(27, 25, 32, 0.72);
-}
-
-.dark .editorial-trust-strip .editorial-icon-disc {
-  background: rgba(235, 229, 241, 0.92);
-  color: #514475;
-}
-
-@media (max-width: 767px) {
   .editorial-card,
   .editorial-card-strong {
     box-shadow: none;
@@ -345,4 +311,49 @@ html:not(.dark) body {
     transform: none;
     box-shadow: none;
   }
+}
+
+.dark .editorial-site-shell {
+  background:
+    radial-gradient(circle at 90% 5%, color-mix(in srgb, var(--hs-gold) 8%, transparent), transparent 22rem),
+    radial-gradient(circle at 8% 90%, color-mix(in srgb, var(--text-primary) 3%, transparent), transparent 22rem),
+    linear-gradient(180deg, var(--surface), var(--bg) 50%, var(--surface));
+}
+
+.dark .editorial-hero,
+.dark .editorial-card,
+.dark .editorial-card-strong,
+.dark .interaction-section-shell,
+.dark .interaction-severity-card {
+  border-color: var(--border-soft);
+}
+
+.dark .editorial-display,
+.dark .editorial-footer,
+.dark .interaction-chip {
+  color: var(--text-primary);
+}
+
+.dark .editorial-footer {
+  border-color: color-mix(in srgb, var(--hs-gold) 18%, var(--border-soft));
+  background:
+    radial-gradient(circle at 94% 18%, color-mix(in srgb, var(--hs-gold) 8%, transparent), transparent 18rem),
+    linear-gradient(180deg, var(--surface), var(--bg));
+}
+
+.dark .interaction-chip,
+.dark .editorial-link-tile,
+.dark .editorial-mobile-dock {
+  border-color: var(--border-soft);
+  background: var(--surface-card);
+}
+
+.dark .editorial-trust-strip {
+  border-color: var(--border-soft);
+  background: color-mix(in srgb, var(--surface-card) 72%, transparent);
+}
+
+.dark .editorial-trust-strip .editorial-icon-disc {
+  background: color-mix(in srgb, var(--hs-gold-soft) 45%, var(--surface-card));
+  color: var(--hs-gold-bright);
 }


### PR DESCRIPTION
Migrate the legacy editorial/botanical surface layer from explicit indigo/lilac styling to the canonical graphite, warm-paper, and brass tokens. Keeps botanical geometry and component structure intact while making the active footer, editorial heroes/cards, icon discs, interaction chips, dock, and mobile search inherit one visual system. Presentation only; no content or interaction logic changes.