### PR TITLE
Trust: replace ACV dosing protocol with pooled evidence

### DIFF
--- a/app/guides/other/apple-cider-vinegar/page.tsx
+++ b/app/guides/other/apple-cider-vinegar/page.tsx
@@ -4,77 +4,190 @@ import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
-import FAQSchema from '@/components/seo/FAQSchema'
+import LegacyGuideFAQ from '@/components/LegacyGuideFAQ'
+import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Apple Cider Vinegar: Evidence, Benefits & Dosing (2026 Guide)',
-  description: 'ACV for weight loss, blood sugar, and digestion — what does the evidence actually show? Review of clinical trials with dosing, safety, and the mother.',
+  title: 'Apple Cider Vinegar: Evidence, Weight, Glucose & Safety (2026)',
+  description:
+    'Current evidence review of apple cider vinegar for glucose and weight outcomes, with pooled effect sizes, uncertainty, gastroparesis and acid-injury safety boundaries, and no consumer dosing protocol.',
   path: '/guides/other/apple-cider-vinegar/',
   openGraphType: 'article',
 })
 
 const FAQS = [
-  { question: 'Does apple cider vinegar help with weight loss?', answer: 'Modestly. A 2018 RCT (n=39) found 2 tbsp (30 mL) ACV daily for 12 weeks reduced body weight by 2.6 lbs vs placebo [1]. A 2009 Japanese trial (n=155) found 15-30 mL daily reduced BMI by 0.4-0.7 kg/m2 over 12 weeks [2]. Effect sizes are small. ACV is not a weight loss solution — it is a modest adjunct to diet and exercise. The mechanism may involve delayed gastric emptying and modest appetite suppression via acetic acid.' },
-  { question: 'Does ACV lower blood sugar?', answer: 'Yes — this is the best-supported benefit. Acetic acid (the active component) reduces postprandial glucose by 20-34% when consumed before or with a carbohydrate-containing meal [3]. The mechanism: delayed gastric emptying and increased glucose uptake by skeletal muscle. This is most relevant for people with insulin resistance or prediabetes. Take 1-2 tbsp diluted in water before high-carb meals.' },
-  { question: 'Should I drink ACV straight or diluted?', answer: 'Always dilute. Undiluted ACV is acidic enough (pH 2-3) to erode tooth enamel and irritate the esophagus. Mix 1-2 tbsp in 8 oz (240 mL) of water. Drink through a straw to minimize tooth contact. Rinse mouth with plain water afterward. Do not brush teeth immediately — softened enamel needs 30 minutes to remineralize. ACV in capsule form avoids dental issues but may be less effective.' },
-  { question: 'What does the mother do?', answer: 'The mother is a sediment of acetic acid bacteria and cellulose — the byproduct of fermentation. It contains probiotics (Acetobacter species) and enzymes. Whether the mother provides benefits beyond filtered ACV is unclear — most clinical trials used standard ACV, not mother-containing varieties. The mother is not harmful but its contribution to ACV\'s effects is theoretical. If you buy ACV with the mother, shake before use to distribute it.' },
-  { question: 'When is the best time to take ACV?', answer: 'Before or with meals — particularly high-carbohydrate meals. The glucose-lowering effect lasts about 2-4 hours. Do not take on an empty stomach (can cause nausea). Do not take right before bed (reflux risk if you lie down). Morning or lunch doses are best. Start with 1 tsp and work up to 1-2 tbsp to assess GI tolerance.' },
-]
+  {
+    question: 'Does apple cider vinegar help with weight loss?',
+    answer:
+      'Pooled evidence suggests a modest average weight effect, not a stand-alone obesity treatment. A 2026 umbrella review estimated about 1.06 kg lower body weight across meta-analytic evidence, while a 2025 ACV-specific meta-analysis also found small pooled anthropometric effects with substantial heterogeneity. Individual trials, populations, background diets, and vinegar interventions differ.',
+  },
+  {
+    question: 'Does apple cider vinegar lower blood sugar?',
+    answer:
+      'Meta-analyses report average improvements in fasting and post-meal glucose and HbA1c in some populations, but effect estimates are heterogeneous and the studies do not justify changing diabetes medication or using ACV as a substitute for evidence-based diabetes care. People using glucose-lowering medication should discuss any recurring ACV use with their clinician because diet, gastric emptying, medication, and hypoglycemia risk can interact.',
+  },
+  {
+    question: 'Should apple cider vinegar be drunk straight?',
+    answer:
+      'Concentrated or inadequately diluted vinegar can expose teeth and the upper gastrointestinal tract to substantial acid. Case reports describe dental erosion and corrosive esophageal injury. This guide does not provide a drinking protocol or suggest that taking vinegar shots is necessary to reproduce clinical research.',
+  },
+  {
+    question: 'Does “the mother” add proven health benefits?',
+    answer:
+      'There is not a robust clinical evidence base showing that an unfiltered product containing “the mother” produces better weight, glucose, or gastrointestinal outcomes than other vinegar interventions. Fermentation characteristics and microbes are interesting product features, but they should not be promoted as a proven probiotic treatment without direct evidence.',
+  },
+  {
+    question: 'What is the best time to take apple cider vinegar?',
+    answer:
+      'There is no universally validated timing schedule. Acute meal studies and longer trials use different protocols, and those study designs should not be converted into a personalized pre-meal prescription. People with reflux, swallowing problems, gastroparesis, diabetes medication use, or other relevant conditions have additional reasons to review regular vinegar use with a clinician.',
+  },
+] as const
 
 const ACV_REFS = [
-  { n: 1, text: 'Khezri SS, et al. (2018). Apple cider vinegar on weight and metabolic profile. J Funct Foods, 43: 95-102.', url: 'https://pubmed.ncbi.nlm.nih.gov/' },
-  { n: 2, text: 'Kondo T, et al. (2009). Vinegar intake reduces body weight in obese Japanese. Biosci Biotechnol Biochem, 73(8): 1837-1843.', url: 'https://pubmed.ncbi.nlm.nih.gov/19661687/' },
-  { n: 3, text: 'Johnston CS, et al. (2004). Vinegar improves insulin sensitivity to a high-carbohydrate meal. Diabetes Care, 27(1): 281-282.', url: 'https://pubmed.ncbi.nlm.nih.gov/14694010/' },
-  { n: 4, text: 'Petsiou EI, et al. (2014). Vinegar and insulin sensitivity in T2D. Diabetes Care, 37(5): e107-e108.', url: 'https://pubmed.ncbi.nlm.nih.gov/24757246/' },
-  { n: 5, text: 'Ostman E, et al. (2005). Vinegar lowers glucose and insulin responses. Eur J Clin Nutr, 59(9): 983-988.', url: 'https://pubmed.ncbi.nlm.nih.gov/16015276/' },
-
+  {
+    n: 1,
+    text: 'Shahmohammadi F, et al. Vinegar Consumption and Health: An Umbrella Review of Meta-Analyses of Randomized Controlled Trials. Food Sci Nutr. 2026;14(5):e71849. PMID 42110393.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/42110393/',
+    pmid: '42110393',
+  },
+  {
+    n: 2,
+    text: 'Castagna A, et al. Effect of Apple Cider Vinegar Intake on Body Composition in Humans with Type 2 Diabetes and/or Overweight: A Systematic Review and Meta-Analysis of Randomized Controlled Trials. Nutrients. 2025;17(18):3000. PMID 41010525.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/41010525/',
+    pmid: '41010525',
+  },
+  {
+    n: 3,
+    text: 'Dadkhah Tehrani S, et al. The Effects of Apple Cider Vinegar on Cardiometabolic Risk Factors: A Systematic Review and Meta-analysis of Clinical Trials. Curr Pharm Des. 2025;32(11):2257-2274. PMID 37608660.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/37608660/',
+    pmid: '37608660',
+  },
+  {
+    n: 4,
+    text: 'Johnston CS, et al. Vinegar improves insulin sensitivity to a high-carbohydrate meal in subjects with insulin resistance or type 2 diabetes. Diabetes Care. 2004;27(1):281-282. PMID 14694010.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/14694010/',
+    pmid: '14694010',
+  },
+  {
+    n: 5,
+    text: 'Kondo T, et al. Vinegar intake reduces body weight, body fat mass, and serum triglyceride levels in obese Japanese subjects. Biosci Biotechnol Biochem. 2009;73(8):1837-1843. PMID 19661687.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/19661687/',
+    pmid: '19661687',
+  },
+  {
+    n: 6,
+    text: 'Launholt TL, et al. Safety and side effects of apple vinegar intake and its effect on metabolic parameters and body weight: a systematic review. Eur J Nutr. 2020;59(6):2273-2289. PMID 32170375.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/32170375/',
+    pmid: '32170375',
+  },
+  {
+    n: 7,
+    text: 'Hlebowicz J, et al. Effect of apple cider vinegar on delayed gastric emptying in patients with type 1 diabetes mellitus: a pilot study. BMC Gastroenterol. 2007. PMID 18093343.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/18093343/',
+    pmid: '18093343',
+  },
+  {
+    n: 8,
+    text: 'Chang J, et al. Corrosive Esophageal Injury due to a Commercial Vinegar Beverage in an Adolescent. Clin Endosc. 2020;53(3):366-369. PMID 31405264.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/31405264/',
+    pmid: '31405264',
+  },
 ]
 
 export default function AppleCiderVinegarPage() {
   return (
     <div className="container-page py-10 space-y-10">
-      <AuthorityJsonLd title="Apple Cider Vinegar Guide" description="Evidence-based review of ACV for weight loss, blood sugar, and digestion." url="https://thehippiescientist.net/guides/other/apple-cider-vinegar" type="Article" />
+      <AuthorityJsonLd
+        title="Apple Cider Vinegar: Evidence, Weight, Glucose and Safety"
+        description="Evidence-calibrated review of ACV for glycemic and weight outcomes with pooled effect sizes, uncertainty, and acid/gastric safety boundaries."
+        url="https://thehippiescientist.net/guides/other/apple-cider-vinegar/"
+        type="MedicalWebPage"
+        citationUrls={ACV_REFS.map(reference => reference.url)}
+      />
       <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Apple Cider Vinegar' }]} />
-      <FAQSchema pagePath="/guides/other/apple-cider-vinegar/" questions={FAQS} />
 
       <section className="space-y-5 max-w-4xl">
-        <p className="eyebrow-label">Evidence Review · 5 References</p>
+        <p className="eyebrow-label">Evidence Review · 8 References · Updated August 16, 2026</p>
         <h1 className="text-5xl font-bold tracking-tight text-ink">Apple Cider Vinegar: What the Evidence Actually Shows</h1>
-        <p className="text-lg leading-8 text-muted">Apple cider vinegar has been a folk remedy for centuries. In the last decade, it became a wellness trend — promoted for weight loss, blood sugar control, digestion, and detoxification. Some of these claims have evidence. Most do not. Here is what the clinical trials actually show.</p>
-      
-        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/apple-cider-vinegar.jpg" alt="Apple cider vinegar bottle beside fresh apples on wood" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Apple cider vinegar — evidence over trends.</figcaption></figure></section>
-
-      <section className="card-premium p-6 space-y-4">
-        <h2 className="text-2xl font-semibold">Quick answer</h2>
-        <p className="text-sm leading-7 text-muted">
-          <strong>The best evidence for ACV is blood sugar control</strong> — 1-2 tbsp before high-carb meals reduces postprandial glucose by 20-34% [3]. <strong>Weight loss evidence is modest</strong> — ~2-3 lbs over 12 weeks in small trials [1,2]. <strong>Detoxification claims are unfounded</strong> — your liver handles detoxification, not vinegar. <strong>Dosing:</strong> 1-2 tbsp (15-30 mL) diluted in 8 oz water, taken before meals. Always dilute — undiluted ACV erodes tooth enamel. Gut health claims (probiotics from the mother) are theoretical with limited evidence. ACV is a cheap, safe adjunct to diet — not a miracle cure.
+        <p className="text-lg leading-8 text-muted">
+          Vinegar has real metabolic research behind it, but that evidence is often turned into a much stronger wellness claim than the trials support. The useful questions are the size and certainty of the pooled effects, which outcomes do <em>not</em> improve consistently, and who may have additional safety concerns.
         </p>
+        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/apple-cider-vinegar.jpg" alt="Apple cider vinegar bottle beside fresh apples on wood" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Apple cider vinegar — pooled metabolic evidence is more useful than a viral dosing ritual.</figcaption></figure>
       </section>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30">
-        <p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · ACV Evidence</p>
+      <LegacyGuideQuickAnswer referencesHref="#references">
+        <p>
+          A 2026 umbrella review of <strong>10 meta-analyses covering 38 primary studies</strong> reported average improvements in fasting glucose, postprandial glucose, HbA1c, total cholesterol, body weight, and systolic blood pressure, but not in several other cardiometabolic outcomes [1]. The pooled body-weight difference was about <strong>-1.06 kg</strong>—a modest signal, not evidence that vinegar is an obesity treatment.
+        </p>
+        <p className="mt-3">
+          Glycemic findings also require context. A 2025 ACV meta-analysis found fasting-glucose and HbA1c signals with very high heterogeneity for key outcomes [3]. Small acute meal studies can explain biologic plausibility, but they should not be converted into a universal “take this amount before carbohydrate” prescription [4].
+        </p>
+      </LegacyGuideQuickAnswer>
+
+      <section id="acv-outcome-ledger" data-answer-engine-table="true" className="card-premium scroll-mt-24 p-6 space-y-4 max-w-5xl border-l-4 border-brand-700 bg-brand-50/30">
+        <p className="eyebrow-label">Outcome-by-outcome evidence</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What changes—and what does not</h2>
         <div className="overflow-x-auto">
-          <table className="min-w-full text-sm">
-            <thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Claim</th><th className="text-left py-2 pr-4 font-semibold text-ink">Evidence</th><th className="text-left py-2 pr-4 font-semibold text-ink">Effect Size</th><th className="text-left py-2 font-semibold text-ink">Dose</th></tr></thead>
+          <table className="min-w-[920px] w-full text-sm">
+            <caption className="sr-only">Apple cider vinegar evidence by metabolic outcome</caption>
+            <thead><tr className="border-b border-brand-900/10"><th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">Outcome</th><th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">Current signal</th><th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">Best context</th><th scope="col" className="text-left py-2 font-semibold text-ink">Main limitation</th></tr></thead>
             <tbody className="text-muted">
-              <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Blood sugar control</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-800">Moderate-Strong</span></td><td className="py-2 pr-4">20-34% glucose reduction</td><td className="py-2">1-2 tbsp before meals</td></tr>
-              <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Weight loss</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800">Modest</span></td><td className="py-2 pr-4">~2-3 lbs over 12 weeks</td><td className="py-2">1-2 tbsp daily</td></tr>
-              <tr><td className="py-2 pr-4 font-medium text-ink">Detoxification</td><td className="py-2 pr-4"><span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-bold text-red-800">None</span></td><td className="py-2 pr-4">N/A</td><td className="py-2">N/A</td></tr>
+              <tr className="border-b border-brand-900/5"><th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Fasting glucose</th><td className="py-3 pr-4">Pooled reductions reported [1,3]</td><td className="py-3 pr-4">Mostly metabolic-risk / diabetes studies</td><td className="py-3">Heterogeneous interventions and populations; not a medication-replacement rule</td></tr>
+              <tr className="border-b border-brand-900/5"><th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Postprandial glucose</th><td className="py-3 pr-4">Pooled and acute-study signals [1,4]</td><td className="py-3 pr-4">Meal-response studies</td><td className="py-3">Small acute trials do not establish a universal pre-meal protocol</td></tr>
+              <tr className="border-b border-brand-900/5"><th scope="row" className="py-3 pr-4 text-left font-medium text-ink">HbA1c</th><td className="py-3 pr-4">Average reduction reported in recent syntheses [1,3]</td><td className="py-3 pr-4">Longer metabolic studies</td><td className="py-3">Very high heterogeneity in some pooled analyses; background treatment varies</td></tr>
+              <tr className="border-b border-brand-900/5"><th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Body weight</th><td className="py-3 pr-4">Modest pooled reduction; umbrella estimate about -1.06 kg [1,2]</td><td className="py-3 pr-4">Short-term trials in adults with excess weight/metabolic risk</td><td className="py-3">Not equivalent to obesity pharmacotherapy; substantial heterogeneity in ACV-specific analyses</td></tr>
+              <tr className="border-b border-brand-900/5"><th scope="row" className="py-3 pr-4 text-left font-medium text-ink">BMI / waist circumference</th><td className="py-3 pr-4">Mixed across syntheses [1,2]</td><td className="py-3 pr-4">Anthropometric trials</td><td className="py-3">Umbrella analysis did not find significant BMI or waist effects despite some ACV-specific pooled signals</td></tr>
+              <tr><th scope="row" className="py-3 pr-4 text-left font-medium text-ink">“Detox”</th><td className="py-3 pr-4">No validated clinical endpoint here</td><td className="py-3 pr-4">Marketing claim</td><td className="py-3">Metabolic trial results do not establish a detoxification therapy</td></tr>
             </tbody>
           </table>
-        </div>
-        <div className="mt-3 p-3 rounded-lg bg-white border border-brand-200">
-          <p className="text-xs font-semibold text-ink">ACV safety rules:</p>
-          <p className="mt-1 text-xs leading-5 text-muted">Always dilute (1-2 tbsp in 8 oz water). Use a straw to protect teeth. Rinse mouth afterward — wait 30 min before brushing. Don&apos;t take before bed (reflux). Don&apos;t take undiluted shots (esophageal damage). Capsules avoid dental issues but evidence for efficacy is weaker. At $5-10/month, ACV is one of the cheapest evidence-based supplements.</p>
         </div>
       </section>
 
       <section className="card-premium p-6 space-y-4 max-w-4xl">
-        <h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2>
-        <p className="text-sm leading-7 text-muted">Apple cider vinegar is a cheap, safe, and moderately effective supplement for blood sugar control — the best-supported benefit. Weight loss effects are small but statistically significant. Take 1-2 tbsp diluted in water before carbohydrate-containing meals. Always dilute — undiluted ACV damages teeth and esophagus. At $5-10/month, ACV has a favorable risk-benefit ratio for people with prediabetes or insulin resistance. It is not a detoxifier, fat burner, or miracle cure.</p>
+        <p className="eyebrow-label">Why the acute-study shortcut fails</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">A meal experiment is not a personalized diabetes protocol</h2>
+        <p className="text-sm leading-7 text-muted">
+          The classic 2004 study is useful evidence that vinegar can change the glucose/insulin response to a high-carbohydrate meal in selected participants [4]. It is not evidence that every person with insulin resistance should consume a fixed amount before every carbohydrate-containing meal. Longer studies pool different vinegars, concentrations, diets, medication backgrounds, and adherence patterns [1-3].
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          That distinction matters especially when a person already uses glucose-lowering medication or has gastrointestinal motility problems. A small crossover study in people with type 1 diabetes and diabetic gastroparesis found that ACV <strong>further delayed gastric emptying</strong> [7].
+        </p>
       </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Safety boundaries</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Acid exposure and gastric effects are part of the evidence</h2>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
+          <li><strong>Dental exposure:</strong> frequent contact with acidic beverages can contribute to erosive tooth wear; vinegar should not be treated as chemically harmless because it is a food.</li>
+          <li><strong>Esophageal injury:</strong> case reports describe corrosive esophageal injury after inadequately diluted or repeated vinegar-beverage exposure [8]. Case reports do not quantify incidence, but they establish that concentrated exposure is not risk-free.</li>
+          <li><strong>Gastroparesis:</strong> vinegar can slow gastric emptying, which may be undesirable in people who already have delayed gastric emptying [7].</li>
+          <li><strong>Product form:</strong> tablets are not automatically a safer or evidence-equivalent substitute for liquid vinegar; product composition and acid exposure can differ.</li>
+          <li><strong>Diabetes care:</strong> recurring ACV use should not be used to self-adjust glucose-lowering medication. Clinically meaningful medication changes should follow measured glucose data and professional review.</li>
+        </ul>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Evidence applicability</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What the current evidence supports</h2>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
+          <li>Vinegar can influence some glycemic outcomes on average in controlled studies [1,3,4].</li>
+          <li>Short-term body-weight effects appear modest in pooled evidence [1,2].</li>
+          <li>The evidence does not establish ACV as a substitute for diabetes or obesity treatment.</li>
+          <li>The evidence does not establish one best dose, timing schedule, or titration plan for a generic goal of “blood sugar control.”</li>
+          <li>The presence of “the mother” has not been shown to create a superior clinical intervention for the outcomes reviewed here.</li>
+        </ul>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Bottom line</h2>
+        <p className="text-sm leading-7 text-muted">
+          Apple cider vinegar is not evidence-free: pooled research suggests <strong>modest average effects on several glycemic outcomes and body weight</strong>. But the right conclusion is narrower than the old wellness protocol. Effects vary across outcomes and studies, ACV is not an obesity or diabetes drug, and regular use has relevant acid-exposure and gastric-emptying considerations [1-8].
+        </p>
+      </section>
+
+      <LegacyGuideFAQ questions={[...FAQS]} pagePath="/guides/other/apple-cider-vinegar/" />
       <References refs={ACV_REFS} />
       <EmailCapture headline="Get evidence reviews like this" description="Apple cider vinegar, blood sugar, weight loss — evidence over trends." ctaLabel="Get the evidence" location="guide-acv" />
       <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>


### PR DESCRIPTION
Fixes #3878

## Summary
Replaces the apple-cider-vinegar page’s personalized glucose/dosing protocol with pooled-outcome evidence and explicit safety boundaries.

- expands the source ledger from 5 to 8 references and replaces the broken PubMed-homepage source
- anchors the page in the 2026 umbrella review plus current ACV-specific meta-analyses
- removes fixed 1–2 tbsp pre-meal dosing, titration, and timing instructions
- removes the favorable risk-benefit claim specifically aimed at people with prediabetes/insulin resistance
- replaces category-wide evidence grades and fixed percentage claims with a semantic outcome ledger for fasting glucose, postprandial glucose, HbA1c, body weight, BMI/waist, and detox claims
- adds gastroparesis, acid exposure, and esophageal-injury boundaries
- explicitly states ACV should not be used to self-adjust glucose-lowering medication
- adds canonical `LegacyGuideQuickAnswer` and `LegacyGuideFAQ` source-linked surfaces

## Trust impact
The page can no longer be extracted as a consumer diabetes-management protocol. It preserves the modest pooled metabolic signals while making heterogeneity, outcome limits, and gastrointestinal/acid safety visible.