### PR TITLE
Trust: rebuild anti-inflammatory guide around outcome-specific evidence

### DIFF
--- a/app/guides/other/anti-inflammatory-supplements/page.tsx
+++ b/app/guides/other/anti-inflammatory-supplements/page.tsx
@@ -4,7 +4,8 @@ import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
-import FAQSchema from '@/components/seo/FAQSchema'
+import LegacyGuideFAQ from '@/components/LegacyGuideFAQ'
+import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
 import RecommendationSection from '@/components/RecommendationSection'
@@ -12,81 +13,238 @@ import { getRevenueProductSet } from '@/config/revenue-products'
 
 export const metadata: Metadata = buildPageMetadata({
   title: 'Anti-Inflammatory Supplements: Evidence Review (2026)',
-  description: 'Turmeric, omega-3, ginger, boswellia, and quercetin — evidence-graded comparison of the best anti-inflammatory supplements for joints, gut, and systemic inflammation.',
+  description:
+    'Outcome-specific 2026 review of curcumin, omega-3, ginger, Boswellia, and quercetin—what human evidence supports, what remains uncertain, and where safety or formulation changes the answer.',
   path: '/guides/other/anti-inflammatory-supplements/',
   openGraphType: 'article',
 })
 
 const FAQS = [
-  { question: 'What is the best natural anti-inflammatory?', answer: 'Turmeric/curcumin has the strongest human evidence for joint inflammation [1]. Omega-3 fatty acids have the broadest evidence — cardiovascular, joint, and systemic inflammatory markers. Ginger shows promise for muscle soreness and menstrual pain. Boswellia has specific evidence for OA knee pain. None replace NSAIDs for acute pain, but all have better long-term safety profiles.' },
-  { question: 'Can I replace ibuprofen with turmeric?', answer: 'Not for acute pain. Curcumin\'s anti-inflammatory effect builds over weeks and is much milder than NSAIDs. For chronic inflammatory conditions (OA), curcumin at 500-1,500 mg/day with bioavailability enhancement (piperine or phytosome) may allow some people to reduce NSAID use. Discuss with your doctor — do not stop prescribed medications without medical guidance.' },
-  { question: 'How much omega-3 for inflammation?', answer: '2,000-4,000 mg EPA+DHA/day for anti-inflammatory effects — higher than general health doses. This typically requires 4-8 standard fish oil capsules or 2-4 high-concentration ones. Prescription omega-3 (Lovaza, Vascepa) provides 2,000-4,000 mg in fewer pills. Effects on inflammatory markers are dose-dependent and appear at 4-12 weeks.' },
-  { question: 'What causes chronic inflammation?', answer: 'Obesity (adipose tissue secretes pro-inflammatory cytokines), poor diet (high in processed foods, sugar, seed oils), chronic stress (elevated cortisol disrupts immune regulation), sleep deprivation, smoking, and sedentary behavior. Supplements can modestly reduce inflammatory markers, but addressing the underlying cause is far more effective.' },
-  { question: 'Can I stack anti-inflammatory supplements?', answer: 'Yes, with caution. Curcumin + omega-3 is a well-studied combination for joint health — they work through different pathways (NF-kB/COX vs membrane lipid modulation). Adding ginger or boswellia is generally safe. Monitor for bleeding risk if combining multiple supplements with blood-thinning effects (omega-3, curcumin, ginger all have mild antiplatelet activity).' },
-]
+  {
+    question: 'What is the best natural anti-inflammatory supplement?',
+    answer:
+      'There is no evidence-based universal winner. Curcumin and Boswellia have human evidence for some knee-osteoarthritis symptoms, omega-3 fatty acids have anti-inflammatory biology plus selected rheumatoid-arthritis and cardiovascular evidence, and ginger has human evidence for primary dysmenorrhea. Those are different outcomes, populations, products, and evidence bases—not one ranking.',
+  },
+  {
+    question: 'Can turmeric or curcumin replace ibuprofen or another NSAID?',
+    answer:
+      'Do not treat turmeric or curcumin as a drop-in replacement for an NSAID. Some osteoarthritis trials and syntheses report symptom improvement, but formulation and study quality vary and NCCIH says the evidence is not definitive. Do not stop or replace prescribed or over-the-counter medicines without discussing the reason, risks, and alternatives with a clinician or pharmacist.',
+  },
+  {
+    question: 'How much omega-3 should someone take for inflammation?',
+    answer:
+      'There is no universal EPA+DHA dose validated for a generic diagnosis of “inflammation.” Dose and formulation depend on the studied outcome. High-dose prescription omega-3 therapy for severe hypertriglyceridemia is a different clinical use from taking a retail fish-oil supplement, and high-dose trials have identified risks that matter in selected patients.',
+  },
+  {
+    question: 'What causes chronic inflammation?',
+    answer:
+      'Inflammation is a biological process, not one diagnosis. Persistent inflammatory activity can accompany infections, autoimmune disease, obesity, smoking, sleep disruption, periodontal disease, inflammatory disorders, and many other conditions. A supplement should not substitute for identifying and treating the underlying cause when symptoms or abnormal inflammatory markers are persistent.',
+  },
+  {
+    question: 'Should curcumin, omega-3, ginger, and Boswellia be stacked together?',
+    answer:
+      'There is not a robust clinical evidence base showing that a four-supplement stack produces better patient-important outcomes than using an appropriately chosen intervention for a specific indication. Combining supplements can also change tolerability and interaction risk. Use the evidence for the actual condition and review combinations with a clinician or pharmacist when medications, pregnancy, bleeding risk, liver disease, or other medical issues are relevant.',
+  },
+] as const
 
 const ANTI_INFLAM_REFS = [
-  { n: 1, text: 'Daily JW, et al. (2016). Efficacy of turmeric extracts and curcumin for arthritis. J Med Food, 19(8): 717-729.', url: 'https://pubmed.ncbi.nlm.nih.gov/27533649/' },
-  { n: 2, text: 'Calder PC. (2017). Omega-3 fatty acids and inflammatory processes. Biochem Soc Trans, 45(5): 1105-1115.', url: 'https://pubmed.ncbi.nlm.nih.gov/28900017/' },
-  { n: 3, text: 'Mashhadi NS, et al. (2013). Ginger and inflammation. Int J Prev Med, 4(Suppl 1): S36-S42.', url: 'https://pubmed.ncbi.nlm.nih.gov/23717767/' },
-  { n: 4, text: 'Mashhadi NS, et al. (2013). Ginger and inflammation. Int J Prev Med, 4(S1): S36-S42.', url: 'https://pubmed.ncbi.nlm.nih.gov/23717767/' },
-  { n: 5, text: 'Kimmatkar N, et al. (2003). Boswellia for knee OA. Phytomedicine, 10(1): 3-7.', url: 'https://pubmed.ncbi.nlm.nih.gov/12622457/' },
-  { n: 6, text: 'Li Y, et al. (2015). Quercetin and inflammation. Nutrients, 8(3): 167.', url: 'https://pubmed.ncbi.nlm.nih.gov/26999193/' },
-
+  {
+    n: 1,
+    text: 'Inprasit C, et al. Evaluating the efficacy and safety of Curcuma longa, Boswellia serrata, and their mixed formulation in treating knee osteoarthritis: a systematic review and network meta-analysis. Complement Ther Med. 2026;96:103256. PMID 41082950.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/41082950/',
+    pmid: '41082950',
+  },
+  {
+    n: 2,
+    text: 'Calder PC. Omega-3 fatty acids and inflammatory processes: from molecules to man. Biochem Soc Trans. 2017;45(5):1105-1115. PMID 28900017.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/28900017/',
+    pmid: '28900017',
+  },
+  {
+    n: 3,
+    text: 'Moshfeghinia R, et al. Ginger for Pain Management in Primary Dysmenorrhea: A Systematic Review and Meta-Analysis. J Integr Complement Med. 2024;30(11):1016-1030. PMID 38770631.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/38770631/',
+    pmid: '38770631',
+  },
+  {
+    n: 4,
+    text: 'Dalmonte T, et al. Efficacy of Extracts of Oleogum Resin of Boswellia in the Treatment of Knee Osteoarthritis: A Systematic Review and Meta-Analysis. Phytother Res. 2024;38(12):5672-5689. PMID 39314013.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/39314013/',
+    pmid: '39314013',
+  },
+  {
+    n: 5,
+    text: 'Li Y, et al. Quercetin, Inflammation and Immunity. Nutrients. 2016;8(3):167. PMID 26999194.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/26999194/',
+    pmid: '26999194',
+  },
+  {
+    n: 6,
+    text: 'National Center for Complementary and Integrative Health. Turmeric: Usefulness and Safety. Current evidence and safety summary, including formulation variability and reported liver injury with some highly bioavailable products.',
+    url: 'https://www.nccih.nih.gov/health/turmeric',
+  },
+  {
+    n: 7,
+    text: 'NIH Office of Dietary Supplements. Omega-3 Fatty Acids: Health Professional Fact Sheet. Current efficacy, safety, and interaction summary.',
+    url: 'https://ods.od.nih.gov/factsheets/Omega3FattyAcids-HealthProfessional/',
+  },
+  {
+    n: 8,
+    text: 'Daily JW, et al. Efficacy of Turmeric Extracts and Curcumin for Alleviating the Symptoms of Joint Arthritis: A Systematic Review and Meta-Analysis of Randomized Clinical Trials. J Med Food. 2016;19(8):717-729. PMID 27533649.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/27533649/',
+    pmid: '27533649',
+  },
 ]
 
 export default function AntiInflammatoryPage() {
   return (
     <div className="container-page py-10 space-y-10">
-      <AuthorityJsonLd title="Anti-Inflammatory Supplements" description="Turmeric, omega-3, ginger — evidence-graded comparison." url="https://thehippiescientist.net/guides/other/anti-inflammatory-supplements" type="Article" />
+      <AuthorityJsonLd
+        title="Anti-Inflammatory Supplements: Outcome-Specific Evidence Review"
+        description="Evidence-calibrated comparison of curcumin, omega-3, ginger, Boswellia, and quercetin by studied outcome, formulation, and safety limitations."
+        url="https://thehippiescientist.net/guides/other/anti-inflammatory-supplements/"
+        type="MedicalWebPage"
+        citationUrls={ANTI_INFLAM_REFS.map(reference => reference.url)}
+      />
       <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Anti-Inflammatory Supplements' }]} />
-      <FAQSchema pagePath="/guides/other/anti-inflammatory-supplements/" questions={FAQS} />
 
-      <section className="space-y-5 max-w-4xl"><p className="eyebrow-label">Evidence Review · 6 References</p><h1 className="text-5xl font-bold tracking-tight text-ink">Anti-Inflammatory Supplements: What the Evidence Shows</h1><p className="text-lg leading-8 text-muted">Chronic inflammation underlies nearly every modern disease — cardiovascular, metabolic, neurodegenerative, and autoimmune. The supplement industry has responded with dozens of "anti-inflammatory" products. Some have evidence. Most don&rsquo;t. Here&rsquo;s the evidence-graded comparison of the five best-studied options.</p>
-        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/anti-inflammatory-supplements.jpg" alt="Turmeric root, omega-3 capsules, and ginger — anti-inflammatory supplements" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Anti-inflammatory supplements — evidence-graded, from strongest to weakest.</figcaption></figure></section>
+      <section className="space-y-5 max-w-4xl">
+        <p className="eyebrow-label">Evidence Review · 8 References · Updated August 16, 2026</p>
+        <h1 className="text-5xl font-bold tracking-tight text-ink">Anti-Inflammatory Supplements: What the Evidence Actually Supports</h1>
+        <p className="text-lg leading-8 text-muted">
+          “Anti-inflammatory” is too broad to rank supplements responsibly. A product can alter an inflammatory pathway or biomarker without improving pain, function, cardiovascular outcomes, or a specific inflammatory disease. This review therefore separates the evidence by <strong>outcome, population, formulation, and study type</strong> rather than declaring one universal best supplement.
+        </p>
+        <figure className="mt-6">
+          <div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white">
+            <Image src="/images/guides/anti-inflammatory-supplements.jpg" alt="Turmeric root, omega-3 capsules, and ginger used in anti-inflammatory supplement research" width={1536} height={1024} priority className="w-full h-auto" />
+          </div>
+          <figcaption className="mt-3 text-center text-sm text-muted">The useful question is not “which supplement lowers inflammation?” but “which intervention improved which outcome in which population?”</figcaption>
+        </figure>
+      </section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Quick answer</h2><p className="text-sm leading-7 text-muted">The best evidence supports <strong>omega-3 fatty acids</strong> (broadest anti-inflammatory evidence, cardiovascular and joint outcomes [2]), <strong>curcumin</strong> (strongest joint-specific evidence, needs bioavailability enhancement [1]), and <strong>ginger</strong> (muscle soreness and menstrual pain [3]). Boswellia has OA-specific evidence. Quercetin is mechanistically interesting but human evidence is limited. No supplement replaces the anti-inflammatory effect of weight loss, exercise, sleep, and a whole-foods diet. Start with omega-3 and curcumin — they cover the most ground with the strongest evidence.</p></section>
+      <LegacyGuideQuickAnswer referencesHref="#references">
+        <p>
+          The most defensible human evidence in this group is <strong>outcome-specific</strong>. Curcumin/turmeric and Boswellia have signals for knee-osteoarthritis symptoms, but results vary by formulation and synthesis [1,4,8]. Omega-3 EPA/DHA has established anti-inflammatory biology and selected clinical evidence, but effects differ by condition and high-dose prescription uses should not be collapsed into a generic supplement recommendation [2,7]. Ginger has a human pain signal for primary dysmenorrhea, with substantial heterogeneity and incomplete safety reporting [3]. Quercetin has interesting inflammatory biology, but the cited literature is much more mechanistic than proof of a specific clinical anti-inflammatory treatment [5].
+        </p>
+        <p className="mt-3">
+          None of these evidence bases supports a universal “anti-inflammatory stack,” a single consumer dose for “inflammation,” or replacing diagnosis and established treatment of an inflammatory condition with supplements.
+        </p>
+      </LegacyGuideQuickAnswer>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30"><p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Anti-Inflammatory Supplements</p>
-        <div className="overflow-x-auto"><table className="min-w-full text-sm"><thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Supplement</th><th className="text-left py-2 pr-4 font-semibold text-ink">Best For</th><th className="text-left py-2 pr-4 font-semibold text-ink">Evidence</th><th className="text-left py-2 pr-4 font-semibold text-ink">Dose</th><th className="text-left py-2 font-semibold text-ink">Note</th></tr></thead><tbody className="text-muted">
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Omega-3 (EPA/DHA)</td><td className="py-2 pr-4">Systemic, CV, joint</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-800">Strong</span></td><td className="py-2 pr-4">2-4 g EPA+DHA</td><td className="py-2">Mild blood thinning</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Curcumin (Turmeric)</td><td className="py-2 pr-4">Joint (OA), general</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-800">Strong</span></td><td className="py-2 pr-4">500-1500 mg</td><td className="py-2">Needs piperine/phytosome</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Ginger</td><td className="py-2 pr-4">Muscle soreness, menstrual</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800">Moderate</span></td><td className="py-2 pr-4">1-2 g/day</td><td className="py-2">Well tolerated</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Boswellia</td><td className="py-2 pr-4">Knee OA</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800">Moderate</span></td><td className="py-2 pr-4">300-500 mg AKBA</td><td className="py-2">Fast onset (days-weeks)</td></tr>
-          <tr><td className="py-2 pr-4 font-medium text-ink">Quercetin</td><td className="py-2 pr-4">Allergy, mast cell</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-bold text-red-800">Limited</span></td><td className="py-2 pr-4">500-1000 mg</td><td className="py-2">Poor bioavailability</td></tr>
-        </tbody></table></div>
-        <div className="mt-3 p-3 rounded-lg bg-white border border-brand-200"><p className="text-xs font-semibold text-ink">Recommended stack:</p><p className="mt-1 text-xs leading-5 text-muted">Omega-3 (2 g EPA+DHA) + curcumin (500 mg with piperine) as the core. Add ginger for muscle soreness or boswellia for OA-specific joint pain. Total: $25-40/month for the core two. This is one of the better-evidenced supplement stacks — both have outcome data, not just biomarker changes.</p></div></section>
-
-      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2><p className="text-sm leading-7 text-muted">Omega-3 fatty acids at 2-4 g EPA+DHA/day and curcumin at 500-1,500 mg/day (with bioavailability enhancement) are the two best-evidenced anti-inflammatory supplements [1,2]. They work through different pathways and can be safely combined. Ginger and boswellia are second-line options with specific use cases. No supplement replaces the anti-inflammatory effect of weight loss, exercise, sleep, and a whole-foods diet — but for people with chronic inflammatory conditions, this stack is one of the most evidence-supported interventions in the supplement world.</p></section>
-
-      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">When to take each one</h2><p className="text-sm leading-7 text-muted"><strong>Omega-3:</strong> With food (fat improves absorption). Split dose morning/evening to reduce fish burps. <strong>Curcumin:</strong> With food + black pepper (piperine) or as phytosome formulation. Morning or midday — some report mild stimulating effects. <strong>Ginger:</strong> With or without food. Before exercise for muscle soreness prevention. <strong>Boswellia:</strong> With food. Morning and evening (split dose). <strong>Quercetin:</strong> With food (fat-soluble). Morning — may be mildly stimulating. Separate from iron supplements by 2 hours (quercetin chelates iron). Do not take all five at once — start with omega-3 + curcumin, assess for 4 weeks, then add ginger or boswellia if needed.</p></section>
-      <section className="card-premium p-6 space-y-4 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Frequently asked questions</h2>
-        <div className="space-y-4">
-          {FAQS.map((faq) => (
-            <div key={faq.question} className="rounded-xl border border-brand-900/10 bg-brand-50/40 p-4">
-              <h3 className="font-semibold text-ink">{faq.question}</h3>
-              <p className="mt-2 text-sm leading-7 text-muted">{faq.answer}</p>
-            </div>
-          ))}
+      <section id="anti-inflammatory-evidence-ledger" data-answer-engine-table="true" className="card-premium scroll-mt-24 p-6 space-y-4 max-w-5xl border-l-4 border-brand-700 bg-brand-50/30">
+        <p className="eyebrow-label">Outcome-specific evidence ledger</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Five ingredients, five different evidence questions</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-[940px] w-full text-sm">
+            <caption className="sr-only">Clinical evidence and limitations for common supplements marketed as anti-inflammatory</caption>
+            <thead>
+              <tr className="border-b border-brand-900/10">
+                <th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">Ingredient</th>
+                <th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">Best-supported question here</th>
+                <th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">What the evidence says</th>
+                <th scope="col" className="text-left py-2 font-semibold text-ink">Main limitation</th>
+              </tr>
+            </thead>
+            <tbody className="text-muted">
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Curcumin / turmeric</th>
+                <td className="py-3 pr-4">Knee-OA pain and function</td>
+                <td className="py-3 pr-4">Several syntheses report symptom signals, including formulation-specific effects [1,8]</td>
+                <td className="py-3">Products and bioavailability strategies differ; NCCIH says evidence is not definitive and reports liver injury with some highly bioavailable formulations [6]</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Omega-3 EPA/DHA</th>
+                <td className="py-3 pr-4">Inflammatory pathways and selected disease-specific outcomes</td>
+                <td className="py-3 pr-4">Human evidence includes rheumatoid-arthritis and cardiometabolic contexts, but results are condition-specific [2,7]</td>
+                <td className="py-3">Retail supplements, diet, and prescription high-dose omega-3 are not interchangeable evidence categories; 4-g/day trials have shown a small atrial-fibrillation signal in high-risk populations [7]</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Ginger</th>
+                <td className="py-3 pr-4">Primary dysmenorrhea pain</td>
+                <td className="py-3 pr-4">A 2024 meta-analysis found lower pain intensity and duration versus placebo [3]</td>
+                <td className="py-3">High heterogeneity; safety reporting was incomplete; this does not establish ginger as a universal anti-inflammatory or muscle-recovery treatment [3]</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Boswellia</th>
+                <td className="py-3 pr-4">Knee-OA symptoms</td>
+                <td className="py-3 pr-4">Some formulations and analyses report symptom improvement [1]</td>
+                <td className="py-3">A separate 2024 meta-analysis found no significant pooled WOMAC/VAS effect because of high heterogeneity, so a category-wide grade would hide real disagreement [4]</td>
+              </tr>
+              <tr className="align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Quercetin</th>
+                <td className="py-3 pr-4">Inflammatory mechanisms and immune biology</td>
+                <td className="py-3 pr-4">Mechanistic and preclinical literature is substantial [5]</td>
+                <td className="py-3">That is not the same as robust evidence for treating allergy, mast-cell disease, arthritis, or a generic state of “inflammation” in humans</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </section>
 
-      <section className="card-premium p-6 space-y-3 max-w-4xl"><h2 className="text-2xl font-semibold tracking-tight text-ink">Related reading</h2>
-        <p className="text-sm leading-7 text-muted">Go deeper on the two best-evidenced picks and the ingredients in the stack:</p>
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Why the old stack model fails</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Mechanisms do not make ingredients automatically additive</h2>
+        <p className="text-sm leading-7 text-muted">
+          Two supplements can act on different inflammatory pathways without a trial showing that the combination improves a patient-important outcome. The previous version of this guide converted pathway diversity into a default curcumin-plus-omega-3 stack and then suggested adding ginger or Boswellia. The cited evidence does not establish that sequence as a validated treatment strategy.
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          A better approach is to start with the <strong>actual clinical problem</strong>: for example, knee-OA symptoms, severe hypertriglyceridemia, primary dysmenorrhea, rheumatoid arthritis, or an unexplained elevated inflammatory marker. Those are different questions and can require very different evaluation and treatment.
+        </p>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Safety and formulation boundaries</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">“Natural” does not remove dose, interaction, or product-quality questions</h2>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
+          <li><strong>Curcumin:</strong> NCCIH notes substantial formulation variability and reports liver injury in some users of highly bioavailable formulations [6]. That makes “more absorption is always better” an unsafe shortcut.</li>
+          <li><strong>Omega-3:</strong> NIH ODS separates food intake, supplements, and prescription products and notes medication interactions plus a small atrial-fibrillation signal in some long-term 4-g/day trials [7].</li>
+          <li><strong>Ginger:</strong> a condition-specific efficacy signal does not substitute for a complete safety database; the 2024 dysmenorrhea synthesis noted infrequent safety reporting [3].</li>
+          <li><strong>Boswellia:</strong> extract composition matters. Results from one standardized formulation should not be generalized automatically to every retail resin extract [1,4].</li>
+          <li><strong>Quercetin:</strong> strong mechanism language is not a clinical indication. Medication use, pregnancy, kidney/liver disease, or other medical conditions can change whether supplement use deserves professional review.</li>
+        </ul>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Evidence applicability</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What this page does not claim</h2>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
+          <li>It does not claim that lowering CRP or changing an inflammatory pathway automatically improves symptoms or prevents disease.</li>
+          <li>It does not rank a supplement as “best” across osteoarthritis, autoimmune disease, cardiovascular disease, exercise soreness, and menstrual pain.</li>
+          <li>It does not convert study doses into a personalized protocol.</li>
+          <li>It does not assume that curcumin, omega-3, ginger, Boswellia, and quercetin are safer than NSAIDs or prescription treatment as a class.</li>
+          <li>It does not treat one branded or bioavailability-enhanced formulation as evidence for all products with the same ingredient name.</li>
+        </ul>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2>
+        <p className="text-sm leading-7 text-muted">
+          Several supplements marketed as anti-inflammatory have legitimate human research, but the evidence is <strong>condition-specific and formulation-sensitive</strong>. Curcumin and Boswellia have the clearest discussion here in knee osteoarthritis, ginger has a signal in dysmenorrhea, omega-3 evidence varies by disease and product type, and quercetin remains much stronger mechanistically than clinically. The useful edge is not a five-product stack—it is matching a claim to the outcome that was actually studied and preserving the uncertainty around safety, formulation, and generalizability [1-8].
+        </p>
+      </section>
+
+      <LegacyGuideFAQ questions={[...FAQS]} pagePath="/guides/other/anti-inflammatory-supplements/" />
+
+      <section className="card-premium p-6 space-y-3 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Related reading</h2>
+        <p className="text-sm leading-7 text-muted">Go deeper on the ingredients and outcome-specific evidence:</p>
         <ul className="grid gap-2 sm:grid-cols-2 text-sm font-semibold text-brand-800">
           <li><Link href="/guides/other/curcumin-absorption-guide/" className="hover:underline">Curcumin absorption guide →</Link></li>
           <li><Link href="/guides/other/omega-3-quality-guide/" className="hover:underline">Omega-3 quality guide →</Link></li>
           <li><Link href="/herbs/turmeric/" className="hover:underline">Turmeric herb profile →</Link></li>
           <li><Link href="/herbs/ginger/" className="hover:underline">Ginger herb profile →</Link></li>
           <li><Link href="/compounds/omega-3-epa/" className="hover:underline">Omega-3 (EPA) compound profile →</Link></li>
-          <li><Link href="/guides/best/supplements-for-joint-support/" className="hover:underline">Best supplements for joint support →</Link></li>
+          <li><Link href="/guides/best/supplements-for-joint-support/" className="hover:underline">Supplements for joint support →</Link></li>
         </ul>
       </section>
 
+      <div className="max-w-4xl rounded-xl border border-brand-900/10 bg-brand-50/40 p-4 text-xs leading-6 text-muted">
+        <strong className="text-ink">Commercial-links boundary:</strong> optional product links are sourcing examples, not evidence that a retail formulation reproduces the products, doses, bioavailability, safety, or clinical effects in the cited studies.
+      </div>
       <div className="max-w-4xl">
         <RecommendationSection
-          title="Curcumin (turmeric) product picks"
-          description="Curcumin is the flagship, best-evidenced anti-inflammatory in this guide — pair it with a high-EPA omega-3 as the core stack. These are sourcing starting points; a formulation with piperine or a phytosome carrier matters more than brand, and the bleeding-risk and dose notes above still apply."
+          title="Curcumin product examples"
+          description="If you are comparing retail curcumin products, formulation and ingredient identity matter. These links are optional sourcing examples—not a recommendation to treat an inflammatory condition, combine products into a stack, or prefer maximal bioavailability."
           products={getRevenueProductSet('turmeric')?.products ?? []}
         />
       </div>


### PR DESCRIPTION
Fixes #3873

## Summary
Replaces the protocol-shaped 'anti-inflammatory stack' page with an outcome-specific evidence review.

- removes the fixed-dose omega-3/curcumin stack and universal timing protocol
- removes simplistic 'seed oils cause chronic inflammation' language
- removes blanket supplement-vs-NSAID safety claims
- replaces Strong/Moderate category badges with a semantic evidence ledger by actual clinical outcome
- separates curcumin/turmeric, omega-3, ginger, Boswellia, and quercetin by evidence type and main limitation
- fixes the quercetin source from incorrect PMID 26999193 to PMID 26999194
- removes the duplicated ginger reference
- adds newer 2024-2026 syntheses plus NCCIH turmeric safety and NIH ODS omega-3 safety/interaction sources
- adds canonical `LegacyGuideQuickAnswer` and `LegacyGuideFAQ` surfaces
- retains optional commercial links only as sourcing examples, not a treatment stack recommendation

## Trust impact
The page can no longer be extracted as a universal dose/stack protocol. It now preserves formulation-specific uncertainty, contradictory Boswellia syntheses, curcumin liver-safety context, and outcome-specific omega-3 evidence.