### PR TITLE
Trust: rebuild curcumin guide around exposure and safety

### DIFF
--- a/app/guides/other/curcumin-absorption-guide/page.tsx
+++ b/app/guides/other/curcumin-absorption-guide/page.tsx
@@ -6,57 +6,222 @@ import Image from 'next/image'
 import { buildPageMetadata } from '../../../../src/lib/seo'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
-import FAQSchema from '@/components/seo/FAQSchema'
+import LegacyGuideFAQ from '@/components/LegacyGuideFAQ'
+import LegacyGuideQuickAnswer from '@/components/LegacyGuideQuickAnswer'
 import References from '@/components/References'
 import EmailCapture from '../../../../components/EmailCapture'
 
 export const metadata: Metadata = buildPageMetadata({
-  title: 'Curcumin Absorption: Why Most Turmeric Supplements Fail (2026)',
-  description: 'Curcumin has strong anti-inflammatory evidence but near-zero bioavailability. Piperine, phytosomes, and nanoparticles compared for absorption.',
+  title: 'Curcumin Bioavailability: Formulations, Evidence & Safety (2026)',
+  description:
+    'Current evidence review of curcumin bioavailability: piperine, phospholipid and micellar formulations, why exposure is not the same as clinical efficacy, analytical-method limits, and liver-safety concerns.',
   path: '/guides/other/curcumin-absorption-guide/',
   openGraphType: 'article',
 })
 
 const FAQS = [
-  { question: 'Why is curcumin so poorly absorbed?', answer: 'Curcumin is hydrophobic (does not dissolve in water), rapidly metabolized by the liver and intestinal wall, and rapidly excreted. Without bioavailability enhancement, less than 1% of oral curcumin reaches the bloodstream. This is why early turmeric trials with unformulated curcumin often failed — the compound could not reach target tissues at meaningful concentrations.' },
-  { question: 'Which curcumin formulation is best absorbed?', answer: 'Phytosome formulations (Meriva, CurcuWIN) show 20-30x higher bioavailability than standard curcumin. Nanoparticle/liposomal forms are similar. Piperine (black pepper extract) increases absorption 20-fold by inhibiting glucuronidation in the liver and intestine. For cost-effectiveness: curcumin + piperine (95% curcuminoids + 5 mg piperine) is the best value. Phytosomes are more expensive but slightly better absorbed.' },
-  { question: 'Can I just eat turmeric with black pepper?', answer: 'Partially. Turmeric root contains only 2-5% curcumin — you would need to eat 5-10 grams of turmeric powder to get 100-500 mg curcumin. Adding black pepper helps but does not achieve the 20x absorption boost of concentrated piperine. Culinary turmeric is a healthy spice — it is not a substitute for curcumin supplementation at studied anti-inflammatory doses.' },
-  { question: 'How much curcumin for anti-inflammatory effect?', answer: '500-1,500 mg/day of curcuminoids with bioavailability enhancement. This typically means: 500 mg Meriva (phytosome) 2x/day, or 500 mg curcumin 95% + 5 mg piperine 2-3x/day. The effective dose depends on the formulation — a 500 mg phytosome provides similar blood levels to 1,500 mg standard curcumin + piperine. Effects appear at 4-8 weeks for joint pain.' },
-  { question: 'Is turmeric the same as curcumin?', answer: 'No. Turmeric is the whole root containing 2-5% curcumin plus other curcuminoids, volatile oils (turmerones), and fiber. Curcumin is the isolated active compound. Most clinical trials use concentrated curcumin extracts (95% curcuminoids), not whole turmeric powder. Turmeric as a spice has health benefits, but the anti-inflammatory evidence is specifically for curcumin at studied doses.' },
-]
+  {
+    question: 'Why is oral curcumin considered poorly bioavailable?',
+    answer:
+      'Native curcumin has low water solubility, limited intestinal absorption, rapid metabolism, and rapid elimination. Those pharmacokinetic limitations are real. But low plasma concentration does not prove that every unformulated product is clinically useless, and a higher measured concentration does not automatically prove a better patient-important outcome.',
+  },
+  {
+    question: 'Does black-pepper extract increase curcumin absorption?',
+    answer:
+      'Piperine can increase measured curcumin exposure. The classic 1998 human experiment used 2 g of curcumin with 20 mg of piperine and reported a large increase in measured bioavailability under that study protocol. That result should not be converted into a universal consumer dose or proof that curcumin-piperine is the best formulation for every condition.',
+  },
+  {
+    question: 'Which curcumin formulation is best absorbed?',
+    answer:
+      'Different phospholipid, micellar, nanoparticle, and other formulations can produce different pharmacokinetic profiles, but there is no single universally valid absorption multiplier. Ratios depend on the comparator, dose, analytical method, and whether total curcuminoids, conjugates, or unconjugated curcumin are measured. Clinical outcome evidence also does not establish one formulation as universally best.',
+  },
+  {
+    question: 'Does better bioavailability mean curcumin works better?',
+    answer:
+      'Not automatically. Higher systemic exposure is a pharmacokinetic finding. Clinical benefit must still be demonstrated for the specific formulation, condition, population, dose, duration, and outcome. A 2024 methodological review found that most curcumin systematic reviews did not adequately account for formulation bioavailability when combining trials.',
+  },
+  {
+    question: 'Are highly bioavailable curcumin supplements safer?',
+    answer:
+      'Higher bioavailability should not be treated as a safety advantage. NCCIH warns that highly bioavailable curcumin formulations may harm the liver, and LiverTox documents clinically apparent turmeric/curcumin-associated liver injury, with highly bioavailable products prominent in reported cases. People with liver disease, symptoms of liver injury, pregnancy, or important medication use should discuss supplemental curcumin with a health professional.',
+  },
+] as const
 
 const CURCUMIN_REFS = [
-  { n: 1, text: 'Anand P, et al. (2007). Bioavailability of curcumin: problems and promises. Mol Pharm, 4(6): 807-818.', url: 'https://pubmed.ncbi.nlm.nih.gov/17999464/' },
-  { n: 2, text: 'Shoba G, et al. (1998). Piperine enhances curcumin bioavailability. Planta Med, 64(4): 353-356.', url: 'https://pubmed.ncbi.nlm.nih.gov/9619120/' },
-  { n: 3, text: 'Cuomo J, et al. (2011). Meriva curcumin absorption. J Nat Prod, 74(4): 664-669.', url: 'https://pubmed.ncbi.nlm.nih.gov/21446728/' },
+  {
+    n: 1,
+    text: 'Anand P, et al. Bioavailability of curcumin: problems and promises. Mol Pharm. 2007;4(6):807-818. PMID 17999464.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/17999464/',
+    pmid: '17999464',
+  },
+  {
+    n: 2,
+    text: 'Shoba G, et al. Influence of piperine on the pharmacokinetics of curcumin in animals and human volunteers. Planta Med. 1998;64(4):353-356. PMID 9619120.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/9619120/',
+    pmid: '9619120',
+  },
+  {
+    n: 3,
+    text: 'Hegde M, et al. Curcumin Formulations for Better Bioavailability: What We Learned from Clinical Trials Thus Far? ACS Omega. 2023;8(12):10713-10746. PMID 37008131.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/37008131/',
+    pmid: '37008131',
+  },
+  {
+    n: 4,
+    text: 'Bučević Popović V, et al. Bioavailability of Oral Curcumin in Systematic Reviews: A Methodological Study. Pharmaceuticals (Basel). 2024;17(2):164. PMID 38399379.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/38399379/',
+    pmid: '38399379',
+  },
+  {
+    n: 5,
+    text: 'Independent crossover pharmacokinetic study and critical reappraisal of curcumin formulations enhancing bioavailability. 2025. PMID 40487425.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/40487425/',
+    pmid: '40487425',
+  },
+  {
+    n: 6,
+    text: 'National Center for Complementary and Integrative Health. Turmeric: Usefulness and Safety. Current evidence and liver-safety summary.',
+    url: 'https://www.nccih.nih.gov/health/turmeric',
+  },
+  {
+    n: 7,
+    text: 'LiverTox: Turmeric. National Institute of Diabetes and Digestive and Kidney Diseases. Updated June 16, 2025. PMID 31643876.',
+    url: 'https://pubmed.ncbi.nlm.nih.gov/31643876/',
+    pmid: '31643876',
+  },
 ]
 
 export default function CurcuminAbsorptionPage() {
   return (
     <div className="container-page py-10 space-y-10">
-      <AuthorityJsonLd title="Curcumin Absorption Guide" description="Why most turmeric fails and which formulations work." url="https://thehippiescientist.net/guides/other/curcumin-absorption-guide" type="Article" />
-      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Curcumin Absorption' }]} />
-      <FAQSchema pagePath="/guides/other/curcumin-absorption-guide/" questions={FAQS} />
+      <AuthorityJsonLd
+        title="Curcumin Bioavailability: Formulations, Evidence and Safety"
+        description="Evidence-calibrated review of curcumin pharmacokinetics, enhanced-bioavailability formulations, analytical limits, clinical applicability, and liver safety."
+        url="https://thehippiescientist.net/guides/other/curcumin-absorption-guide/"
+        type="MedicalWebPage"
+        citationUrls={CURCUMIN_REFS.map(reference => reference.url)}
+      />
+      <AuthorityBreadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Guides', href: '/guides/' }, { label: 'Curcumin Bioavailability' }]} />
 
-      <section className="space-y-5 max-w-4xl"><p className="eyebrow-label">Evidence Review · 3 References</p><h1 className="text-5xl font-bold tracking-tight text-ink">Curcumin Absorption: Why Most Turmeric Supplements Are a Waste</h1><p className="text-lg leading-8 text-muted">Curcumin has excellent anti-inflammatory evidence — in a petri dish. In the human body, it is nearly impossible to absorb. Without bioavailability enhancement, over 99% of what you take is metabolized before reaching your bloodstream. Here is how to fix that.</p>
-        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/curcumin-absorption-guide.jpg" alt="Fresh turmeric root with curcumin capsules and peppercorns" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Curcumin — the formulation matters more than the dose.</figcaption></figure></section>
+      <section className="space-y-5 max-w-4xl">
+        <p className="eyebrow-label">Evidence Review · 7 References · Updated August 16, 2026</p>
+        <h1 className="text-5xl font-bold tracking-tight text-ink">Curcumin Bioavailability: More Absorption Is Not Automatically Better</h1>
+        <p className="text-lg leading-8 text-muted">
+          Curcumin really is difficult to absorb and rapidly metabolized. That has led to piperine, phospholipid complexes, micelles, nanoparticles, and other delivery systems designed to increase exposure. The missing step in many supplement comparisons is that <strong>pharmacokinetic exposure, clinical benefit, and safety are three different questions</strong>.
+        </p>
+        <figure className="mt-6"><div className="overflow-hidden rounded-2xl border border-brand-900/10 shadow-sm bg-white"><Image src="/images/guides/curcumin-absorption-guide.jpg" alt="Fresh turmeric root with curcumin capsules and peppercorns" width={1536} height={1024} priority className="w-full h-auto" /></div><figcaption className="mt-3 text-center text-sm text-muted">Formulation changes exposure. It does not automatically establish superior efficacy or safety.</figcaption></figure>
+      </section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Quick answer</h2><p className="text-sm leading-7 text-muted"><strong>Standard curcumin supplements (95% curcuminoids, no enhancer) are poorly absorbed — less than 1% reaches the bloodstream [1].</strong> The fix: add piperine 5-10 mg (black pepper extract) for a 20x absorption boost [2], or use a phytosome formulation (Meriva) for 20-30x improvement [3]. For most people: 500 mg curcumin 95% + 5 mg piperine 2x/day is the best value at $15-25/month. Meriva/phytosome forms are slightly better absorbed but cost $25-40/month. Skip turmeric powder supplements — they contain too little curcumin to match studied doses. Skip formulations without bioavailability enhancement — you are paying for expensive urine.</p></section>
+      <LegacyGuideQuickAnswer referencesHref="#references">
+        <p>
+          Native curcumin has low oral bioavailability because of poor solubility, limited absorption, rapid metabolism, and elimination [1]. Piperine can increase measured exposure—the famous 1998 experiment reported about a <strong>20-fold increase</strong> in human bioavailability after 2 g curcumin plus 20 mg piperine [2]. But that is a pharmacokinetic result from a specific small experiment, not evidence that a lower-dose curcumin-piperine supplement is the best clinical choice for most people.
+        </p>
+        <p className="mt-3">
+          Newer evidence makes the comparison even less tidy. A 2024 methodological study found that curcumin systematic reviews rarely handled formulation bioavailability adequately [4], and a 2025 independent pharmacokinetic study found very low unconjugated curcumin with several formulations and no piperine advantage in that experiment [5]. Meanwhile, NCCIH warns that highly bioavailable formulations may harm the liver [6].
+        </p>
+      </LegacyGuideQuickAnswer>
 
-      <section className="card-premium p-6 space-y-4 max-w-4xl border-l-4 border-brand-700 bg-brand-50/30"><p className="text-xs font-bold uppercase tracking-wider text-brand-700">At a Glance · Curcumin Absorption Methods</p><div className="overflow-x-auto"><table className="min-w-full text-sm"><thead><tr className="border-b"><th className="text-left py-2 pr-4 font-semibold text-ink">Method</th><th className="text-left py-2 pr-4 font-semibold text-ink">Absorption Boost</th><th className="text-left py-2 pr-4 font-semibold text-ink">Cost/mo</th><th className="text-left py-2 font-semibold text-ink">Best For</th></tr></thead><tbody className="text-muted">
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Curcumin + Piperine</td><td className="py-2 pr-4">20x</td><td className="py-2 pr-4">$15-25</td><td className="py-2">Best value for most people</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Phytosome (Meriva)</td><td className="py-2 pr-4">20-30x</td><td className="py-2 pr-4">$25-40</td><td className="py-2">Slightly better, higher cost</td></tr>
-          <tr className="border-b"><td className="py-2 pr-4 font-medium text-ink">Nanoparticle/Liposomal</td><td className="py-2 pr-4">30-50x</td><td className="py-2 pr-4">$30-50</td><td className="py-2">Maximum absorption</td></tr>
-          <tr><td className="py-2 pr-4 font-medium text-ink">Standard curcumin (no enhancer)</td><td className="py-2 pr-4 text-red-600">1x (baseline)</td><td className="py-2 pr-4">$5-10</td><td className="py-2">Avoid — cannot reach studied doses</td></tr>
-        </tbody></table></div></section>
+      <section id="curcumin-bioavailability-ledger" data-answer-engine-table="true" className="card-premium scroll-mt-24 p-6 space-y-4 max-w-5xl border-l-4 border-brand-700 bg-brand-50/30">
+        <p className="eyebrow-label">Bioavailability evidence ledger</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What each formulation claim can actually establish</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-[960px] w-full text-sm">
+            <caption className="sr-only">Curcumin formulation evidence, interpretation, and limitations</caption>
+            <thead>
+              <tr className="border-b border-brand-900/10">
+                <th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">Approach</th>
+                <th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">What is reasonably established</th>
+                <th scope="col" className="text-left py-2 pr-4 font-semibold text-ink">What is not established</th>
+                <th scope="col" className="text-left py-2 font-semibold text-ink">Important caveat</th>
+              </tr>
+            </thead>
+            <tbody className="text-muted">
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Native / unformulated curcumin</th>
+                <td className="py-3 pr-4">Low systemic exposure is a well-described pharmacokinetic limitation [1]</td>
+                <td className="py-3 pr-4">That every unformulated product is clinically useless</td>
+                <td className="py-3">Clinical effects and plasma concentrations are not interchangeable endpoints</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Piperine coadministration</th>
+                <td className="py-3 pr-4">Can alter curcumin pharmacokinetics; a small 1998 human study found a large exposure increase under its protocol [2]</td>
+                <td className="py-3 pr-4">A universal piperine dose, superior clinical efficacy, or lower risk</td>
+                <td className="py-3">Piperine deliberately alters metabolism; the classic result should not be copied into a consumer protocol</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Phospholipid, micellar, nano and other enhanced formulations</th>
+                <td className="py-3 pr-4">Many formulations increase one or more measured pharmacokinetic parameters [3]</td>
+                <td className="py-3 pr-4">One universal “20×/50×/100×” hierarchy that predicts clinical outcomes</td>
+                <td className="py-3">Ratios depend on comparator, analytical method, metabolites/conjugates measured, dose, and formulation [4,5]</td>
+              </tr>
+              <tr className="border-b border-brand-900/5 align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Clinical-outcome evidence</th>
+                <td className="py-3 pr-4">Some formulation-specific trials report benefits for selected conditions [3,6]</td>
+                <td className="py-3 pr-4">That the most bioavailable product is automatically the most effective for every condition</td>
+                <td className="py-3">Most systematic reviews have not adequately accounted for formulation bioavailability when pooling studies [4]</td>
+              </tr>
+              <tr className="align-top">
+                <th scope="row" className="py-3 pr-4 text-left font-medium text-ink">Safety</th>
+                <td className="py-3 pr-4">Turmeric/curcumin-associated clinically apparent liver injury is now well documented, although uncommon [6,7]</td>
+                <td className="py-3 pr-4">That maximizing absorption is inherently safer</td>
+                <td className="py-3">NCCIH specifically warns about highly bioavailable formulations; LiverTox notes many reported cases involve enhanced-bioavailability products [6,7]</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
 
-      <section className="card-premium p-6 space-y-4"><h2 className="text-2xl font-semibold">Bottom line</h2><p className="text-sm leading-7 text-muted">The curcumin absorption problem is solved — but only if you buy the right formulation. Standard curcumin without bioavailability enhancement is a waste of money [1]. Curcumin + piperine (20x absorption) is the best value [2]. Phytosomes are slightly better at a premium [3]. Whichever you choose, the effective dose is 500-1,500 mg/day of enhanced curcumin. This is one of the few supplement categories where the formulation matters more than the dose.</p></section>
-      <References refs={CURCUMIN_REFS} />
-      <div className="max-w-4xl">
-        <RecommendationSection products={getRevenueProductSet('turmeric')?.products ?? []} />
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Why the multiplier can mislead</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">“20× more bioavailable” is not one standardized measurement</h2>
+        <p className="text-sm leading-7 text-muted">
+          Bioavailability ratios can change dramatically depending on the reference product, dose, sampling window, and what the laboratory counts. Total curcuminoids, glucuronide/sulfate conjugates, and unconjugated curcumin are not interchangeable measurements. A 2025 independent crossover study found that unconjugated plasma curcumin remained very low across several formulations, while some conjugated forms rose much more strongly [5].
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          This does not mean enhanced formulations never improve absorption. It means a marketing multiplier should be treated as a <strong>study-specific pharmacokinetic comparison</strong>, not a clinical grade or a universal product ranking.
+        </p>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Liver and interaction boundary</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">Increasing exposure can increase the importance of safety review</h2>
+        <p className="text-sm leading-7 text-muted">
+          NCCIH says highly bioavailable curcumin formulations may harm the liver and notes reported liver damage in users of some enhanced products [6]. LiverTox now considers turmeric a well-documented cause of clinically apparent liver injury and describes numerous cases involving supplemental turmeric or curcumin, including enhanced-bioavailability products [7]. The absolute incidence appears low, but “natural” and “better absorbed” are not safety guarantees.
+        </p>
+        <p className="text-sm leading-7 text-muted">
+          Piperine is used precisely because it can alter intestinal/hepatic metabolism [2]. People taking prescription medicines, people with liver disease, and people who develop symptoms such as jaundice, dark urine, marked fatigue, or persistent nausea should not treat an absorption enhancer as merely a formulation upgrade; medication and liver-safety context matters.
+        </p>
+      </section>
+
+      <section className="card-premium p-6 space-y-4 max-w-4xl">
+        <p className="eyebrow-label">Evidence applicability</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">What this guide does and does not conclude</h2>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-7 text-muted">
+          <li>Curcumin has genuine oral-bioavailability limitations [1].</li>
+          <li>Some formulations can increase measured exposure [2,3].</li>
+          <li>There is no universal absorption multiplier that can be transferred across products and laboratories [4,5].</li>
+          <li>Higher measured exposure does not, by itself, prove superior patient-important efficacy.</li>
+          <li>Higher bioavailability does not, by itself, establish superior safety; liver injury is a real though uncommon concern [6,7].</li>
+          <li>This page does not convert pharmacokinetic study regimens into a consumer dosing or piperine protocol.</li>
+        </ul>
+      </section>
+
+      <LegacyGuideFAQ questions={[...FAQS]} pagePath="/guides/other/curcumin-absorption-guide/" />
+
+      <div className="max-w-4xl rounded-xl border border-brand-900/10 bg-brand-50/40 p-4 text-xs leading-6 text-muted">
+        <strong className="text-ink">Commercial-links boundary:</strong> optional product links below are sourcing examples. They do not establish that a more bioavailable formulation is more effective, safer, appropriate with medications, or appropriate for a particular health condition.
       </div>
-      <EmailCapture headline="Get evidence reviews like this" description="Curcumin absorption — the formulation matters more than the dose." ctaLabel="Get the evidence" location="guide-curcumin" />
-      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/" className="text-sm font-bold text-brand-800 hover:underline">Herb library →</Link></div>
+      <div className="max-w-4xl">
+        <RecommendationSection
+          title="Curcumin product examples"
+          description="Formulation identity matters when comparing products, but this is not a ranking by maximal absorption. Review the evidence and safety context above, especially if medications or liver concerns are relevant."
+          products={getRevenueProductSet('turmeric')?.products ?? []}
+        />
+      </div>
+
+      <References refs={CURCUMIN_REFS} />
+      <EmailCapture headline="Get evidence reviews like this" description="Curcumin bioavailability, formulation, and safety — evidence over multipliers." ctaLabel="Get the evidence" location="guide-curcumin" />
+      <div className="pt-4 border-t border-brand-900/10 flex items-center justify-between"><Link href="/guides/" className="inline-flex rounded-full border border-brand-900/10 bg-[var(--surface-card)] px-4 py-2 text-sm font-bold text-ink transition hover:bg-brand-50">← Back to guides</Link><Link href="/herbs/turmeric/" className="text-sm font-bold text-brand-800 hover:underline">Turmeric evidence profile →</Link></div>
     </div>
   )
 }


