### PR TITLE
refactor(visual): trim obsolete editorial ornament

### DIFF
--- a/styles/editorial-botanical-refresh.css
+++ b/styles/editorial-botanical-refresh.css
@@ -1,12 +1,11 @@
-/* Editorial specimen visual system.
-   Botanical geometry remains distinctive, while shared surfaces now derive from
-   the canonical graphite, warm-paper, and brass tokens. Green remains semantic. */
+/* Editorial shared surfaces.
+   Keep useful card, CTA, interaction, and footer primitives; decorative visual
+   generations have been removed so the graphite/ivory/brass system stays clear. */
 
 :root {
   --editorial-paper: var(--bg);
   --editorial-paper-strong: var(--surface-elevated);
   --editorial-cream: var(--surface);
-  /* Legacy names remain for component compatibility, but no longer imply sage. */
   --editorial-sage: var(--surface-subtle);
   --editorial-sage-strong: color-mix(in srgb, var(--surface) 82%, var(--text-primary));
   --editorial-evergreen: var(--text-primary);
@@ -23,108 +22,11 @@ html.dark {
   --editorial-shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.24);
 }
 
-.editorial-site-shell {
-  position: relative;
-  overflow: hidden;
-  background:
-    radial-gradient(circle at 92% 5%, color-mix(in srgb, var(--hs-gold) 10%, transparent), transparent 22rem),
-    radial-gradient(circle at 4% 30%, color-mix(in srgb, var(--text-primary) 4%, transparent), transparent 24rem),
-    linear-gradient(180deg, var(--surface-elevated) 0%, var(--bg) 42%, var(--surface) 100%);
-}
-
-.editorial-site-shell::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.24;
-  background-image: radial-gradient(circle at 24px 24px, color-mix(in srgb, var(--text-primary) 5%, transparent) 1px, transparent 1.5px);
-  background-size: 46px 46px;
-  mask-image: linear-gradient(to bottom, #000 0%, transparent 48%);
-}
-
-.editorial-hero {
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--hs-gold) 20%, var(--border-soft));
-  border-radius: clamp(1.5rem, 4vw, 2.5rem);
-  background:
-    radial-gradient(circle at 82% 18%, color-mix(in srgb, var(--surface-elevated) 88%, transparent), transparent 17rem),
-    radial-gradient(circle at 100% 100%, color-mix(in srgb, var(--hs-gold) 7%, transparent), transparent 20rem),
-    linear-gradient(135deg, var(--surface-elevated), color-mix(in srgb, var(--surface) 88%, var(--surface-elevated)));
-  box-shadow: var(--editorial-shadow);
-}
-
-.editorial-hero::before,
-.editorial-hero::after {
-  content: '';
-  position: absolute;
-  z-index: -1;
-  pointer-events: none;
-  border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold) 18%, transparent), color-mix(in srgb, var(--text-primary) 4%, transparent));
-  filter: blur(0.2px);
-}
-
-.editorial-hero::before {
-  width: 19rem;
-  height: 8rem;
-  right: -5rem;
-  top: 8rem;
-  transform: rotate(-24deg);
-}
-
-.editorial-hero::after {
-  width: 13rem;
-  height: 5.5rem;
-  right: 2rem;
-  bottom: 2.5rem;
-  transform: rotate(23deg);
-}
-
-.editorial-botanical-orbit {
-  position: absolute;
-  right: -2.5rem;
-  bottom: -3.5rem;
-  width: 16rem;
-  height: 20rem;
-  opacity: 0.68;
-  pointer-events: none;
-}
-
-.editorial-botanical-orbit::before {
-  content: '';
-  position: absolute;
-  left: 48%;
-  bottom: 0;
-  width: 2px;
-  height: 18rem;
-  transform: rotate(18deg);
-  transform-origin: bottom;
-  background: linear-gradient(to top, color-mix(in srgb, var(--text-secondary) 48%, transparent), color-mix(in srgb, var(--hs-gold) 12%, transparent));
-}
-
-.editorial-botanical-orbit span {
-  position: absolute;
-  display: block;
-  width: 5.5rem;
-  height: 2.2rem;
-  border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold) 42%, transparent), color-mix(in srgb, var(--text-secondary) 15%, transparent));
-  box-shadow: inset 0 0 0 1px var(--border-soft);
-}
-
-.editorial-botanical-orbit span:nth-child(1) { right: 6.7rem; bottom: 4rem; transform: rotate(15deg); }
-.editorial-botanical-orbit span:nth-child(2) { right: 2rem; bottom: 7.2rem; transform: rotate(168deg); }
-.editorial-botanical-orbit span:nth-child(3) { right: 7.3rem; bottom: 10.4rem; transform: rotate(5deg); }
-.editorial-botanical-orbit span:nth-child(4) { right: 1.7rem; bottom: 13.5rem; transform: rotate(172deg); }
-
 .editorial-eyebrow {
   color: var(--editorial-gold);
   font-size: 0.72rem;
   font-weight: 800;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
@@ -132,38 +34,37 @@ html.dark {
   color: var(--editorial-evergreen);
   font-family: var(--font-fraunces), Fraunces, Georgia, serif;
   font-weight: 650;
-  letter-spacing: -0.045em;
-  line-height: 0.98;
+  letter-spacing: -0.04em;
+  line-height: 1;
 }
 
 .editorial-cta {
-  border: 1px solid color-mix(in srgb, var(--hs-gold) 38%, var(--border-strong));
-  background: linear-gradient(135deg, #3b3b3d, #242426);
+  border: 1px solid color-mix(in srgb, var(--hs-gold) 34%, var(--border-strong));
+  background: linear-gradient(180deg, #3b3b3d, #29292b);
   color: #fffdf8;
-  box-shadow: 0 12px 28px rgba(29, 29, 31, 0.20), inset 0 0 0 1px rgba(255, 255, 255, 0.07);
+  box-shadow: 0 10px 24px rgba(29, 29, 31, 0.16);
 }
 
 .editorial-cta:hover {
-  transform: translateY(-2px);
-  background: linear-gradient(135deg, #49494b, #2d2d2f);
-  box-shadow: 0 16px 36px rgba(29, 29, 31, 0.24), inset 0 0 0 1px rgba(255, 255, 255, 0.09);
+  transform: translateY(-1px);
+  background: linear-gradient(180deg, #454547, #303032);
+  box-shadow: 0 14px 30px rgba(29, 29, 31, 0.20);
 }
 
 .dark .editorial-cta {
   border-color: var(--hs-gold);
-  background: linear-gradient(135deg, var(--hs-gold-bright), var(--hs-gold));
+  background: linear-gradient(180deg, var(--hs-gold-bright), var(--hs-gold));
   color: #0e1011;
 }
 
 .dark .editorial-cta:hover {
-  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold-bright) 88%, white), var(--hs-gold-bright));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--hs-gold-bright) 88%, white), var(--hs-gold-bright));
 }
 
 .editorial-card {
   border: 1px solid var(--editorial-border);
-  background: color-mix(in srgb, var(--surface-card) 92%, transparent);
+  background: var(--surface-card);
   box-shadow: var(--editorial-shadow-soft);
-  backdrop-filter: blur(12px);
 }
 
 .editorial-card-strong {
@@ -184,34 +85,34 @@ html.dark {
   justify-content: center;
   border: 1px solid var(--border-soft);
   border-radius: 999px;
-  background: linear-gradient(145deg, color-mix(in srgb, var(--hs-gold-soft) 55%, var(--surface-card)), var(--surface-card));
+  background: var(--surface-card);
   color: var(--hs-gold-ink);
-  box-shadow: 0 4px 18px rgba(46, 44, 40, 0.055);
+  box-shadow: none;
 }
 
 .editorial-link-tile {
   border: 1px solid var(--border-soft);
-  background: linear-gradient(145deg, var(--surface-subtle), var(--surface-card));
+  background: var(--surface-card);
 }
 
 .editorial-link-tile:hover {
   border-color: color-mix(in srgb, var(--hs-gold) 30%, var(--border-soft));
   background: var(--surface-card-strong);
-  transform: translateY(-2px);
+  transform: translateY(-1px);
   box-shadow: var(--editorial-shadow-soft);
 }
 
 .interaction-section-shell {
-  border-radius: 2rem;
+  border-radius: 1.5rem;
   border: 1px solid color-mix(in srgb, var(--hs-gold) 18%, var(--border-soft));
-  background: linear-gradient(145deg, var(--surface-card-strong), var(--surface));
+  background: var(--surface-card-strong);
   box-shadow: var(--editorial-shadow);
 }
 
 .interaction-severity-card {
   overflow: hidden;
   border: 1px solid var(--border-soft);
-  border-radius: 1.35rem;
+  border-radius: 1.1rem;
   background: var(--surface-card);
   box-shadow: var(--editorial-shadow-soft);
 }
@@ -233,9 +134,8 @@ html.dark {
 
 .interaction-chip {
   border: 1px solid var(--border-soft);
-  background: linear-gradient(145deg, var(--surface-subtle), var(--surface-card));
+  background: var(--surface-card);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.20);
 }
 
 .interaction-chip:hover {
@@ -245,87 +145,9 @@ html.dark {
 
 .editorial-footer {
   position: relative;
-  overflow: hidden;
   border-top: 1px solid color-mix(in srgb, var(--hs-gold) 16%, var(--border-soft));
-  background:
-    radial-gradient(circle at 94% 18%, color-mix(in srgb, var(--hs-gold) 9%, transparent), transparent 18rem),
-    radial-gradient(circle at 8% 90%, color-mix(in srgb, var(--text-primary) 4%, transparent), transparent 20rem),
-    linear-gradient(180deg, var(--bg), var(--surface));
+  background: transparent;
   color: var(--text-primary);
-}
-
-.editorial-footer::after {
-  content: '';
-  position: absolute;
-  right: -5rem;
-  bottom: 4rem;
-  width: 18rem;
-  height: 8rem;
-  border-radius: 999px 0 999px 0;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--hs-gold) 12%, transparent), color-mix(in srgb, var(--text-primary) 3%, transparent));
-  transform: rotate(-18deg);
-  pointer-events: none;
-}
-
-.editorial-mobile-dock {
-  border: 1px solid var(--border-soft);
-  background: var(--surface-card-strong);
-  box-shadow: 0 -6px 24px rgba(46, 44, 40, 0.09);
-  backdrop-filter: blur(14px);
-}
-
-.editorial-mobile-search {
-  border: 1px solid color-mix(in srgb, var(--hs-gold) 38%, var(--border-strong));
-  background: linear-gradient(145deg, #3b3b3d, #242426);
-  color: #fffdf8;
-  box-shadow: 0 3px 10px rgba(29, 29, 31, 0.17);
-}
-
-.dark .editorial-mobile-search {
-  border-color: var(--hs-gold);
-  background: var(--hs-gold);
-  color: #0e1011;
-}
-
-@media (max-width: 767px) {
-  .editorial-hero::before {
-    width: 12rem;
-    height: 5rem;
-    right: -5rem;
-    top: 12rem;
-  }
-
-  .editorial-botanical-orbit {
-    right: -6rem;
-    bottom: -5rem;
-    opacity: 0.42;
-  }
-
-  .editorial-card,
-  .editorial-card-strong {
-    box-shadow: none;
-    backdrop-filter: none;
-  }
-
-  .editorial-link-tile:hover {
-    transform: none;
-    box-shadow: none;
-  }
-}
-
-.dark .editorial-site-shell {
-  background:
-    radial-gradient(circle at 90% 5%, color-mix(in srgb, var(--hs-gold) 8%, transparent), transparent 22rem),
-    radial-gradient(circle at 8% 90%, color-mix(in srgb, var(--text-primary) 3%, transparent), transparent 22rem),
-    linear-gradient(180deg, var(--surface), var(--bg) 50%, var(--surface));
-}
-
-.dark .editorial-hero,
-.dark .editorial-card,
-.dark .editorial-card-strong,
-.dark .interaction-section-shell,
-.dark .interaction-severity-card {
-  border-color: var(--border-soft);
 }
 
 .dark .editorial-display,
@@ -336,14 +158,11 @@ html.dark {
 
 .dark .editorial-footer {
   border-color: color-mix(in srgb, var(--hs-gold) 18%, var(--border-soft));
-  background:
-    radial-gradient(circle at 94% 18%, color-mix(in srgb, var(--hs-gold) 8%, transparent), transparent 18rem),
-    linear-gradient(180deg, var(--surface), var(--bg));
+  background: transparent;
 }
 
 .dark .interaction-chip,
-.dark .editorial-link-tile,
-.dark .editorial-mobile-dock {
+.dark .editorial-link-tile {
   border-color: var(--border-soft);
   background: var(--surface-card);
 }
@@ -354,6 +173,18 @@ html.dark {
 }
 
 .dark .editorial-trust-strip .editorial-icon-disc {
-  background: color-mix(in srgb, var(--hs-gold-soft) 45%, var(--surface-card));
+  background: var(--surface-card);
   color: var(--hs-gold-bright);
+}
+
+@media (max-width: 767px) {
+  .editorial-card,
+  .editorial-card-strong {
+    box-shadow: none;
+  }
+
+  .editorial-link-tile:hover {
+    transform: none;
+    box-shadow: none;
+  }
 }


### PR DESCRIPTION
Removes orphan decorative shell/orbit/mobile-dock styling and flattens shared editorial surfaces to the graphite/ivory/brass system. Keeps the useful card, CTA, interaction, footer, and typography primitives while deleting ornamental geometry and redundant gradients.