### PR TITLE
refactor(visual): simplify dense publication surfaces

### DIFF
--- a/styles/premium-surface-details.css
+++ b/styles/premium-surface-details.css
@@ -1,14 +1,12 @@
-/*
-  Premium surface detail layer.
-  Owns dense utility surfaces only: tables, forms, details, chips, and semantic
-  callout rails. Global palette, navigation, buttons, and selection styling are
-  owned by the later canonical visual-system layers.
-*/
+/* Dense publication surfaces.
+   Tables, forms, and disclosures should be quiet and readable. Semantic safety
+   and evidence colors are left untouched so visual branding never competes
+   with meaning. */
 
 :root {
   --surface-detail-border: rgba(46, 44, 40, 0.13);
   --surface-detail-border-strong: rgba(46, 44, 40, 0.23);
-  --surface-detail-bg-strong: rgba(255, 253, 248, 0.95);
+  --surface-detail-bg-strong: rgba(255, 253, 248, 0.97);
   --surface-detail-focus: rgba(177, 132, 73, 0.28);
   --surface-detail-text: #1d1d1f;
   --surface-detail-muted: #6c6862;
@@ -17,48 +15,37 @@
 html.dark {
   --surface-detail-border: rgba(227, 211, 181, 0.13);
   --surface-detail-border-strong: rgba(227, 211, 181, 0.24);
-  --surface-detail-bg-strong: rgba(28, 31, 33, 0.94);
+  --surface-detail-bg-strong: rgba(28, 31, 33, 0.96);
   --surface-detail-focus: rgba(208, 163, 91, 0.30);
   --surface-detail-text: #f3eee4;
   --surface-detail-muted: #aaa49a;
 }
 
-/* Tables: neutral publication surfaces with restrained brass interaction. */
 main table {
-  border-radius: 1rem;
   overflow: hidden;
+  border-radius: 0.9rem;
 }
 
 main thead th {
-  background: linear-gradient(180deg, rgba(246, 243, 237, 0.96), rgba(235, 231, 222, 0.82)) !important;
-  color: #2e2c28 !important;
-}
-
-html.dark main thead th {
-  background: linear-gradient(180deg, rgba(35, 38, 40, 0.94), rgba(25, 28, 30, 0.90)) !important;
-  color: #f3eee4 !important;
+  background: var(--surface-subtle) !important;
+  color: var(--text-primary) !important;
 }
 
 main tbody tr {
-  transition: background-color 160ms ease;
+  transition: background-color 140ms ease;
 }
 
 main tbody tr:hover {
-  background-color: rgba(177, 132, 73, 0.055) !important;
+  background-color: color-mix(in srgb, var(--hs-gold) 5%, transparent) !important;
 }
 
-html.dark main tbody tr:hover {
-  background-color: rgba(208, 163, 91, 0.075) !important;
-}
-
-/* Forms and search fields: designed, neutral editorial controls. */
 main input,
 main select,
 main textarea {
   border-color: var(--surface-detail-border) !important;
   background: var(--surface-detail-bg-strong) !important;
   color: var(--surface-detail-text) !important;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.42), 0 8px 22px rgba(46, 44, 40, 0.045);
+  box-shadow: none !important;
 }
 
 main input::placeholder,
@@ -73,29 +60,13 @@ main textarea:focus {
   border-color: var(--surface-detail-border-strong) !important;
   outline: 3px solid var(--surface-detail-focus) !important;
   outline-offset: 2px;
-  box-shadow: 0 0 0 1px var(--surface-detail-border-strong), 0 14px 32px rgba(46, 44, 40, 0.07);
+  box-shadow: none !important;
 }
 
-html.dark main input,
-html.dark main select,
-html.dark main textarea {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.045), 0 10px 28px rgba(0, 0, 0, 0.24);
-}
-
-/* Details / FAQ / accordion surfaces. */
 main details {
   border-color: var(--surface-detail-border) !important;
-  background:
-    radial-gradient(circle at 100% 0%, rgba(177, 132, 73, 0.075), transparent 10rem),
-    linear-gradient(180deg, rgba(255, 253, 248, 0.94), rgba(243, 240, 233, 0.84)) !important;
-  box-shadow: 0 12px 32px rgba(46, 44, 40, 0.055), inset 0 1px 0 rgba(255, 255, 255, 0.58);
-}
-
-html.dark main details {
-  background:
-    radial-gradient(circle at 100% 0%, rgba(208, 163, 91, 0.085), transparent 10rem),
-    linear-gradient(180deg, rgba(31, 34, 36, 0.92), rgba(22, 25, 27, 0.88)) !important;
-  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.26), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  background: var(--surface-card) !important;
+  box-shadow: none !important;
 }
 
 main details[open] {
@@ -107,40 +78,13 @@ main summary {
   text-wrap: pretty;
 }
 
-/* Chips and badges preserve local semantic fills while sharing border treatment. */
+/* Small evidence/status pills keep their local semantic fill; only their edge
+   treatment is normalized. */
 .evidence-pill-strong,
 .evidence-pill-moderate,
 main :is([class*='rounded-full'][class*='text-']) {
   border-color: var(--surface-detail-border) !important;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.30);
-}
-
-html.dark .evidence-pill-strong,
-html.dark .evidence-pill-moderate,
-html.dark main :is([class*='rounded-full'][class*='text-']) {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.055);
-}
-
-/* Semantic callouts keep their severity fill; the decorative rail stays neutral/brass. */
-.safety-block,
-main :is(.bg-amber-50\/80, .bg-amber-50\/85, .bg-rose-50, .bg-red-50, .bg-emerald-50) {
-  position: relative;
-  overflow: hidden;
-}
-
-.safety-block::before,
-main :is(.bg-amber-50\/80, .bg-amber-50\/85, .bg-rose-50, .bg-red-50, .bg-emerald-50)::before {
-  content: '';
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 3px;
-  background: linear-gradient(180deg, rgba(177, 132, 73, 0.82), rgba(46, 44, 40, 0.42));
-  pointer-events: none;
-}
-
-html.dark .safety-block::before,
-html.dark main :is(.bg-amber-50\/80, .bg-amber-50\/85, .bg-rose-50, .bg-red-50, .bg-emerald-50)::before {
-  background: linear-gradient(180deg, rgba(208, 163, 91, 0.86), rgba(227, 211, 181, 0.28));
+  box-shadow: none !important;
 }
 
 @media (max-width: 768px) {
@@ -148,6 +92,6 @@ html.dark main :is(.bg-amber-50\/80, .bg-amber-50\/85, .bg-rose-50, .bg-red-50, 
   main input,
   main select,
   main textarea {
-    border-radius: 1rem;
+    border-radius: 0.9rem;
   }
 }


### PR DESCRIPTION
Flattens tables, forms, and disclosures into quieter editorial surfaces, removes decorative gradients/shadows, and stops applying a brass rail to semantic safety callouts so severity colors remain visually meaningful.