### PR DESCRIPTION
Fixes #3885

## Summary
Replaces the old maximum-bioavailability/product-ranking curcumin page with an exposure-versus-efficacy-versus-safety evidence review.

- removes the fixed curcumin+piperine consumer regimen and 'best value for most people' claim
- removes universal 20x/30x/50x formulation rankings and price hierarchy
- explains that the classic Shoba 1998 20-fold result came from a specific small 2 g curcumin + 20 mg piperine pharmacokinetic experiment
- adds a semantic evidence ledger separating native curcumin, piperine, enhanced formulations, clinical outcomes, and safety
- adds the 2024 systematic-review methodology study and 2025 independent pharmacokinetic reappraisal
- adds current NCCIH and LiverTox liver-safety boundaries for highly bioavailable turmeric/curcumin products
- makes clear that analytical method, conjugates versus unconjugated curcumin, comparator, and dose can change reported bioavailability ratios
- adds canonical `LegacyGuideQuickAnswer` and `LegacyGuideFAQ` source-linked surfaces
- retains optional product links only as sourcing examples, not an absorption ranking or treatment recommendation

## Trust impact
The page can no longer be extracted as 'maximize curcumin absorption with piperine.' It now preserves the distinction between pharmacokinetic exposure, clinical benefit, and liver/interaction safety.