### PR TITLE
refactor(research-quality): make underlying-study dependency canonical

### DIFF
--- a/lib/__tests__/research-gap-dependency-source-of-truth.test.ts
+++ b/lib/__tests__/research-gap-dependency-source-of-truth.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('research gap dependency source of truth', () => {
+  it('scores high-study dependency only from underlying-study topology', () => {
+    const policy = readFileSync('lib/research-quality-policy.ts', 'utf8')
+    const topologySignals = readFileSync('lib/research-quality-policy-topology-signals.ts', 'utf8')
+
+    expect(policy).not.toContain('profile.overDependentOnSingleStudy')
+    expect(policy).not.toContain('profile.dominantStudySupportedClaimShare')
+    expect(topologySignals).toContain('topology.underlyingStudyIndependence.newlyOverDependentProfiles')
+    expect(topologySignals).toContain("kind: 'high-study-dependency'")
+  })
+})

--- a/lib/research-quality-policy.ts
+++ b/lib/research-quality-policy.ts
@@ -215,10 +215,6 @@ function addEditorialBacklogReasons(analysis: ResearchQualityAnalysis, add: AddR
 
 function addProfileReasons(analysis: ResearchQualityAnalysis, add: AddReason) {
   for (const profile of analysis.profileAnalyses) {
-    if (profile.overDependentOnSingleStudy) {
-      const concentrationBonus = Math.round(Math.min(15, profile.studyConcentrationIndex * 20))
-      add(profile.url, 'high-study-dependency', Math.round(25 + profile.dominantStudySupportedClaimShare * 30 + concentrationBonus), `${Math.round(profile.dominantStudySupportedClaimShare * 100)}% of supported approved claims depend on one canonical study; effective study count ${profile.effectiveStudyCount}`)
-    }
     if (profile.narrativeDominatedVsPrimaryHuman) {
       const detail = profile.narrativeToPrimaryHumanRatio === null ? 'no primary-human studies' : `${profile.narrativeToPrimaryHumanRatio}:1 narrative-to-primary-human ratio`
       add(profile.url, 'narrative-review-dominated-profile', RESEARCH_GAP_WEIGHTS.narrativeReviewDominatedProfile, detail)


### PR DESCRIPTION
Remove the legacy publication-level high-study-dependency scoring path from research-gap policy. Dependency concentration remains descriptive in profile analysis, but remediation scoring now comes only from topology.underlyingStudyIndependence.newlyOverDependentProfiles, which is adjusted for proven same-trial/cohort publication reuse. Adds a regression guard preventing the legacy scorer from returning.