### PR TITLE
fix(evidence-report): expose path identity in CSV relationships

### DIFF
--- a/lib/__tests__/public-evidence-csv-relationship-identity.test.ts
+++ b/lib/__tests__/public-evidence-csv-relationship-identity.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  publicEvidenceDatasetToCsv,
+  type PublicEvidenceDataset,
+  type PublicStudyEntity,
+} from '@/lib/public-evidence-dataset'
+
+function dataset(study: PublicStudyEntity): PublicEvidenceDataset {
+  return {
+    schemaVersion: 1,
+    datasetVersion: 'test',
+    title: 'Test dataset',
+    generatedFrom: 'current indexable runtime records',
+    methodologyPath: '/info/editorial-policy/',
+    citationExplorerPath: '/learn/citation-explorer/',
+    citationText: 'Test citation',
+    ingredients: [],
+    studies: [study],
+    metrics: {} as PublicEvidenceDataset['metrics'],
+  }
+}
+
+describe('public evidence csv relationship identity', () => {
+  it('exports path and type when herb and compound relationships share a slug', () => {
+    const csv = publicEvidenceDatasetToCsv(dataset({
+      id: 'doi:10.1000/shared',
+      title: 'Shared publication',
+      evidenceClass: 'randomized_controlled_trial',
+      confidence: 'moderate',
+      conditions: [],
+      relationshipSummary: 'mixed',
+      relationships: [
+        {
+          ingredientSlug: 'shared',
+          ingredientName: 'Shared Herb',
+          ingredientType: 'herb',
+          ingredientPath: '/herbs/shared/',
+          evidenceGrade: 'B',
+          relationship: 'supports',
+        },
+        {
+          ingredientSlug: 'shared',
+          ingredientName: 'Shared Compound',
+          ingredientType: 'compound',
+          ingredientPath: '/compounds/shared/',
+          evidenceGrade: 'C',
+          relationship: 'contradicts',
+        },
+      ],
+    }))
+
+    const [header, row] = csv.trimEnd().split('\n')
+    expect(header).toContain('ingredient_slugs,ingredient_types,ingredient_paths,ingredient_names,ingredient_grades')
+    expect(row).toContain('shared|shared')
+    expect(row).toContain('herb|compound')
+    expect(row).toContain('/herbs/shared/|/compounds/shared/')
+  })
+})

--- a/lib/public-evidence-dataset.ts
+++ b/lib/public-evidence-dataset.ts
@@ -715,7 +715,8 @@ export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): stri
     'study_class', 'study_class_candidates', 'study_class_ambiguous',
     'sample_size', 'participant_count_candidates', 'participant_count_ambiguous',
     'dose', 'duration', 'population', 'outcome', 'result', 'limitation',
-    'relationship_summary', 'conditions', 'safety_outcome', 'ingredient_slugs', 'ingredient_names', 'ingredient_grades',
+    'relationship_summary', 'conditions', 'safety_outcome',
+    'ingredient_slugs', 'ingredient_types', 'ingredient_paths', 'ingredient_names', 'ingredient_grades',
     'relationships_json',
   ]
 
@@ -745,6 +746,8 @@ export function publicEvidenceDatasetToCsv(dataset: PublicEvidenceDataset): stri
     study.conditions.join('|'),
     study.safetyOutcome,
     study.relationships.map(item => item.ingredientSlug).join('|'),
+    study.relationships.map(item => item.ingredientType).join('|'),
+    study.relationships.map(item => item.ingredientPath).join('|'),
     study.relationships.map(item => item.ingredientName).join('|'),
     study.relationships.map(item => item.evidenceGrade).join('|'),
     JSON.stringify(study.relationships),


### PR DESCRIPTION
Add first-class ingredient type and ingredient path columns to the public evidence CSV relationship flattening. This keeps same-slug herb/compound relationships unambiguous even for consumers that do not parse relationships_json. Includes a focused regression covering one publication related to both /herbs/shared/ and /compounds/shared/.